### PR TITLE
Document issue in Preview 2 with SocketsHttpHandler on single core machines

### DIFF
--- a/release-notes/2.1/Preview/2.1.0-preview2-known-issues.md
+++ b/release-notes/2.1/Preview/2.1.0-preview2-known-issues.md
@@ -27,3 +27,23 @@ We have temporarily removed the Preview 2 installers from the Linux package feed
 ```bash
 sudo apt install dotnet-host=2.0.6-1
 ```
+
+## SocketsHttpHandler hangs on single core machines
+
+There is an issue with the new default HttpClientHandler that will cause hangs on single core machines when multiple connections are opened simultaneously. [corefx/issues/28979](https://github.com/dotnet/corefx/issues/28979). This issue has since been fixed, but is present in the Preview 2 build.
+
+**Workaround** - Disable SocketsHttpHandler as the default, and fall back to the platform handler.
+
+From code, use the AppContext class:
+
+```csharp
+AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
+```
+
+The AppContext switch can also be set by config file.
+
+The same can be achieved via the environment variable DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER. To opt out, set the value to either false or 0.
+
+On Windows, you can choose to use WinHttpHandler or SocketsHttpHandler on a call-by-call basis. To do that, instantiate one of those types and then pass it to HttpClient when you instantiate it.
+
+On Linux and macOS, you can only configure HttpClient on a process-basis. On Linux, you need to deploy libcurl yourself if you want to use the old HttpClient implementation. If you have .NET Core 2.0 working on your machine, then libcurl is already installed.


### PR DESCRIPTION
Documenting corefx issue [#28979](https://github.com/dotnet/corefx/issues/28979). The instructions on switching to the platform handler are taken from the [Preview 2 release blog post](https://blogs.msdn.microsoft.com/dotnet/2018/04/11/announcing-net-core-2-1-preview-2/).