### PR TITLE
Remove VS2012 pre-reqs

### DIFF
--- a/Documentation/prereqs.md
+++ b/Documentation/prereqs.md
@@ -16,7 +16,6 @@ On Windows, the only dependency is the VC++ Redistributable. Depending on the ve
 * Pre-Windows 10
     * Please make sure that your Windows installation is up-to-date and includes hotfix [KB2533623] (https://support.microsoft.com/en-us/kb/2533623) installed through Windows Update.
     * [Universal CRT update](https://www.microsoft.com/en-us/download/details.aspx?id=48234) (you can get more info on what Universal CRT is in [this blog post](https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/))
-    * [Visual C++ Redistributable for Visual Studio 2012 Update 4](https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679)
 
 ## Ubuntu
 Ubuntu distributions require the following libraries installed:


### PR DESCRIPTION
Removing the VS2012 CRT pre-requisite since it is no longer needed, as confirmed by @leecow.