### PR TITLE
Update known issues for Visual Studio for Mac

### DIFF
--- a/release-notes/2.0/2.0.0-known-issues.md
+++ b/release-notes/2.0/2.0.0-known-issues.md
@@ -76,7 +76,7 @@ Because the .NET Core CLI is itself .NET Core application, it has minimum versio
 
 ## Visual Studio for the Mac
 
-[Visual Studio for the Mac](https://www.visualstudio.com/vs/visual-studio-mac/) 7.1 (build 1258) was recently released into beta and supports .NET Core 2.0 Preview 2.
+[Visual Studio for the Mac](https://www.visualstudio.com/vs/visual-studio-mac/) 7.1 (build 1297) was recently released and supports .NET Core 2.0.
 
 ## NETStandard 2.0 and the .NET Framework
 
@@ -126,10 +126,6 @@ Adding `<PackProjectInputFile>$(MSBuildProjectFile)</PackProjectInputFile>` to y
 #### Unit Test Templates Do Not Exist
 
 Unit test templates don’t exist in Preview 1 because test discovery fails for VB projects. This issue is under investigation and there is no workaround at this time.
-
-#### Visual Studio for Mac
-
-There are a [few items to be aware of](https://gist.github.com/mrward/70b8132003ef77d893111ecbea3e2225) if you are using .NET Core 2.0 with Visual Studio for Mac.
 
 #### Visual Studio Code
 


### PR DESCRIPTION
VS for Mac 7.1 (build 1297) is now a stable release and supports
.NET Core 2.0 RTM.

Removed reference to VS for Mac known issues which only applies
to VS for Mac 7.0.

Fixes #864