### PR TITLE
Update instructions for ANCM

### DIFF
--- a/release-notes/preview-download.md
+++ b/release-notes/preview-download.md
@@ -94,4 +94,4 @@ dotnet-sdk-ubuntu.16.10-x64.1.0.0-preview2.1-003155.deb
 
 ## Windows Server Hosting
 If you are looking to host stand-alone apps on Windows Servers, the ASP.NET Core Module for IIS can be installed separately on servers without installing .NET Core runtime. You can download the Windows (Server Hosting) installer and run the following command from an Administrator command prompt:
-``DotNetCore.1.0.1-WindowsHosting.exe OPT_INSTALL_REDIST=0``
+``DotNetCore.1.1.0.Preview1-WindowsHosting.exe OPT_INSTALL_LTS_REDIST=0 OPT_INSTALL_FTS_REDIST=0``


### PR DESCRIPTION
The server hosting bundle carries ANCM, LTS shared framework, and FTS shared framework. To install ANCM, you have to opt out of both the shared frameworks.