### PR TITLE
Fix root descriptor examples

### DIFF
--- a/samples/linker-instructions-advanced.md
+++ b/samples/linker-instructions-advanced.md
@@ -44,7 +44,7 @@ For example, the xml file might be used to root an entire assembly:
 
 ```xml
 <linker>
-  <assembly fullname="AssemblyToRoot.dll" />
+  <assembly fullname="AssemblyToRoot" />
 </linker>
 ```
 
@@ -52,7 +52,7 @@ or just a specific type within the assembly:
 
 ```xml
 <linker>
-  <assembly fullname="AssemblyName.dll">
+  <assembly fullname="AssemblyName">
     <type fullname="Type.To.Root" />
   </assembly>
 </linker>


### PR DESCRIPTION
The xml file should list assemblies without extensions.