### PR TITLE
Fix incorrect command name in 2.1 release notes

### DIFF
--- a/release-notes/2.1/2.1.0.md
+++ b/release-notes/2.1/2.1.0.md
@@ -64,7 +64,7 @@ Watch for future posts delving into what Snaps are about. In the meantime, we wo
 You can manually terminate the build server processes via the following command:
 
 ```console
-dotnet buildserver shutdown
+dotnet build-server shutdown
 ```
 
 You can prevent worker processes from being created with the following syntax:


### PR DESCRIPTION
Change `buildserver` to `build-server`, as it was renamed in `preview2` I think.