### PR TITLE
Fix duplicate link in telemetry data tsv

### DIFF
--- a/release-notes/cli-usage-data.md
+++ b/release-notes/cli-usage-data.md
@@ -11,7 +11,7 @@ See: [What we’ve learned from .NET Core SDK Telemetry](https://blogs.msdn.micr
 * [2017 - Q2](https://dotnetcli.blob.core.windows.net/usagedata/dotnet-cli-usage-2017-q2.tsv)
 * [2017 - Q1](https://dotnetcli.blob.core.windows.net/usagedata/dotnet-cli-usage-2017-q1.tsv)
 * [2016 - Q4](https://dotnetcli.blob.core.windows.net/usagedata/dotnet-cli-usage-2016-q4.tsv)
-* [2016 - Q3](https://dotnetcli.blob.core.windows.net/usagedata/dotnet-cli-usage-2016-q4.tsv)
+* [2016 - Q3](https://dotnetcli.blob.core.windows.net/usagedata/dotnet-cli-usage-2016-q3.tsv)
 
 # License
 


### PR DESCRIPTION
2016 Q3 previously had a duplicate copy of the 2016 Q4 link. Changed it to link to the correct file.