### PR TITLE
add ubuntu 17.10 feed info

### DIFF
--- a/release-notes/download-archives/2.0.0-download.md
+++ b/release-notes/download-archives/2.0.0-download.md
@@ -33,11 +33,19 @@ Images for .NET Core 2.0.0 are available on [Docker](https://hub.docker.com/r/mi
 
 If you have .NET Core Previews installed, it will need to be removed before attempting to install .NET Core 2.0. This can be done by running a command such as the following.
 
-`sudo apt remove dotnet-dev-2.0.0-preview2-006497`
+`sudo apt autoremove dotnet-dev-2.0.0-preview2-006497`
 
 ### Ubuntu and Debian based systems
 
-Register the Microsoft key, the product repository for your distro and install required system dependencies with the following scripts.
+Register the Microsoft signing key, the product repository for your distro and install required system dependencies with the following scripts.
+
+#### Ubuntu 17.10
+
+```bash
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-artful-prod artful main" > /etc/apt/sources.list.d/dotnetdev.list'
+```
 
 #### Ubuntu 17.04
 


### PR DESCRIPTION
Add Ubuntu 17.10 (artful) feed information to the 2.0 download instructions. Resolves https://github.com/dotnet/core/issues/1042