### PR TITLE
Update a instruction to copy whole published directory

### DIFF
--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -51,10 +51,10 @@ Note: Pi Zero is not supported because the .NET Core JIT depends on armv7 instru
 
 * Install the [prereq packages](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) for .NET Core.
 
-* Copy your app to the Raspberry Pi and execute run `./helloworld` to see `Hello World!` from .NET Core running on your Pi! (make sure you `chmod 755 ./helloworld`)
+* Copy your app, i.e. whole `publish` directory mentioned above, to the Raspberry Pi and execute run `./helloworld` to see `Hello World!` from .NET Core running on your Pi! (make sure you `chmod 755 ./helloworld`)
 
 ### Win10 IoT Core
 
 * Install [Windows 10 IoT Core](https://developer.microsoft.com/en-us/windows/iot/GetStarted) on your Pi.
 
-* Copy your app to the Raspberry Pi and execute run `helloworld.exe` to see `Hello World!` from .NET Core running on your Pi
+* Copy your app, i.e. whole `publish` directory mentioned above, to the Raspberry Pi and execute run `helloworld.exe` to see `Hello World!` from .NET Core running on your Pi


### PR DESCRIPTION
Update a instruction for copying app to Raspberry Pi, because sometimes newcomers were confused and only copy `helloworld`.

