### PR TITLE
Use 'comprises' (active voice)

### DIFF
--- a/release-notes/download-archives/1.0.10-download.md
+++ b/release-notes/download-archives/1.0.10-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.0.10
 
-.NET Core 1.0.10 is comprised of:
+.NET Core 1.0.10 comprises:
 
 * .NET Core Runtime 1.0.10
 * .NET Core SDK 1.1.8

--- a/release-notes/download-archives/1.0.7-download.md
+++ b/release-notes/download-archives/1.0.7-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.0.7
 
-.NET Core 1.0.7 is comprised of:
+.NET Core 1.0.7 comprises:
 
 * .NET Core Runtime 1.0.7
 * .NET Core SDK 1.1.4

--- a/release-notes/download-archives/1.0.8.md
+++ b/release-notes/download-archives/1.0.8.md
@@ -1,6 +1,6 @@
 # .NET Core 1.0.8
 
-.NET Core 1.0.8 is comprised of:
+.NET Core 1.0.8 comprises:
 
 * .NET Core Runtime 1.0.8
 * .NET Core SDK 1.1.5

--- a/release-notes/download-archives/1.0.9-download.md
+++ b/release-notes/download-archives/1.0.9-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.0.9
 
-.NET Core 1.0.9 is comprised of:
+.NET Core 1.0.9 comprises:
 
 * .NET Core Runtime 1.0.9
 * .NET Core SDK 1.1.7

--- a/release-notes/download-archives/1.1.4-download.md
+++ b/release-notes/download-archives/1.1.4-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.1.4
 
-.NET Core 1.1.4 is comprised of:
+.NET Core 1.1.4 comprises:
 
 * .NET Core Runtime 1.1.4
 * .NET Core SDK 1.1.4

--- a/release-notes/download-archives/1.1.5.md
+++ b/release-notes/download-archives/1.1.5.md
@@ -1,6 +1,6 @@
 # .NET Core 1.1.5
 
-.NET Core 1.1.5 is comprised of:
+.NET Core 1.1.5 comprises:
 
 * .NET Core Runtime 1.1.5
 * .NET Core SDK 1.1.5

--- a/release-notes/download-archives/1.1.6-download.md
+++ b/release-notes/download-archives/1.1.6-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.1.6
 
-.NET Core 1.1.6 is comprised of:
+.NET Core 1.1.6 comprises:
 
 * .NET Core Runtime 1.1.6
 * .NET Core SDK 1.1.7

--- a/release-notes/download-archives/1.1.7-download.md
+++ b/release-notes/download-archives/1.1.7-download.md
@@ -1,6 +1,6 @@
 # .NET Core 1.1.7
 
-.NET Core 1.1.7 is comprised of:
+.NET Core 1.1.7 comprises:
 
 * .NET Core Runtime 1.1.7
 * .NET Core SDK 1.1.8

--- a/release-notes/download-archives/2.0.0-preview1-download.md
+++ b/release-notes/download-archives/2.0.0-preview1-download.md
@@ -1,6 +1,6 @@
 # .NET Core 2.0.0 Preview 1
 
-.NET Core 2.0.0 Preview 1 is comprised of:
+.NET Core 2.0.0 Preview 1 comprises:
 
 * .NET Core Runtime 2.0.0 Preview 1 build 002111
 * .NET Core SDK 2.0.0 Preview 1 build 005977

--- a/release-notes/download-archives/2.0.0-preview2-download.md
+++ b/release-notes/download-archives/2.0.0-preview2-download.md
@@ -1,6 +1,6 @@
 # .NET Core 2.0.0 Preview 2
 
-.NET Core 2.0.0 Preview 2 is comprised of:
+.NET Core 2.0.0 Preview 2 comprises:
 
 * .NET Core Runtime 2.0.0 Preview 2 build 25407-01
 * .NET Core SDK 2.0.0 Preview 2 build 006497


### PR DESCRIPTION
This is a hard one. The way I remember it is that 'comprise' works the same as 'encompass':

".NET Core encompasses the runtime and SDK"—works.
".NET Core is encompassed of the runtime and SDK"—awkward enough to remind me that I should avoid using 'is comprised of' also.

Like everything English does, it's a matter of taste. This is mostly for consistency with 2.0.0-download.md and five other files.