### PR TITLE
Raspberry Pi Instructions addition

### DIFF
--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -11,7 +11,7 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 
 * From the terminal/commandline create a folder named helloworld and go into it.
 * Run `dotnet new console -n helloworld`.
-* Run `dotnet` to get the current RuntimeFrameworkVersion.
+* Run `dotnet` and note the current RuntimeFrameworkVersion.
 * Edit the helloworld.csproj file to look like this (Note the version may be newer for RuntimeFrameworkVersion but not lower than 2.0.0-beta-001620-00).
 
 ```

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -27,7 +27,7 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 </Project>
 ```
 
-* Add a new package source to the project with source: `https://dotnet.myget.org/F/dotnet-core/api/v3/index.json`.
+* Make sure you have a nuget.config file next to your csproj that includes the dotnet-core myget feed: `<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />`.
 
 * Run `dotnet restore`.
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -11,6 +11,7 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 
 * From the terminal/commandline create a folder named helloworld and go into it.
 * Run `dotnet new console -n helloworld`.
+* Run `dotnet` to get the current RuntimeFrameworkVersion.
 * Edit the helloworld.csproj file to look like this (Note the version may be newer for RuntimeFrameworkVersion but not lower than 2.0.0-beta-001620-00).
 
 ```
@@ -25,6 +26,8 @@ These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
 
 </Project>
 ```
+
+* Add a new package source to the project with source: `https://dotnet.myget.org/F/dotnet-core/api/v3/index.json`.
 
 * Run `dotnet restore`.
 


### PR DESCRIPTION
The current instructions were hard to follow for me. I did not know what version I needed to insert at `RuntimeFrameworkVersion`. Running the `dotnet` command returned the correct value.

Adding the new package source is essential for resolving packages before restoring the project.