### PR TITLE
Fixed package version for System.Console in project.json 

### DIFF
--- a/samples/helloworld/project.json
+++ b/samples/helloworld/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "System.Console": "4.0.0-beta-*",
+        "System.Console": "4.0.0-beta-23019", 
         "System.Runtime": "4.0.21-beta-*"
     },
 


### PR DESCRIPTION
 This change should fix the issue some people have when calling dotnet restore and the System.IO package is not loaded correctly. If the * is used for the package version dotnet restore can´t load the System.IO package because it references to the newest package with the Version number 4.0.0-beta-23516, that might have not the correct dependencies. You may find the package here

https://www.nuget.org/packages/System.Console/4.0.0-beta-23516

So we can either merge this pull request to fix it for the current version, or add the correct Depenencies to System.Console Package. Another possibility would be to add a Dependency to System.IO to the project.json dependencies.