### PR TITLE
Fix typo in Fedora 26 in 2.0.0 preview 2 release notes

### DIFF
--- a/release-notes/2.0/2.0.0-preview2.md
+++ b/release-notes/2.0/2.0.0-preview2.md
@@ -9,6 +9,6 @@ New and Updated Linux Distro Support
 * SUSE SLES 12 SP2
 * Debian 9
 * Fedora 25
-* Fedora 25
+* Fedora 26
 
 Testing has begun on MacOS High Sierra to ensure compatibility when .NET Core 2.0 releases later this year.


### PR DESCRIPTION
See https://github.com/dotnet/core/pull/691 which suggests this was supposed to be 26.

cc @leecow 