### PR TITLE
typo error at installation instructions section

### DIFF
--- a/release-notes/download-archives/2.0.0-download.md
+++ b/release-notes/download-archives/2.0.0-download.md
@@ -28,7 +28,7 @@ Images for .NET Core 2.0.0 are available on [Docker](https://hub.docker.com/r/mi
 
 ## Installation from a binary archive
 
-When using binary archives to install, we the contents must be extracted to a user location such as `~/dotnet` and a symbolic link created for `dotnet`. This is a change from previous versions of .NET Core. Additional details can be seen in [.NET Core 2.0 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.0-known-issues.md). Ubuntu and Mint users should follow the instructions in the Ubuntu Installation section below.
+When using binary archives to install, the contents must be extracted to a user location such as `~/dotnet` and a symbolic link created for `dotnet`. This is a change from previous versions of .NET Core. Additional details can be seen in [.NET Core 2.0 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.0-known-issues.md). Ubuntu and Mint users should follow the instructions in the Ubuntu Installation section below.
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet


### PR DESCRIPTION
The sentence below makes no sense.

> we the contents must be extracted...

I'm assuming that it's a typo, something missing or something unnecessarily typed