### PR TITLE
dotnetsay: use stdin for message when redirected

### DIFF
--- a/samples/dotnetsay/Program.cs
+++ b/samples/dotnetsay/Program.cs
@@ -6,7 +6,11 @@ public static class Program
     {
         string message = "Welcome to using a .NET Core global tool!";
 
-        if (args.Length > 0)
+        if (Console.IsInputRedirected)
+        {
+            message = Console.In.ReadToEnd();
+        }
+        else if (args.Length > 0)
         {
             message = String.Join(" ", args);
         }


### PR DESCRIPTION
This adds a feature to the dotnetsay program to allow using stdin as the message when stdin is redirected. This lets us do fun things like:

    fortune | dotnetsay