### PR TITLE
Specifically include Windows 8 supported version(s)

### DIFF
--- a/release-notes/2.0/2.0-supported-os.md
+++ b/release-notes/2.0/2.0-supported-os.md
@@ -10,7 +10,7 @@ The tables below provide OS version information supported by .NET Core 2.0.
 
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
-Windows Client                | 7 SP1+                        | x64, x86       |
+Windows Client                | 7 SP1+, 8.1+                  | x64, x86       |
 Windows 10 Client             | Version 1607+                 | x64, x86       |
 Windows Server                | 2008 R2 SP1+                  | x64, x86       |
 


### PR DESCRIPTION
The way the original is written, it looks like only Windows 7SP1+ and Windows 10 are supported, and Windows 8.x might no longer supported.  Especially as compared to the .NET Core 1.x document, which lists "Windows Client, 7 SP1 - 10".  Added a specific mention of 8.1+, per the linked Windows lifecycle document.  (Note - if Windows 8.x is no longer supported, then it should be specifically added to the "Out of support OS versions" section at the bottom.)