### PR TITLE
Added 'What you can expect from Maintainers' doc

### DIFF
--- a/Documentation/contributing/maintainers.md
+++ b/Documentation/contributing/maintainers.md
@@ -37,6 +37,6 @@ Maintainers may make the following changes to contributor comments:
 
 ## Reporting Code of Conduct Violations
 
-All .NET Foundation repositories have adopted the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct). Maintainers will report potential code of conduct violations they observe to the [.NET Foundation Code of Conduct Review Group](https://github.com/dotnet).
+All .NET Foundation repositories have adopted the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct). Maintainers will report potential code of conduct violations they observe to the [.NET Foundation Code of Conduct Review Group](mailto:conduct@dotnetfoundation.org).
 
 The Code of Conduct team will delete comments that are considered code of conduct violations. Maintainers will unilaterally delete comments that are objectively severe violations of the code of conduct and submit the original comment to the Code of Conduct team after-the-fact for review.

--- a/Documentation/contributing/maintainers.md
+++ b/Documentation/contributing/maintainers.md
@@ -37,8 +37,6 @@ Maintainers may make the following changes to contributor comments:
 
 ## Reporting Code of Conduct Violations
 
-All .NET repositories have adopted a code of conduct, either the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct) or the [Microsoft Code of Conduct](https://opensource.microsoft.com/codeofconduct/). Most have adopted the former code of conduct since most .NET repos are part of the .NET Foundation.
-
-Maintainers will report potential code of conduct violations they observe to the appropriate code of conduct review group at either conduct@dotnetfoundation.org (for [dotnet org](https://github.com/dotnet) and [aspnet org](https://github.com/aspnet)) or opencode@microsoft.com (for [microsoft org](https://github.com/microsoft)). You are encouraged to report concerns via these same email addresses. Don't worry which one you use (or both); the concern will end up in the right place.
+All .NET Foundation repositories have adopted the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct). Maintainers will report potential code of conduct violations they observe to the [.NET Foundation Code of Conduct Review Group](https://github.com/dotnet).
 
 The Code of Conduct team will delete comments that are considered code of conduct violations. Maintainers will unilaterally delete comments that are objectively severe violations of the code of conduct and submit the original comment to the Code of Conduct team after-the-fact for review.

--- a/Documentation/contributing/maintainers.md
+++ b/Documentation/contributing/maintainers.md
@@ -1,0 +1,44 @@
+# What you can expect from Maintainers
+
+The .NET Core maintainer team aims to support a productive and safe working environment for everyone participating in .NET repositories. You can expect maintainers to do three things to that end: respect your contributions make engagement efficient and report potential .NET Foundation Code of Conduct violations. These three actions are defined below.
+
+## Respect your Contributions
+
+Maintainers understand the work that goes into submitting a pull request (PR) or an issue. They will encourage you to contribute and provide feedback to help you land PRs or adequately define an issue to make it actionable. They will also provide direct and clear feedback if they have decided not to accept your contribution.
+
+Maintainers won't as a general rule edit your comments.
+
+Maintainers may sometimes create a new PR based on an existing PR created by you, including your commits. In that case, maintainers will aim to merge instead of squash the final result when landing the PR to preserve your contribution.
+
+## Make Engagement Efficient
+
+Maintainers will take actions to make repo engagement more efficient for everyone. They may close issues and PRs that are stale or because the initial creator is no longer engaged. As appropriate, maintainers will link between related issues and PRs to preserve continuity. This approach helps to make accountability clear and to make it easier for everyone to identify which issues and PRs have active engagement/progress.
+
+Maintainers may edit PR and issue titles to improve readability and/or accuracy. GitHub provides history for title changes.
+
+Maintainers may edit your comments if and only if the edit adds substantially to the readability or usability of the comment and doesn't change the content. The maintainer will add a short descriptive note with their @handle to explain their change at the end of your comment (for example: "_Edited by @richlander -- added call-stack formatting_"). 
+
+Maintainers may make the following changes to contributor comments:
+
+- Improving markdown formatting - Changes limited to [single/triple-ticks](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code) for code and call-stacks, broken markdown links, and broken formatting (but not adding formatting or altering spelling or grammar).
+- Adding "fixes link" - GitHub automatically closes issues from a PR if a [fixes link](https://help.github.com/articles/closing-issues-via-commit-messages/) is part of a commit message or initial PR comment. The addition of the link makes it easier to understand the relationship between issues and PRs.
+- Adding links to latest or related content - The addition of a link to another issue or PR or another comment significantly improves readability (for example: "_Edited by @richlander -- latest version of proposal at URL_"). The link can be placed at the top and/or bottom the existing comment.
+
+## Reporting Code of Conduct Violations
+
+All .NET repositories have adopted a code of conduct, either the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct) or the [Microsoft Code of Conduct](https://opensource.microsoft.com/codeofconduct/). Most have adopted the former code of conduct since most .NET repos are part of the .NET Foundation.
+
+Maintainers will report potential code of conduct violations they observe to the appropriate code of conduct review group at either conduct@dotnetfoundation.org (for [dotnet org](https://github.com/dotnet) and [aspnet org](https://github.com/aspnet)) or opencode@microsoft.com (for [microsoft org](https://github.com/microsoft)). You are encouraged to report concerns via these same email addresses. Don't worry which one you use (or both); the concern will end up in the right place.
+
+The Code of Conduct team will delete comments that are considered code of conduct violations. Maintainers will unilaterally delete comments that are objectively severe violations of the code of conduct and submit the original comment to the Code of Conduct team after-the-fact for review.
+
+## Summary of Maintainer Code
+
+**Maintainers will**
+- Encourage your contributions and participation and provide clear and direct feedback, including when your contributions are not accepted.
+- Close issues and PRs as a means of making repos more efficient to use for everyone. They can be re-opened, as needed.
+- Edit comments for formatting [if and only if (iff)](https://en.wikipedia.org/wiki/If_and_only_if) the edit adds substantially to the readability or usability of the comment. No changes will be made to spelling, wording, meaning, or emphasis.
+- Report abusive behavior to the [Code of Conduct review group](mailto:conduct@dotnetfoundation.org).
+
+**Maintainers won't**
+- Edit contributor comments as a general rule. GitHub comments don't provide edit history and therefore don't offer maintainers a transparent and accurate way to describe changes made to contributor comments. Transparency is a cornerstone of effective discourse and its absence undermines trust.

--- a/Documentation/contributing/maintainers.md
+++ b/Documentation/contributing/maintainers.md
@@ -1,6 +1,17 @@
 # What you can expect from Maintainers
 
-The .NET Core maintainer team aims to support a productive and safe working environment for everyone participating in .NET repositories. You can expect maintainers to do three things to that end: respect your contributions make engagement efficient and report potential .NET Foundation Code of Conduct violations. These three actions are defined below.
+The .NET Core maintainer team aims to support a productive and safe working environment for everyone participating in .NET repositories. You can expect maintainers to do three things to that end: respect your contributions, make engagement efficient, and report potential .NET Foundation Code of Conduct violations.
+
+The following two lists summarize how maintainers will act. A more detailed description follows this summary.
+
+**Maintainers will**
+- Encourage your contributions and participation and provide clear and direct feedback, including when your contributions are not accepted.
+- Close issues and PRs as a means of making repos more efficient to use for everyone. They can be re-opened, as needed.
+- Edit comments for formatting [if and only if (iff)](https://en.wikipedia.org/wiki/If_and_only_if) the edit adds substantially to the readability or usability of the comment. No changes will be made to spelling, wording, meaning, or emphasis.
+- Report abusive behavior to the [Code of Conduct review group](mailto:conduct@dotnetfoundation.org).
+
+**Maintainers won't**
+- Edit contributor comments as a general rule. GitHub comments don't provide edit history and therefore don't offer maintainers a transparent and accurate way to describe changes made to contributor comments. Transparency is a cornerstone of effective discourse and its absence undermines trust.
 
 ## Respect your Contributions
 
@@ -31,14 +42,3 @@ All .NET repositories have adopted a code of conduct, either the [.NET Foundatio
 Maintainers will report potential code of conduct violations they observe to the appropriate code of conduct review group at either conduct@dotnetfoundation.org (for [dotnet org](https://github.com/dotnet) and [aspnet org](https://github.com/aspnet)) or opencode@microsoft.com (for [microsoft org](https://github.com/microsoft)). You are encouraged to report concerns via these same email addresses. Don't worry which one you use (or both); the concern will end up in the right place.
 
 The Code of Conduct team will delete comments that are considered code of conduct violations. Maintainers will unilaterally delete comments that are objectively severe violations of the code of conduct and submit the original comment to the Code of Conduct team after-the-fact for review.
-
-## Summary of Maintainer Code
-
-**Maintainers will**
-- Encourage your contributions and participation and provide clear and direct feedback, including when your contributions are not accepted.
-- Close issues and PRs as a means of making repos more efficient to use for everyone. They can be re-opened, as needed.
-- Edit comments for formatting [if and only if (iff)](https://en.wikipedia.org/wiki/If_and_only_if) the edit adds substantially to the readability or usability of the comment. No changes will be made to spelling, wording, meaning, or emphasis.
-- Report abusive behavior to the [Code of Conduct review group](mailto:conduct@dotnetfoundation.org).
-
-**Maintainers won't**
-- Edit contributor comments as a general rule. GitHub comments don't provide edit history and therefore don't offer maintainers a transparent and accurate way to describe changes made to contributor comments. Transparency is a cornerstone of effective discourse and its absence undermines trust.


### PR DESCRIPTION
This document is a new contributing document that describes what contributors can expect from maintainers (hence the title).

I am using this PR to gather feedback on the proposed content, both the content itself and the more general engagement between contributors and maintainers that it describes.

At a minimum, this PR will be held open for 1 week before merging. If feedback suggests otherwise, a different course of action will be taken.

I wrote this document and have gotten initial feedback from a small set of maintainers and contributors.