### PR TITLE
Add link to 2.1.3 release notes, fix download link

### DIFF
--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -8,7 +8,7 @@ This page provides an archive of previously released versions of the .NET Core r
 
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
-| 2017/12/12 | 2.0.4 with SDK 2.1.3 | - | [download](download-archives/2.1.3-sdk-download.md) |
+| 2017/12/12 | 2.0.4 with SDK 2.1.3 | [release notes](https://github.com/dotnet/cli/releases/tag/v2.1.3) | [download](download-archives/2.0.4-download.md) |
 | 2017/12/04 | 2.0.3 with SDK 2.1.2 | [release notes](https://github.com/dotnet/cli/releases/tag/v2.1.2) | [download](download-archives/2.1.2-sdk-download.md) |
 | 2017/11/14 | 2.0.3 with SDK 2.0.3 | [release notes](2.0/2.0.3.md) | [download](download-archives/2.0.3.md) |
 | 2017/10/10 | 2.0.0 with SDK 2.0.2 | [release notes](https://github.com/dotnet/cli/releases/tag/v2.0.2) | [download](download-archives/2.0.2-sdk-download.md) |


### PR DESCRIPTION
Fixes https://github.com/dotnet/core/issues/1167

Overview
=============
The link to the 2.1.3 SDK release notes is missing. This adds it.
The download link is to a missing page. This links to the page listed in the tagged release.

## Note
The download link does not follow the previous pattern.
The download page was added with https://github.com/dotnet/core/pull/1157
The release is tagged here: https://github.com/dotnet/cli/releases/tag/v2.1.3 and links to the download page.