### PR TITLE
Add instruction for dotnet-svcutil.xmlserializer

### DIFF
--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -37,7 +37,7 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
 3. Add a package reference to System.ServiceModel.Http
    
-   Run command: `dotnet add package System.ServiceModel.Http -v 4.4.2`
+   Run command: `dotnet add package System.ServiceModel.Http -v 4.5.0`
 
 4. Add WCF Client code
     ```c#

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -66,12 +66,12 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
 5. Edit the .csproj and add a reference to the dotnet-svcutil.xmlserializer package. For example,
 
-    i. Run command: `dotnet add package dotnet-svcutil.xmlserializer -v 1.0.0-preview1-26515-1`
+    i. Run command: `dotnet add package dotnet-svcutil.xmlserializer -v 1.0.0-preview1`
 
     ii. Add the following lines in MyWCFClient.csproj,
     ```xml
     <ItemGroup>
-      <DotNetCliToolReference Include="dotnet-svcutil.xmlserializer" Version="1.0.0-preview1-26515-1" />
+      <DotNetCliToolReference Include="dotnet-svcutil.xmlserializer" Version="1.0.0-preview1" />
     </ItemGroup>
     ```
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -9,7 +9,7 @@ You can start using the tool today following the instructions below.
 The following is required for svcutil.xmlserializer to work. 
 
 * [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300)
-* [.NET Core runtime 2.1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0)
+* [.NET Core Runtime 2.1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0)
 
 You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -8,8 +8,8 @@ You can start using the tool today following the instructions below.
 
 The following is required for svcutil.xmlserializer to work. 
 
-* [.NET Core SDK 2.1.2 or later](https://www.microsoft.com/net/download/windows)
-* [.NET Core runtime 2.1.0-preview1 or later](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.1.0-preview1-download.md)
+* [.NET Core SDK 2.1.300-preview2](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2)
+* [.NET Core runtime 2.1.0-preview1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0-preview1)
 
 You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
 
@@ -37,10 +37,12 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
 3. Add a package reference to System.ServiceModel.Http
    
-   Run command: `dotnet add packages System.ServiceModel.Http -v 4.4.2`
+   Run command: `dotnet add package System.ServiceModel.Http -v 4.4.2`
 
 4. Add WCF Client code
     ```c#
+    using System.ServiceModel;
+    
     class Program
     {
         static void Main(string[] args)
@@ -64,7 +66,7 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
 5. Edit the .csproj and add a reference to the dotnet-svcutil.xmlserializer package. For example,
 
-    i. Run command: `dotnet add packages dotnet-svcutil.xmlserializer -v 1.0.0-preview1-26515-1`
+    i. Run command: `dotnet add package dotnet-svcutil.xmlserializer -v 1.0.0-preview1-26515-1`
 
     ii. Add the following lines in MyWCFClient.csproj,
     ```xml

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -1,4 +1,4 @@
- # Using svctuil.xmlserializer on .NET Core
+# Using svctuil.xmlserializer on .NET Core
 
 Just like the svcutil XmlSerializer Type Generation function on desktop, dotnet-svcutil.xmlserializer NuGet package is the solution for .NET Core and .NET Standard Libraries. It pre-generates c# serialization code for the types used by Service Contract in the client applications that can be serialized using the XmlSerializer to improve the startup performance of Xml Serialization when serializing or de-serializing objects of those types using XmlSerializer. 
 
@@ -11,13 +11,13 @@ The following is required for svcutil.xmlserializer to work.
 * [.NET Core SDK 2.1.2 or later](https://www.microsoft.com/net/download/windows)
 * [.NET Core runtime 2.1.0-preview1 or later](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.1.0-preview1-download.md)
 
-You can use command `dotnet --info` to check which versions of .NET Core SDK and runtime you may already have installed.
+You can use command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
 
 ## Instructions
 
 Here are the step by step instructions on how to use dotnet-svcutil.xmlserializer in a .NET Core console application.
 
-1. Create a WCF Service named 'MyWCFService' using default template 'WCF Service Application' in .NET Framework.  Add [XmlSerializerFormat] attribute on the service method like the following
+1. Create a WCF Service named 'MyWCFService' using default template 'WCF Service Application' in .NET Framework.  Add ```[XmlSerializerFormat]``` attribute on the service method like the following
     ```c#
     [ServiceContract]
     public interface IService1
@@ -31,11 +31,11 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
     dotnet new console --name MyWCFClient
     ```
-    And make sure your csproj targets at netcoreapp 2.1 as the following in .csproj
+    Make sure your csproj targets at netcoreapp 2.1 as the following in .csproj. This is done using the following XML element in your .csproj
     ```xml
     <TargetFramework>netcoreapp2.1</TargetFramework>
     ```
-3. Add package reference for servicemodel
+3. Add a package reference for to System.ServiceModel.Http
    
    Run command: `dotnet add packages System.ServiceModel.Http -v 4.4.2`
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -34,6 +34,7 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     <TargetFramework>netcoreapp2.1</TargetFramework>
     ```
 3. Add WCF client code like the following
+   
    i. Add package reference for servicemodel
    ```xml
     <ItemGroup>

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -1,6 +1,6 @@
 # Using svctuil.xmlserializer on .NET Core
 
-Just like the svcutil XmlSerializer Type Generation function on desktop, dotnet-svcutil.xmlserializer NuGet package is the solution for .NET Core and .NET Standard Libraries. It pre-generates c# serialization code for the types used by Service Contract in the client applications that can be serialized using the XmlSerializer to improve the startup performance of Xml Serialization when serializing or de-serializing objects of those types using XmlSerializer. 
+Just like the svcutil XmlSerializer Type Generation function on desktop, dotnet-svcutil.xmlserializer NuGet package is the solution for WCF applications on .NET Core and .NET Standard Libraries. It pre-generates c# serialization code for the types used by Service Contract in the WCF client applications that can be serialized using the XmlSerializer to improve the startup performance of Xml Serialization when serializing or de-serializing objects of those types using XmlSerializer. 
 
 You can start using the tool today following the instructions below. 
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -8,8 +8,8 @@ You can start using the tool today following the instructions below.
 
 The following is required for svcutil.xmlserializer to work. 
 
-* [.NET Core SDK 2.1.300-preview2 or later](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2)
-* [.NET Core runtime 2.1.0-preview1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0-preview1)
+* [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300)
+* [.NET Core runtime 2.1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0)
 
 You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -43,13 +43,19 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
     ii. Add WCF Client code
     ```c#
-    var myBinding = new BasicHttpBinding();
-    var myEndpoint = new EndpointAddress("http://localhost:2561/Service1.svc"); //Fill your service url here
-    var myChannelFactory = new ChannelFactory<IService1>(myBinding, myEndpoint);
-    IService1 client = myChannelFactory.CreateChannel();
-    string s = client.GetData(1);
-    ((ICommunicationObject)client).Close();
-    
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var myBinding = new BasicHttpBinding();
+            var myEndpoint = new EndpointAddress("http://localhost:2561/Service1.svc"); //Fill your service url here
+            var myChannelFactory = new ChannelFactory<IService1>(myBinding, myEndpoint);
+            IService1 client = myChannelFactory.CreateChannel();
+            string s = client.GetData(1);
+            ((ICommunicationObject)client).Close();
+        }
+    }
+
     [ServiceContract]
     public interface IService1
     {

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -36,6 +36,7 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     <TargetFramework>netcoreapp2.1</TargetFramework>
     ```
 3. Add package reference for servicemodel
+   
    Run command: `dotnet add packages System.ServiceModel.Http -v 4.4.2`
 
 4. Add WCF Client code

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -6,16 +6,18 @@ You can start using the tool today following the instructions below.
 
 ## Prerequisites
 
-The following is required for svcutil.xmlserializer to work. You can use command `dotnet --info` to check which versions of .NET Core SDK and runtime you may already have installed.
+The following is required for svcutil.xmlserializer to work. 
 
 * [.NET Core SDK 2.1.2 or later](https://www.microsoft.com/net/download/windows)
 * [.NET Core runtime 2.1.0-preview1 or later](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.1.0-preview1-download.md)
-  
+
+You can use command `dotnet --info` to check which versions of .NET Core SDK and runtime you may already have installed.
+
 ## Instructions
 
 Here are the step by step instructions on how to use dotnet-svcutil.xmlserializer in a .NET Core console application.
 
-1. Create a WCF Service named 'MyWCFService' using default template 'WCF Service Application'.  Add [XmlSerializerFormat] attribute on the service method like the following
+1. Create a WCF Service named 'MyWCFService' using default template 'WCF Service Application' in .NET Framework.  Add [XmlSerializerFormat] attribute on the service method like the following
     ```c#
     [ServiceContract]
     public interface IService1
@@ -25,23 +27,18 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
         string GetData(int value);
     }
     ```
-2. Create a .NET Core console application as WCF client target at netcoreapp 2.1, e.g. create an app named 'MyWCFClient' with the command,
+2. Create a .NET Core console application as WCF client application that targets at netcoreapp 2.1, e.g. create an app named 'MyWCFClient' with the command,
     ```
     dotnet new console --name MyWCFClient
     ```
-    And make sure your csproj target at netcoreapp 2.1 as the following
+    And make sure your csproj targets at netcoreapp 2.1 as the following in .csproj
     ```xml
     <TargetFramework>netcoreapp2.1</TargetFramework>
     ```
-3. Add WCF client code like the following
-   
-   i. Add package reference for servicemodel
-   ```xml
-    <ItemGroup>
-      <PackageReference Include="System.ServiceModel.Http" Version="4.4.2" />
-    </ItemGroup>
-    ```
-    ii. Add WCF Client code
+3. Add package reference for servicemodel
+   Run command: `dotnet add packages System.ServiceModel.Http -v 4.4.2`
+
+4. Add WCF Client code
     ```c#
     class Program
     {
@@ -64,7 +61,7 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
         string GetData(int value);
     }
     ```
-4. Edit the .csproj and add a reference to the dotnet-svcutil.xmlserializer package. For example,
+5. Edit the .csproj and add a reference to the dotnet-svcutil.xmlserializer package. For example,
 
     i. Run command: `dotnet add packages dotnet-svcutil.xmlserializer -v 1.0.0-preview1-26515-1`
 
@@ -75,6 +72,6 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     </ItemGroup>
     ```
 
-5. Build the application by running `dotnet build`. If everything succeeds, an assembly named MyWCFClient.XmlSerializers.dll will be generated in the output folder. You will see warnings in the build output if the tool failed to generate the assembly.
+6. Build the application by running `dotnet build`. If everything succeeds, an assembly named MyWCFClient.XmlSerializers.dll will be generated in the output folder. You will see warnings in the build output if the tool failed to generate the assembly.
 
-Start the application and it will automatically load and use the pre-generated serializers at runtime.
+7. Start the WCF service e.g. running http://localhost:2561/Service1.svc in the IE. Then start the client application and it will automatically load and use the pre-generated serializers at runtime.

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -11,13 +11,13 @@ The following is required for svcutil.xmlserializer to work.
 * [.NET Core SDK 2.1.2 or later](https://www.microsoft.com/net/download/windows)
 * [.NET Core runtime 2.1.0-preview1 or later](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.1.0-preview1-download.md)
 
-You can use command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
+You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.
 
 ## Instructions
 
 Here are the step by step instructions on how to use dotnet-svcutil.xmlserializer in a .NET Core console application.
 
-1. Create a WCF Service named 'MyWCFService' using default template 'WCF Service Application' in .NET Framework.  Add ```[XmlSerializerFormat]``` attribute on the service method like the following
+1. Create a WCF Service named 'MyWCFService' using the default template 'WCF Service Application' in .NET Framework.  Add ```[XmlSerializerFormat]``` attribute on the service method like the following
     ```c#
     [ServiceContract]
     public interface IService1
@@ -31,11 +31,11 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     ```
     dotnet new console --name MyWCFClient
     ```
-    Make sure your csproj targets at netcoreapp 2.1 as the following in .csproj. This is done using the following XML element in your .csproj
+    Make sure your csproj targets a netcoreapp 2.1 as the following in .csproj. This is done using the following XML element in your .csproj
     ```xml
     <TargetFramework>netcoreapp2.1</TargetFramework>
     ```
-3. Add a package reference for to System.ServiceModel.Http
+3. Add a package reference to System.ServiceModel.Http
    
    Run command: `dotnet add packages System.ServiceModel.Http -v 4.4.2`
 

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -8,7 +8,7 @@ You can start using the tool today following the instructions below.
 
 The following is required for svcutil.xmlserializer to work. 
 
-* [.NET Core SDK 2.1.300-preview2](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2)
+* [.NET Core SDK 2.1.300-preview2 or later](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2)
 * [.NET Core runtime 2.1.0-preview1 or later](https://www.microsoft.com/net/download/dotnet-core/runtime-2.1.0-preview1)
 
 You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.

--- a/samples/dotnet-svcutil.xmlserializer-instructions.md
+++ b/samples/dotnet-svcutil.xmlserializer-instructions.md
@@ -49,6 +49,14 @@ Here are the step by step instructions on how to use dotnet-svcutil.xmlserialize
     IService1 client = myChannelFactory.CreateChannel();
     string s = client.GetData(1);
     ((ICommunicationObject)client).Close();
+    
+    [ServiceContract]
+    public interface IService1
+    {
+        [XmlSerializerFormat]
+        [OperationContract(Action = "http://tempuri.org/IService1/GetData", ReplyAction = "http://tempuri.org/IService1/GetDataResponse")]
+        string GetData(int value);
+    }
     ```
 4. Edit the .csproj and add a reference to the dotnet-svcutil.xmlserializer package. For example,
 


### PR DESCRIPTION
Draft of instruction for dotnet-svcutil.xmlserializer. Please ignore the svcutil.xmlserializer package version. It is a fake one now. I will update it when I get the release version. You can also edit on the instruction directly.

@mconnew @Lxiamail @zhenlan @yujayee 