### PR TITLE
Update 1.0-1.1-api-diff_System.Runtime.CompilerServices.md to show ref returns

### DIFF
--- a/release-notes/1.1/1.0-1.1-api-diff/1.0-1.1-api-diff_System.Runtime.CompilerServices.md
+++ b/release-notes/1.1/1.0-1.1-api-diff/1.0-1.1-api-diff_System.Runtime.CompilerServices.md
@@ -21,10 +21,10 @@
 
      }
      public static class Unsafe {
-+        public static T Add<T>(ref T source, int elementOffset);
++        public static ref T Add<T>(ref T source, int elementOffset);
 +        public static bool AreSame<T>(ref T left, ref T right);
-+        public static TTo As<TFrom, TTo>(ref TFrom source);
-+        public static T Subtract<T>(ref T source, int elementOffset);
++        public static ref TTo As<TFrom, TTo>(ref TFrom source);
++        public static ref T Subtract<T>(ref T source, int elementOffset);
      }
  }
 ```


### PR DESCRIPTION
Fix unsafe API changes that return a ref.