### PR TITLE
fix broken download archive links

### DIFF
--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -8,7 +8,7 @@ This page provides an archive of previously released versions of the .NET Core r
 
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
-| 2017/04/13 | 1.0.4 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](/download-archives/1.0.3-sdk-download.md) |
+| 2017/04/13 | 1.0.4 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
 | 2017/03/07 | 1.0.4 with SDK 1.0.1     | [release notes](1.0/1.0.4.md) | [download](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.0.4-download.md) |
 | 2017/02/07 | 1.0.3 with SDK RC4 build 004771     | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3-SDK-RC4.md) | [download](download-archives/rc4-download.md) |
 | 2017/01/27 | 1.0.3 with SDK RC3 build 004530     | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md) | [download](download-archives/rc3-download.md) |
@@ -25,7 +25,7 @@ This page provides an archive of previously released versions of the .NET Core r
 
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
-| 2017/04/13 | 1.1.1 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](/download-archives/1.0.3-sdk-download.md) |
+| 2017/04/13 | 1.1.1 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
 | 2017/03/07 | 1.1.1 with SDK 1.0.1     | [release notes](1.1/1.1.1.md) | [download](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.1.1-download.md) |
 | 2017/02/07 | 1.1 with SDK RC4 build 004771       | - | [download](download-archives/rc4-download.md) |
 | 2017/01/27 | 1.1 with SDK RC3 build 004530       | - | [download](download-archives/rc3-download.md) |

--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -9,15 +9,15 @@ This page provides an archive of previously released versions of the .NET Core r
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
 | 2017/04/13 | 1.0.4 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
-| 2017/03/07 | 1.0.4 with SDK 1.0.1     | [release notes](1.0/1.0.4.md) | [download](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.0.4-download.md) |
-| 2017/02/07 | 1.0.3 with SDK RC4 build 004771     | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3-SDK-RC4.md) | [download](download-archives/rc4-download.md) |
-| 2017/01/27 | 1.0.3 with SDK RC3 build 004530     | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md) | [download](download-archives/rc3-download.md) |
-| 2016/12/13 | 1.0.3 with SDK Preview 2 build 3156 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md) | [download](download-archives/1.0.3-preview2-download.md) |
-| 2016/10/24 | 1.0.1 with SDK Preview 4 build 4233 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) | [download](download-archives/preview4-download.md) |
+| 2017/03/07 | 1.0.4 with SDK 1.0.1     | [release notes](1.0/1.0.4.md) | [download](download-archives/1.0.4-download.md) |
+| 2017/02/07 | 1.0.3 with SDK RC4 build 004771     | [release notes](1.0/1.0.3-SDK-RC4.md) | [download](download-archives/rc4-download.md) |
+| 2017/01/27 | 1.0.3 with SDK RC3 build 004530     | [release notes](1.0/1.0.3.md) | [download](download-archives/rc3-download.md) |
+| 2016/12/13 | 1.0.3 with SDK Preview 2 build 3156 | [release notes](1.0/1.0.3.md) | [download](download-archives/1.0.3-preview2-download.md) |
+| 2016/10/24 | 1.0.1 with SDK Preview 4 build 4233 | [release notes](1.0/1.0.1-release-notes.md) | [download](download-archives/preview4-download.md) |
 | 2016/10/17 | 1.0.2 with SDK Preview 2 build 3148 | [release notes](https://github.com/dotnet/core/releases/tag/1.0.2) | [download](download-archives/1.0.2-preview2-download.md) |
-| 2016/10/03 | 1.0.1 with SDK Preview 3 build 4056 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) | [download](download-archives/preview3-download.md) |
-| 2016/09/13/ | 1.0.1 with SDK Preview 2 build 3131 and 3133 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |
-| 2016/06/27 | 1.0 with SDK Preview 2 build 3121 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0.md) | [download](download-archives/1.0-preview2-download.md) |
+| 2016/10/03 | 1.0.1 with SDK Preview 3 build 4056 | [release notes](1.0/1.0.1-release-notes.md) | [download](download-archives/preview3-download.md) |
+| 2016/09/13/ | 1.0.1 with SDK Preview 2 build 3131 and 3133 | [release notes](1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |
+| 2016/06/27 | 1.0 with SDK Preview 2 build 3121 | [release notes](1.0/1.0.0.md) | [download](download-archives/1.0-preview2-download.md) |
 
 ## ["Current"](https://www.microsoft.com/net/core/support) Releases
 
@@ -26,14 +26,14 @@ This page provides an archive of previously released versions of the .NET Core r
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
 | 2017/04/13 | 1.1.1 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
-| 2017/03/07 | 1.1.1 with SDK 1.0.1     | [release notes](1.1/1.1.1.md) | [download](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.1.1-download.md) |
+| 2017/03/07 | 1.1.1 with SDK 1.0.1     | [release notes](1.1/1.1.1.md) | [download](download-archives/1.1.1-download.md) |
 | 2017/02/07 | 1.1 with SDK RC4 build 004771       | - | [download](download-archives/rc4-download.md) |
 | 2017/01/27 | 1.1 with SDK RC3 build 004530       | - | [download](download-archives/rc3-download.md) |
-| 2016/11/16 | 1.1 with SDK Preview 2.1 build 3177 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.md) | [download](download-archives/1.1-preview2.1-download.md) |
-| 2016/10/24 | 1.1 Preview 1 with SDK Preview 2.1 build 3155 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.0-preview1.md) | [download](download-archives/preview-download.md) |
+| 2016/11/16 | 1.1 with SDK Preview 2.1 build 3177 | [release notes](1.1/1.1.md) | [download](download-archives/1.1-preview2.1-download.md) |
+| 2016/10/24 | 1.1 Preview 1 with SDK Preview 2.1 build 3155 | [release notes](1.1/1.1.0-preview1.md) | [download](download-archives/preview-download.md) |
 
 ### .NET Core Tools for Visual Studio 2015
 
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
-| 2016/09/13/ | DotNetCore.1.0.1-VS2015Tools.Preview2.0.2.exe | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |
+| 2016/09/13/ | DotNetCore.1.0.1-VS2015Tools.Preview2.0.2.exe | [release notes](1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |


### PR DESCRIPTION
hi there,

the link to download sdk 1.0.3 is currently broken. https://github.com/imiuka/core/commit/12f82433cad993ccf7c08b726a281dddea2f025d fixes that.

while doing this, i saw that half of the downloads used relative uris paths to link to the download page, and the other half uses absolute uris. the second commit normalizes them all to use relative paths, because links in forks should link to their forked version of those pages, not `https://github.com/dotnet/core/....`.

hope this is ok.