### PR TITLE
Update roadmap.md

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -34,7 +34,7 @@ there are some big themes you will identify in the early work on GitHub:
   applications faster, especially in the inner loop. This is the cycle of
   changing the source code and then restarting the application and making that
   as fast as possible. You can follow part of this work in the
-  [dotnet/roslyn](https://github.com/dotnet/standard) repo.
+  [dotnet/roslyn](https://github.com/dotnet/roslyn) repo.
 
 * **.NET Core and Cloud**. Continue to improve how you run .NET Core
   applications in Azure. Better logging, tracing and diagnosing errors in your


### PR DESCRIPTION
"dotnet/roslyn" link was navigating to .NET standard, now fixed to land on its own.