### PR TITLE
Update download-archive.md to fix version mistake

### DIFF
--- a/release-notes/download-archive.md
+++ b/release-notes/download-archive.md
@@ -8,7 +8,7 @@ This page provides an archive of previously released versions of the .NET Core r
 
 | Release Date | Description | Release Notes | |
 | :-- | :-- | :--: | :--: |
-| 2018/02/27 | 2.0.1-Preview1 with SDK 2.0.1-Preview1 | [release notes](2.1/2.0.1-preview1.md) | [download](download-archives/2.0.1-preview1-download.md) |
+| 2018/02/27 | 2.1.0-Preview1 with SDK 2.1.0-Preview1 | [release notes](2.1/2.1.0-preview1.md) | [download](download-archives/2.1.0-preview1-download.md) |
 
 ### .NET Core 2.0
 


### PR DESCRIPTION
Wrong version under .NET Core 2.1 release (was 2.0.1-preview1 instead of 2.1.0-preview1) which caused broken links to release note and download page.