### PR TITLE
Initial import of our release notes

### DIFF
--- a/release-notes/Microsoft.Bcl.Async.md
+++ b/release-notes/Microsoft.Bcl.Async.md
@@ -1,0 +1,291 @@
+# Microsoft.Bcl.Async
+
+## Information
+
+* [NuGet Package](https://nuget.org/packages/Microsoft.Bcl.Async)
+* [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl.Async/ContactOwners)
+
+## Version History
+
+### 1.0.168
+
+* Updated package dependencies and clarified supported platforms.
+
+### 1.0.166
+
+* Added Windows Phone 8.1 support
+
+### 1.0.166-beta
+
+* Fixed issue with missing Microsoft.Threading.Tasks.Extensions.Desktop.dll when targeting .Net 4.5
+
+### 1.0.165
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 1.0.16
+
+* Switched to RTM
+* Added support for build-time warnings around missing package references
+* Release announcement can be found [here](http://blogs.msdn.com/b/bclteam/archive/2013/04/17/microsoft-bcl-async-is-now-stable.aspx)
+
+### 1.0.14-rc
+
+* Changed: Moved to latest Microsoft.Bcl package (1.0.16-rc).
+
+### 1.0.13-beta
+
+* Fixed: [ConfigureAwait(false) still continue on captured context when using Async Targeting Pack](http://connect.microsoft.com/VisualStudio/feedback/details/767008/configureawait-false-still-continue-on-captured-context-when-using-async-targeting-pack)
+* Fixed: Silverlight 4 projects now get Microsoft.Threading.Tasks.Extensions.Silverlight
+* Added: Package now references System.Net.dll automatically for .NET 4.0 projects so that networking extension methods work out of the box.
+* Changed: Moved types in Microsoft.Threading.Tasks from System.* to Microsoft.* namespace to prevent name conflicts
+* Changed: Package now includes Microsoft.Threading.Tasks for .NET 4.5, Windows Store apps and Windows Phone 8 projects to enable the consumption of custom awaiters.
+* Changed: Microsoft.Bcl dependency is now not included for .NET 4.5, Windows Store apps and Windows Phone 8 projects because it is not needed.
+
+### 1.0.12-beta
+
+* Fixed: [TypeLoadException when using Async for WP7.5 version 1.0.11-beta](https://connect.microsoft.com/VisualStudio/feedback/details/768521/system-typeloadexception-when-using-async-for-wp7-5-version-1-0-11-beta)
+
+### 1.0.11-beta
+
+* Initial release
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/10/22/using-async-await-without-net-framework-4-5.aspx)
+
+## Troubleshooting
+
+### Issue 1
+
+#### Symptom
+
+You may get the following error when trying to add a reference to the Microsoft.Bcl.Async package:
+
+    Attempting to resolve dependency 'Microsoft.Bcl (= 1.0.0-beta)'.
+    Successfully installed 'Microsoft.Bcl 1.0.10-beta'.
+    Successfully installed 'Microsoft.Bcl.Async 1.0.10-beta'.
+    Successfully uninstalled 'Microsoft.Bcl 1.0.10-beta'.
+    Install failed. Rolling back...
+    Could not install package 'Microsoft.Bcl 1.0.10-beta'.
+    You are trying to install this package into a project that targets '.NETPortable,Version=v4.0,Profile=Profile4',
+    but the package does not contain any assembly references or content files that are compatible with that framework.
+    For more information, contact the package author.
+
+#### Resolution
+
+This happens when trying to reference a NuGet package from a Portable Class
+Library that supports platforms not supported by the package. For
+`Microsoft.Bcl.Async`, this usually occurs when trying to reference it from a
+Portable Class Library which supports Windows Phone 7.0. To resolve this, change
+the Portable Class Library to target Windows Phone 7.5 and higher.
+
+### Issue 2
+
+#### Symptom
+
+After installing the `Microsoft.Bcl` or `Microsoft.Bcl.Async` packages to
+certain projects, you may get build errors or warnings similar to:
+
+    Cannot await 'System.Threading.Tasks.Task'.
+
+-or-
+
+    The primary reference "Microsoft.Threading.Tasks" could not be resolved because it has an indirect dependency on the framework assembly "System.Runtime, Version=1.5.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" which could not be resolved in the currently targeted framework. ".NETFramework,Version=v4.0". To resolve this problem, either remove the reference "Microsoft.Threading.Tasks" or retarget your application to a framework version which contains "System.Runtime, Version=1.5.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
+
+#### Resolution
+
+`Microsoft.Bcl.Async` package is not supported in Visual Basic Web Application
+projects. As a workaround, place all async/await usage in a class library and
+consume that from the Web Application project.
+
+Otherwise, for other project types add an `App.Config` to the project with the
+following contents, replacing [version] with the version (for example,
+`2.5.10.0`) of `System.Runtime` and `System.Threading.Tasks` that you are
+referencing:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-[version]" newVersion="[version]" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-[version]" newVersion="[version]" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+```
+
+### Issue 3
+
+#### Symptom
+
+After retargeting a .NET Framework, Portable or Windows Phone project from an
+older target framework version to a newer target framework version, you may get
+build warnings similar to:
+
+    The predefined type 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' is defined in multiple assemblies in the global alias; using definition from 'c:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll'
+
+#### Resolution
+
+Higher versions of these platforms already include the types from the
+`Microsoft.Bcl` and `Microsoft.Bcl.Async` packages. Uninstall them from the
+project, and remove the `<assemblyBinding>` elements from any `app.config` that
+refers to `System.Runtime` and `System.Threading.Tasks`.
+
+### Issue 4
+
+#### Symptom
+
+You get syntax errors when you attempt to use the Microsoft.Bcl.Async package in
+a web site project, similar to:
+
+    The type or namespace name 'async' could not be found (are you missing a using directive or an assembly reference?)
+
+-or-
+
+    The type or namespace name 'await' could not be found (are you missing a using directive or an assembly reference?)
+
+#### Solution
+
+`Microsoft.Bcl.Async` package is not supported in Web Sites. As a workaround,
+place all async/await usage in a class library and consume that from the Web Site.
+
+### Issue 5
+
+#### Symptoms
+
+When using the NuGet package restore feature the code doesn’t build with the
+following error message:
+
+    The imported project "<ProjectPath>\packages\Microsoft.Bcl.Build.<version>\tools\Microsoft.Bcl.Build.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
+
+#### Solution
+
+Package Restore is a feature of NuGet that will download any missing packages as
+part of the build, which means the packages folder doesn’t need to be checked
+into source control. However, this doesn’t work for NuGet packages that inject
+MSBuild targets files. You will need to make sure all *.targets files under the
+packages folder are being checked into version control.
+
+For `Microsoft.Bcl.Build` you need check in the following file:
+
+    Microsoft.Bcl.Build.<version>\tools\Microsoft.Bcl.Build.targets
+
+### Issue 6
+
+#### Symptoms
+
+When adding the NuGet package to a project that is consumed by another project
+with a different target framework you might see warnings similar to the
+following:
+
+    The primary reference "Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" could not be resolved because it has an indirect dependency on the framework assembly "System.Runtime, Version=2.5.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" which could not be resolved in the currently targeted framework. ".NETFramework,Version=v4.5". To resolve this problem, either remove the reference "Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" or retarget your application to a framework version which contains "System.Runtime, Version=2.5.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
+    The primary reference "Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" could not be resolved because it has an indirect dependency on the framework assembly "System.Runtime, Version=2.5.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" which could not be resolved in the currently targeted framework. ".NETFramework,Version=v4.5". To resolve this problem, either remove the reference "Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" or retarget your application to a framework version which contains "System.Runtime, Version=2.5.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
+
+#### Solution
+
+The problem is that NuGet added incorrect binding redirects for platform
+assemblies. To remove them, please open the `app.config` for the project that
+caused the warnings and remove the highlighted entries:
+
+```xml
+<?xmlversion="1.0"encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBindingxmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentityname="System.Runtime"publicKeyToken="b03f5f7f11d50a3a"culture="neutral" />
+        <bindingRedirectoldVersion="0.0.0.0-2.5.19.0"newVersion="2.5.19.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentityname="System.Threading.Tasks"publicKeyToken="b03f5f7f11d50a3a"culture="neutral" />
+        <bindingRedirectoldVersion="0.0.0.0-2.5.19.0"newVersion="2.5.19.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+```
+
+### Issue 7
+
+#### Symptoms
+
+When building a Windows Runtime Component (.winmd) you might get one of the following error messages:
+
+    Could not resolve reference 'Assembly(Name=System.Threading.Tasks, Version=1.5.11.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)'.
+    Could not resolve reference 'Assembly(Name=System.Threading.Tasks, Version=2.5.11.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)'.
+
+Please note the version number that it mentions.
+
+#### Solution
+
+This is an issue with the tool that creates a Windows Runtime Component
+(WINMDEXP). Until we address this issue you will need to work around this by
+adding a reference to the assembly directly by following these steps:
+
+1. Unload the Windows Runtime Component project by right click the project node
+   in Solution Explorer and selecting Unload Project.
+2. Edit the project by right clicking it again in Solution Explorer and
+   selecting Edit `<Project Name>`.
+3. Jump to end of the file (after the imports). Depending on the version number
+   of the error message paste in one of the following snippets before the
+   closing `</Project>` element.
+
+Version 1.5.x:
+
+```xml
+<Target Name="InjectAsyncDependencies" BeforeTargets="ExportWindowsMDFile">
+  <ItemGroup>
+    <ReferencePath Include="..\packages\Microsoft.Bcl.1.0.19\lib\sl4\System.Threading.Tasks.dll" />
+  </ItemGroup>
+</Target>
+```
+
+Version 2.5.x:
+
+```xml
+<Target Name="InjectAsyncDependencies" BeforeTargets="ExportWindowsMDFile">
+  <ItemGroup>
+    <ReferencePath Include="..\packages\Microsoft.Bcl.1.0.19\lib\net40\System.Threading.Tasks.dll" />
+  </ItemGroup>
+</Target>
+```
+
+### Issue 8
+
+#### Symptom
+
+When targeting .NET 4 you get the following error:
+
+    Could not load file or assembly 'System.Core, Version=2.0.5.0
+
+#### Resolution
+
+Using `Microsoft.Bcl.Async` on .NET 4 requires http://support.microsoft.com/kb/2468871 to be installed.
+
+### Issue 9
+
+#### Symptom
+
+ClickOnce applications targeting .NET Framework 4.0 that reference the
+`Microsoft.`Bcl or `Microsoft.Bcl.Async` packages may experience a
+`TypeLoadException` or other errors after being installed.
+
+#### Resolution
+
+This occurs because ClickOnce fails to deploy certain required assemblies. As a
+workaround, do the following:
+
+1. Right-click on the project and choose **Add Existing Item**
+2. Browse to the folde `net40` within the `Microsoft.Bcl` package folder
+3. In the File name text box enter `*.*`
+4. Holding CTRL, select `System.Runtime.dll` and `System.Threading.Tasks.dll`
+5. Click the down-arrow next to the Add button and choose Add as Link
+6. In Solution Explorer, holding CTRL select `System.Runtime.dll` and `System.Threading.Taks.dll`
+7. Right-click the selection, choose Properties and change **Copy to Output Directory** to **Copy always**
+8. Republish

--- a/release-notes/Microsoft.Bcl.Async.md
+++ b/release-notes/Microsoft.Bcl.Async.md
@@ -3,6 +3,7 @@
 ## Information
 
 * [NuGet Package](https://nuget.org/packages/Microsoft.Bcl.Async)
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2013/04/17/microsoft-bcl-async-is-now-stable.aspx)
 * [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl.Async/ContactOwners)
 
 ## Version History

--- a/release-notes/Microsoft.Bcl.Build.md
+++ b/release-notes/Microsoft.Bcl.Build.md
@@ -3,6 +3,7 @@
 ## Information
 
 * [NuGet Package](https://nuget.org/packages/Microsoft.Bcl.Build)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/08/12/improved-package-restore.aspx)
 * [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl.Build/ContactOwners)
 
 ## Version History

--- a/release-notes/Microsoft.Bcl.Build.md
+++ b/release-notes/Microsoft.Bcl.Build.md
@@ -1,0 +1,50 @@
+# Microsoft.Bcl.Build
+
+## Information
+
+* [NuGet Package](https://nuget.org/packages/Microsoft.Bcl.Build)
+* [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl.Build/ContactOwners)
+
+## Version History
+
+### 1.0.21
+
+* Updated to stable, no other changes.
+
+### 1.0.20-Beta
+
+* Remove PowerShell scripts and use Nuget's built-in targets file support.
+
+### 1.0.17-Beta
+
+* Updated to use in-box binding redirect functionality for supported projects
+  types from VS2013 onwards
+
+### 1.0.14
+
+* Added Windows Phone 8.1 support
+
+### 1.0.13
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 1.0.10
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/08/12/improved-package-restore.aspx)
+* Marked as stable
+
+### 1.0.9-beta
+
+* Improved experience around package restore. The import to the targets is now
+  optional which allows VS to load the project, even if the package is missing.
+  A build that restored packages will now fail with an error message asking to
+  build again.
+
+### 1.0.8
+
+* Marked as stable
+
+### 1.0.7
+
+* Fixed issues with building on a .NET 4 machine

--- a/release-notes/Microsoft.Bcl.Compression.md
+++ b/release-notes/Microsoft.Bcl.Compression.md
@@ -1,3 +1,3 @@
 # Microsoft.Bcl.Compression
 
-This package has been renamed to [System.IO.Compression].
+This package has been renamed to [System.IO.Compression](System.IO.Compression.md).

--- a/release-notes/Microsoft.Bcl.Compression.md
+++ b/release-notes/Microsoft.Bcl.Compression.md
@@ -1,0 +1,3 @@
+# Microsoft.Bcl.Compression
+
+This package has been renamed to [System.IO.Compression].

--- a/release-notes/Microsoft.Bcl.Metadata.md
+++ b/release-notes/Microsoft.Bcl.Metadata.md
@@ -1,3 +1,3 @@
 # Microsoft.Bcl.Metadata
 
-This package has been renamed to [System.Reflection.Metadata.md].
+This package has been renamed to [System.Reflection.Metadata](System.Reflection.Metadata.md).

--- a/release-notes/Microsoft.Bcl.Metadata.md
+++ b/release-notes/Microsoft.Bcl.Metadata.md
@@ -1,0 +1,3 @@
+# Microsoft.Bcl.Metadata
+
+This package has been renamed to [System.Reflection.Metadata.md].

--- a/release-notes/Microsoft.Bcl.Simd.md
+++ b/release-notes/Microsoft.Bcl.Simd.md
@@ -1,3 +1,3 @@
 # Microsoft.Bcl.Simd
 
-This package has been renamed to [System.Numerics.Vectors.md].
+This package has been renamed to [System.Numerics.Vectors](System.Numerics.Vectors.md).

--- a/release-notes/Microsoft.Bcl.Simd.md
+++ b/release-notes/Microsoft.Bcl.Simd.md
@@ -1,0 +1,3 @@
+# Microsoft.Bcl.Simd
+
+This package has been renamed to [System.Numerics.Vectors.md].

--- a/release-notes/Microsoft.Bcl.md
+++ b/release-notes/Microsoft.Bcl.md
@@ -1,0 +1,64 @@
+# Microsoft.Bcl
+
+## Information
+
+* [NuGet Package](https://nuget.org/packages/Microsoft.Bcl)
+* [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl/ContactOwners)
+
+## Version History
+
+### 1.1.10
+
+* Added specific lib folder for Xamarin.iOS Unified API.
+
+### 1.1.9
+
+* Added specific lib folders for `monotouch` and `monoandroid`.
+
+### 1.1.8
+
+* Updated package dependencies and clarified supported platforms.
+
+### 1.1.7
+
+* Added Windows Phone 8.1 support
+
+### 1.1.6
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 1.1.3
+
+* Marked as stable
+
+### 1.1.2-rc
+
+* Added `System.IO.InvalidDataException`.
+
+### 1.1.0-beta
+
+* Added `InvalidDataException` so that this type will unify on platforms that support compression
+
+### 1.0.19
+
+* Marked as stable
+
+### 1.0.16-rc
+
+* Fixed: Adding empty content to .NET 4.5, Windows Phone 8, Windows 8 and
+  portable combinations, so that `app.config` transforms are not applied to
+  projects targeting them
+* Fixed: `System.Runtime` is missing a type forward for `Tuple<T1, T2>`
+* Fixed: `System.Runtime` now has a fixed version for Phone 7.x due to the lack
+  of a way to redirect them to a later version.
+* Fixed: First-chance exceptions when running on Phone 7.x
+* Fixed: `Microsoft.Bcl.targets` are not imported when using NuGet 2.0 to
+  install `Microsoft.Bcl`
+* Changed: Pulled build targets into a separate package (`Microsoft.Bcl.Build`)
+  so other BCL packages can depend on it.
+
+### 1.0.11-beta
+
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/10/22/using-async-await-without-net-framework-4-5.aspx)
+* Initial release

--- a/release-notes/Microsoft.Bcl.md
+++ b/release-notes/Microsoft.Bcl.md
@@ -3,6 +3,7 @@
 ## Information
 
 * [NuGet Package](https://nuget.org/packages/Microsoft.Bcl)
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/10/22/using-async-await-without-net-framework-4-5.aspx)
 * [Report an issue](https://www.nuget.org/packages/Microsoft.Bcl/ContactOwners)
 
 ## Version History

--- a/release-notes/Microsoft.Composition.md
+++ b/release-notes/Microsoft.Composition.md
@@ -1,0 +1,43 @@
+# Microsoft.Composition
+
+## Information
+
+* [NuGet Package](http://nuget.org/packages/Microsoft.Composition)
+* [Documentation](http://msdn.microsoft.com/en-us/library/jj635137.aspx)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 1.0.30
+
+* Fixed a bug preventing correct behavior of
+  `System.Composition.Convention.ConventionBuilder.GetCustomAttributes`, when
+  [compiling to native](http://msdn.microsoft.com/vstudio/dotnetnative.aspx).
+
+### 1.0.27
+
+* Updated to stable, no other changes.
+
+### 1.0.26-beta
+
+* Added Windows Phone 8.1 support
+
+### 1.0.24-alpha
+
+* Added Windows Phone 8 support
+
+### 1.0.17.0
+
+* Minor branding update
+
+### 1.0.16.0
+
+* Added support for consuming nuget package from Portable Library project
+* Platforms that are supported are Windows Store App, .Net 4.5
+
+### 1.0.15.0
+
+* Updated version information to .NET 4.5 RTM
+* Added symbol package with source information for debugging
+* Updated branding to say "Windows Store Apps" instead of "Metro style apps"

--- a/release-notes/Microsoft.Composition.md
+++ b/release-notes/Microsoft.Composition.md
@@ -4,6 +4,7 @@
 
 * [NuGet Package](http://nuget.org/packages/Microsoft.Composition)
 * [Documentation](http://msdn.microsoft.com/en-us/library/jj635137.aspx)
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/03/02/introducing-mef-lightweight-composition-and-an-updated-composition-provider-for-asp-net-mvc-nick.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 
@@ -41,3 +42,4 @@
 * Updated version information to .NET 4.5 RTM
 * Added symbol package with source information for debugging
 * Updated branding to say "Windows Store Apps" instead of "Metro style apps"
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/03/02/introducing-mef-lightweight-composition-and-an-updated-composition-provider-for-asp-net-mvc-nick.aspx)

--- a/release-notes/Microsoft.Experimental.Collections.md
+++ b/release-notes/Microsoft.Experimental.Collections.md
@@ -1,0 +1,17 @@
+# Microsoft.Experimental.Collections
+
+## Information
+
+* [NuGet Package](https://www.nuget.org/packages/Microsoft.Experimental.Collections/)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+
+## Version History
+
+### 1.0.3-alpha
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2014/08/05/multidictionary-becomes-multivaluedictionary.aspx)
+
+### 1.0.1-alpha
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2014/06/20/would-you-like-a-multidictionary.aspx)
+

--- a/release-notes/Microsoft.Experimental.Collections.md
+++ b/release-notes/Microsoft.Experimental.Collections.md
@@ -3,6 +3,7 @@
 ## Information
 
 * [NuGet Package](https://www.nuget.org/packages/Microsoft.Experimental.Collections/)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2014/06/20/would-you-like-a-multidictionary.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 
 ## Version History

--- a/release-notes/Microsoft.Net.Http.md
+++ b/release-notes/Microsoft.Net.Http.md
@@ -1,0 +1,3 @@
+# Microsoft.Net.Http
+
+This package has been renamed to [System.Net.Http.md].

--- a/release-notes/Microsoft.Net.Http.md
+++ b/release-notes/Microsoft.Net.Http.md
@@ -1,3 +1,3 @@
 # Microsoft.Net.Http
 
-This package has been renamed to [System.Net.Http.md].
+This package has been renamed to [System.Net.Http](System.Net.Http.md).

--- a/release-notes/Microsoft.Tpl.Dataflow.md
+++ b/release-notes/Microsoft.Tpl.Dataflow.md
@@ -1,0 +1,5 @@
+# Microsoft.Tpl.Dataflow
+
+This package has been renamed to [System.Threading.Tasks.Dataflow.md].
+
+

--- a/release-notes/Microsoft.Tpl.Dataflow.md
+++ b/release-notes/Microsoft.Tpl.Dataflow.md
@@ -1,5 +1,5 @@
 # Microsoft.Tpl.Dataflow
 
-This package has been renamed to [System.Threading.Tasks.Dataflow.md].
+This package has been renamed to [System.Threading.Tasks.Dataflow](System.Threading.Tasks.Dataflow.md).
 
 

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+This folder contains the release notes for the .NET Core NuGet packages.

--- a/release-notes/System.Collections.Immutable.md
+++ b/release-notes/System.Collections.Immutable.md
@@ -4,6 +4,7 @@
 
 * [NuGet Package](http://nuget.org/packages/System.Collections.Immutable)
 * [Documentation](https://msdn.microsoft.com/en-us/library/dn769092.aspx)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/09/25/immutable-collections-ready-for-prime-time.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 

--- a/release-notes/System.Collections.Immutable.md
+++ b/release-notes/System.Collections.Immutable.md
@@ -1,0 +1,84 @@
+# System.Collections.Immutable
+
+## Information
+
+* [NuGet Package](http://nuget.org/packages/System.Collections.Immutable)
+* [Documentation](https://msdn.microsoft.com/en-us/library/dn769092.aspx)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 1.1.36
+
+* First stable release of version 1.1
+* `ImmutableArray<T>`'s explicit implementation of `ICollection.SyncRoot`
+  changed to throw `NotSupportedException` instead of returning new boxed
+  instance on every call.
+
+### 1.1.34-rc
+
+* `ImmutableArray.MoveToImmutable` API added to avoid copying in known size scenario
+* `ImmutableArray.Update` API added to support an arbitrary interlocked transformation
+* **[Breaking change]** `ImmutableArray.Create<T, TDerived>` replaced by `ImmutableArray<T>.CastUp` and `ImmutableArray<T>.CastArray`
+* **[Breaking change]** `ImmutableArray<T>.Builder.EnsureCapacity` replaced with `ImmutableArray<T>.Builder.Capacity` property
+* **[Breaking change]** `ImmutableArray<T>.ReverseContents` renamed to `ImutableArray<T>.Reverse`
+* Bug fixes and performance improvements
+
+### 1.1.33-beta
+
+* Several performance optimizations
+* Thread-safety fix to `ImmutableArray`
+* **[Breaking change]** Removal of `ImmutableArrayInterop`
+* Allow null comparer arguments
+* Doc comment updates
+* Fix `DebuggerTypeProxy` issue on Windows Store apps
+* Fix AVL tree balancing issues
+* Add `ImmutableArrayExtensions.SelectMany`
+* Add indexed to `ImmutableSortedSet<T>.Builder`
+* Throw `ArgumentOutOfRangeException` instead of `OverflowException` for negative capacity passed to `ImmutableArray.CreateBuilder`
+
+### 1.1.32-beta
+
+* Renamed the package from `Microsoft.Bcl.Immutable` to `System.Collections.Immutable`
+    - You can upgrade the existing package. It will automatically add and open a
+      readme file explaining that you should now remove the reference to
+      `Microsoft.Bcl.Immutable`
+* Note that the name of the .DLL is unchanged
+
+### 1.1.22-beta (Microsoft.Bcl.Immutable)
+
+* Added support for Windows Phone 8.1
+
+### 1.1.20-beta (Microsoft.Bcl.Immutable)
+
+* Re-included ImmutableArray<T>
+
+### 1.0.34 (Microsoft.Bcl.Immutable)
+
+* Added support for Windows Phone 8.1
+
+### 1.0.30 (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 1.0.27 (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/09/25/immutable-collections-ready-for-prime-time.aspx)
+
+### 1.0.23-rc (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/09/12/immutable-collections-are-now-rc.aspx)
+
+### 1.0.12-beta (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/06/24/please-welcome-immutablearray.aspx)
+
+### 1.0.8-beta (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2013/03/06/update-to-immutable-collections.aspx)
+
+### 1.0.5-beta (Microsoft.Bcl.Immutable)
+
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2012/12/18/preview-of-immutable-collections-released-on-nuget.aspx)

--- a/release-notes/System.IO.Compression.md
+++ b/release-notes/System.IO.Compression.md
@@ -4,6 +4,7 @@
 
 * [NuGet Package](http://nuget.org/packages/System.IO.Compression)
 * [Documentation](https://msdn.microsoft.com/en-us/library/system.io.compression.aspx)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/08/22/portable-compression-is-now-stable.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 

--- a/release-notes/System.IO.Compression.md
+++ b/release-notes/System.IO.Compression.md
@@ -1,0 +1,93 @@
+# System.IO.Compression
+
+## Information
+
+* [NuGet Package](http://nuget.org/packages/System.IO.Compression)
+* [Documentation](https://msdn.microsoft.com/en-us/library/system.io.compression.aspx)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 4.0.0-beta-22231
+
+* Package was renamed to `System.IO.Compression`
+
+### 3.9.85 (Microsoft.Bcl.Compression)
+
+* Updated to stable, no other changes.
+
+### 3.9.84-beta (Microsoft.Bcl.Compression)
+
+* Remove PowerShell scripts and use Nuget's built-in targets file support.
+
+### 3.9.83 (Microsoft.Bcl.Compression)
+
+* Added Windows Phone 8.1 support
+
+### 3.9.73 (Microsoft.Bcl.Compression)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 3.9.69 (Microsoft.Bcl.Compression)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/08/22/portable-compression-is-now-stable.aspx)
+* Marked as stable
+* Improved experience around package restore. The import to the targets is now
+  optional which allows VS to load the project, even if the package is missing.
+  A build that restored packages will now fail with an error message asking to
+  build again.
+
+### 3.9.66-rc (Microsoft.Bcl.Compression)
+
+* Minor branding update
+
+### 3.9.65-beta (Microsoft.Bcl.Compression)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/06/06/portable-compression-and-httpclient-working-together.aspx)
+* Initial Release
+
+## Troubleshooting
+
+### Issue 1
+
+#### Symptom
+
+When building a phone application you get the following error:
+
+    Phone Application: Project must install NuGet package Microsoft.Bcl.Compression.
+
+After adding the reference to `Microsoft.Bcl.Compression` and rebuilding your
+app, a new MSBuild task (which comes with the NuGet package) will deploy CPU-
+specific binaries as dependencies of your app. If your app is configured as Any
+CPU, the build will fail again with this error message:
+
+    Phone Application: Microsoft.Bcl.Compression does not support the currently selected platform of 'AnyCPU'. The supported platforms are 'x86' and 'ARM'.
+
+##### Resolution
+
+The project should build successfully after you change the platform target to
+`X86` or `ARM`.
+
+### Issue 2
+
+#### Symptom
+
+When creating large ZIP files, the resulting archive is corrupted and can't be
+read by either the ZipArchive class nor by any other 3rd party compression tool.
+
+#### Resolution
+
+The problem occurs due to a bug in `ZipArchive`. Whenever the sized of the
+compressed data exceeds 4GB the very next entry that is written will cause to
+overwrite existing data.
+
+The workaround is to avoid creating ZIP files where the compressed data exceeds
+4GB. You can achieve this by compressing multiple ZIP files instead.
+
+This problem exists on the following platforms:
+
+* .NET Framework 4.5
+* .NET for Windows Store apps
+* Windows Phone 8

--- a/release-notes/System.Net.Http.md
+++ b/release-notes/System.Net.Http.md
@@ -102,7 +102,7 @@
 
 ### 2.1.3 Beta (Microsoft.Net.Http)
 
-* Announcement
+* [Announcement](http://blogs.msdn.com/b/bclteam/archive/2013/02/18/portable-httpclient-for-net-framework-and-windows-phone.aspx)
 * First release of the portable version of `HttpClient`
 
 ## Troubleshooting

--- a/release-notes/System.Net.Http.md
+++ b/release-notes/System.Net.Http.md
@@ -1,0 +1,186 @@
+# System.Net.Http
+
+## Information
+
+* [NuGet Package](https://nuget.org/packages/System.Net.Http)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 4.0.0-beta-22231
+
+* Renamed package to `System.Net.Http`
+
+### 2.2.29 (Microsoft.Net.Http)
+
+* Added specific lib folder for Xamarin.iOS Unified API.
+
+### 2.2.28 (Microsoft.Net.Http)
+
+* Updated to stable, no other changes
+
+### 2.2.27-beta (Microsoft.Net.Http)
+
+* Fixed issue causing hang when an exception was thrown within `BeginGetRequestStream` method.
+
+### 2.2.23-beta (Microsoft.Net.Http)
+
+* Fixed issue with content buffer allocation for `HEAD` requests.
+* Fixed issue for `HttpRequestMessage` unbounded range throwing exception.
+
+### 2.2.22 (Microsoft.Net.Http)
+
+* Fixed an issue with Windows Phone 8.1 when using portable libraries and `IWebProxy`, `DecompressionMethods`, or `TransportContext`.
+* Added specific lib folders for monoandroid and monotouch.
+
+### 2.2.20 (Microsoft.Net.Http)
+
+* Updated package dependencies and clarified supported platforms.
+
+### 2.2.19 (Microsoft.Net.Http)
+
+* Added Windows Phone 8.1 support
+
+### 2.2.18 (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 2.2.15 (Microsoft.Net.Http)
+
+* Fixed bug where the decompression would always run synchronously, even if the stream is read asynchronously
+
+### 2.2.13 (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/07/17/httpclient-2-2-is-now-stable.aspx)
+
+### 2.2.10-RC (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/07/10/httpclient-2-2-is-now-rc.aspx)
+* Disabled write stream buffering on Windows Phone 8 when AllowAutoRedirect is set to false, which reduces memory usage.
+* Enabled setting credentials for Silverlight when using the client networking stack
+* Fixed some exception messages which referred to nonexistent APIs
+* Made package metadata updates
+
+### 2.2.7-Beta (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/06/19/update-to-httpclient-and-automatic-decompression.aspx)
+* Removed dependency on `Microsoft.Bcl.Compression` while keeping support for automatic decompression
+
+### 2.2.3-Beta (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/06/06/portable-compression-and-httpclient-working-together.aspx)
+* Added support for automatic decompression
+
+### 2.1.10 RTM (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/05/29/get-httpclient-rtm-200-ok.aspx)
+* Minor branding changes
+
+### 2.1.6 RC (Microsoft.Net.Http)
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/05/22/portable-httpclient-is-now-available-as-rc.aspx)
+* When consuming a portable class library depending on `HttpClient` from a
+  Windows Store application, the app can crash with a `MissingMethodException`.
+  We’ve fixed it by using the same technique we explained in our [blog post about Microsoft.Bcl.Async](http://blogs.msdn.com/b/bclteam/archive/2013/04/17/microsoft-bcl-async-is-now-stable.aspx):
+  we ensure during the build that the application has a reference to the NuGet
+  package.
+* Installing `HttpClient` NuGet package into an application can corrupt existing
+  binding redirects in the app.config file
+* The encoding ISO-8859-1 isn’t supported on Silverlight-based platforms
+* When using `HttpClient` in Silverlight over the browser networking stack
+  aborting the HTTP connection can result in a `NullReferenceException`
+* Header values containing commas get incorrectly split into multiple headers.
+* `HttpClientHandler.AllowAutoRedirect` can’t be set on Windows Phone 8 although
+  it should be supported.
+* `HttpWebRequest.AllowReadStreamBuffering` defaults to true on Windows Phone
+  which prevents practical use of `HttpClient` with chunked responses, such as
+  streaming live data.
+
+### 2.1.3 Beta (Microsoft.Net.Http)
+
+* Announcement
+* First release of the portable version of `HttpClient`
+
+## Troubleshooting
+
+### ~~Issue 1~~
+
+Fixed.
+
+### ~~Issue 2~~
+
+Fixed.
+
+### Issue 3
+
+#### Symptom
+
+When using HttpClient from a Silverlight application many http headers are not
+supported and will result in an `ArgumentException` or `NotImplementedException`
+when set and calling `HttpClient` methods that send a request.
+
+#### Resolution
+
+For a list of headers which are not supported in Silverlight please see:
+http://msdn.microsoft.com/en-us/library/system.net.webheadercollection(v=vs.95).aspx
+http://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.headers(v=vs.95).aspx
+
+### Issue 4
+
+#### Symptom
+
+When `HttpClientHandler.SupportsProtocolVersion()` is `false` the
+`HttpResponseMessage` returned from a request will have a `null` value for
+`Version`.
+
+#### Resolution
+
+Make sure that anytime you are using a version from the `HttpResponseMessage`,
+you do a null check on it if `SupportsProtocolVersion()` is `false`.
+
+### ~~Issue 5~~
+
+Fixed.
+
+### Issue 6
+
+#### Symptom
+
+When using `HttpClient` on Silverlight or the Phone be aware that the networking
+stack may cache responses.
+
+#### Resolution
+
+To avoid inconsistencies when creating  portable class library that runs on both
+platforms be sure that your server sets the cache control-header on the response
+to match your expected caching behavior on the Phone.  If you do not control the
+server, consider making a portion of the request unique if you do not want a
+cached result.
+
+### ~~Issue 7~~
+
+Fixed.
+
+### Issue 8
+
+#### Symptom
+
+ClickOnce applications targeting .NET Framework 4.0 that reference the
+`Microsoft.Net.Http` package may experience a `TypeLoadException` or other
+errors after being installed.
+
+#### Resolution
+
+This occurs because ClickOnce fails to deploy certain required assemblies. As a
+workaround, do the following:
+
+1. Right-click on the project and choose Add Existing Item
+2. Browse to the `net40` in the `HttpClient`  package folder
+3. In the File name text box enter *.*
+4. Holding CTRL, select `System.Net.Http.dll` and `System.Net.Http.Primitives.dll`
+5. Click the down-arrow next to the **Add** button and choose **Add as Link**
+6. In **Solution Explorer**, holding CTRL select `System.Net.Http.dll` and `System.Net.Http.WebRequest.dll`
+7. Right-click the selection, choose **Properties** and change **Copy to Output Directory** to **Copy always**
+8. Republish

--- a/release-notes/System.Net.Http.md
+++ b/release-notes/System.Net.Http.md
@@ -3,6 +3,8 @@
 ## Information
 
 * [NuGet Package](https://nuget.org/packages/System.Net.Http)
+* [Documentation](https://msdn.microsoft.com/en-us/library/system.net.http.aspx)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/07/17/httpclient-2-2-is-now-stable.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 

--- a/release-notes/System.Numerics.Vectors.md
+++ b/release-notes/System.Numerics.Vectors.md
@@ -1,0 +1,43 @@
+# System.Numerics.Vectors
+
+## Information
+
+* [NuGet Package](https://www.nuget.org/packages/System.Numerics.Vectors)
+* [Samples](http://code.msdn.microsoft.com/SIMD-Sample-f2c8c35a)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 4.0.0
+
+* Stabilized surface area for fixed-size types and removed "beta" pre-release tag
+* Removed `Vector` and `Vector<T>` from stable-version package, please continue
+  using the pre-release package (1.1.6) if you rely on these types).
+
+### 1.1.6
+
+* Fixed an issue in `Matrix4x4.Decompose` which caused the method to return
+  incorrect values when passed a matrix transform with a degenerate (zero)
+  scale factor.
+
+### 1.1.5
+
+* Renamed `Microsoft.Bcl.Simd` NuGet package to `System.Numerics.Vectors`
+* Expanded support for graphics programming by adding types for matrices,
+  planes, and quaternions
+
+### 1.0.2 (Microsoft.Bcl.Simd)
+
+* Added support for new generic vector types:
+    - `Byte`, `Sbyte`, `UInt16`, `Int16`
+* Mutable Fixed Vector types
+* (JIT) Added additional intrinsics for various operations:
+    - `CopyTo` (array) method now intrinsic
+    - Comparison operators completed for all types
+    - `Min` / `Max` for all types
+* Some performance improvements in the BCL code and general cleanup
+
+### 1.0.1 (Microsoft.Bcl.Simd)
+
+* Initial release

--- a/release-notes/System.Numerics.Vectors.md
+++ b/release-notes/System.Numerics.Vectors.md
@@ -3,7 +3,9 @@
 ## Information
 
 * [NuGet Package](https://www.nuget.org/packages/System.Numerics.Vectors)
+* [Documentation](https://msdn.microsoft.com/en-us/library/dn858218.aspx)
 * [Samples](http://code.msdn.microsoft.com/SIMD-Sample-f2c8c35a)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2014/04/07/the-jit-finally-proposed-jit-and-simd-are-getting-married.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 

--- a/release-notes/System.Reflection.Metadata.md
+++ b/release-notes/System.Reflection.Metadata.md
@@ -1,0 +1,45 @@
+# System.Reflection.Metadata
+
+## Information
+
+* [NuGet Package](https://www.nuget.org/packages/System.Reflection.Metadata)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 1.0.21
+
+* First stable release
+* [Breaking change] Support for very large heaps. Introduces `EntityHandle`
+  for non-heap handles and modifies the API to work with them wherever possible.
+* Fix issue running in a Windows Store App on a machine with .NET 4.6 installed.
+
+### 1.0.19-rc
+
+* Small bug fixes
+
+### 1.0.18-beta
+
+* [Breaking change] Fix spelling error in `MetadataTokens.ExportedTypeHandle`
+  method
+* Fix race condition when calling `GetMetadataReader` concurrently on the same
+  `PEReader`
+* Minor performance optimizations
+
+### 1.0.17-beta
+
+* Renamed the package from `Microsoft.Bcl.Metadata` to `System.Reflection.Metadata`
+    - In order to get the new version, uninstall `Microsoft.Bcl.Metadata` and
+      install `System.Reflection.Metadata` instead
+    - The name of the .DLL is unchanged
+* Minor bug fixes
+
+### 1.0.11-alpha (Microsoft.Bcl.Metadata)
+
+* Optimization data added for Roslyn
+* Minor bug fixes
+
+### 1.0.9-alpha (Microsoft.Bcl.Metadata)
+
+* Initial release

--- a/release-notes/System.Threading.Tasks.Dataflow.md
+++ b/release-notes/System.Threading.Tasks.Dataflow.md
@@ -1,0 +1,65 @@
+# System.Threading.Tasks.Dataflow
+
+## Information
+
+* [NuGet Package](http://nuget.org/packages/System.Threading.Tasks.Dataflow)
+* [Documentation](http://msdn.microsoft.com/en-us/library/hh228603.aspx)
+* [Report an issue](http://github.com/dotnet/corefx/issues/new)
+* [Source](https://github.com/dotnet/corefx/tree/master/src)
+
+## Version History
+
+### 4.5.25-beta-23019
+
+* Package has been renamed to `System.Threading.Tasks.Dataflow`
+
+### 4.5.24
+
+* Fix bug where `ActionBlock<T>` stopped once its bounded capacity was reached
+* Fix bug where `InvalidOperationException` was thrown instead of
+  `TaskCanceledException` in certain cases
+
+### 4.5.23
+
+* Updated to stable, no other changes
+
+### 4.5.22-beta
+
+* Fixed issue resulting in `ActionBlock<T>` stopping when its Bounded Capacity
+  is reached.
+
+### 4.5.20
+
+* Updated to stable, no other changes
+
+### 4.5.19-beta
+
+* Added Windows Phone 8.1 support
+
+### 4.5.16-alpha
+
+* Added Windows Phone 8.0 support
+
+### 4.5.14
+
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
+* Updated license to remove Windows-only restriction
+
+### 4.5.11
+
+* Minor branding update
+
+### 4.5.10.0
+
+* Fixed bug that thorws when we connect `EncapsulateBlock` with a `TargetBlock`
+
+### 4.5.7.0
+
+* Added support for consuming nuget package from Portable Library project
+* Platforms that are supported are Windows Store Apps and .Net 4.5
+
+### 4.5.6.0
+
+* Updated version information to .NET 4.5 RTM
+* Added symbol package
+* Updated branding to say "Windows Store Apps" instead of "Metro style apps"

--- a/release-notes/System.Threading.Tasks.Dataflow.md
+++ b/release-notes/System.Threading.Tasks.Dataflow.md
@@ -4,6 +4,7 @@
 
 * [NuGet Package](http://nuget.org/packages/System.Threading.Tasks.Dataflow)
 * [Documentation](http://msdn.microsoft.com/en-us/library/hh228603.aspx)
+* [Announcement](http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx)
 * [Report an issue](http://github.com/dotnet/corefx/issues/new)
 * [Source](https://github.com/dotnet/corefx/tree/master/src)
 


### PR DESCRIPTION
Previously, the release notes were living as individual pages on our blog. At the time we started to ship .NET platform libraries as individual NuGet packages, that was the solution with the least amount of overhead.

Since we're now fully embracing open source on GitHub it seems much simpler to provide these release  notes as Markdown pages.

@richlander @weshaggard 