### PR TITLE
Use win10-arm on Raspberry Pi

### DIFF
--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -38,7 +38,7 @@ Note: Pi Zero is not supported because the .NET Core JIT depends on armv7 instru
 </configuration>
 ```
 
-* Run `dotnet publish -r <runtime identifier>` for example `dotnet publish -r win-arm` to publish the application for windows and `dotnet publish -r linux-arm` for Linux running on Raspberry Pi.
+* Run `dotnet publish -r <runtime identifier>` for example `dotnet publish -r win10-arm` to publish the application for windows and `dotnet publish -r linux-arm` for Linux running on Raspberry Pi.
 
 * Under `./bin/Debug/netcoreapp2.0/<runtime identifier>/publish` or `.\bin\Debug\netcoreapp2.0\<runtime identifier>\publish` you will see the whole self contained app that you need to copy to your Raspberry Pi.
 


### PR DESCRIPTION
Raspberry Pi runs Windows 10 IoT Core. When publishing, you should specify `win10-arm` so that the correct runtime assets get published. For example, a package could contain assets for both `win8-arm` and `win10-arm`, but the `win10-arm` ones should be used.