### PR TITLE
Fix typo

### DIFF
--- a/release-notes/2.1/Preview/2.1.0-rc1.md
+++ b/release-notes/2.1/Preview/2.1.0-rc1.md
@@ -65,7 +65,7 @@ Many APIs received updates from Preview 1 which are considered breaking changes.
 
 ### Global Tools
 
-Global tools let you install a tool from a NuGet feed into your local path. This makes in available in a similar manner to npm -g. Alternatively you can install tools in a specific directory with --tool-path, which is particularly useful in CI scenarios.
+Global tools let you install a tool from a NuGet feed into your local path. This makes it available in a similar manner to npm -g. Alternatively you can install tools in a specific directory with --tool-path, which is particularly useful in CI scenarios.
 NOTE: There were significant changes after Preview 1 to both syntax and structure.
 
 ```bash


### PR DESCRIPTION
Fixed typo. Changes the text from "in" to "it" for dotnet tools -g option