### PR TITLE
Fix internal section link for fixes

### DIFF
--- a/release-notes/1.0/1.0.10.md
+++ b/release-notes/1.0/1.0.10.md
@@ -1,6 +1,6 @@
 # .NET Core March 2018 Update - March 13, 2018
 
-Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#fixes) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
+Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#notable-fixes-and-commits) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
 
 .NET Core 1.0.10 and SDK 1.1.8 are available for download and usage in your environment.
 

--- a/release-notes/1.1/1.1.7.md
+++ b/release-notes/1.1/1.1.7.md
@@ -1,6 +1,6 @@
 # .NET Core March 2018 Update - March 13, 2018
 
-Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#fixes) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
+Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#notable-fixes-and-commits) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
 
 .NET Core 1.1.7 and SDK 1.1.8 are available for download and usage in your environment.
 

--- a/release-notes/2.0/2.0.6.md
+++ b/release-notes/2.0/2.0.6.md
@@ -1,6 +1,6 @@
 # .NET Core March 2018 Update - March 13, 2018
 
-Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#fixes) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
+Microsoft is releasing security advisories for .NET Core and ASP.NET Core. Issues addressed by this update are summarized in the [fixes](#notable-fixes-and-commits) section below. Details can be found in corresponding announcements in the [.NET Core](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) and [ASP.NET Core](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) repos.
 
 .NET Core 2.0.6 and SDK 2.1.101 are available for download and usage in your environment.
 


### PR DESCRIPTION
The MarkDown links for internal sections are an exact match of the section name with spaces replaced by hyphen `-` characters.  So as an example [this](#goes-here) will go to last section below.

### What was broken
The previous templates used `[fixes](#fixes)` to construct a link to the section `## Fixes` later in the release notes.  When someone changed the lower section heading to `## Notable Fixes and Commits` they didn't update the internal link

### How it was fixed
Updated the relative link to `[fixes](#notable-fixes-and-commits)` to match the new section heading

### Goes Here
When clicking the `this` above, browser will jump to here in rendered MarkDown.

