### PR TITLE
Introducing display version in releases.json

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -138,6 +138,8 @@
     {
         "version-runtime": "2.1.0-preview1-26216-03",
         "version-sdk": "2.1.300-preview1-008174",
+        "version-runtime-display": "2.1.0-preview1",
+        "version-sdk-display": "2.1.300-preview1",
         "date": "02/27/18",
         "dlc-runtime": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/",
         "dlc-sdk": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/",


### PR DESCRIPTION
For some versions we don't want to display the full version number in places like the marketing site.