### PR TITLE
Fix markdown headings

### DIFF
--- a/Documentation/minimum_requirements.md
+++ b/Documentation/minimum_requirements.md
@@ -1,8 +1,8 @@
-#.NET Core Minimum System Requirements:
+# .NET Core Minimum System Requirements:
 
 In general, the minimum requirements of your operating system will be enough to run .NET Core applications.
 
-##1.X 
+## 1.X
  
 The minimum available resources required for a simple standalone application are:
  

--- a/release-notes/1.0/1.0.0.md
+++ b/release-notes/1.0/1.0.0.md
@@ -1,4 +1,4 @@
-#Release Notes
+# Release Notes
 
 ## .NET Core 1.0.0 released 6/27/2016
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -5,7 +5,7 @@ There is no SDK that runs on ARM32 yet, but you can publish an application that 
 
 These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 
-##Creating an app:
+## Creating an app:
 
 * [Install .NET Core 2.0 SDK](https://github.com/dotnet/cli/tree/master) into a supported developer configuration.
 
@@ -33,9 +33,9 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 * Under `./bin/Debug/netcoreapp2.0/<runtime identifier>/publish` or `.\bin\Debug\netcoreapp2.0\<runtime identifier>\publish` you will see the whole self contained app that you need to copy to your Raspberry Pi.
 
 
-##Getting the app to run on the Pi.
+## Getting the app to run on the Pi.
 
-###Linux (Ubuntu)
+### Linux (Ubuntu)
 
 * Install [Ubuntu 14.04 or 16.04](https://www.raspberrypi.org/downloads/) on your Pi.
 
@@ -45,7 +45,7 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 
 Note: While it is possible to build the product on the Pi, it isn't easy today and it's slow. We are working on making it very easy to do.
 
-###Win10 IoT Core
+### Win10 IoT Core
 
 * Install [Windows 10 IoT Core](https://developer.microsoft.com/en-us/windows/iot/GetStarted) on your Pi.
 


### PR DESCRIPTION
GitHub recently changed how it renders headings. Now headings need a space after the last `#` to be recognized as a heading.

See https://github.github.com/gfm/#atx-headings

This affects [a ton of repos](https://gist.github.com/vmarkovtsev/59cd7349d41cf804b9a8775388e681f8), including .NET Core.