### PR TITLE
Enable tiered compilation for dotnetsay

### DIFF
--- a/samples/dotnetsay/README.md
+++ b/samples/dotnetsay/README.md
@@ -45,12 +45,6 @@ dotnetsay
 
 > Note: On macOS and Linux, `.\nupkg` will need be switched to `./nupkg` to accomodate for the different slash directions.
 
-If you are using .NET Core 2.1 RC1, use the following command:
-
-```console
-dotnet tool install --source-feed .\nupkg -g dotnetsay --version 2.1.2
-```
-
 You can uninstall the tool using the following command.
 
 ```console

--- a/samples/dotnetsay/README.md
+++ b/samples/dotnetsay/README.md
@@ -45,7 +45,11 @@ dotnetsay
 
 > Note: On macOS and Linux, `.\nupkg` will need be switched to `./nupkg` to accomodate for the different slash directions.
 
-> Note: For .NET Core 2.1 RC1, the argument to specify a NuGet feed was `--source-feed`. It was changed to `--add-source` for the final release. You will need to use `--source-feed` if you are using .NET Core 2.1 RC1.
+If you are using .NET Core 2.1 RC1, use the following command:
+
+```console
+dotnet tool install --source-feed .\nupkg -g dotnetsay --version 2.1.2
+```
 
 You can uninstall the tool using the following command.
 

--- a/samples/dotnetsay/dotnetsay.csproj
+++ b/samples/dotnetsay/dotnetsay.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Description>A simple .NET Core global tool called "dotnetsay".</Description>
     <LangVersion>Latest</LangVersion>
-    <VersionPrefix>2.1.3</VersionPrefix>
+    <VersionPrefix>2.1.4</VersionPrefix>
     <Authors>.NET Team</Authors>
     <Product>dotnetsay</Product>
     <Copyright>MIT</Copyright>
@@ -17,10 +17,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <!-- Optional performance setting - enables tiered JIT compilation-->
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)'=='true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62909-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Enables tiered compilation as a project property.
- Tiered compilation isn't currently a benefit for such small and short-run apps. 
- The property was added as an example on how to enable the feature. It can also be set as an environment variable.
- Try it in your app, measure, and determine if it is a benefit.

More info: 
- https://github.com/dotnet/coreclr/issues/4331
- https://blogs.msdn.microsoft.com/dotnet/2018/05/07/announcing-net-core-2-1-rc-1/