### PR TITLE
Changed Roslyn link from CodePlex to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ managed compilers, the runtime, the BCL and the application model, such as
 ASP.NET.
 
 * [.NET Core Framework](https://github.com/dotnet/corefx)
-* [.NET Compiler Platform ("Roslyn")](https://roslyn.codeplex.com)
+* [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)
 * [ASP.NET 5](https://github.com/aspnet/home)
 
 At present, only a few .NET Core libraries are available on GitHub. The rest of


### PR DESCRIPTION
Noticed that this file hasn't been updated with the move of Roslyn to GitHub.

Is there a reason why the `How to Contribute` page hasn't been moved over from CodePlex?