### PR TITLE
Add Docker tags to RC3 Archive Table

### DIFF
--- a/release-notes/rc3-download.md
+++ b/release-notes/rc3-download.md
@@ -2,16 +2,16 @@
 
 The installers and binary archives on this page include .NET Core 1.0 SDK RC 3.
 
-| .NET Core 1.0 RC 3      | Installer                                        | Binaries                                        |
-| ----------------------- | :----------------------------------------------: | :----------------------------------------------:|
-| Windows                 | [32-bit](https://go.microsoft.com/fwlink/?linkid=839629) / [64-bit](https://go.microsoft.com/fwlink/?linkid=839640)  | [32-bit](https://go.microsoft.com/fwlink/?linkid=839632) / [64-bit](https://go.microsoft.com/fwlink/?linkid=839634) |
-| macOS                   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839635)  | [64-bit](https://go.microsoft.com/fwlink/?linkid=839641)                          |
-| CentOS 7.1              | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839642)                          |
-| Debian 8                | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839630)                          |
-| Fedora 23               | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839639)                          |
-| openSUSE 13.2           | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839637)                          |
-| Ubuntu 14.04            | See notes below for Ubuntu 14.04 and Mint 17 installers   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839628)                          |
-| Ubuntu 16.04            | See notes below for Ubuntu 16.04 and Mint 18 installers   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839636)                          |
+| .NET Core 1.0 RC 3      | Installer                                        | Binaries                                        | Docker Images                                        |
+| ----------------------- | :----------------------------------------------: | :----------------------------------------------:| :----------------------------------------------:|
+| Windows                 | [32-bit](https://go.microsoft.com/fwlink/?linkid=839629) / [64-bit](https://go.microsoft.com/fwlink/?linkid=839640)  | [32-bit](https://go.microsoft.com/fwlink/?linkid=839632) / [64-bit](https://go.microsoft.com/fwlink/?linkid=839634) |  [1.1.0-sdk-msbuild-rc3-nanoserver](https://hub.docker.com/r/microsoft/dotnet/)  |
+| macOS                   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839635)  | [64-bit](https://go.microsoft.com/fwlink/?linkid=839641)                          |  |
+| CentOS 7.1              | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839642)                          |  |
+| Debian 8                | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839630)                          | [1.1.0-sdk-msbuild-rc3](https://hub.docker.com/r/microsoft/dotnet/)  |
+| Fedora 23               | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839639)                          |  |
+| openSUSE 13.2           | -                                                         | [64-bit](https://go.microsoft.com/fwlink/?linkid=839637)                          |  |
+| Ubuntu 14.04            | See notes below for Ubuntu 14.04 and Mint 17 installers   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839628)                          |  |
+| Ubuntu 16.04            | See notes below for Ubuntu 16.04 and Mint 18 installers   | [64-bit](https://go.microsoft.com/fwlink/?linkid=839636)                          |  |
 
 ## Installation from a binary archive
 


### PR DESCRIPTION
# Add Docker tags to RC3 Archive Table

* Added Docker tags for nano and debian images that both link to [dotnet docker hub](https://hub.docker.com/r/microsoft/dotnet/)
* All other OSes should use debian image.

## Reviewers
@leecow @richlander @MichaelSimons 