### PR TITLE
Fix debug symbols links in release notes

### DIFF
--- a/release-notes/download-archives/2.0.3.md
+++ b/release-notes/download-archives/2.0.3.md
@@ -16,8 +16,8 @@
 * [Checksums_SDK](https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.3-sdk-sha.txt)
 
 **Debug Symbols**
-* [Shared Framework](https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/corefx-2.0-symbols.zip)
-* [Runtime](https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/coreclr-2.0-symbols.zip)
+* [Shared Framework](https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/corefx-2.0.3-symbols.zip)
+* [Runtime](https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/coreclr-2.0.3-symbols.zip)
 
 ## Docker
 


### PR DESCRIPTION
PR to fix debug symbols links in release notes – I was able to guess the correct URLs.