### PR TITLE
move openSUSE 42.2 to eol table

### DIFF
--- a/release-notes/2.0/2.0-supported-os.md
+++ b/release-notes/2.0/2.0-supported-os.md
@@ -28,12 +28,12 @@ Mac OS X                      | 10.12+                        | x64            |
 
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
-Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux     | 7                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
-Fedora                        | 26, 27                | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
-Debian                        | 9, 8.7+                   | x64            | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
-Ubuntu <br> Linux Mint        | 17.10, 16.04, 14.04 <br> 18, 17      | x64            | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases) <br> [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
+Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
+Fedora                        | 26, 27                        | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
+Debian                        | 9, 8.7+                       | x64            | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
+Ubuntu <br> Linux Mint        | 17.10, 16.04, 14.04 <br> 18, 17  | x64         | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases) <br> [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
 openSUSE                      | 42.2+                         | x64            | [OpenSUSE lifecycle](https://en.opensuse.org/Lifetime)
-SUSE Enterprise Linux (SLES)  | 12                   | x64            | [SUSE lifecycle](https://www.suse.com/lifecycle/)
+SUSE Enterprise Linux (SLES)  | 12                            | x64            | [SUSE lifecycle](https://www.suse.com/lifecycle/)
 
 * **Bold numbers** indicate additions to this release.
 * '+' indicates the minimum supported version.
@@ -49,3 +49,4 @@ Fedora                        | 25                            | x64            |
 Fedora                        | 24                            | x64            | [August 2017](https://fedoramagazine.org/fedora-24-eol/)
 Ubuntu                        | 16.10                         | x64            | [July 2017](https://lists.ubuntu.com/archives/ubuntu-announce/2017-July/000223.html)
 openSUSE                      | 42.1                          | x64            | [May 2017](https://lists.opensuse.org/opensuse-security-announce/2017-05/msg00053.html)
+openSUSE                      | 42.2                          | x64            | [January 2017](https://lists.opensuse.org/opensuse-security-announce/2017-11/msg00066.html)


### PR DESCRIPTION
openSUSE 42.2 goes eol today. Updating support table to reflect as well as a little formatting cleanup. 