### PR TITLE
Order releases as descending

### DIFF
--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -2,7 +2,35 @@
 
 This page provides an archive of previously released versions of the .NET Core runtime, libraries and the .NET Core SDK.
 
+## ["Current"](https://www.microsoft.com/net/core/support) Releases
+
+### .NET Core 2.0
+
+| Release Date | Description | Release Notes | |
+| :-- | :-- | :--: | :--: |
+| 2017/08/14 | 2.0.0 with SDK 2.0.0 | [release notes](2.0/2.0.0.md) | [download](download-archives/2.0.0-download.md) |
+| 2017/06/28 | 2.0.0-Preview2 with SDK 2.0.0-Preview2 | [release notes](2.0/2.0.0-preview2.md) | [download](download-archives/2.0.0-preview2-download.md) |
+| 2017/05/10 | 2.0.0-Preview1 with SDK 2.0.0-Preview1 | [release notes](2.0/2.0.0-preview1.md) | [download](download-archives/2.0.0-preview1-download.md) |
+
+### .NET Core Tools for Visual Studio 2015
+
+| Release Date | Description | Release Notes | |
+| :-- | :-- | :--: | :--: |
+| 2016/09/13 | DotNetCore.1.0.1-VS2015Tools.Preview2.0.2.exe | [release notes](1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |
+
 ## [LTS](https://www.microsoft.com/net/core/support) Releases
+
+### .NET Core 1.1
+
+| Release Date | Description | Release Notes | |
+| :-- | :-- | :--: | :--: |
+| 2017/05/09 | 1.1.2 with SDK 1.0.4 (Promoted to LTS)     | [release notes](1.1/1.1.2.md) | [download](download-archives/1.1.2-download.md) |
+| 2017/04/13 | 1.1.1 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
+| 2017/03/07 | 1.1.1 with SDK 1.0.1     | [release notes](1.1/1.1.1.md) | [download](download-archives/1.1.1-download.md) |
+| 2017/02/07 | 1.1 with SDK RC4 build 004771       | - | [download](download-archives/rc4-download.md) |
+| 2017/01/27 | 1.1 with SDK RC3 build 004530       | - | [download](download-archives/rc3-download.md) |
+| 2016/11/16 | 1.1 with SDK Preview 2.1 build 3177 | [release notes](1.1/1.1.md) | [download](download-archives/1.1-preview2.1-download.md) |
+| 2016/10/24 | 1.1 Preview 1 with SDK Preview 2.1 build 3155 | [release notes](1.1/1.1.0-preview1.md) | [download](download-archives/preview-download.md) |
 
 ### .NET Core 1.0
 
@@ -19,31 +47,3 @@ This page provides an archive of previously released versions of the .NET Core r
 | 2016/10/03 | 1.0.1 with SDK Preview 3 build 4056 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) | [download](download-archives/preview3-download.md) |
 | 2016/09/13 | 1.0.1 with SDK Preview 2 build 3131 and 3133 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |
 | 2016/06/27 | 1.0 with SDK Preview 2 build 3121 | [release notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0.md) | [download](download-archives/1.0-preview2-download.md) |
-
-### .NET Core 1.1
-
-| Release Date | Description | Release Notes | |
-| :-- | :-- | :--: | :--: |
-| 2017/05/09 | 1.1.2 with SDK 1.0.4 (Promoted to LTS)     | [release notes](1.1/1.1.2.md) | [download](download-archives/1.1.2-download.md) |
-| 2017/04/13 | 1.1.1 with SDK 1.0.3     | [release notes](https://github.com/dotnet/cli/releases/tag/v1.0.3) | [download](download-archives/1.0.3-sdk-download.md) |
-| 2017/03/07 | 1.1.1 with SDK 1.0.1     | [release notes](1.1/1.1.1.md) | [download](download-archives/1.1.1-download.md) |
-| 2017/02/07 | 1.1 with SDK RC4 build 004771       | - | [download](download-archives/rc4-download.md) |
-| 2017/01/27 | 1.1 with SDK RC3 build 004530       | - | [download](download-archives/rc3-download.md) |
-| 2016/11/16 | 1.1 with SDK Preview 2.1 build 3177 | [release notes](1.1/1.1.md) | [download](download-archives/1.1-preview2.1-download.md) |
-| 2016/10/24 | 1.1 Preview 1 with SDK Preview 2.1 build 3155 | [release notes](1.1/1.1.0-preview1.md) | [download](download-archives/preview-download.md) |
-
-## ["Current"](https://www.microsoft.com/net/core/support) Releases
-
-### .NET Core 2.0
-
-| Release Date | Description | Release Notes | |
-| :-- | :-- | :--: | :--: |
-| 2017/08/14 | 2.0.0 with SDK 2.0.0 | [release notes](2.0/2.0.0.md) | [download](download-archives/2.0.0-download.md) |
-| 2017/06/28 | 2.0.0-Preview2 with SDK 2.0.0-Preview2 | [release notes](2.0/2.0.0-preview2.md) | [download](download-archives/2.0.0-preview2-download.md) |
-| 2017/05/10 | 2.0.0-Preview1 with SDK 2.0.0-Preview1 | [release notes](2.0/2.0.0-preview1.md) | [download](download-archives/2.0.0-preview1-download.md) |
-
-### .NET Core Tools for Visual Studio 2015
-
-| Release Date | Description | Release Notes | |
-| :-- | :-- | :--: | :--: |
-| 2016/09/13 | DotNetCore.1.0.1-VS2015Tools.Preview2.0.2.exe | [release notes](1.0/1.0.1-release-notes.md) |  [download](download-archives/1.0.1-preview2-download.md) |


### PR DESCRIPTION
Order releases as descending to lightly nudge users to use the latest version.