### PR TITLE
Reflect shipped 2.0 in roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,82 +1,32 @@
 # .NET Core Roadmap
 
-We aim to continuously deliver updates to the .NET Core Runtime and Tools and our primary focus right now is on .NET Core 2.0. 
+We aim to continuously deliver updates to the .NET Core Runtime and Tools.
+We are primarily focused on delivering UWP 6.0 (.NET Standard 2.0 for UWP) and .NET Core 2.1.
 
-We shipped Visual Studio 2017 RTM with .NET Core 1.X support. [Please try VS 2017][vs2017].
+We shipped .NET Core 2.0 and .NET Standard 2.0 - you can try it by installing [Visual Studio 2017 (15.3)][vs2017] and [.NET Core 2.0 SDK][Core20Sdk].
 
-[vs2017]: https://www.visualstudio.com/downloads/
-
-## Primary scenarios for .NET Core 2.0
-
-* **Lower the Barrier of Entry and Reach**. .NET Standard 2.0 standardizes the
-  shared APIs across .NET Framework, .NET Core and Xamarin making it easy to
-  share code across all of .NET. .NET Core gain over 5,000 APIs from .NET
-  Framework as part of this work making it a broader platform. Simplifying how a
-  developer references .NET Core from many packages to one. Simplified
-  acquisition of runtime and tools. And easier to reference Linux platforms and
-  their dependencies. You can follow this work in the
-  [dotnet/standard](https://github.com/dotnet/standard) and
-  [dotnet/corefx](https://github.com/dotnet/corefx) repos.
-
-* **.NET Core Tooling**. Evolve the tooling aligned with the next .NET Core
-  runtime release. This will include tooling for choosing which .NET Core
-  version to target, to change the version of .NET Core for existing projects,
-  full package IntelliSense in .csproj files and more. You can follow this work
-  in the
-  [dotnet/project-system](https://github.com/dotnet/project-system),
-  [dotnet/sdk](https://github.com/dotnet/sdk), 
-  [microsoft/msbuild](https://github.com/microsoft/msbuild), and 
-  [dotnet/cli](https://github.com/dotnet/cli) 
-  repos.
-
-* **Performance**. Continue to make the performance of building .NET Core
-  applications faster, especially in the inner loop. This is the cycle of
-  changing the source code and then restarting the application and making that
-  as fast as possible. You can follow part of this work in the
-  [dotnet/sdk](https://github.com/dotnet/sdk) repo.
-
-* **.NET Core and Cloud**. Continue to improve how you run .NET Core
-  applications in Azure. Better logging, tracing and diagnosing errors in your
-  applications when running in the cloud. You can follow this work in the
-  [dotnet/corefx](https://github.com/dotnet/corefx),
-  [dotnet/corefxlab](https://github.com/dotnet/corefxlab/blob/master/docs/roadmap.md),
-  and
-  [aspnet](https://github.com/aspnet) repos.
-
-* **Build from Source**. Make it very easy to clone the .NET Core repository at
-  GitHub and build the product. Great for experimenting with customizing the
-  product or trying to get it to run on Linux distributions other than the ones
-  we officially support. You can follow the bulk of the work in the
-  [dotnet/coreclr](https://github.com/dotnet/coreclr) and
-  [dotnet/corefx](https://github.com/dotnet/corefx) repos.
-
-As mentioned above these are just some of the early big themes we are going to
-invest in, we will also continue to invest in ASP.NET, Entity Framework,
-Languages and many other parts of .NET.
+[vs2017]: https://www.visualstudio.com/downloads
+[Core20Sdk]: https://www.microsoft.com/net/download/core
 
 ## Ship Dates
 
 | Milestone                 | Release Date |
 |---------------------------|--------------|
-| .NET Core 2.0 Preview 1   | [Released on 2017/5/10](https://github.com/dotnet/core/issues/640), see [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/05/10/announcing-net-core-2-0-preview-1/) |
-| .NET Standard 2.0 Preview 1 | [Released on 2017/5/10](https://github.com/dotnet/core/issues/640), see [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/05/10/announcing-net-core-2-0-preview-1/) |
-| .NET Core 2.0 Preview 2   | [Released on 2017/6/28](https://github.com/dotnet/core/issues/711), see [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/06/28/announcing-net-core-2-0-preview-2/) |
-| .NET Core 2.0             | Q3 2017, see also [latest build](https://github.com/dotnet/cli/tree/release/2.0.0#installers-and-binaries) |
-| .NET Standard 2.0         | Q3 2017      |
+| .NET Core 2.0 & .NET Standard 2.0 | [Released on 2017/8/14](https://github.com/dotnet/core/issues/812), see [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/08/14/announcing-net-core-2-0/) |
 | UWP 6.0 (implements .NET Standard 2.0) | Q4 2017 ([Win10 Fall Creators Update](https://www.microsoft.com/en-us/windows/upcoming-features)) |
-| .NET Core 2.1 | Q4 2017 (after UWP 6.0) |
+| .NET Core 2.1 Preview | Q4 2017 |
+| .NET Core 2.1 | Q1 2018 |
 
 Details on sub-milestones are also captured in milestone details of our repos, e.g. [CoreFX repo milestones](https://github.com/dotnet/corefx/milestones).
 
 # Components
 
-.NET Core is a general purpose, modular, cross-platform and open source
-implementation of .NET. It includes a runtime, framework libraries, compilers
-and tools that support a variety of chip and OS targets. These components can be
-used together or separately.
+.NET Core is a general purpose, modular, cross-platform and open source implementation of .NET.
+It includes a runtime, framework libraries, compilers and tools that support a variety of chip and OS targets.
+These components can be used together or separately.
 
-Major .NET Core components are listed below. Please note that this is not meant
-to be an exhaustive list.
+Major .NET Core components are listed below.
+Please note that this is not meant to be an exhaustive list.
 
 * [Runtime](https://github.com/dotnet/coreclr)
 * [Libraries](https://github.com/dotnet/corefx)
@@ -90,10 +40,13 @@ to be an exhaustive list.
 * [MSBuild](https://github.com/microsoft/msbuild)
 * [Docker Images](https://github.com/dotnet/dotnet-docker)
 
-This roadmap is intended to communicate project priorities for evolving and
-extending the scope of .NET Core.
+This roadmap is intended to communicate project priorities for evolving and extending the scope of .NET Core.
 
 # Supported OS Versions
+
+## .NET Core 2.1 - Supported OS Versions
+
+Proposal: TBD
 
 ## .NET Core 2.0 - Supported OS Versions
 
@@ -151,16 +104,12 @@ Developers](https://support.microsoft.com/en-us/gp/contactus81?Audience=Commerci
 
 Broad goals:
 
-* .NET Core code is high quality, has compelling performance, and is highly
-  reliable.
+* .NET Core code is high quality, has compelling performance, and is highly reliable.
 * .NET Core can be ported to a broad set of OS platforms and chip architectures.
-* .NET Core can be deployed with the application, side-by-side with other
-  versions.
+* .NET Core can be deployed with the application, side-by-side with other versions.
 * .NET Core has a broad API surface that makes it suitable for most payloads.
-* Developers can acquire a .NET Core developer environment quickly and
-  intuitively.
-* Developers can productively and intuitively build apps, using documentation,
-  samples, community resources, and NuGet packages.
+* Developers can acquire a .NET Core developer environment quickly and intuitively.
+* Developers can productively and intuitively build apps, using documentation, samples, community resources, and NuGet packages.
 
 # Contributions
 
@@ -168,20 +117,17 @@ Contribution goals:
 
 * Encourage an active community welcoming contributions from all.
 
-The .NET Core maintainers have taken a liberal approach to contributions since
-the outset of the .NET Core open source project.
+The .NET Core maintainers have taken a liberal approach to contributions since the outset of the .NET Core open source project.
 
 # Microsoft Distro
 
-Microsoft ships multiple .NET Core distros. It is important that Microsoft can
-successfully ship .NET Core at quality and meet its desired dates.
+Microsoft ships multiple .NET Core distros.
+It is important that Microsoft can successfully ship .NET Core at quality and meet its desired dates.
 
 # Other Distros
 
-.NET Core will ship as part of many Linux distros and we are actively working
-with key partners in the Linux community to make it natural for .NET Core to go
-everywhere people need it. We are constantly looking to expand our distro
-support and welcome contributions and collaborations in this direction.
+.NET Core will ship as part of many Linux distros and we are actively working with key partners in the Linux community to make it natural for .NET Core to go everywhere people need it.
+We are constantly looking to expand our distro support and welcome contributions and collaborations in this direction.
 
 ## Goals
 


### PR DESCRIPTION
* Add .NET Core 2.0 ship date
* Update .NET Core 2.1 ship date estimate (can change in future)
* Delete irrelevant .NET Core 2.0 information
* Update next focus

Fixes #882