### PR TITLE
add rc3 (1.0, 1.1) to download-archive

### DIFF
--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -15,6 +15,7 @@ This page provides an archive of previously released versions of the .NET Core r
 | 10/17/2016 | 1.0.2 with SDK Preview 2 build 3148 | [release notes](https://github.com/dotnet/core/releases/tag/1.0.2) | [download](download-archives/1.0.2-preview2-download.md) |
 | 10/24/2016 | 1.0.1 with SDK Preview 4 build 4233 | - | [download](https://github.com/dotnet/core/blob/master/release-notes/preview4-download.md) |
 | 12/13/2016 | 1.0.3 with SDK Preview 2 build 3156 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md) | [download](download-archives/1.0.3-preview2-download.md) |
+| 01/27/2017 | 1.0.3 with SDK RC3 build 004530     | - | [download](https://github.com/dotnet/core/blob/master/release-notes/rc3-download.md) |
 
 ## ["Current"](https://www.microsoft.com/net/core/support) Releases
 
@@ -24,3 +25,4 @@ This page provides an archive of previously released versions of the .NET Core r
 | --: | :-- | :--: | :--: |
 | 10/24/2016 | 1.1 Preview 1 with SDK Preview 2.1 build 3155 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.0-preview1.md) | [download](https://github.com/dotnet/core/blob/master/release-notes/preview-download.md) |
 | 11/16/2016 | 1.1 with SDK Preview 2.1 build 3177 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.md) | [download](download-archives/1.1-preview2.1-download.md) |
+| 01/27/2017 | 1.1 with SDK RC3 build 004530       | - | [download](https://github.com/dotnet/core/blob/master/release-notes/rc3-download.md) |


### PR DESCRIPTION
The rc3 page already exists, but is not linked from download archive.
This add rc3 to both Current/LTS because contains both

@blackdwarf @kendrahavens @leecow 
