### PR TITLE
WIP - updated json format for releases metadata

### DIFF
--- a/release-notes/releases-v2.json
+++ b/release-notes/releases-v2.json
@@ -10,9 +10,6 @@
             "lts": false,
             "eol": null,
             "eol-date": null,
-            "dlc": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/",
-            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/2.1.2/",
-            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.2-runtime-sha.txt",
             "files":[
                 {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-x64.tar.gz", "hash": "229db61d9c1f9f587ce20f06ac3517e459a3c16b465dbbcf4fd0457ba216e0aea2d0a73df94b651992e744a8456de8bacf0211bff3a281198cf9fad845e9d8cf"},
                 {"name": "runtime-linux-arm-x32", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm.tar.gz", "hash": "c720033a558284b139e891b588642e7975afdb0137da9aee096cd8c4bd73453d1641a75d18a13bb4aebb282d31730cf2a6fe963e84bec315f3296efd72924973"},
@@ -34,9 +31,6 @@
             "lts": false,
             "eol": null,
             "csharp-language": "7.3",
-            "dlc": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/",
-            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.302/",
-            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.302-sdk-sha.txt",
             "files":[
                 {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-x64.tar.gz", "hash": "2166986e360f1c3456a33723edb80349e6ede115be04a6331bfbfd0f412494684d174a0cfb21d2feb00d509ce342030160a4b5b445e393ad83bedb613a64bc66"},
                 {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.tar.gz", "hash": "67a83f30f5c4d504eeafe5200711bff6e7c4c365067f4e6140e31f3e149974aa34e993d5ce9b39377b6e3e031c85e4348a46723519e87f200618dfebafd0b1f5"},
@@ -54,12 +48,10 @@
                 {"name": "sdk-rhel.6-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-rhel.6-x64.tar.gz", "hash": "9991d57f1e5f4f2cd227bca9ef980457d3422ae28a36f6c5ed2a7d0665f9d378aad2c57d4b375a7d410eb229b13a18e818f3f980dc222e9c5347ef62dbde8633"}
             ]
         },
-        "asp":{
+        "aspnet-core-runtime":{
             "version": "2.1.2",
             "version-display": "2.1.2",
             "lts": false,
-            "dlc": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/",
-            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/2.1.2/",
             "files":[
                 {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-hosting-2.1.2-win.exe", "hash": "1b20f9eee7b83d5068e8e4ac5230b7e584be944c4da1264fe117fa3a93aa520250e38e8bce7b54f87db73a40188e49c6caa9baa0f3ab45e38d4eba8a54e98e53"},
                 {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.exe", "hash": "63c8dfc01ff5a3a852a4d2930e185748f534ddc6c8aae96fac1cd6f7780a97aeb7d38a2b7be1f90c61df8bb3ca406cab37c5673676434d3597925ecbd2643276"},
@@ -71,6 +63,106 @@
                 {"name": "asp-runtime-linux-arm", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-arm.tar.gz", "hash": "49565a49e8357894b34a8cd12e1cccf9702c2c9c3dd06e1fc7c184ebee5b2fec43290e18998b60a77dbd5dfc5d59b838f3f4210675db1d64313cf206a22fc6b2"},
                 {"name": "asp-runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-musl-x64.tar.gz", "hash": "7e4ccfd0610949c4e228da38d40223ea8086bc98ec92d83fb0823909f40e897c3ad59706ff84e4dfec7873a587e83d9d98826dd13dc2bbea239a927f6906a9cb"}
             ]
+        }
+    },
+    {
+        "date": "2018-07-10",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.9.md",
+        "runtime":{
+            "version": "1.1.9",
+            "version-display": "1.1.9",
+            "vs-version":null,
+            "lts":true,
+            "eol":null,
+            "eol-date":null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.9-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-osx-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.zip", "hash":""},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.exe", "hash":""},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.zip", "hash":""},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.exe", "hash":""},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-centos-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-debian-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-fedora.27", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.27-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-fedora.28", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.28-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-opensuse.42.1-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.16.04-x64.1.1.9.tar.gz", "hash":""},
+                {"name": "runtime-ubuntu.18.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.18.04-x64.1.1.9.tar.gz", "hash":""}
+            ]
+        },
+        "sdk":{
+            "version": "1.1.10",
+            "version-display":"1.1.10",
+            "vs-version":null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.10-sdk-sha.txt",
+            "files":[
+                {"name":"sdk-mac-x64", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-osx-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-osx-x64.1.1.10.pkg", "hash":""},
+                {"name":"sdk-win-x86", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-win-x86.1.1.10.zip", "hash":""},
+                {"name":"sdk-win-x86.exe", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-win-x86.1.1.10.exe", "hash":""},
+                {"name":"sdk-win-x64", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-win-x64.1.1.10.zip", "hash":""},
+                {"name":"sdk-win-x64.exe", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-win-x64.1.1.10.exe", "hash":""},
+                {"name":"sdk-centos", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-centos-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-debian", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-debian-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-fedora.27", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-fedora.27-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-fedora.28", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-fedora.28-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-opensuse.42.3", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-ubuntu-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz", "hash":""},
+                {"name":"sdk-ubuntu.18.04", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz", "hash":""}
+            ]
+        },
+        "aspnet-core-runtime":{
+            "file": [
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/DotNetCore.1.0.12_1.1.9-WindowsHosting.exe", "hash": ""}
+            ]
+        }
+    },
+    {
+        "date": "2018-07-10",
+        "version-runtime": "1.0.12",
+        "version-sdk": "1.1.10",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.12.md",
+        "runtime":{
+            "lts-runtime": true,
+            "lts-sdk": false,
+            "checksums-runtime": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.12-runtime-sha.txt",
+            "files": [
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-osx-x64.1.0.12.tar.gz", "hash": "6d69022219c117f2db307884daf225fc01c09b9e8f0b2a4f72c10a4ee6fedf54060643f0221857279687a0c417507a53b142b64f691d425cd94576852513be91"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.zip", "hash": "26debb4b4a75be877e55ebde22badec0e6acd8aa83800056132c83d3492bf92f0e5fcac98e947a685a744aef1b3ef843f4109404b97061b532cc411c19dd2f3d"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.exe", "hash": "b2a55df7716677c5b9ac33b33686b07617fa9a97f0629b23e9869cb2db4ff9004b472aff09857921290853d56672e4c6da4eda7c4dcfe55c734ba5de3fe22ab3"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.zip", "hash": "43c22c1273c1055cda580e7bcec4274c8f40a40bacab07107899679afb12ddb6cdbaa544d778c65c593e3e65395d50c42a2f1d71dc10a60436437c709a126ef3"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.exe", "hash": "0eedfca647ef551b19243eaec5417393562f5b1c9bbc920d91db8cc0a192543c59237980f0b2c5d388ffc89c4cb121b2acd75c1e21c2bdf9daafeeb9780b28f4"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-centos-x64.1.0.12.tar.gz", "hash": "3758c4a1b3e853864ef955ad9cee5f852e484f896d7a05c3994bb6f9b2b487c248577c3fd30c35eed674de649c1c8d0de709e432b0b2a7ccda9b81ed1f1c4f22"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-debian-x64.1.0.12.tar.gz", "hash": "a69bfa909454b5de50cb177f00528a7f05641f823e1aa30569fc9357d50cc3cc22a2dae6ca806fb8300345765cb4873b9884fd42807d922a4a2476f1b8cc72ea"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu-x64.1.0.12.tar.gz", "hash": "338c1dbd127205d6e10dccf51ca4ac00685a3062aaf2297bac6b78771a0dad37bd7da0d9991e14c09ca90ff6066c00584d90848eeaf816ab6cb5a871956410e9"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu.16.04-x64.1.0.12.tar.gz", "hash": "e0122f97adfde7a30ce1c251e7ec62700e7e02083ac94b445d5708b924bec99304f280068c345f9352f0ed20ceb83f77fee05553264e2768d669dc63c6872b76"}
+            ]
+        },
+        "sdk":{
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.10-sdk-sha.txt",
+            "files": [
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.tar.gz", "hash": "bf3bf5f22c70c944a9459565626ef935cd15465a189ef9dd65d18560f7e71e44e2ac93552999774eb9a6672530a99baa30347bf3ea1cc7f4ac4d583e1f0e60b9"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.pkg", "hash": "990d54a53702f5314ad06aab3fa7b6ad0944f2d8863d5ba99f9e86a660fc542378e0fa2cf9aebbd44bdee71bdd37d287409ded40f98d4a43f77e613a3d84fee3"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.zip", "hash": "f46778149a785c0ffed4611966c07668061bd07dcf0c4ebb42e68461aa9dc5a8fe5bcd0d99f1ebb279a7f8269d84dd7f34e34b6c953d63ce1acbc85c4c88b743"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.exe", "hash": "871baf6e9e7ca12a222ad0c9eb6060b933448c58f289defe1723934c66c07b2da6bd6f3495878afb280f188e64fd6200ed18b59ea5659e62be538956cb502a5a"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.zip", "hash": "d0b01871251265b9a07c24e94e2e33f4a5d96ec6165ec0f60b032ce5c35895985e37cc01f73134fc8802a442eeb243b1d1403ebe898d6455907095e5b6b854c1"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.exe", "hash": "d686d2514f45df597791d4fb60ccc272f5d42239e21803dbbf050891f79dbc7c0c8a72623606f312fd0aed0eef7ec5270c4adcfba105e3ec635d27729ff5c4af"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-centos-x64.1.1.10.tar.gz", "hash": "30af1b4c9d8bd46bc48a52c9a9bee9e3a9a750ffd2308236458acd4cc3b313b8a4ca6259b34422caabd47540e30f5467b8f9237595e49be963d29abbdbfbd0e9"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-debian-x64.1.1.10.tar.gz", "hash": "f4ac12ff20db06a7c6232c2645f35486d5369201429e3aa9c89a65a3e5f53957cd6ab612c225cc1dd6afebd4dd28695ca5a1f9cbcc812d8fa08635d6cedb1dff"},
+                {"name": "sdk-fedora.27", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.27-x64.1.1.10.tar.gz", "hash": "89cb369e8205224db77e314b6e236570e94b1d351689dddab5c4fbd63f444389e9745b84c57f855ddef9d693866b1103af6b8d889d6626ccc5c08c6783185d6d"},
+                {"name": "sdk-fedora.28", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.28-x64.1.1.10.tar.gz", "hash": "91e3bd421cadaf3a3a3e65486a088d9d4b0aaab9f35757068f6f09736cacbe498fc9469aaab9a4d5c209074af253761a8325adf525e991e40c5ffc10acd8ba93"},
+                {"name": "sdk-opensuse.42.3", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz", "hash": "227928df186dbd0fcc152f602383efcb66c45e467e5b88e135c725a53f69fbba26debbcb0536629e53b15e0caac65ef3af8db9b242195f3bf517d2f629125439"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu-x64.1.1.10.tar.gz", "hash": "21bb88c12a094aced52d5161dee6d345698210ddc942a597e489c167fdeef4a1ebab90f7bd4bc0c23fba1c912d24e73b333635b70f7571b4ab5d8d8d1ce4b713"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz", "hash": "89300ca6c519ba17eebe0e425f332bd457c0af49d9ba0cd00f4df14be471bb6d5a0207486e484b106a6b1071fb140b0738f752475dd88d8d7f833e8b8e26da58"},
+                {"name": "sdk-ubuntu.18.04", "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz", "hash": "38a3cd266f3b1f680e878c981adca1cebe81fbfd161ce4ea083ea4c7809c0a92e03ac33d292e29f43b5ebae18622ea83360c6b07186a6fa35ca6b2ad8450d140"} 
+            ]       
+        },
+        "aspnet-core-runtime":{
         }
     },
     {
@@ -141,6 +233,32 @@
                 {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-hosting-2.1.1-win.exe", "hash": "6c24ec02e6c8996a419ad0f7092ada5e58754a5e1db7f1828670ce8f4503c22e14bd74ae8b86a99833147605157763a8d95bc5dbebbc5643c92fc28c4b58391f"}
                 ]
             }
+    },
+    {
+        "date": "2018-05-21",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.201-sdk.md",
+        "sdk":{
+            "version": "2.1.201",
+            "version-display": "2.1.201",
+            "vs-version": "15.7",
+            "lts":false,
+            "eol":null,
+            "csharp-language":"7.2",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.201-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-linux-x64.tar.gz", "hash": "3c456d5f564e7c56a8b33f4116ba79f5ec1c5f6ee87494532efb68f407f25deae1d075c83e6f86624e51b99b090c7d3f1fd6ecd812808aede9017a8877782358"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.tar.gz", "hash": "3d2d49f6b6b22e777e80d3ea396ee28e4e71d133478d5aa3e118ed48d3933071d4abc108ea6fded410b218ed9e15b05e99f52f6741af5d102aa0323a01a795b7"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.pkg", "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-gs-x64.pkg", "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.zip", "hash": "08ec5d4e913f973aaebbe34fc34bfc1671a60dd132b2a2323ca48be3af71482d17e6347d72f164ac509d0d6aaaee5ee5f841ab4244ba6eaf49ac1fb424dffe79"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.zip", "hash": "34c4c7a48ee9b88cf2c523d615816b1c597f0187e716271926e7fbe478b92f6d6c0faab4884cc897309f38168a033039a8315a395e887a4c90dddb1791f7d2a0"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe", "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"},
+                {"name": "sdk-win-x86.exe-gs", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe", "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.exe", "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-gs-x64.exe", "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"}
+            ]
+        }
     },
     {
         "date": "2018-05-08",
@@ -299,6 +417,1184 @@
                 {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz", "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"},
                 {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz", "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"}
             ]
+        }
+    },
+    {
+        "date": "2018-05-07",
+        "security": false,
+        "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.0-rc1.md",
+        "runtime":{
+            "version": "2.1.0-rc1",
+            "version-display": "2.1.0-rc1",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1-rc1-runtime-sha.txt",
+            "files": [
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-x64.tar.gz", "hash": "29f27f7b208ed20be71941f8c57aa5dc3c4a0e0fceffa4cf80553fca81dcfbe3b7f26a93662aae86c10ebf5f43a150bcac9290033dff6876d28683141e5d98e4"},
+                {"name": "runtime-linux-arm-x32", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm.tar.gz", "hash": "d2a49b3b08ab282bbecfc578a3e24f76dc25dc15be5cf2021a33942b6629e47f81ac6c4766f97d4529fd92c4dd8c781a28c13eff3bff2e7b484a5b2c994ae37e"},
+                {"name": "runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-musl-x64.tar.gz", "hash": "4f4b6bb043bc927643448de7744139cd5006f6c6108d39aeb24af1c79f76d4bcac05013e0700972f230d35315fa73241113fee2374d82e3318bc9f170a533652"},
+                {"name": "runtime-linux-arm-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm64.tar.gz", "hash": "a5ddf10cf8477d811b1ad5958e4347cdb40a3fcdc9cd0e471d38245fca4e59e42e27d0c756a4e354988c979276ad41e33d42d151aae60f32601ddad21df56d85"},
+                {"name": "runtime-rhel.6-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-rhel.6-x64.tar.gz", "hash": "13e4cdc01d4dc0985a1d6edb9aa228b809532e4e07d29ba7e6f001663c2e2e8478fb4b3459622699133debd122214279a5597762f659000e3efe18d9544ccbe0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.tar.gz", "hash": "db2c6d403f5cd37c1fe0988d0f207d8dccc9940046553e280b16690f71225a638f3f90b86e43e2c26b02adedb86978c86ad6831c583f603dd43dcb7fb93fdcb2"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.pkg", "hash": "5895c7dc2e721b921da579ec37b8defb47e53a5ccbca39a0dc989b04be24c9736c0b9c4fe2eeb0bb078f3a5cf472aae2d42c3f8f08b9fd2305f5e4e101503075"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.zip", "hash": "1a161832ac0ded127b0f4ab36569b5d06cc1681818f72341cc530c4a645d7cc5b21b568c5e07749aa27968982487d9b18aae5e246cbf5ee385a10fc9783520f0"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.zip", "hash": "781a67337f7717f38f061f623c8491dcb91be58750dcb47c15ef5519ab4be928ce8645500fad67a30026476e64e507d18210aab8f18213ffb48d83e0fa935cf7"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.exe", "hash": "e5ea1830f5cc94a5aa5dee744797b19a6af5c59c4e222b1e694e05acd9deb5474ffd24b6aea49ff72d8d8743eba20f3adc19158c7b5fa7ea3168a20333562980"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.exe", "hash": "279a5378ecff673dc15acb56c94fbd04e2261d77eea78f0679fa0a975a81b6f5bec37d3fe99f6a9bd2d228047afe024627071ebdbdd28ac6a57d76ed3e4eb1c0"}
+            ]
+        },
+        "sdk":{
+            "version": "2.1.300-rc1-008673",
+            "version-display": "2.1.300-rc1",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1-rc1-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-x64.tar.gz", "hash": "f3964951e577b7b829a8f6cdc8b9477fd8ea39ad6baaed30f369280d06523ca3574cd8679d74bca027acdad0cb02fce76e46d742d705741a7074d99fdf95cc06"},
+                {"name": "sdk-mac-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.tar.gz", "hash": "0e3e86ad493d7844d226d3e423b4d912124ea62ef8cb440de8fd318a579e105aacecde774e24c7c1c082d395e6b732970ae7c08c6e47e4e7477066174c251206"},
+                {"name": "sdk-mac-x64.pkg", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg", "hash": "3a0c2356712007232f83b38b89427d4cc6d576778e3db331455eedab393e1bc86ce771226eb7e2e6edd8230170fefb54e82d2a3b13ebf09d4478600c5b518ec8"},
+                {"name": "sdk-mac-x64.pkg-gs", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-gs-x64.pkg", "hash": "3a0c2356712007232f83b38b89427d4cc6d576778e3db331455eedab393e1bc86ce771226eb7e2e6edd8230170fefb54e82d2a3b13ebf09d4478600c5b518ec8"},
+                {"name": "sdk-win-x86", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.zip", "hash": "9e4e904f7743b6e0635f3474361eebb00f1164aa96e12fabcf6ecf2c56fa84abf974a1af5c7df8dc0139c8f11e43faaf5b85bd4401896320ea52f87f87aa37b3"},
+                {"name": "sdk-win-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.zip", "hash": "a9e8b89dcac02ebaec82bcd8bbb55b42480e1ce040b8204e5fb8c2241978af7a090952de09982c02b6f9a1bdb85555f7bf356c6c8aea2d0207003e1d5f521ab4"},
+                {"name": "sdk-win-x86.exe", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.exe", "hash": "803c748bb67c77939232b36ddcc90b3663fd3679cf82aab0baba5979caf28252a2b171e2e3c69bd313a87e2ca78869bd484597170a2118c359fffa3dfb2a4470"},
+                {"name": "sdk-win-x64.exe", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.exe", "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"},
+                {"name": "sdk-win-x64.exe-gs", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-gs-x64.exe", "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"},
+                {"name": "sdk-linux-arm-x32", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm.tar.gz", "hash": "2600659fe88f2ae0fa3e491e5495123d441d87aa392a2ea40d0eaedb0aee471c2c824de4b425742d1e4cc5c4abaf272ec56b079458b9f062eab31c6343a14862"},
+                {"name": "sdk-linux-arm-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm64.tar.gz", "hash": "75ad50527eb4468b313bcd79d8e506c9da1670a92d4f06dfdfc6f524153edfd46447799ec50d90bb5b1dc6fbd04fbbd3fb7e4cf11b387db8005bdca2a947a67e"},
+                {"name": "sdk-linux-musl-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-musl-x64.tar.gz", "hash": "852b51b0802297c13d6b86f6fae38c515eaaf51893dedfce129966134a8100f5da2ab789295528ae868cf54cb9f7004fd37bf97927f716bb193a6232f181a38a"},
+                {"name": "sdk-rhel.6-x64", "url":  "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-rhel.6-x64.tar.gz", "hash": "687f0bd409c6370d7cdb6429eb59f345b31c6ae14ba1e76dafd518cecffee33ea23fd4705e3e89409dfa1ec6eeb31137656a00e791f59e5157a430a12cd42947"}
+            ]
+        },
+        "aspnet-core-runtime":{
+            "version": "2.1.0-rc1",
+            "version-display": "2.1.0-rc1",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1-rc1-runtime-sha.txt",
+            "files": [
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-hosting-2.1.0-rc1-final-win.exe", "hash": "45ae5913e8fca08513fef71bd9a849dabd829bbaf5fbd6e9489ffeb38177e65b1042e267243d40bd70df404ccd292c15746ecd2c820ad35527308b83da4bddc0"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.exe", "hash": "1138f7e2a23cf0309cb53986e219d52a27cba30d8d5caa3697317b4cab951bf2976211f0894eaf60900da778b4aa790490c417041abe9bc741695a259ff94789"},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.exe", "hash": "b5e9a89ecfbd638c0f92bbb1626183def620c22e50169fa58a7a21faa83a2d48ef8f3cdc9b2815527e8885617db3624e25a5c63cdb23cf73ecd07056afe997f9"},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.zip", "hash": "18ce3332214fdf8e68afba978c2cc35213595e2b0d70c77d5e108f939990bc6234b6fda9159e9a020db3a7fe8ed5bee2d85df5bf569314056cd495a0a06fd1c3"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.zip", "hash": "c11d4d533828267d661cd7c01afa8a6e14a979a7595bc446284635e2e24ba10c299aad451c960f0c39afe7597e00aa311c77c9eef85cbc6768c8a136f05b2b2a"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-osx-x64.tar.gz", "hash": "d929b601885bbd965ae47d2942d0e9d875a9750d63ebfe4015879b9f54c928bf833b966f3a58430d0e650d4de5afca524dffa7a71d5a4a5af901b51be2012f3d"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-x64.tar.gz", "hash": "156ab969bc533c3a64b770f2b88214f0b07d1d867922257182d496828ac3cad6d6c01ea44f2a2a1d568278bfdf916db9825452de26a1262bdc591ff19f6e4b99"},
+                {"name": "asp-runtime-linux-arm", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-arm.tar.gz", "hash": "c76690fb147b39ab8113efefd3442e40d26c3767bcd9e1c3b0692d6cb022ceb0aeb5eecd1ef38af89e3cba59adf8579347e005608b09622e10186732ecc41f47"},
+                {"name": "asp-runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-musl-x64.tar.gz", "hash": "701a96fc3b27d6ebc46f2c9192bc1a048d1c3915888cdc2223183e7a8c7be7e591e9ea317c2e6a363c841013ae2209564da470e48f268c374084ab57c28a66a2"}
+            ]
+        }
+    },
+    {
+        "date": "2018-04-17",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.7.md",
+        "runtime":{
+            "version": "2.0.7",
+            "version-display": "2.0.7",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.7-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-linux-x64.tar.gz", "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.tar.gz", "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.pkg", "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.zip", "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.zip", "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.exe", "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.exe", "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"}                
+            ]
+        },
+        "sdk":{
+            "version": "2.1.105",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.105-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-linux-x64.tar.gz", "hash": "b5e71dee8720595b0eff7518cca49854ed183e7ca68b98e2ca0580be3f6893f25a1bb267367601f575529a0fd8c94bb379a1411564ed5beaa340a54f37a5e16a"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.tar.gz", "hash": "68b060271e5e5d8257a9f87d55c6e9386fa72bec2fa6d9d37d5634837f1a2ccfe4a09934988e4f41aa4efa131708bf5cc1dac2c0609edcd86b966edf2319cae7"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.pkg", "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-gs-x64.pkg", "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"},
+                {"name": "sdk-mac-x64.pkg-nj", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-nj-x64.pkg", "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.zip", "hash": "0e027eda462877d2aa2bbe9b763e2494a01c1a739190e317cde3dd7a905e7cb5c20036ef90e846ba2c9e251386859e4b0600016a536da1b392ef12eb04236236"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.zip", "hash": "9e902468b1f40434092d0100dd0054344f085d5d64a325d1e27c86fb2f54cccddda615bc119e3cffa357b8d9ffad455ba6ea9739ac592795d3499d0f1fe498d5"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.exe", "hash": "a06393e1030e88f39628e070c6743745d142c754f0a604d26f33a35a5635ad6622f2994db719fa566352c1d0dc1f97a58dcf2792e80e6529359ae1e5454ee2a6"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.exe", "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-gs-x64.exe", "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"},
+                {"name": "sdk-win-x64.exe-nj", "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-nj-x64.exe", "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version": "2.0.7",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/DotNetCore.2.0.7-WindowsHosting.exe", "hash": "83f7c2607a0ad97800d2302cd6b9462b623cc66960974bdb1c404eff89eedb0d1f876a957a671b885f7ac81584bc9fd97a34231c342fa19affa38fa603c4974e"},
+                {"name": "hosting-linux-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-hosting-2.0.7-linux-x64.tar.gz", "hash": "44cfe2404f5fe87e6381d039ae1a4f6de4935d5564be073f1ebf2624c62a97a35f35862730ab03f38e71ce64e0921444c3058a8aae5564915b18b848fd8e08a3"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x64.exe", "hash": "81d8bb363a7d8b517027229fce7d60800902b84921dbf926582213e3b0f9b856daeba4cfed8f6ab52974f04752722303a09e2370a9cb3dae2c443fad188dbe05"},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x86.exe", "hash": "071d19f2d897a0fcd6d61e1ea8c418b305ece143eaf1c0ad03af9de03cf49084d17408f2edb3e950b9ac3bff24638638865e88a6e149bf6f7d37f8d5f9ec22d6"},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x64.zip", "hash": "12f4035ceab8385849c60ae9883ce68b8350de0a20100a9a5f91176a5bb52a2bd7b677fbddc1bc2f3f30a3b1926693c1eec801fe044d3b93f0dde4861d816c48"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x86.zip", "hash": "d145bb1ec3ba95166c46b22e29271476d215561ac93f866f155d8016bec0cad2a8f8645f0f7e09365fb49dee966446cbdfb058f49ef3a023a0d4a47492fd09ce"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-osx-x64.tar.gz", "hash": "6cf6d3fca8401944b28d8da5cd82ed09a1187196289d7a142ee5a48194ed74c7df55881cb54b99235dfe20d8914c2bdb29e7bc1fc5bbb349d5a78650aecea765"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-linux-x64.tar.gz", "hash": "422d6fd1598628d72bf5687582c90b2178bb0c0485d2df224af7b0cedea09b9768408c6940cb60c09fee1cd36e064fa013d79dd417104ae8a42b428a2b0d395a"}                
+            ]            
+        }
+    },
+    {
+        "date": "2018-04-10",
+        "security": false,
+        "runtime":{
+            "version": "2.1.0-preview2-26406-04",
+            "version-display": "2.1.0-preview2",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.0-preview2-26406-04-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-linux-x64.tar.gz", "hash": "9f8dce51f0438e0cff5fbdf38a60c620d879825902aae4d59ec026c6cfd0f6d2237f220a5346836e6e3c50a5be7b357443ab4ae01f85c596abceec12a8dc29d7"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.tar.gz", "hash": "5c8602cebe11b08a34e60b7bf2a826ee1e907e0e6aa4106b27f4af9063ffb2dc3cd03123c8bb1677445cdaab1fc0af758d11f752d5228187ac1f256eb9f82d75"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.pkg", "hash": "a09fe3640b4dbfbf1ad005a44f488da264aceae83f8f9afac9d60df1ac51e0e8c96c2a5a88e880d545ea72162c286c206b833c2133260d10096bb8c50f50b065"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.zip", "hash": "46816c29827516328f39147b5bf52f8f1786e8f58e3628ee02bdf5b080f7420e62b57751a9fb16caec8f4de41766be28693f29e42d5de1eae722938def6780ec"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.zip", "hash": "eabf2cb0fbaa096739b5e25fb43ebe7b3a8a62756e25cdccf740658a0b7d1166259645c61f8c6e5c1c3577d440ee6285c9ce504ad6b9f66ba9d7fd71c211bd1a"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.exe", "hash": "80a5894d44d153de640a9c9216c1ddd7c3a98033e06661658dc71be6d8c8f750e13f03f217ba01a4917fb2a20a78d8eadec742836357dc8d4f5e6bfaea60b732"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.exe", "hash": "53c42d54ba7ce83d234efa63a6dae7c38593091ac28839d2f8706ea866f2fe2bebe88c8d03a09eaf8673ea257a3da099b4b7b8647cb100cdb17f3aa5257b2716"}
+            ]
+        },
+        "sdk":{
+            "version": "2.1.300-preview2-008533",
+            "version-display": "2.1.300-preview2",
+            "csharp-language": "7.3",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.300-preview2-008533-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-linux-x64.tar.gz", "hash": "a50ce826458092cc0547c36ff0d281e00b71b5689109414ab41b8bd9b57fc1f20c04fd55c6c298503bd552b1eb1ddf9eb634f947ea3ded2ceb3fb61436df0457"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.tar.gz", "hash": "088ee5309bc07a32d8b142c6f8c4bc981d37f6d14a1138dec452baa67dac4840f82b091fb3a5dc0b8902dba540ccaf96bef10d9fb0b040ab07e2af170ceabe25"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.pkg", "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-gs-x64.pkg", "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.zip", "hash": "fb906747d1bd7258eb803fae29256de02c1ca92d48041142cfc3a64feb5a36e7a91a04ffe12b407a2a67e003ae621a6181313a1f8833ce48417c7d2aa76c2566"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.zip", "hash": "e2858d0809cd727ef361ecd192cc79208bfb04b258b1c7375c4a8fc34b897a4d0f244c67744f2c4154c1b8cf47cff4f656b70357f8c2d06c30058e82d115ef46"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.exe", "hash": "3fe6174590802bea4e37f8c415d8ce5afc72113b8189511f15110057ba04cbf24d8495d57e8b67584a13706c033278a0daec33530ba43dea0403bf106524ea19"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.exe", "hash": "584ff392f4a49700afe2e18819b888be8320cfcb3133618866934690d23f127a1b663eb35ea91072c19c8d2d498b4847f0f4ab4dfc15b4bf4f4ee4b96419308b"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-gs-x64.exe", "hash": "584ff392f4a49700afe2e18819b888be8320cfcb3133618866934690d23f127a1b663eb35ea91072c19c8d2d498b4847f0f4ab4dfc15b4bf4f4ee4b96419308b"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version": "2.1.0-preview2-26406-04",
+            "version-display": "2.1.0-preview2",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.0-preview2-26406-04-runtime-sha.txt",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-hosting-2.1.0-preview2-final-win.exe", "hash": "5cca21d9f1cadebc130607f1ff14ab17db05f971ee218a7d855f452bd1f36ac8c7773af4662887c711c93ec6bd2c85a5e648aad845c2c9543ddf25e186cabd44"},
+                {"name": "hosting-linux-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz", "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.exe", "hash": "79567d9c4ee73195ea49d735b9a4a70f1f2485c3f38c53e83f624488b112a6304118f7ce8a48b7f5a169365165a8b11f5743c69141b260237846e24a560fb684"},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.exe", "hash": "a574395e4a478bd7f6a3f932e0ceccfc527661218ed24c7e33ea761a909d3598be522e7002b67f67a6569e9be5f79d4021cb1207d7877e17b48d0a82be6b0587"},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.zip", "hash": "5e247e07e29dc6932bdd810911461e78c16d30c5724403953d20971383be06dbed7b579a21a10b0da7d90ada884ef9f2d8a9ea7dfc442bcb4cefbc1a397c00bb"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.zip", "hash": "857560b9e780b686e5503d84574da811a302c3f1435d8dc09398b5e28a1cb2b5f82da87fc04ea170e92f37e5bb68f2669d5ff68b8cf64ea10d8f1735bde34cfa"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-osx-x64.tar.gz", "hash": "7f8463f06af03cd951d1a2497c7d76def63239269ef510443bd6843f6fc9e3b68f4b0d812f8d22236a9d45c0c0cfd8166793461250c76037f08c0122b151c3ae"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz", "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"}                
+            ]            
+        }
+    },
+    {
+        "date": "2018-04-04",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.104",
+        "sdk":{
+            "version-sdk": "2.1.104",
+            "vs-version": "",
+            "csharp-language": "7.2",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.104-sdk-sha.txt",
+            "files":[
+                {"name":"sdk-linux-x64", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-linux-x64.tar.gz", "hash": "813334694667f8c1389d88cd3128a7749f4f65b13a0a8e2cb47380823849b8fe7f4816ab66c2d77e589fac9cb5748390b262beae9673aef86cad5a3d8f24986e"},
+                {"name":"sdk-mac-x64", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.tar.gz", "hash": "625aa1e52f9a03cf0ed0bc2ede40f94749f35ecf142a655f8d353c6d8223f8f7e6e715f46d6bd546dec9d888a8ae75ccf9d79e91b5b92b7ee633a92d6ae82e53"},
+                {"name":"sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.pkg", "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"},
+                {"name":"sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-gs-x64.pkg", "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"},
+                {"name":"sdk-win-x86", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.zip", "hash": "0d4fa339d125f780bf293ad566f5127b602c228fa3312bc0c02d455499797114aea1cb27de6b187c18908ae8a4358e7b6c91a596219f572e08ec091cadb4cba8"},
+                {"name":"sdk-win-x64", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.zip", "hash": "f3a46570f220cafbdb2f7d40cddd09a8f718b62f02fbea79fdf8e48ac1871a20d2e79191b037a559b7f2bd88064e1ec70d2c68988312a7ee23d34dc757b9981b"},
+                {"name":"sdk-win-x86.exe", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.exe", "hash": "4462a33130b09ba6b9d5f8b579b91ff797f4081717ccc4ecde507bfd2c774985e73458716b6b1f3ea714b020d0607d99c9a013629497c26e89b3424e1713ab97"},
+                {"name":"sdk-win-x64.exe", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.exe", "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"},
+                {"name":"sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-gs-x64.exe", "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"}
+            ]            
+        }
+    },
+    {
+        "date": "2018-03-22",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.103",
+        "sdk":{
+            "version": "2.1.103",
+            "vs-version": "15.6.6",
+            "csharp-language": "7.2",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.103-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-linux-x64.tar.gz", "hash": "5252ece4fa8eefdd401ef90cc1fcaecaaa6ad71ae5e25351578c7f497488039b0aa334b5c6481c6c839a95dbf9ab4aec89404dc760cfbcd06564ef5869dd9377"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.tar.gz", "hash": "1ad9f16fc72362fa810951bf0f129ea48c4c0f10d465eed73b4706066956c063a41964bcf84fb7f7590c3c90f31261bd33162cb2aa8348bcb5c96d75473a610d"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.pkg", "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-gs-x64.pkg", "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.zip", "hash": "61ee3cb4e12e435e9b3ead8426c2ae528dcf9c77de0878e51e7e3baa04b3928a83cd60f5822e785302884f5f034723a6c45599cb2eabd8c03e3f525f3cc0f1cc"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.zip", "hash": "8166b0f2fda1533df4397209616754b5255fb1ee5a775d581640b99158adf371538dd373001c2431f6d12abcc9648b325f88653b9891c8eaf9f50c9e2e1b4b1e"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.exe", "hash": "ba0f0f9519a6c5a3bcd8325034f466212797e820e7671b019eec199c8ab9ffb2f3543eb5594c76f2374459e5c0e175bc8604b67f7de3c7505959c4e209d6d835"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.exe", "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe", "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"}                
+            ]
+        }
+    },
+    {
+        "date": "2018-03-19",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.102",
+        "sdk":{
+            "version-sdk": "2.1.102",
+            "csharp-language": "7.2",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.102-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-linux-x64.tar.gz", "hash": "39bcc14c6453552ea5f400aac7b5838a0361dd15cc2ed9d2794f1185ac2e38c82478e32712e1ad483eeb4edf4b485bb799de26368fccacd98e6c0819f8ff7eef"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.tar.gz", "hash": "a3f3acb6be30047970764dd657353262822addeb669b6179336b83c6bcf4d97faf2c9bfda3ef07fbe56630d7083de04fdb49c5d9b4c03ec9e8090c9f5ab0c4ae"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.pkg", "hash": "982522821d3d6ab7f98810ab70084eb1c10381326bd91237bc9de9821e8434803f76d3231ab8b1762f2598cde48d5ebb1b53a84da3e28424f6c7ce946fa5e859"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.zip", "hash": "642162de05c3d7265da4fb644a9fb6c965788bea93adc2ee381ccab4992dd15dd7ffb02cf8a54485391943627533ea496ec8799d4850b6922f196e3c7cabdeb4"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.zip", "hash": "c1e169cac4200b944d708c46712389f0cadf3eb319f1b6f6f90eb2a8c3e01b18a569acacabb4b7985c9c54165a63e3ca9dc8f1ce7170db650442052d35fbe310"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.exe", "hash": "3850b7ed490d64599f7aa592ab1cc59609c77f5f131e04c81cdc47b884db521b4ff421c25730907694b6107573c0fbc38765f6417b0ad5a1bbbd915765d8d617"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.exe", "hash": "ee698f7a3d88d22c344f3bf692a671c03abed634250a58c55de7eba33135df6d26315bf75caf8de5dd614900e51b3f602a07a0acbcee9ecc22ba9e323c5d0cdb"}
+            ]            
+        }
+    },
+    {
+        "date": "2018-03-13",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.6.md",
+        "runtime":{
+            "version": "2.0.6",
+            "lts": false,
+            "lts-sdk": false,
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-linux-x64.tar.gz", "hash": "b8a00bbac9b0f4f9cf03785afa2aa71e6e5d24c1035ad9865e14c259eb06b3d98a524c1f2bb1567810a556a5c2380252642b7b43d919982c89962707e5361383"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.tar.gz", "hash": "b9ccb006c62cc9ac717d9b5894b3fc1dad5713c9b870a134b3232aa803c8239a05d10826458205b52207b525b75109963aedfe12a2d280e491d5ea0437152276"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.pkg", "hash": "6fc023b8c03c049b57597122ccd4c471924986c8962b903ebf296be394013fb18222deba5ea1dab0663d5c064640e6b11c46b89dc68452a8a34384bf84b74f41"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.zip", "hash": "ba29f7386f4d4adfd81649798cca730e4e8d40c4cf041e084bcfb3ee8823a789d4fada73c6ff1e323d376cf8cc3704a8b0c3d18515445b1246a98c99a1c9c087"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.zip", "hash": "c139ee4f8f65581d908efad230111948abb29431c26d058995386d796c71890423ef0654fbc6791ac6e1a889ba2c0bb755c58ac08232d9d009da3e7d55da60d1"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.exe", "hash": "a74bab1888f6ae973c35d78c21f382c5945a0f1d6ecce10f2d8e9219b8e400f4db7600f3a6f8d580e0b0ed853a40b9f8d81a77492e30d21188f793841be62aea"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.exe", "hash": "d5c185982e31fe6dd5baa01c45fe2e75d36a962b189511a69591639da9501a9ba9ac9a8e6b94160a06acb22953e235c5fb14b4a120e62537272fda872482fc4e"}
+            ]
+        },
+        "sdk":{
+            "version": "2.1.101",
+            "vs-version": "15.6.6",
+            "csharp-language": "7.2",            
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-linux-x64.tar.gz", "hash": "d231ac3562f025b848497eddbcb254cfd547bd622b35dc4b1ed5bcd29153f832610b77cf7edf15d9f05c707d4d06abecbdcd7633fa721246d6d7ba61d78eea81"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.tar.gz", "hash": "d8465acf3a0410ca6a35847e79d8063aaa46cb6d3704ef53f9257e49eaa0242aa2b7ba64eeb625ef984a7109b733988b3b400816bfa0ea09c6db9ba5a7d3de30"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.pkg", "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-gs-x64.pkg", "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"},
+                {"name": "sdk-mac-x64.pkg-nj", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-nj-x64.pkg", "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.zip", "hash": "7973c10b7cf32d71a1e564967f85e00f293f948d4f3ff58bc0a3ebdb4b936b1e5d2e247166f40e6f82cb4ba3d9fabc3d72ea78e145f76789c6f26ae5550acdf6"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.zip", "hash": "794901f629921c2ef8db9de9ef984725a3b7f7b165289294593f4add34a5abb456d1165b90cf63df287d22ba21d06a136086e4db37a63c74196332608f18b0e8"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.exe", "hash": "22527e8d3ce51189707c411bf67a23d3745bd39f994b67d2a5004f3c143439d3583d7df3935b89f5a3d58ac5a51970c2ee61043897258d45c3fff74e95091fe0"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.exe", "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-gs-x64.exe", "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"},
+                {"name": "sdk-win-x64.exe-nj", "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-nj-x64.exe", "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version": "2.0.6",
+            "lts": false,
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/DotNetCore.2.0.6-1-WindowsHosting.exe", "hash": ""},
+                {"name": "hosting-linux-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-hosting-2.0.6-linux-x64.tar.gz", "hash": "f70d88731859d63b632851c0a2214a6dc6c041fadfa291c97ecc5a84b4ffcd3fda89d7304fcb79392c5bbb354d98cd03bb83d4c523ce4b404bf429fdac016dc1"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x64.exe", "hash": ""},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x86.exe", "hash": ""},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x64.zip", "hash": "6dd368be3c46e920aca55a982866a77b6d599daa74b29b87db4a3346d5d05515c3f9f6d7bff501ec0afbd7f7edfd95a8bc47c5166486c5e57fe6642e86259a01"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x86.zip", "hash": "4f12f9fe3007691cfc98bf8d7026b4c0fb1785ac5fe95af692c5355275d0ba0d4a3b4b5088c587b1ae815b46b881c63a8164ef61c45d52dddc2613bcccd67e61"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-osx-x64.tar.gz", "hash": "29a4b4905866d6cffb314122902cd78886deac91a6348256b45f625f8461c006b790daac2318e58393280c164ce80e5a92c083123cca54859a785c23e2b1fc6e"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-linux-x64.tar.gz", "hash": "178f9384a4010daec34a9846fe2dc597e3dffc7170ffb889cc82f6ae6bf9aa2e93254c64af90a3ee3f8f9e024d6615f1f1857eacded6ef1bffd7601ad32eff5f"}
+            ]            
+        }
+    },
+    {
+        "date": "2018-03-13",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.100",
+        "sdk":{
+            "version-sdk": "2.1.100",
+            "vs-version":"15.6.1",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-linux-x64.tar.gz", "hash": "71b55610baa809017ccf2c133b3238344e6e238128ea3c6302e3d57ccdf88629e70f48e5cf086ed62c72101d224e94092d8776fcd42528014951dc49f578e72d"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.tar.gz", "hash": "f0ea5bd796f58fe2544b00331cc88cf54639560135107409cacbebe8ce8ee1fce2c905379368433c4b275080a72526df087df61837d3150c6feae5e7fff68b87"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.pkg", "hash": "1d60d14e201727681d3206286fef873e613590c51b6cfa6ea4db23c1444b89aebeaff6c7a1619dade2a0cb6ab5b5f8bed28f92b73b6d6051fc3b113251d9081b"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.zip", "hash": "7d221f9f194154410ab8be064e2bbc02d84c3067bb511cba78b4a2b57b378a10860fb0a2d0fa75e4ff992d9f76fe132df7afde056ab8e78b2038aba1fd3cfdd6"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.zip", "hash": "dbed1bde38f5ff5b97d75c7bb45a84dfc6270093f8e8bce124f2318e28b9dbd60c21b373e7862007bff28fe7b21a45a3cd754f4fede4ad70cce070dc7a2fd14d"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.exe", "hash": "1826f5ab39efad23e1c7aef844d6e5d2d0aef5bc2bb0c708b4e3dfe577fe4b8d715cce2d754cb5774c15eea888ad260f83e4f6018092f4ceb327eb68910bb63e"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.exe", "hash": "7fff3190e67f70792009ff9f15999757f769182ef7256bbb5133382f139ef5cdea86c724dbdcfd7763dd48f9619e39778238502b59d5cc4f05af4e055a1b789e"}
+            ]            
+        }
+    },
+    {
+        "date": "2018-03-13",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.7.md",
+        "runtime":{
+            "version-runtime": "1.1.7",
+            "lts-runtime": true,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-osx-x64.1.1.7.tar.gz", "hash": "b4068d5551017208879f6e9fcb887d630b13e5bca992478fb543a291f42d3bfc6071f8821aabcd0baa1f9ef4d18f22dadfb9218f8eba98c63c01bbd70339a7d6"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x86.1.1.7.zip", "hash": "623dd7438b925c7063820a60e1fbe09011cc429ee325e519462fd537dfb17b53402b896aa89ffa09f695866166a410ea28cf1a8e92a9749ffc924c64034ca804"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.zip", "hash": "43a414489f2bcc492a7b8874e0bf8d2693cf2b2bbe0720bf9e574f81e2537b1c509a801b56a6e49d755a9ee67da0d18a10a303a1acb23b69819898238c9ad2c8"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.exe", "hash": "16c1356c809059a767f17156fa2529cdf1ccddee0d6d18b3a10899e7c4de6a843fd4f1ef553297a329a6c76b8c22c9335a47c32072e8ef4860f5e9c627b003d6"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-centos-x64.1.1.7.tar.gz", "hash": "cd99355697c5afeab3974b6b1a4ddf49ea74a4a8b08efc54ed9b6a561b665a6d1c59254965cfe59f8f5eea00d93bfeaf9684efc70dc4e339d6976e11f6104a6c"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-debian-x64.1.1.7.tar.gz", "hash": "08e26b44547025e6b3edc75e6ad75c5a81eb4f6dcb0eda0452edaee1e66d04d2fa84914842f495d978cb9b8917eda192d0041e0548232a014e0e919e21d7d1a6"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-fedora.24-x64.1.1.7.tar.gz", "hash": "22d2d6b1d3ee21ecfb256a0fa257d1a14a83689b63f0560ec58c88ddfa33aeff9800c5c62dda03abeff4966247d50a80b76db5ed3b6930448fd576b85e36f229"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-opensuse.42.1-x64.1.1.7.tar.gz", "hash": "945abd08d56e1f81bd162af8ddf881a920a3f6d42790d5536cc6763dd82b8b0320125b9970ddc4d866657f2d07461b744b830f2d09ecc57d0bf0c120455e5206"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu-x64.1.1.7.tar.gz", "hash": "621158af199e26c6fe9eba69dc934397b644db58ee63dd815634fc6b7bbba38b244ecce957aced307547df8e4725a6aa7a3039ee2e1eac8974c0248f662892f8"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu.16.04-x64.1.1.7.tar.gz", "hash": "6e43dec9222b2d72e9ab763ee00e6f0244b73e9d02d129846afae00a474cf93656e85c5434c69b580015661f9bc5cb8fbfe09bb1f98d9df9dc6c5cc5921f3359"}
+            ]
+        },
+        "sdk":{
+            "version-sdk": "1.1.8",
+            "vs-version": "",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz", "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-sdk-osx-x64.1.1.8.pkg", "hash": "39f04d5bb258915794b91f0c39486f8a405fbff3bcd54524243f6685822824a605da9f2c694c0a966b5f27cc567346af57ba25d5381ea9fcbee3ddb7273a7f8b"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip", "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip", "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.exe", "hash": "278304c8ef455e3c0d24d5b9dc3c2d0019b1a429d968e4a39f499b8e63636685ef6cfef38a50b954fa24189c3421f9a3d157a0113064af09bc55f66f391a0b8f"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz", "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz", "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz", "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz", "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz", "hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version-runtime": "1.1.7",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/DotNetCore.1.0.10_1.1.7-WindowsHosting.exe", "hash": ""}
+            ]            
+        }
+    },
+    {
+        "date": "2018-03-13",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.10.md",
+        "runtime":{
+            "version": "1.0.10",
+            "lts": true,
+            "checksums-runtime": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.10-runtime-sha.txt",
+            "dlc-runtime": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-osx-x64.1.0.10.tar.gz", "hash": "326cdd0bad8529a954ff407b8387eb054b97af739b1203a559a9433220fb988b1ef120bbf0abcfc953d9bd5304b8fe0115c6e0d181e7518be948500c5e89d6c9"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x86.1.0.10.zip", "hash": "5a0a281e4e65d4ae08eacbb8bb57f1431992e5de1be1028f9bd1b7dffd124d424b4d0521a0bb606f5bbf9e77dd658868ac9c7c848d591d14a2d5852cc1a8bb8f"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x64.1.0.10.zip", "hash": "3e31fc8ee712184707c5a811944aad444019cb71b3feced22aa96ad0cf9a6e2bc31a36271414202b24d1039c5ea3058ef7e6274775df6dedc95fa249651e277b"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-centos-x64.1.0.10.tar.gz", "hash": "ea6ca96aeb2940937ea88815f061f3721cc04a1335228984476d5f2e46037136b07abf1241a7ffaff69b0ae5dab6627f9c22ab778c92361687d330fe0da786a3"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-debian-x64.1.0.10.tar.gz", "hash": "21e57ed1934a12c44cc0de17cf212dadc07654e398df85ef9a79e233e1095c086eff2d28a9e3129c4f93a979237be72fa5a7934f04217fad2d0a487470dc167b"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu-x64.1.0.10.tar.gz", "hash": "87e0df0cac7a3700fc80801b8220f77fedae464b925ebeb83e8059c61258ca8a0ac0b46463b1e0fa0727a75c371b0f1a0dfe30ad7fe164cc4f06e9e38c349781"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu.16.04-x64.1.0.10.tar.gz", "hash": "979e24f6b1416157290e7fe983d28325a9d1954366625ebaffb167901ba68bd68ce5d2e76ba5c8e147a2c6a303e5bd922ac9f2175a452e0c2a190d28eb3040e3"}
+            ]
+        },
+        "sdk":{
+            "version": "1.1.8",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.8-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz", "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.pkg", "hash": "f1d438376839cb9343b2a893608a482d91134e4fa4aa1bc015b50ca58e9aea419043da134102496f13c9a90302abeaf9cb7b07df4e2dfaf528b3614f84847ea2"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip", "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip", "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz", "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz", "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz", "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz", "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz","hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"}
+            ]            
+        }
+    },
+    {
+        "date": "2018-02-27",
+        "security": false,
+        "release-notes": "",
+        "runtime":{
+            "version": "2.1.0-preview1-26216-03",
+            "version-display": "2.1.0-preview1",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.0-preview1-26216-03-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-linux-x64.tar.gz", "hash": "0249b32f68d1266e6f481e16266b4b2d027b1644d182da31e34ef3c60b37fc755c5f85a482de6c85cdf095c8185221f666c7d6bc62364a786f0f2f8b72919c88"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.tar.gz", "hash": "47431a5e6126ebb883d8e8a18ea7327dce285da41fd809860597c9574ab1e35fb323933f743a49e7a5078fb6e41740ec4611f5e1ffddd3114379f0b4db30a8a7"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.pkg", "hash": "8cbf0f7cacbb537619c580ff8ec7ac012aa40196ac00b2fbc2514a5097c878f766158d79a72e0582418ec20c6d98be7bfa81867c55e989b7da055f0942307ad7"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.zip", "hash": "1c6c6a6821eb5e3435fa57c2661584c4118a5a951f5f7df8087922f692859ee230566dc806b9a48e8dceed703f157cac3ae3619c645e18db487a8f740db4ed95"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.zip", "hash": "511447ea54aab82b9b890936440fe08a0c25e7b579050ec7706bf9212a58a31cfc56420a9de8775a7bf3bc1e39143045c542617c065e59b471323eb00567f9d4"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.exe", "hash": "8ec6e0efe7134b79debea41fa7bb45736f7a317260b15955c33d018ccf21fc13c46f1b30f4d0abed385ba76437d3be861e97fdc12022b99bc69c31cf22497214"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.exe", "hash": "b7830445ac00a37718ed1b3b563fa323ca5889484141d9dd30e9b46b004c62ac2c003cc8f8bba1d4266ead62966817c93dc21c36f0660de3867125dfaffe04d3"}                
+            ]
+        },
+        "sdk":{
+            "version": "2.1.300-preview1-008174",
+            "version-display": "2.1.300-preview1",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.300-preview1-008174-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-linux-x64.tar.gz", "hash": "3030d6876eef6770c54e6d1e23f1be544b72dfe171915d2e55e00e40faacec0035fe4f9d72a6dc5fc5fb29b768ff64c57dcce0b9fddd8f1b7f7ce8389f535da9"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.tar.gz", "hash": "65de990bdfd131f9246e5b47480211a2b829c73b1dd0248c6c32417c0489539c15d98d12ffd70034a69b952b49a89eb79360eb9e0f34802706ade2563c78e1c4"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg", "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-gs-x64.pkg", "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.zip", "hash": "e1466e7652e7787206c06f2e642f10bf8815a8d02a06b8fb4db7c7941bdb64463c10a4dc1fe59b8c768353404016fa384a00c5b14f228272845f6a75f14f1896"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.zip", "hash": "d1195ec86e745854735c2d8431858987b937963d5b96dd2f1fbecfe8f3b9c4259fbd9454fc7e81542aef117903a0674c7aba242bef3a761a9c8237f71286793f"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.exe", "hash": "bd8a9145f651026cfa1ca7c264c2e05b3740afc0b5f8ac5572409a95836d8f87e1a8c460eb985182501f679b721a97fd174b7690ab8cdc5e43c8155ee8af94b5"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.exe", "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-gs-x64.exe", "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"}                
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version": "2.1.0-preview1-final",
+            "version-display": "2.1.0-preview1",
+            "lts": false,
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-hosting-2.1.0-preview1-final-win.exe", "hash": "4f2b8bf998bbda10f32cad96b5fa15bc944f321afe97e9a21da3e1984d25aa4cc39fac5c138e88ae126b7e3db78f07149517a38acf1066f8e5d2321044f76aa0"},
+                {"name": "hosting-linux-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz", "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.exe", "hash": "c14bfbfc0ceed63e08340384ee849ab9700f708486a3d09c4cb4651c7989a920563e008faaa3809e13e610231576cd55e3e676bdfb8e31c24f012484c4cbf433"},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.exe", "hash": "8f114a4842d6f30c16b929f163e2c88428de25f2477baa0d4a0beb5965e7dd05c7c6e52d305ff1da9d3377bd3f7f6bb766a78920383a732542b1af30cad7d162"},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.zip", "hash": "3a56bdf4ff099bd8f51e9b6b06a3bf3c34ff9769bbc655d81df2660be3af0de4508d97295e820fb3b04f7c79c3034b313509ad7cfa897636db8afab2115b8b63"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.zip", "hash": "4792e530651ef0a276218e3ffb7c7d4e0bbd44d68eebb384f2f4f627024b4ba69d74ddce8fb9a6b2e0d9b11910bd7dea542c3b19eabc2e9396d2475ef681523c"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-osx-x64.tar.gz", "hash": "f8c78d7ea16f54d4ed87aec532b57bed8271265eefc3134647b50d760e6bd7fe001eaa6fdcba5d15d2db5330f3bc82ce2ff0b88b5bfedeaff53cf42143e2cc47"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz", "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"}                
+            ]            
+        }
+    },
+    {
+        "date": "2018-01-09",
+        "security": true,
+        "runtime":{
+            "version-runtime": "2.0.5",
+            "lts-runtime": false,
+            "checksums-runtime": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.5-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-linux-x64.tar.gz", "hash": "21d54e559c5130bb3f8c38eadacb7833ec90943f71c4e9c8fa2d53192313505311230b96f1afeb52d74d181d49ce736b83521754e55f15d96a8756921783cd33"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/otnet-runtime-2.0.5-osx-x64.tar.gz", "hash": "993dab75a25b961b474f147bf42273b86b561c1823cb53458aa864599003f131880b54c5f31241bcbcee7b89b9a21bdd90d0f43fb440e2b9b5a1266f624e2e45"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-osx-x64.pkg", "hash": "94de569a3124ab1de8b52d82dfa48bf58bfb85cac532a20b1111704d31bb0c8e361f4074d7ca3cca7d0e21a7e90cbcbd2a95361cf62b2cd4cb74424c83f16bee"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.zip", "hash": "671fde7ff5a64738de7863feb8501692f4b62c2496acea9e3c47c381f14e51805f9e7237002ae63bc71189431411de0e051ab1e23200bfbe830a254ec5f7fa8e"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.zip", "hash": "5a4381d01d7b7769254aff980bb4a333aec41fdfe92e74bca95147931f1500a1d391ae8da873bc802524a83899e270e24e30faf3759a121505aef110fe9902dd"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.exe", "hash": "84dc1b30e36dc0aef5cc7294aeb43963570bf4bd6fd824ff9c9ae9fe5c7bb574b9b2a48d299d526097732879317ce92e76f9ac1b034b8c14eaebb27297b4401b"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.exe", "hash": "dc6c0f438258e8a5ea825809cc5d7e3f0e69d6aa233894086ffafafe8e539d707aac1abcf4f56ea324fc54f578b52d7796c2b828c26bb838b9b94299bf754c20"}                
+            ]
+        },
+        "sdk":{
+            "version-sdk": "2.1.4",
+            "vs-version": "15.5.5",
+            "csharp-language": "7.1",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.4-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-linux-x64.tar.gz", "hash": "05fe90457a8b77ad5a5eb2f22348f53e962012a55077ac4ad144b279f6cad69740e57f165820bfd6104e88b30e93684bde3e858f781541d4f110f28cd52ce2b7"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.tar.gz", "hash": "1b08705b8679bf1800d40908408e0d8c1fac7963f6ce508710cf6425cdc1663fd46526e8b6ba8a67d6d327e6bbc143797aa7be4acfdb5205d4d3143de3951849"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.pkg", "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-gs-x64.pkg", "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"},
+                {"name": "sdk-mac-x64.pkg-nj", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-nj-x64.pkg", "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.zip", "hash": "e4d4872733710ddb93bb00fe724a63be4c7fb352d120841c255a89fc42c3e81da8749c201f63ecfc0e86cb473c9854da719e92a3e665f0c380c3e7cf862b1db3"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.zip", "hash": "955e20434007592f77fb866aa8543ef13efdc0b1cb91f0c946824f60d8726db5227d1245fbeb7409f93293cf918d50b99f96b0d4512b62a70577e69874f8c777"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.exe", "hash": "57703986a5c7eea8ceee265ce206a047e85dec5c698ad570df74b68cbfed36026bf70aa454924ec94be4d37ff492c76716beb23e12ed98816e5cb8e25eeeff0b"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.exe", "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-gs-x64.exe", "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"},
+                {"name": "sdk-win-x64.exe-nj", "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-nj-x64.exe", "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"}                
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "files":[
+                {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/DotNetCore.2.0.5-WindowsHosting.exe", "hash": "98a577cfee15a521484972fc7b6f212ccc37141502b417fcb003b29e67af732b6018b01dbe7b3eca22dcad7ec4e6fbb4f01898a15ffcf8342d7f4f5712eaee1c"},
+                {"name":"hosting-linux-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-hosting-2.0.5-linux-x64.tar.gz", "hash": ""},
+                {"name":"asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x64.exe", "hash": "df4576532b715c9a8b7a6797458982d156a05acd3f676a9261886f892a98ba3fb71db17027c8ef065ae9792beedd4f4bd82f3791fce497ed9cff38f4139d978b"},
+                {"name":"asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x86.exe", "hash": "c5df5b0b2f1848c9a797d44cb464061c99c367ecdd6f05cc93aa82b49b2191f7122043bfa34349673d5b2af7018f7062c6be2e0f3fb1e63afad34d2ffa7030fa"},
+                {"name":"asp-runtime-win-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x64.zip", "hash": ""},
+                {"name":"asp-runtime-win-x86", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x86.zip", "hash": ""},
+                {"name":"asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-osx-x64.tar.gz", "hash": ""},
+                {"name":"asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-linux-x64.tar.gz", "hash": ""}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-12-04",        
+        "security": true,
+        "runtime":{
+            "version": "2.0.3",
+            "lts": false,
+            "checksums-runtime": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.3-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz", "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz", "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-sdk-2.1.2-osx-x64.pkg", "hash": ""},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip", "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip", "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"}
+            ]
+        },
+        "sdk":{
+            "version": "2.1.2",
+            "lts": false,
+            "vs-version": "15.5.5",
+            "csharp-language": "7.1",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.2-sdk-sha.txt",
+            "files":[
+               {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-linux-x64.tar.gz", "hash": "0f1006a5844f860242abb42c8d930f50dc5116ff5a3282b3cdae01ed9ac75dbfc6c74dc3d201358832082d7b6d0aa29b55043afa0493f61892e748c1cfbd0afa"},
+               {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.tar.gz", "hash": "078df91dff760652dddb8090967a59f552959f8b2cf217188793eb8dc21a47c797f22f334f8d958959a0184e0cf4ec2648549478188f8d32e4686cce7c87d699"},
+               {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x86.zip", "hash": "db638b7dff1f384f136da9358a57393b2a5f0365a663beda08130a3fd5694ac8660f8a02823f39490b435d9c96e45a475e848448fffef0b52824f7e54d08cf76"},
+               {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x64.zip", "hash": "1b0988b048cc0d4aa7f6335a35e873d343546d1f11e2c19e323138205cdeefa8e0961390fb9477e750a46ec244ef9886ac83b6127ddcdfd77a75550d4aeeab27"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe", "hash": ""},
+                {"name": "hosting-linux-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz", "hash": ""},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe", "hash": ""},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe", "hash": ""},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip", "hash": ""},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip", "hash": ""},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz", "hash": ""}
+            ]            
+        }
+    },
+    {
+        "date": "2017-11-14",
+        "security": true,
+        "runtime":{
+            "version": "2.0.3",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.3-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz", "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz", "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip", "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip", "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"}                
+            ]
+        },
+        "sdk":{
+            "version": "2.0.3",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.3-sdk-sha.txt",
+            "vs-version": "15.5.4",
+            "csharp-language": "7.1",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-linux-x64.tar.gz", "hash": "74a0741d4261d6769f29a5f1ba3e8ff44c79f17bbfed5e240c59c0aa104f92e93f5e76b1a262bdfab3769f3366e33ea47603d9d725617a75cad839274ebc5f2b"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.tar.gz", "hash": "f3f78ed62c1c7b996a62e591843bc34be5d76d083d257c8a839049964c35d3054d56437ebf0f4890c96396d8f230a91ae8e9c64f030ccd3b62c8e18032081c1c"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.pkg", "hash": "052f42870a42f97a3f25863386d7337ff176258e775787ab0f567231337ebc62eec1f5ce7cf7adaf31b377aec7942be52a024bc9c2572dac69501c046b5a7ceb"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x86.zip", "hash": "37deddbfc1a8ea72da4e864343bb4374bd50d744e1621910de30f8d83eaa3860b14f262750810a7ff66f8ab05a587cd71a935a130acf499257d8d4509e0b3cb2"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x64.zip", "hash": "8b4bd2174f413f9043374d0cfa7d4061f0aeedc28c16257e66b99f28454bc0a898c6f52d4cf8349413ae222b21e6f594a8f70c1892844a0416e2be2994af13f1"}                
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version": "2.0.3",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.3-runtime-sha.txt",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe", "hash": ""},
+                {"name": "hosting-linux-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz", "hash": ""},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe", "hash": ""},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe", "hash": ""},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip", "hash": ""},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip", "hash": ""},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz", "hash": ""}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-11-14",
+        "security": true,
+        "runtime":{
+            "version-runtime": "1.1.6",
+            "lts-runtime": true,
+            "dlc-runtime": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/",
+            "checksums-runtime": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.6-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-osx-x64.1.1.6.tar.gz", "hash": "216d4489d6d0f6cb5c1fc08e36fbf07ec051760abdeed4027dc3a21239424f54a958ae46d0e2428418a57a0cd5273adac46d63725369a8b9a0ea99a32589c90b"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x86.1.1.6.zip", "hash": "03809a2c1ef3b75e3753e92c82063304915132991f42f2ad3576e2076fd3b56dbfa586896b6539bdf1c3667f09a32fc745df683b3fa38636d3027642b082d45a"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.zip", "hash": "d1562159c16764d8313cf039e8fb59aa777acf9a479cc34db9665022053765f4608e6633d6fddb490aa40e2fdfe6248fc4d29265958648029d07a5bd27fe4a80"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.exe", "hash": "57a4beaf70dcf38c055013a9595970c1e5a997f48a8091553c5cd69e3b7cfeddd3d2f2848007e0319ba546c97a5e211c46a59421c6e8f0964b8db1d9523ce9e5"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-centos-x64.1.1.6.tar.gz", "hash": "e5cf8a038a613241426a878751fef23fefac674206153fc9e7cf12e5f063eae2916e74a9a9a51b18075aeabca62f4651d6ac5b466cd60feaeae6a721eb6de3d6"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-debian-x64.1.1.6.tar.gz", "hash": "54c1d4a3a0125f177f4e61e4a3c4d447cf2ee18e436e2e62bc435d081b6cd9d9255be7130a792d4a667e2fa8940f8e33ad9596f1c08cf8f02340aa6cd3d4c361"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-fedora.24-x64.1.1.6.tar.gz", "hash": "bcc570398f9a3148dff1da6627cc4b6ca397806db74b80881c4719ff815ac09a35298eee59c19b8bdfce05c8ce6c71ac4ed172558127eade4c680f6f58755243"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-opensuse.42.1-x64.1.1.6.tar.gz", "hash": "83a282254ca690de5e10e230614e28b48a18b58ba0ff390ca15d06b88bde5ea786c1915055e3d78d2a9e10c9164dbc4562d4a0ca650a24591435e8c584900505"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu-x64.1.1.6.tar.gz", "hash": "503e3d9e3adc87e90114e2e54fab7cc14c94f9df68961e77da996f293da8c8f50cb5b9a089ba7cddd2cd09eed3c3c357e4a8b52eda0f0d7f5e220fcfe41df140"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu.16.04-x64.1.1.6.tar.gz", "hash": "bc8aa9990a99df631338af0d796ca0e51e452001e0593e22d3835621a45f7e3404f1214395e36cf64793d829702dddd4724c66ad841069dcac495ea4b57375db"}
+            ]
+        },
+        "sdk":{
+            "version-sdk": "1.1.7",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.7-sdk-sha.txt",
+            "dlc-sdk": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/",
+            "files":[
+               {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz", "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"},
+               {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.pkg", "hash": "080313d0b501502829e043f417fb2ebcced2aeba7640b84d83175dba25faea7219ee2f301aed7e5db857300e600e2d6b42a35cacb5d7bebf7569df193318666f"},
+               {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip", "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"},
+               {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip", "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"},
+               {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.exe", "hash": "94daa61ccebed6925f94b921af74ca3fd62c086f4680116fb4ca97c03c79b50910dfff5a7f4e957d72fd8f6d27bf07223cb29588b107181adbe3e9ec641186db"},
+               {"name": "sdk-centos", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz", "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"},
+               {"name": "sdk-debian", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz", "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"},
+               {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz", "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"},
+               {"name": "sdk-opensuse.42.1", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-opensuse.42.1-x64.1.1.7.tar.gz", "hash": ""},
+               {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz", "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"},
+               {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz", "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version-runtime": "1.1.6",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/DotNetCore.1.0.9_1.1.6-WindowsHosting.exe", "hash": ""}
+            ]            
+        }
+    },
+    {
+        "date": "2017-11-14",
+        "security": true,
+        "runtime":{
+            "version": "1.1.5",
+            "lts": true,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.5-runtime-sha.txt",            
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-osx-x64.1.1.5.tar.gz", "hash": "ac538259ec3ac7cad13f9b4d3e1303e70b5a641d197e4bddbcccc4b91ca170fbdb0cc17fd9224efdb14c767b94d3c37997440e3e51750b8bdfb88060d4532516"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x86.1.1.5.zip", "hash": ""},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x64.1.1.5.zip", "hash": ""},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-centos-x64.1.1.5.tar.gz", "hash": "d32e844c01fea03cb1906fd9d00b91a64f21646993748f8569d02ffeed28dc89a1eedcff60eeaf1ebbb5c7b0176ce360b929582f48725c13415b0a8f37d992b6"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-debian-x64.1.1.5.tar.gz", "hash": "2d8e2a4f17f6986d1d1cf5f8191aa94f858e2121efa9283a97ac5ee6c8b2ed8c169f0312c6797e1fbcfdb981f501f38dc710ca95898d63a859597081523df095"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-fedora.24-x64.1.1.5.tar.gz", "hash": "2d813462072ad7cf31529835d6be9afa55cc47c08b3fa749de337f5f214eda520d9b071aa67a2325c9f16711366a58380caee5c76372a747b4fda550df6dfaef"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-opensuse.42.1-x64.1.1.5.tar.gz", "hash": ""},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu-x64.1.1.5.tar.gz", "hash": "9c3d08ad516ad85ce9f5ce0118b550232d5b67f8466715ccfda8b98ab350e5535d66573525691a58dd2499bfb32446cc689d713efb05ddf672af18b862ecab84"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu.16.04-x64.1.1.5.tar.gz", "hash": ""}
+            ]
+        },
+        "sdk":{
+            "version": "1.1.5",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.5-sdk-sha.txt",
+            "files":[
+               {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz", "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"},
+               {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip", "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"},
+               {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip", "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"},
+               {"name": "sdk-centos", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz", "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"},
+               {"name": "sdk-debian", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz", "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"},
+               {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz", "hash": ""},
+               {"name": "sdk-opensuse.42.1", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-opensuse.42.1-x64.1.1.5.tar.gz", "hash": ""},
+               {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz", "hash": "6024e9e5ca8a986c6a63ba1d4d89234b682157f2814b379cd8d2890699f5d4acc197a5ae7204f136fd1bc2bad15c9896be99df6648a863dd1fb8e4758ba0daf5"},
+               {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz", "hash": "0f666b7cf806cde0c5d93788bbf6dd4d808417aa0c1bdbdb1453d8046262188f8e5dabf593076d296e60ad77f34d858efd3137045943cec54e6d61ccf2556ec0"}
+            ]            
+        }
+    },
+    {
+        "date": "2017-11-14",
+        "security": true,
+        "runtime":{
+            "version": "1.0.9",
+            "lts": true,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.9-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-osx-x64.1.0.9.tar.gz", "hash": "f1f0210f9517e274b13d33c49ec3641b8d3248874f28b00d278faeb792ff88cee431d43af300ef7423122776aecdb63155d1a2f84d31deb7c9baa16237109d78"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x86.1.0.9.zip", "hash": "f10a3d1ddb7b7302e73314c47bc9075a3ab2a8c3072f4bbd95a5340b7a1798a1964e798cec0f528ec64ce3ae947563b46b145f5da8b2a3f50d30cf0770c84a2a"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x64.1.0.9.zip", "hash": "1d632c7392c35677c9e549e3559bd31e1c203d0523d502109429cb89512a6dc755030ded4f30964a48a59ac636ef1fda3617ea62b34204b586309b18f0109ecd"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-centos-x64.1.0.9.tar.gz", "hash": "bbdc00f11b391e6e89818e74a32cb3a9ae13eb9e9acae5409a2a4b00986fe4968be9e325638adba4b119cc82cb33111fa36445c2beff07f098233b22b752bddc"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-debian-x64.1.0.9.tar.gz", "hash": "3d11fb2881fde022dba3453816192e10845f09fb6d5f7cb83d8f2691161e73cc3b459516cd0ba5e425c430844d733f4b61bdcd3f0a3b9ac4bdb5d0b06ce91438"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-fedora.24-x64.1.0.9.tar.gz", "hash": ""},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu-x64.1.0.9.tar.gz", "hash": "9dd1de2f20b278bf9ad8b7204fee67e2597ba03afd20a16e667430b1c89ac69101df54ef04b7d4dc9600eca558f868ad3b8189ea8f0e2ef359b05a8c2ef4e9d1"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu.16.04-x64.1.0.9.tar.gz", "hash": "65e85314ed2085f1e5a4ba641174c7120002cdedc5abab673e87606beffa842a5ab9f378992a9a7358ffea2104d084b7f90a822d80990a8e492fa24563b4fa5d"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.1.7",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.7-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz", "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip", "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip", "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz", "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz", "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz", "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz", "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz", "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-11-14",
+        "security": true,
+        "runtime":{
+            "version": "1.0.8",
+            "lts": true,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.8-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-osx-x64.1.0.8.tar.gz", "hash": "1e513f3f41518aa6f37ad138d711d32dd1031ec37f2e8c98835c7aa65425af9a95e153eecd18600a8fa4207c898d23721cca36c16006d538f3eb3e5b3872242e"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x86.1.0.8.zip", "hash": "2761942eebc13152d79fd697e361bdea711c04668b7587d89360972fadedefa55eba2fbeffc580d10d191cd3b3fde7a4fa6a99522af5278b1dace16d57967298"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x64.1.0.8.zip", "hash": "63af1fb406ba14b75fb9386036ed129a96bdba8f4bf3d7e3410c33e723163116c63062130113441fac4aeb7c343f24b20eb785a2c82d0d1b162dbf516f287ad1"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-centos-x64.1.0.8.tar.gz", "hash": "f3cf87b89f5daa364268e4ec3000dc20d7aac4d0b056cceb65ea1faed5ab55d9df1b3bc23fe01b32cb67cbb407e1056ffb664eb3b5b7dc30a907e9057cad3c44"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-debian-x64.1.0.8.tar.gz", "hash": "e663014f763efccadf5b5868a286bc56a432e6349042e4ab3816e3cc0a05d9e67b05113d6dfe55260cfb1c3e1a554c235813bafe2cbc2debb75c638e0c77d02d"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-fedora.24-x64.1.0.8.tar.gz", "hash": ""},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu-x64.1.0.8.tar.gz", "hash": "c639b2a21337dc5120a9d7d768057ab38eda5bf7c7cc6a307821096e7b09c136786be13278bbcdc3fa30acf0d21cd28201b6e25a1cd001ddb20709020517bef9"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu.16.04-x64.1.0.8.tar.gz", "hash": "43ef03e5598d5ed080331f91bfe543795635e15fc19060f954d8b4ad4c8ebd1a50c92527c30d73d14ea3dda332cbb8fa8ec89210beb152d5de9be2120d1892d7"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.1.5",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.5-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz", "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip", "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip", "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz", "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz", "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz", "hash": ""},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz", "hash": "e0e3e3c54cbd81bd3b2e1d16776e1b597415307e06c2415438ad482c315191d87ba99b6c4981b0e077449dbb5f453bd3facf814b4818f14e3fd9b35fcd95de8f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz", "hash": "ef32e224fdffe7d4fced2b576fa94bb3738a19ed76d01d9cf3fa67a3bc0a74d80bdb6e35a554b8a89810e17a9a3d67ebc7e1b4f1a0ac3604510d62a4f363d90c"}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-09-21",
+        "security": false,
+        "runtime":{
+            "version-runtime": "1.1.4",
+            "lts-runtime": false,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-osx-x64.1.1.4.tar.gz", "hash": "58e93d00ddcaa14d58150f923b700c6190c87b1609d59040a262625853eae136"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x86.1.1.4.zip", "hash": "265ec7d4b178e5c03e4b8250d0f368de714e3205c90180de71a3c514251d8eaf"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x64.1.1.4.zip", "hash": "51a363fb5378f461e67793954e452cbdda4fbf825e7718e286c5ac4250c48b77"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-centos-x64.1.1.4.tar.gz", "hash": "4b35bacfbf56c22e389739a4750b4773e51907944d4e24e4f5fca0b8355a83c4"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-debian-x64.1.1.4.tar.gz", "hash": "8b3f0cd9a100a41436f316952128c0bfbd9bafc2808734599c643345de2e5304"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-fedora.24-x64.1.1.4.tar.gz", "hash": "1897ef8729d3356b6f3b19b20ccdb744d49c78f2b05014282b98e7ce53e0a3e2"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu-x64.1.1.4.tar.gz", "hash": "7948d90eac05b56a7c37a8ac37a5c83012843feeaa0194dfb079a90db9717e6c"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu.16.04-x64.1.1.4.tar.gz", "hash": "fe412836910718d3f91ea5ba815a116f5fa872ac0a9ff683db2d8670aceb9b56"}
+            ]
+        },
+        "sdk":{
+            "version-sdk": "1.1.4",
+            "vs-version": "",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz", "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip", "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip", "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz", "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz", "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz", "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz", "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz", "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version":"1.1.4",
+            "files":[
+                {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe", "hash": ""}
+            ]
+        }
+    },
+    {
+        "date": "2017-09-21",
+        "security": true,
+        "runtime":{
+            "version-runtime": "1.0.7",
+            "lts-runtime": true,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-osx-x64.1.0.7.tar.gz", "hash": "b5ec0b5d86814989c21398084fc3ee4d64d334aa9ccc34cd9300a1527d5f173f"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x86.1.0.7.zip", "hash": "a8bd2c4babda3ed2fe870f40e178e139cd75dd32489e76ecd4ed73295a117138"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x64.1.0.7.zip", "hash": "c4d338c3382507e52641d9509b2fb44b287ac11ad2f3c33b94592a09723784d1"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-centos-x64.1.0.7.tar.gz", "hash": "dc7bc1b69729e801141daac7fd6a21b9ff46be6459a7acfb63b32544d566a036"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-debian-x64.1.0.7.tar.gz", "hash": "fe8da8515029e00415b3675903fde02dade148ba44540745de3ebc6f0e0c83c2"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu-x64.1.0.7.tar.gz", "hash": "f4ffe75aa180bc609f573478e3e6a4be6ae4bd32ff1eb2aadca44141463c1f16"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu.16.04-x64.1.0.7.tar.gz", "hash": "4b12c5c5317d68922af2e93a4771186b497f5c82f00498df9d8e685ef9757658"}
+            ]
+        },
+        "sdk":{
+            "version-sdk": "1.1.4",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz", "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip", "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip", "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz", "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz", "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz", "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz", "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz", "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "version":"1.0.7",
+            "files":[
+                {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe", "hash": ""}
+            ]
+        }
+    },
+    {
+        "date": "2017-08-14",
+        "security": false,
+        "runtime":{
+            "version": "2.0.0",
+            "lts": false,
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-linux-x64.tar.gz", "hash": "69ecad24bce4f2132e0db616b49e2c35487d13e3c379dabc3ec860662467b714"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.tar.gz", "hash": "b92e6cff9e4f40d4d5126d0896d632951bc9a339dbc7b032098bf5ab76d571a0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.tar.gz", "hash": "b92e6cff9e4f40d4d5126d0896d632951bc9a339dbc7b032098bf5ab76d571a0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.tar.gz", "hash": "b92e6cff9e4f40d4d5126d0896d632951bc9a339dbc7b032098bf5ab76d571a0"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.pkg", "hash": "a70cffe0bb2b73a77c59c9de6c7080510a67cff56e519bed77055353e7f90104"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x64.exe", "hash": "ea7f9fce864932b25b6c709d3fe9e4432cb6d119658d1dafcafaac59b75066a1"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x86.exe", "hash": "e2c57d314bbba4c2ebbfb18a75a41e7948ec913e0bd24a2cae21f361b2f96849"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x86.zip", "hash": "f6f595a8f842a73c7176a16ce9c4568af756894cd67a1870c245216e4990587e"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x64.zip", "hash": "750cee101278cb3d521447a0a2ed11a779a42ee680baa32cd7a6cb5ceb8d08a6"}
+
+            ]
+        },
+        "sdk":{
+            "version": "2.0.0",
+            "vs-version": "15.3.3",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-linux-x64.tar.gz", "hash": "6059a6f72fb7aa6205ef4b52583e9c041fd128e768870a0fc4a33ed84c98ca6b"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-osx-x64.tar.gz", "hash": "6e87270e72b5a02ea4e3c4b2266d079366e0e55d6892f9dad5f64dee3f8a341b"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x86.zip", "hash": "5eaa475a12843cfff9a97f4b7d3b205eb169fd372ddfc9ddde92225e9e4c1c7c"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip", "hash": "541d4dd17023aff14a0aeb6505b200ccabffffc34ab2f629caeb994cedf8afd9"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-osx-x64.pkg", "hash": "69300051d696f5ae8e42bd79e5aa13a08116723d79c324fd248df7ead2869291"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x64.exe", "hash": "cc490d28f55b67185688ff51dc6274aea6a582e47a07e9d084437e940c69f7a0"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x86.exe", "hash": "af488629001e60d50bd0ca268de28b2ab97f6c20213be007dda763b93d51c3d4"}
+            ]            
+        },
+        "aspnet-core-runtime":{
+            "files":[
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x64.exe", "hash": ""},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x86.exe", "hash": ""},
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/DotNetCore.2.0.0-WindowsHosting.exe", "hash": ""}
+            ]            
+        }
+
+    },
+    {
+        "date": "2017-06-28",
+        "security": false,
+        "runtime":{
+            "version": "2.0.0-preview2-25407-01",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.0-preview2-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-linux-x64.tar.gz", "hash": "1fe615f179fef606b97d43ce07a491da9067716ff594f929b82d8772d461c027"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.tar.gz", "hash": "3b09436c2e03e81da9d08ddd32334d1d50906e9e03cfa94831a8cc6f6fbfeb70"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x86.zip", "hash": "e4f7630d7f4ac1a9510ce60bee712b94712b76f5581fa278b75bc7ba8ba3d810"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x64.zip", "hash": "807e1361c628f43e395f349b9e921f7340aba9a2f699142791ed5330c0918491"}
+            ]
+        },
+        "sdk":{
+            "version": "2.0.0-preview2-006497",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.0-preview2-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-linux-x64.tar.gz", "hash": "f70b6dfc4e46230001ef863b54992b32bb04c998b098ad58dd47152f348a0997"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-osx-x64.tar.gz", "hash": "97dfd57b1e3f3c6ae365654141d3670619699449cca76c3d7ef13a9f0b967ad5"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x86.zip", "hash": "2a804fcb5d7502cc6d6fe0b2fc17676c96002d64075b32ea0e3eb6240812b863"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x64.zip", "hash": "c9b0205f24d310204dde39e80b996f98b6d546ad4507723cceb2578a208e507f"}
+            ]            
+        }
+    },
+    {
+        "date": "2017-05-10",
+        "security": false,        
+        "runtime":{
+            "version": "2.0.0-preview1-002111-00",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.0-preview1-sharedfx-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-linux-x64.2.0.0-preview1-002111-00.tar.gz", "hash": "421ab6b516f68e6302878750d565a48ed7a41d6f04eedca7b03e0a8ac55cc5ba"}, 
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-osx-x64.2.0.0-preview1-002111-00.tar.gz", "hash": "10f37ee22e6c0495a91b0aaac7978305b223258e81bd4c5997046325db90a55a"}, 
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-win-x86.2.0.0-preview1-002111-00.exe", "hash": "da1cc72c84e79f1e2aef0c334535f5170339108fc07a3b026d835300370ca55a"}, 
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-win-x64.2.0.0-preview1-002111-00.zip", "hash": "df73f34c35a0ed5286e2dc0f5db545502d917221aacf04cdeab266eb013936e1"}                
+            ]
+        },
+        "sdk":{
+            "version": "2.0.0-preview1-005977",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.0-preview1-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-linux-x64.2.0.0-preview1-005977.tar.gz", "hash": "1774a15ae12dd1786d14397c691411e936cb0937d59add08cc16c89e80aa65c1"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-osx-x64.2.0.0-preview1-005977.tar.gz", "hash": "b3394f082f4aa00a25e2ef5a18b067fdd84faccb40f0863509f29dce496643e9"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x86.2.0.0-preview1-005977.exe", "hash": "44e03bb1b703745b07316980bcc7ce86792cd33865fca6e932f96a3da001fdf9"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x64.2.0.0-preview1-005977.exe", "hash": "ba2a47e5e63f2e695317dfcee928f5655ce87b2956a4de9e31d9a7a57e0618fd"}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-05-09",
+        "security": true,
+        "runtime":{
+            "version": "1.0.5",
+            "lts": true,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.5-1.1.2-sharedfx-SHA.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-osx-x64.1.0.5.tar.gz", "hash": "86228ed7ba5f4eb14565104e85f30a3ccc01c544865cdf573b3edfba1cd3bf80"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x86.1.0.5.zip", "hash": "e34a62fa697f778c90732f552aefc161f425ae735a20dd66ea5e772cdef7496b"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x64.1.0.5.zip", "hash": "c930b72b6510b916423ab93a6a4c19b334b9c2215ec2abbe446e4e2defc76177"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-centos-x64.1.0.5.tar.gz", "hash": "b4e8adebada8e140e0e5fbaaedd459bf090a2fd521dfb7c98adbb6b02daf13b9"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-debian-x64.1.0.5.tar.gz", "hash": "55481b0254a72d8c342ba6ccca3908ffb5c99d7eeb54f83dec6cc93c6b4cc3ae"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-fedora.23-x64.1.0.5.tar.gz", "hash": "aaa236d77d1ec4d8bef85761e578a59bbd5153d3af8744407605de940509ebce"},
+                {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-opensuse.13.2-x64.1.0.5.tar.gz", "hash": "5d43aaab95262cd44a017b4dc95226b1249dcd95547721eb3565599a404af439"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu-x64.1.0.5.tar.gz", "hash": "860a22f2adc783a1ab10cb373109682d32435c76b9045bc9966d097512bec937"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu.16.04-x64.1.0.5.tar.gz", "hash": "cec3ed3464a0982b92d92d46088039f302c5b861c8dd13db90d2d99eb9e7fa96"}                
+            ]
+        },
+        "sdk":{
+            "version-sdk": "1.0.4",
+            "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.4-SDK-SHA.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz", "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip", "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip", "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz", "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz", "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz", "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"},
+                {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz", "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz", "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz", "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-05-09",
+        "security": false,
+        "runtime":{
+            "version": "1.1.2",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.5-1.1.2-sharedfx-SHA.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-osx-x64.1.1.2.tar.gz", "hash": "620a98213e423301fa44abfc1ca0b15e0bc538e676cbf0344c711abef5ed4231"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x86.1.1.2.zip", "hash": "31e49e6ae491795c99221307dc829bbb57e645d568a94820a031688b6d8df4c6"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x64.1.1.2.zip", "hash": "a4ccb23a6cf2ddf9894cb178ce8e69b5788880a1e3d9d659f26fb914a4bc2988"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-centos-x64.1.1.2.tar.gz", "hash": "49c54129b39a4a873074b80691733d68ba596782f411cc6565d601aeb6229d1e"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-debian-x64.1.1.2.tar.gz", "hash": "26f6a2e247dd0b9ac4003d12cf1bd8647985255fdd7659b60e36a7a26fce15de"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.23-x64.1.1.2.tar.gz", "hash": "5cb04a3a7f8fd780af87cc6e3273ade1fe9803b7518228999649fcbc95528278"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.24-x64.1.1.2.tar.gz", "hash": "96204460bd7998e78ad2e84b1eb6821bff97c4a3dc2bb7a79cf828c5b6dfa37f"},
+                {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.13.2-x64.1.1.2.tar.gz", "hash": "24be24522531d560513c54fe4b08116a48b81be27e0a43c39f150b8e71a816d3"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.42.1-x64.1.1.2.tar.gz", "hash": "4112308f5e4bbbf38051140ee7bd47df79d4eee40d65f67a0fd1b14782da8166"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu-x64.1.1.2.tar.gz", "hash": "9032e88d43d28004ac10618ef0abac502cdeb02228297d1b51dd67c7e40cd3d1"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.04-x64.1.1.2.tar.gz", "hash": "c003ccc3942e327aed42c395bdcfacfc703f5adc5ec69246588a8aaab52b1513"},
+                {"name": "runtime-ubuntu.16.10", "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.10-x64.1.1.2.tar.gz", "hash": "0a4d4061931e0154c9186446dbc8d4c3e69ba49537699be98185d55fc24a1b56"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.4",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.4-SDK-SHA.txt",
+            "vs-version": "15.2.2",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz", "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip", "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip", "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz", "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz", "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz", "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.24-x64.1.0.4.tar.gz", "hash": "f3f049e099c4ea73342ec6448cb0eef61d81cfca7c476b989fcb0f09d918c31c"},
+                {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz", "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"},
+                {"name": "sdk-opensuse.42.1", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.42.1-x64.1.0.4.tar.gz", "hash": "91f133a77ba5ba9cd3ec5b243ce6c69ceb5ec164b2ff1fd256a28fbb73d6991e"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz", "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz", "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"},
+                {"name": "sdk-ubuntu.16.10", "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.10-x64.1.0.4.tar.gz", "hash": "9e784b554a9cb68df9ce541cc220dafcb71b185837e05420c182e4a496b68f47"}                
+            ]            
+        }
+    },
+    {
+        "date": "2017-03-07",
+        "security": false,
+        "runtime":{
+            "version": "1.0.4",
+            "lts": true,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.4-1.1.1-sharedfx-SHA.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-osx-x64.1.0.4.tar.gz", "hash": "7f999ad206b9da7f2e41e0657d4c4827e8863628a97036efa34ff74914338c2b"},
+                {"name": "runtime-win-x86", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x86.1.0.4.zip", "hash": "caa47a54f25145c680f0da1dad54f39443bf3db3b561ba84754f411cfdf874ce"},
+                {"name": "runtime-win-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x64.1.0.4.zip", "hash": "35eaf27e9643679ad53b3db94bee1b7fe56d35eb4a09afbf22b64ef63381bc9f"},
+                {"name": "runtime-centos", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-centos-x64.1.0.4.tar.gz", "hash": "c73de2a339508ee5ddcd3ac2fe524c3ab012b872ac5ad8b27d8c396d8d41925f"},
+                {"name": "runtime-debian", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-debian-x64.1.0.4.tar.gz", "hash": "1223e8456789125b0fb4113ab87c46ae58f214dec59b1c28fd2a851bfbf6762a"},
+                {"name": "runtime-fedora.23", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-fedora.23-x64.1.0.4.tar.gz", "hash": "70b17dc13cf87f9c51f772a7c85c03f1530e608389a7c0e090d8a8534c14a6c2"},
+                {"name": "runtime-opensuse.13.2", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-opensuse.13.2-x64.1.0.4.tar.gz", "hash": "a23c49d83b83d797b1fc9da0ab9d6be8026fcee26896afddbedb088a66424f30"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu-x64.1.0.4.tar.gz", "hash": "309296da11b302c48a035fadc1e6cade3aa68b2263af69f4038053db8be56526"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu.16.04-x64.1.0.4.tar.gz", "hash": "d9af9252e5987e7fa4acdc1cdd13c7a22e09336389a3429015737dca0124bc70"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.1",
+            "vs-version": "15.0",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.1-SDK-SHA.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz", "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"},
+                {"name": "sdk-win-x86", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip", "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"},
+                {"name": "sdk-win-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip", "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"},
+                {"name": "sdk-centos", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz", "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"},
+                {"name": "sdk-debian", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz", "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"},
+                {"name": "sdk-fedora.23", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz", "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"},
+                {"name": "sdk-fedora.24", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz", "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"},
+                {"name": "sdk-opensuse.13.2", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz", "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"},
+                {"name": "sdk-opensuse.42.1", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz", "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz", "hash": "d85dc4043049ff6ccf45282b6dda5484d8cd3b49554a8f18e2c45b7a0fdb24f5"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz", "hash": "2f89e03968d44824278e62f8b8b1e720a2bd0ede4be32da095a748336528551a"},
+                {"name": "sdk-ubuntu.16.10", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz", "hash": "2450b62653ccc6d6c0b5f0c454a1563d659e20c19159d9e8b59a71c744adfa9f"}
+            ]            
+        }
+    },
+    {
+        "date": "2017-03-07",
+        "security": false,
+        "runtime":{
+            "version": "1.1.1",
+            "lts": false,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.4-1.1.1-sharedfx-SHA.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-osx-x64.1.1.1.tar.gz", "hash": "a809eb4f47a8468edacfab8dfd9ddc1015a2e4ec3643fdcedd4d7c9ab3f028f6"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x86.1.1.1.zip", "hash": "0c69428e55782603982b173bc66eb24fbf80f9b01ffdf8a00f012beaab3c4653"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x64.1.1.1.zip", "hash": "b0f7fc902308b98fa8e202081884d310a94a93264a1f5beeb4632acccf2c0bb2"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-centos-x64.1.1.1.tar.gz", "hash": "2eca7129424c50bd4a312bf519e5f3add2398cc11f53e4032e233b787528c3e4"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-debian-x64.1.1.1.tar.gz", "hash": "6359fcd443c686476c6b55bfcd5fdc214a64f8f399bfc1801e4d841c4ca163de"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.23-x64.1.1.1.tar.gz", "hash": "f5813c020d0b5c507ab857a168f7faea54f745ff8b34404b85f8dc5c03aa3537"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.24-x64.1.1.1.tar.gz", "hash": "060d05dc338cb722cad94e379e354cca174309b789b686cf4e2cdfed2c238503"},
+                {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.13.2-x64.1.1.1.tar.gz", "hash": "86180fb3d67293be760abbe6a28d73a7717a2910852e8b047ba771d0fecd3430"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.42.1-x64.1.1.1.tar.gz", "hash": "97535294b174d09d685f46687d30ebc7d929afa11ed99fcc1645954b1cdeecb3"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu-x64.1.1.1.tar.gz", "hash": "bd2807bf3d5b316bf7360bddab276bc4af13106de406491a41a4fae522d1c0be"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.04-x64.1.1.1.tar.gz", "hash": "e1737cfc3df8336d7469e1c3df431abcb56f94d021a941dc33af9a0d090f512c"},
+                {"name": "runtime-ubuntu.16.10", "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.10-x64.1.1.1.tar.gz", "hash": "d2d439fd7e544e120db4fb7246ec99cad199ad8d827a78e3e4157f8e331aa066"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.1",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.1-SDK-SHA.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz", "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"},
+                {"name": "sdk-win-x86", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip", "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"},
+                {"name": "sdk-win-x64", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip", "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"},
+                {"name": "sdk-centos", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz", "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"},
+                {"name": "sdk-debian", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz", "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"},
+                {"name": "sdk-fedora.23", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz", "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"},
+                {"name": "sdk-fedora.24", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz", "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"},
+                {"name": "sdk-opensuse.13.2", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz", "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"},
+                {"name": "sdk-opensuse.42.1", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz", "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz", "hash": "4d4399e090c436e7037dc393373345aa0521b2acfa325dec80771f7adb448daf"},
+                {"name": "sdk-ubuntu.16.10", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz", "hash": "4a59413a0b2ba8914ceecb4a505dae4f93ede10cae4246d714178b11cbe32a2f"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz", "hash": "828af612b3e691f27d93153c3c7fd561e041535e907e9823f206ccab51030ecf"}
+            ]            
+        }
+    },
+    {
+        "date": "2016-12-13",
+        "security": false,
+        "runtime":{
+            "version": "1.0.3",
+            "lts": true,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-osx-x64.1.0.3.tar.gz", "hash": "7355f4a6d2b07e373a6e86d196d134a9c4167e40915e9ae9515fd36af6376923"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x86.1.0.3.zip", "hash": "135cdad343d18343386f41163462ef8755568f2bfcc31809c5d5d0c58b9358fa"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x64.1.0.3.zip", "hash": "4f984e8ca364f8524f00551f1cc7fc8caf8483b9165596538027f5112e066884"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-centos-x64.1.0.3.tar.gz", "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-debian-x64.1.0.3.tar.gz", "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-fedora.23-x64.1.0.3.tar.gz", "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"},
+                {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-opensuse.13.2-x64.1.0.3.tar.gz", "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-ubuntu-x64.1.0.3.tar.gz", "hash": "d48aa0ffc135b89838777124844df06deb12b480fa0e6acb9b4a29804e91b0cf"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-ubuntu.16.04-x64.1.0.3.tar.gz", "hash": "7193d0f922208bca47ea4e43ace662774514624e377dbe034b59a061c9808afa"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.0-preview2-003156",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-osx-x64.1.0.0-preview2-003156.tar.gz", "hash": "8923307b4c17262dab995171733a05b2f6ec9c166b31f6971795e219a789fd24"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x86.1.0.0-preview2-003156.zip", "hash": "7cf1891e6129a357cdaf0410b0f3de27ffd3b67473ac124d586d6df75cf8f235"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x64.1.0.0-preview2-003156.zip", "hash": "ebef0a9b8055d70c5ab27d5a06b933f31650e43696740c8989b877145a158aa0"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-centos-x64.1.0.0-preview2-003156.tar.gz", "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-debian-x64.1.0.0-preview2-003156.tar.gz", "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-fedora.23-x64.1.0.0-preview2-003156.tar.gz", "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"},
+                {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003156.tar.gz", "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-ubuntu-x64.1.0.0-preview2-003156.tar.gz", "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003156.tar.gz", "hash": "701173691ab79f85a071163e33309da89f7ede008804a73d36d2042487b7cc98"}                
+            ]            
+        }
+    },
+    {
+        "date": "2016-11-16",
+        "security": false,
+        "runtime":{
+            "version": "1.1.0",
+            "lts": false,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-osx-x64.1.1.0.tar.gz", "hash": "b8c28c32ca6bf677982999543feec0cea4e7275ed034e1b503451de0744d13f2"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x86.1.1.0.zip", "hash": "6e08a9753f96ed2087d189dd1adea7611e90bd88614157c1fe51cf397a967ed9"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x64.1.1.0.zip", "hash": "cc66a190edc10866494df9e72dbaf4b872c83045e26431161131459ab413a08c"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-centos-x64.1.1.0.tar.gz", "hash": "6f2a99f2aba9afd4c8470d5c423d06eec8e7dc9b2c6d2521216eefcceccdd254"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-debian-x64.1.1.0.tar.gz", "hash": "91acd357628a3ae510e6f9ff2f912fb69b7a477125a66dca8f8cf3015d87df19"},
+                {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.23-x64.1.1.0.tar.gz", "hash": "de34ecd0bae6865d5ff15898415517892caf1894301a9368c7b68a62b9e188b4"},
+                {"name": "runtime-fedora.24", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.24-x64.1.1.0.tar.gz", "hash": "4bf2fed6c9607cfb19c8b80cce74a99aee3f7549b644841d46ea47238d39feee"},
+                {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.13.2-x64.1.1.0.tar.gz", "hash": "97b98c12693683bd5bb5e3b1745f72b8e5a4e50ed72dbfe0155749135bc09b84"},
+                {"name": "runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.42.1-x64.1.1.0.tar.gz", "hash": "f1b5055ffd1e8df4bcfbdbee8c99ff81315d493d2e24ebfbcab5b324e9bb7671"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu-x64.1.1.0.tar.gz", "hash": "1c067b32dd40dd2b88a6d25c8634c94f37399a590b5036e609550de7f5fda935"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.04-x64.1.1.0.tar.gz", "hash": "917fa16e95fe9d2434134e09025c23b766387c67e91f5f88947ccd6b5e3032e2"},
+                {"name": "runtime-ubuntu.16.10", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.10-x64.1.1.0.tar.gz", "hash": "48243753a3b4429b51e1c919955f40c977886849aacc03a2a207f472d78bfae9"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.0-preview2.1-003177",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-osx-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "8f1ffef37aa9da7273674185dab3b78feb44082d3a9d3156dfc20329acfe7e0d"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x86.1.0.0-preview2-1-003177.zip", "hash": "38a451069f6bc1d2e226218f260b19fc1a2aca775fbd88c083b2d23d5a3af737"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x64.1.0.0-preview2-1-003177.zip", "hash": "d4056a91f83699894c9f9fbac1b8965597ded079b0d8848dacc7505f372f85a0"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-centos-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "168099d73a4be8dacf148a4c9300602a4a74e78fa86495a6d819a2ecca2db406"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-debian-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "a2f228dc79501ee85ac5fcdf771886d8f84409bacfd3f9b3ba4225663cbfa3ef"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.23-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "9802a59b2e68c1fd2c91648503302066bf0ab09b1d286dd6264e2ccc75f50b09"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.24-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "4ff0b843f00f89b4391cb2b442f973117d676c56b571b40c9ffa49af3740f717"},
+                {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "a46585f907b73336878076ab9942db6565445b8b7a435f85537fece4ae4456a0"},
+                {"name": "sdk-opensuse.42.1", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.42.1-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "b9bec78bbb710a47baa79e2af65b5dc0242bbc7850571d67f8153f6d6cb3f542"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "9f6f72c581534ec4367bc3952fe3bfe7649179d86c55b31371b4294edc96d1d1"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "4fdae55113557171a0898b283eef13669a7d722fb2b918a595eb2ab70db1d8a8"},
+                {"name": "sdk-ubuntu.16.10", "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.10-x64.1.0.0-preview2-1-003177.tar.gz", "hash": "835bfcb0cf56457a7c5f953f5fd7d6a37b7a68eb23dc0fb3d9161def833345ea"}                
+            ]            
+        }
+    },
+    {
+        "date": "2016-10-17",
+        "security": false,
+        "runtime":{
+            "version": "1.0.2",
+            "lts": true,
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-osx-x64.1.0.2.pkg", "hash": "c05310b26134fb0fcbcdc42b7b34d75a6b9185838bb27329e089bf3626c47bae33426c5840cc9ce2e47799a25d3f49414b6988a80d6b48528d4c0fe3c2c2eb8f"}
+            ]
+        },
+        "sdk":{
+            "version": "1.0.0-preview2-003148",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.1.0.0-preview2-003148.pkg", "hash": "8523e2249665b081d2a90de07f146d5dd3cba43c40ca65038b1095db4357cbc37425e424f652f3662cdebf2db090929a7e8677bf3b9bbd921af626bd72111627"}
+            ]            
+        }
+    },
+    {
+        "date": "2016-09-13",
+        "security": false,
+        "runtime":{
+            "version": "1.0.1",
+            "lts": true,
+            "files":[
+               {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-osx-x64.1.0.1.tar.gz", "hash" : "45a06f7eec05b32b511cd42074708bbb03a4c16d74b576b31ee282019f7a1149"},
+               {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x86.1.0.1.zip", "hash" : "10d76abf6a5bebe57a9dd7bd6b112501d4bfee7eeb649e581c287713746814f9"},
+               {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x64.1.0.1.zip", "hash" : "86b9a242e14296d266697c7a1004ef379ea7f3faed231fbe196561d6f9591868"},
+               {"name": "runtime-centos", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-centos-x64.1.0.1.tar.gz", "hash" : "4e35226bcc6006c46c0ecbe6b16b8c879d9d30fd5e9250d238e025b7357bee0b"},
+               {"name": "runtime-debian", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-debian-x64.1.0.1.tar.gz", "hash" : "aab094ab47d266b11194caa285c0adef3bf311ac48cdb17e4a6e0d1de0365543"},
+               {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-fedora.23-x64.1.0.1.tar.gz", "hash" : "a61fa03d5519e029f59addf9dd740a2e8fb834ff2cfab2856d7052fd9dbbb7ce"},
+               {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-opensuse.13.2-x64.1.0.1.tar.gz", "hash" : "8b50b6c920eb38e7e2b6e686d85f8d1ff56c357f630c6a3d26e943913134a9e3"},
+               {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu-x64.1.0.1.tar.gz", "hash" : "d462661db3f8b9a8b4435b03114c90190b3f5bb30fa02617c5c6f99af5b3d458"},
+               {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu.16.04-x64.1.0.1.tar.gz", "hash" : "ad4d4a8ebae995410667fa598a9afb0f5a273f08b7d57d7b7b2256c350943aed"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.0-preview2-003131",
+            "files":[
+               {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003131.tar.gz", "hash": "36629fbad1dc1609360482140de3e5c074fcab538c2f2ce67ff6e246375ecd2b"},
+               {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003131.zip", "hash": "93a67a5b8cc8aaba5f33e297a524fdff3098442b84232b1a85160f455369ee68"},
+               {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003131.zip", "hash": "392f494301427f4d1172f60efa61be6f25f016aa2ff6e6fa2ad4137fa184eb5c"},
+               {"name": "sdk-centos", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003131.tar.gz", "hash": "c51797746b5ce338e74e85f6cc43a5201db1af50247d47c28c9cb25f6a37833d"},
+               {"name": "sdk-debian", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003131.tar.gz", "hash": "bb3458b0e771182e1387ca5d9fa5946fc775b77ec55a2501fb3f75ddf29f8124"},
+               {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003131.tar.gz", "hash": "8cd233fdf2d12eca47d558e70e90000aee34a75c718fc9f22d8680e6cb688047"},
+               {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003131.tar.gz", "hash": "d52077e0401a9cd39faaaa90e9003d32e765b0294d30eabc418ba76386766428"},
+               {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003131.tar.gz", "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"},
+               {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003131.tar.gz", "hash": "ba36382d95307a6526d675bba4160f8035e9a5b9b1c2295fb1e6e752be337298"}                
+            ]            
+        }
+    },
+    {
+        "date": "2016-06-27",
+        "security": false,
+        "runtime":{
+            "version": "1.0.0",
+            "lts": true,
+            "files":[
+               {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-osx-x64.1.0.0.tar.gz", "hash": ""},
+               {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x86.1.0.0.zip", "hash": ""},
+               {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x64.1.0.0.zip", "hash": ""},
+               {"name": "runtime-centos", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-centos-x64.1.0.0.tar.gz", "hash": "c01e6a474e95a02c38f327dc5b7830b7a31109f87563d735a6e272008726f262"},
+               {"name": "runtime-debian", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-debian-x64.1.0.0.tar.gz", "hash": "df8b71809626960c26a632e8c1801973ff9f1b8fa4fdeaa51a27bc070ce3f03a"},
+               {"name": "runtime-fedora.23", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-fedora.23-x64.1.0.0.tar.gz", "hash": "49b4f9037e2c75b0abc1c364dc67c15125fcb5d353c6935ff487e6aefec86353"},
+               {"name": "runtime-opensuse.13.2", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-opensuse.13.2-x64.1.0.0.tar.gz", "hash": "a4bc924aa0ebfc4d6123baad15e270bbcb99ce25fbe7ea8f0fd721cb8ad725ba"},
+               {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-ubuntu-x64.1.0.0.tar.gz", "hash": "304165580cf2eeac1ba8db994ec9cd7c83084c9a4a094387d180400ce2fdd1aa"}                
+            ]
+        },
+        "sdk":{
+            "version": "1.0.0-preview2-003121",
+            "files":[
+               {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003121.tar.gz", "hash": "1df92ad4eb117e717acbd68c46b06df4a677f590652099d0cc0982253bdf4534"},
+               {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003121.zip", "hash": "107a27f5c1dec01932f26bcbd2640ae2d098266f05fafe1ab6c6ada7a5f43a27"},
+               {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003121.zip", "hash": "a7ab3ad9c28c9952a9f6e1fee158c337b82aac3ba502e742a92d23bab258e621"},
+               {"name": "sdk-centos", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003118.tar.gz", "hash": ""},
+               {"name": "sdk-debian", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003118.tar.gz", "hash": "204ceab7bc92c17d17691b0d5c1d54992fc78a969fc217a8423045875a4c63ed"},
+               {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003121.tar.gz", "hash": "dde9f8326583f351a89e57095dc523ba92560896cd1d4b8e0ca5ac7fd8499138"},
+               {"name": "sdk-opensuse.13.2", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003121.tar.gz", "hash": "293aa02e528d6c4621b4dda859caf14d670ab212a497945ef5ea17cca31f4ac8"},
+               {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003121.tar.gz", "hash": "02aa1990cf130ea7d772baee6e066bfe249c914c881f5e2cb8e482f524cdb54d"}                
+            ]            
         }
     }
 ]

--- a/release-notes/releases-v2.json
+++ b/release-notes/releases-v2.json
@@ -1,0 +1,304 @@
+[
+    {
+        "date": "2018-07-10",
+        "security": true,
+        "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.2.md",
+        "runtime":{
+            "version": "2.1.2",
+            "version-display": "2.1.2",
+            "vs-version": null,
+            "lts": false,
+            "eol": null,
+            "eol-date": null,
+            "dlc": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/",
+            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/2.1.2/",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.2-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-x64.tar.gz", "hash": "229db61d9c1f9f587ce20f06ac3517e459a3c16b465dbbcf4fd0457ba216e0aea2d0a73df94b651992e744a8456de8bacf0211bff3a281198cf9fad845e9d8cf"},
+                {"name": "runtime-linux-arm-x32", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm.tar.gz", "hash": "c720033a558284b139e891b588642e7975afdb0137da9aee096cd8c4bd73453d1641a75d18a13bb4aebb282d31730cf2a6fe963e84bec315f3296efd72924973"},
+                {"name": "runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-musl-x64.tar.gz", "hash": "092c966af4e3b697aaff06315c3eb3e342651643d3a1929bd33bb5f638e73989944ecdfb02ac18b251b797ff4cadcb312f4be9fe8627b4dd4b8dd8b51ea59ba1"},
+                {"name": "runtime-linux-arm-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm64.tar.gz", "hash": "0567b927c23bfcb67b45d15d1c052036676c5196b7432ee918eba6f99e5538d9052d049de93234e469e3fafbebebcd2bdeacd6cf8ea9a787b632e0aff6dd06c8"},
+                {"name": "runtime-rhel.6-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-rhel.6-x64.tar.gz", "hash": "81eb0031553ccabf92fc63fb0c1bc7eaa5a746c95363ae55525ca48a9c638ef457ca51c785e0f13b03cdab49c16b04fe3d1c8c23e22148f504dbac8171c6fcb0"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.tar.gz", "hash": "a39d10c1680e2adf98200285ee4b704b3861e371113e0359388fc0fa479222dd69e513b473e547b8382303918d708ce78a42edc06bcf4f6885775788dc0632d7"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.pkg", "hash": "8cd973a1efe329c16b3099acd33ee191359314d4a6c9755ba0ea717ecb4ca773bb44bcfcc64181e68cfbd4ff6f214ab67ba1611b89b0c399423ffeb88b8f1d92"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.zip", "hash": "e0e941c2b89b8638447e42f93a0a028cd81464ac4cea6123acb4130b72dda03744b3bcbb42683f1e9554b1cadd1c28f35d97523278f40de5e8c57606460556b8"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.zip", "hash": "9e67c62feb34aeb52a45d0e623d1ad098637a322545956eb5e6de2287ddad2412b766c492ae5a7dddc123a4cb47cfc51d9bb10d0e30c007ec3fc90666f9733c8"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.exe", "hash": "3539dbc699a1bd29f79c4fe95d28246cc53c4916acd30927868e9e6fe1da3a40693bbe9bc8e69b814a25d7f044c289231a200a74204a2f374d38545083440fbd"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.exe", "hash": "b15d988c51bc2da9edeb9ad3b1b643ef1f71d16eda0e35dec6224a67a78e9e1d58a3f8d0fdd727cd9643b5d9816664b02aba158d7884f0bd2098561e237a3ffb"}
+            ]
+        },
+        "sdk":{
+            "version": "2.1.302",
+            "version-display": "2.1.302",
+            "vs-version": null,
+            "lts": false,
+            "eol": null,
+            "csharp-language": "7.3",
+            "dlc": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/",
+            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.302/",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.302-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-x64.tar.gz", "hash": "2166986e360f1c3456a33723edb80349e6ede115be04a6331bfbfd0f412494684d174a0cfb21d2feb00d509ce342030160a4b5b445e393ad83bedb613a64bc66"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.tar.gz", "hash": "67a83f30f5c4d504eeafe5200711bff6e7c4c365067f4e6140e31f3e149974aa34e993d5ce9b39377b6e3e031c85e4348a46723519e87f200618dfebafd0b1f5"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.pkg", "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"},
+                {"name": "sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-gs-x64.pkg", "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.zip", "hash": "bb540fa18f32bc9d911ccf29df682c216d08cd5881e6b6a988e182ee2350a60eed24e56392370f2bc5bdef046496ac7c63da7e7ffbaca79fbb54c299f109a0b7"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.zip", "hash": "a8a74d3329191df6357a00e26591cdc64153970e0cf42f820ade0fb520c9cb0e6ab16ab357dc9538a8c488245c505930b4b0a6b63721e4eebf8682613a63441e"},
+                {"name": "sdk-win-x86.exe", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.exe", "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"},
+                {"name": "sdk-win-x86.exe-gs", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x86.exe", "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.exe", "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"},
+                {"name": "sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x64.exe", "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"},
+                {"name": "sdk-linux-arm-x32", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm.tar.gz", "hash": "af18d6dc918bd638342a5910415e4f53b55aa802adfed551f164ccd6d1441aff70947b7985d7ad1ce7c7eb7d8f05995b45c0405a520d9577ff9c019b0ef5cd6a"},
+                {"name": "sdk-linux-arm-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm64.tar.gz", "hash": "93f481278d9da6ed7ba16d66c9742cdc9f66b31e6d09cd14b4b27621f44116f9a26386076de11e5ad3e967d51d95c17816287e164c80eebfd55852227a038457"},
+                {"name": "sdk-linux-musl-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-musl-x64.tar.gz", "hash": "0f9a6fcbad609ef1ff5b398de9a1f1bf59eebc59b28a4c8cfead28f0209bf77601d05d49f5ea1223c860a803fb82cd7e2401b6df290da34e54b36bdd8788ed48"},
+                {"name": "sdk-rhel.6-x64", "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-rhel.6-x64.tar.gz", "hash": "9991d57f1e5f4f2cd227bca9ef980457d3422ae28a36f6c5ed2a7d0665f9d378aad2c57d4b375a7d410eb229b13a18e818f3f980dc222e9c5347ef62dbde8633"}
+            ]
+        },
+        "asp":{
+            "version": "2.1.2",
+            "version-display": "2.1.2",
+            "lts": false,
+            "dlc": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/",
+            "blob": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/2.1.2/",
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-hosting-2.1.2-win.exe", "hash": "1b20f9eee7b83d5068e8e4ac5230b7e584be944c4da1264fe117fa3a93aa520250e38e8bce7b54f87db73a40188e49c6caa9baa0f3ab45e38d4eba8a54e98e53"},
+                {"name": "asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.exe", "hash": "63c8dfc01ff5a3a852a4d2930e185748f534ddc6c8aae96fac1cd6f7780a97aeb7d38a2b7be1f90c61df8bb3ca406cab37c5673676434d3597925ecbd2643276"},
+                {"name": "asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.exe", "hash": "cf0f185c906dae5e359f230f2c5bcc65e6f04a3cf6fbac89b79f02ffe2e13f2c4085fb817a7f65038df5884be39057a992b43631d74f52c6d5951861c03f6031"},
+                {"name": "asp-runtime-win-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.zip", "hash": "a9ab3f01fc07527016513f47fc46427f6da8ee45ab847eebe228ca940f00d7b791431295b5aeaf8c8fb07f4ff1d4e8894fb4cfe5c36e74684f08f7d9d15a0e6b"},
+                {"name": "asp-runtime-win-x86", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.zip", "hash": "86414db4ce9ca76b3c40649da098fdc8d8e6dd79e4f94ec3a1402eb5506070ca8d9ae571a6845262720d42e5ef35e4ef396a0c01ecaa58fc55bc503c1ab8dd65"},
+                {"name": "asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-osx-x64.tar.gz", "hash": "5b9ad8e0fbe473cfc4f39516e3f793940287cefbb5fc2eac4dfcc346693d9b50242073aec605972fac0ac6f3d77f3d3715af32362061339565fb50db17f994d7"},
+                {"name": "asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-x64.tar.gz", "hash": "294a6c256ce7954c05c3dee85d4114e320c7b94b2ae2e854a268b2bb4383a967e1063ee0df0da0f09511b3dc9c215aa735899f5c6db4f11bd58da3cb9cc8b6da"},
+                {"name": "asp-runtime-linux-arm", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-arm.tar.gz", "hash": "49565a49e8357894b34a8cd12e1cccf9702c2c9c3dd06e1fc7c184ebee5b2fec43290e18998b60a77dbd5dfc5d59b838f3f4210675db1d64313cf206a22fc6b2"},
+                {"name": "asp-runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-musl-x64.tar.gz", "hash": "7e4ccfd0610949c4e228da38d40223ea8086bc98ec92d83fb0823909f40e897c3ad59706ff84e4dfec7873a587e83d9d98826dd13dc2bbea239a927f6906a9cb"}
+            ]
+        }
+    },
+    {
+        "date": "2018-06-19",
+        "security": false,
+        "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.1.md",    
+        "runtime": {
+            "version": "2.1.1",
+            "version-display": "2.1.1",
+            "vs-version": null,
+            "lts": false,
+            "eol": null,
+            "eol-date": null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.1-runtime-sha.txt",
+            "files": [
+                {"name": "runtime-linux-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-x64.tar.gz", "hash": "39737997bc10de06b8fcae448f1c740dd422d9f6e4f71a61f364b5643adfade3f3902ea07eebf38c6505e5262312d05cbc9f295d3ec5f8d5830f4ab73236a5a5"},
+                {"name": "runtime-linux-arm-x32", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm.tar.gz", "hash": "470b0cc3a614b716ad288ad527e1f00e5e7321636ba6bdecfab770a3d84da20417fe4ac362a22f4c6eab4b34614b7b3490b4b00a2f9824ec957199e14696f7b9"},
+                {"name": "runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-musl-x64.tar.gz", "hash": "5bb938b012d86bcecac42e3c4e915cded051ffeffcdb4122ce41cfd53896395b952d61ef10e22e37d330a78eeb861550e0c73d0595ae001228a03bb0d94bd286"},
+                {"name": "runtime-linux-arm-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm64.tar.gz", "hash": "28c170e1d7e01e0de67f77b0e65f26816cb20e3ea4cccb148506bef830d6dfc9ac0825408bd36432aee15027f6c0a41ca52c69f01060db134f21be724b6115e2"},
+                {"name": "runtime-rhel.6-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-rhel.6-x64.tar.gz", "hash": "d6e512a3f854ace827b0528299f4d2286e43f5dc526440d0c014bafebe98932ecef5079879e4eb53f965a4304e724a2238913e4233c9633d06e058a296bd32db"},
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.tar.gz", "hash": "4e1ccaa728a12f508fcc69dd75270b9bac5cd6e4458eeb3ecad8d7ab718f5c1750d7d191420af9669a1d87c503b645f3b1dde98a92d818e9ab7e79a504136a1f"},
+                {"name": "runtime-mac-x64.pkg", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.pkg", "hash": "7b5c750aacb9c62e3fea36889661b63e7ad1fd2ed331a8d413f36c54e136d3d219e27fec8874202e9dd66f7458d6c60dd949c56f1dbdce927cdcdcb8ddd017f5"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.zip", "hash": "864df7bc475e7a05dd20b8b5c927f8a7c2370446046070b5b1262a07c34253259769d1442a1f5c144cd4b91285a5f275a3919f8de2ae49d0e35a122e57af051c"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.zip", "hash": "4414fe957d2630404ef23d2ceb9d8d2d37fa4d1249ef4755d05302b179a64821fca6d21d4de011f4b466c090ffd7c5422f2b94e88168bd868ddc3b22557bfacd"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.exe", "hash": "5d2968020c2d255429860606b509f25ae3a5a4fa79569cdb4c5ae1fca6decd0c6c43feff171000111378d99c413e349504b7b413051e73b1dd9c2ce73f4d23dc"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.exe", "hash": "e1ecf007a7ceb18e92acde8ea3d3f5c15c2adbadcb6366c8d743eb6752761efdac02185551a009420a9c878cba76a5abe6bd8d73626edaff104a2592a241d3ad"}
+            ]
+        },    
+        "sdk": {
+            "version": "2.1.301",
+            "version-display": "2.1.301",
+            "vs-version": null,
+            "lts": false,
+            "eol": null,
+            "csharp-language": "7.3",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.301-sdk-sha.txt",
+            "files": [
+                {"name": "sdk-linux-x64", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-x64.tar.gz", "hash": "2101df5b1ca8a4a67f239c65080112a69fb2b48c1a121f293bfb18be9928f7cfbf2d38ed720cbf39c9c04734f505c360bb2835fa5f6200e4d763bd77b47027da"},
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.tar.gz", "hash": "120444d800d7761b4c535d601b6e79a32c9d7443f8029a47600b6d30c59e0e0f0573ce7ff435b6a563028c2cd19abcb5406fff48afa3f969ee8464db7e216bde"},
+                {"name":"sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.pkg", "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"},
+                {"name":"sdk-mac-x64.pkg-gs", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-gs-x64.pkg", "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.zip", "hash": "237a0a980d8bcdb4d8c9adf7824f9bb9e50da47af224fd291d7667f88efbe7432a66a606ea4fedae018f1a252db938c19bded3d451f7a2fe47b0ba47d0861e9f"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.zip", "hash": "f2f6cc020f89dc4d4f8064cc914cffabde0ce422715138778a6bcbbb6803ca66d6fd967097a0209c47c89b85dd9e93db48486ac86999bd3a533e45b789fcea89"},
+                {"name":"sdk-win-x86.exe", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.exe", "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"},
+                {"name": "sdk-win-x86.exe-gs", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x86.exe", "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.exe", "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"},
+                {"name":"sdk-win-x64.exe-gs", "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x64.exe", "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"},
+                {"name":"sdk-linux-arm-x32", "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm.tar.gz", "hash": "f241a9e6b910f0000691973784a28b652ab7feaf329fd732a7a808a2c5926e7116c8c78e6c42806663135b6d3fecd7f9e1c28e24ec3db742a585a93befb17500"},
+                {"name": "sdk-linux-arm-x64", "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm64.tar.gz", "hash": "852d29e572398347afe166bbde5b17c5e09130d7af72ba5b483766b80b6fb657695102a92f5bd247f0d011f807cc05a4e7c61f8aeae577b95fa9fae9819bb3fc"},
+                {"name":"sdk-linux-musl-x64", "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-musl-x64.tar.gz", "hash": "86e288cce53999b719ced7959f5ba652f667b8c1e0aec266c3012c9870380e5142e3f5ac103f03691d4426158d9da4d7c89f0739dee5815419a6150c8ee84a12"},
+                {"name":"sdk-rhel.6-x64", "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-rhel.6-x64.tar.gz", "hash": "e638c0fdbf41668477e92afefe9a2ee29229aa2880dfaa83fc01b6c4298ab8d2699581fdbf543533d70873c8a4d430bf8da32c64a90b6b2c19a7766f34632739"}
+                ]
+            },
+        "aspnetcore-runtime": {
+            "version": "2.1.1",
+            "version-display": "2.1.1",
+            "vs-version": null,
+            "lts": false,
+            "files": [
+                {"name":"asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.exe", "hash": "bc4c6ba1a5955e8486d3960d354182fa885afe1e56989e49b12420b6fa8dbbc28a42e653bbbde85e5ad638ad2fbf96bf99a52f5d5b1ade03b399e8585b28f897"},
+                {"name":"asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.exe" , "hash": "83041e846f74ed2594d2ad0f6f28efb007ac5b7b8a7489326d9d6f2dedbe7132c3f5e769daaacbfcf56d183f66b339bc278c773496573adfedd52cdd30ed8f48"},
+                {"name":"asp-runtime-win-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.zip", "hash": "312b4610e3fffd2bcd92c6a215c245bb112f40276837bfa2edea9cb9376554f6c237fc773f2c83c146cca6e7bfcfc53d708627d9a76a896996174ff300666528"},
+                {"name":"asp-runtime-win-x86", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.zip", "hash": "18c6fcb50376a57657ed0a4c254cea5fde0a5b7e7f7086dec7fb1153711f5545bb1f70beddf688c2ee7cc473fb607ec9a6a4663f05a25d473f2dad3a41de7034"},
+                {"name":"asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-osx-x64.tar.gz", "hash": "2ef0ac04986c587914a9bcb9062d5abfbf4ec66efc68be8f3e8a6d46df20a839e0a04d0cfb7d6265a275bbc4e26245cf3d496a769e90bb88e1c5b8a7f944123b"},
+                {"name":"asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-x64.tar.gz", "hash": "ab7de9d3e01d940ec985b1787532d856abb24d64b59066f0cee343f79edd2cd67be4b0de2788b9bfc97968311308384f912888e9ea8fd8d6def7e143c4e825c0"},
+                {"name":"asp-runtime-linux-arm", "url":"https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-arm.tar.gz", "hash": "5160edb49a16e24ff4cb018bf7ff2eb6638b514abaa9e0d5006e83399bd5830116c35e317b4d9418d2ecc7b757b21d7cf1353d445a7162fa81e990e9f9034a42"},
+                {"name":"asp-runtime-linux-musl-x64", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-musl-x64.tar.gz", "hash": "b8d3ac5c1970b2a6d6fe812c66b55ff74b1a130010889d6b828a031296355c7b507b7289a90c149d5f710f93847609c6264fec0da5d196df6c2aab3100a8797f"},
+                {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-hosting-2.1.1-win.exe", "hash": "6c24ec02e6c8996a419ad0f7092ada5e58754a5e1db7f1828670ce8f4503c22e14bd74ae8b86a99833147605157763a8d95bc5dbebbc5643c92fc28c4b58391f"}
+                ]
+            }
+    },
+    {
+        "date": "2018-05-08",
+        "security": true,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.200-sdk.md",
+        "runtime": {
+            "version": "2.0.8",
+            "version-display":"2.0.8",
+            "vs-version":"15.7",
+            "lts": false,
+            "eol":null,
+            "eol-date": null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.0.8-runtime-sha.txt",
+            "files": [
+                {"name":"runtime-linux-x64", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-linux-x64.tar.gz", "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"},
+                {"name":"runtime-mac-x64", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.tar.gz", "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"},
+                {"name":"runtime-mac-x64.pkg", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.pkg", "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"},
+                {"name":"runtime-win-x86", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.zip", "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"},
+                {"name":"runtime-win-x64", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.zip", "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"},
+                {"name":"runtime-win-x86.exe", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.exe", "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"},
+                {"name":"runtime-win-x64.exe", "url":"https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.exe", "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"}
+            ]
+        },
+        "sdk": {
+            "version": "2.1.200",
+            "version-display":"2.1.200",
+            "vs-version":"15.7",
+            "lts": false,
+            "eol":null,
+            "csharp-language": "7.2",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.200-sdk-sha.txt",                
+            "files":[
+                {"name":"sdk-linux-x64", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-linux-x64.tar.gz", "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"},
+                {"name":"sdk-mac-x64", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.tar.gz", "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"},
+                {"name":"sdk-mac-x64.pkg", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.pkg", "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"},
+                {"name":"sdk-mac-x64.pkg-gs", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-gs-x64.pkg", "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"},
+                {"name":"sdk-win-x86", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.zip", "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"},
+                {"name":"sdk-win-x64", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.zip", "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"},
+                {"name":"sdk-win-x86.exe", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.exe", "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"},
+                {"name":"sdk-win-x64.exe", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.exe", "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"},
+                {"name":"sdk-win-x64.exe-gs", "url":"https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-gs-x64.exe", "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"}
+            ]
+        },
+        "aspnetcore-runtime":{
+            "version":"2.0.8",
+            "version-display":"2.0.8",
+            "vs-version": "15.7",
+            "lts":false,
+            "eol":null,
+            "eol-date": null,
+            "files": [
+                {"name":"hosting-win-x64.exe", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/DotNetCore.2.0.8-WindowsHosting.exe", "hash": "393346d9668b4cfb4d520bc198fdff43d3137ef35a512b5ca4c8c7607c99e08c0ea173bb478ec5a8b75c7e719425abc224c2dd88ddf46b92bafec4a9e3f0bd6a"},
+                {"name":"hosting-linux-x64", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-hosting-2.0.8-linux-x64.tar.gz", "hash": ""},
+                {"name":"asp-runtime-win-x64.exe", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x64.exe", "hash": "8c9199f6ede36c24c9d5350e5b71401d2154ecb37e641c0fac9c53055235a4e4844a37369255c59926924f3d4f96868affe47fbb9fef8b96fc5f658cf7dc5cca"},
+                {"name":"asp-runtime-win-x86.exe", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x86.exe", "hash": "1c943c82451bdda0bc3526bd3471010ab5a9a508ff07396888986e05b55218fea8c89eb6ba504c300b438a68b100d0198549ff3ad0546280d0be15db50150279"},
+                {"name":"asp-runtime-win-x64", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x64.zip", "hash": "c739e056f62391c8d2b8d3348c0116a54b13c1d81ba938b8ce84897289f2ac2f81ce4539599e6014389e67feead27fcea2ec09e72cd920dbf5405b9c5ec13624"},
+                {"name":"asp-runtime-win-x86", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x86.zip", "hash": "89e63e53f0b903de59ba0174128b7baeba4a1ce6f2c95732916e50b65fc405a601d05cfe0c018db809fdd890cd24ec65ced3ce77989cc4da37433f2236a07e03"},
+                {"name":"asp-runtime-mac-x64", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-osx-x64.tar.gz", "hash": "045034f21790e92f493ce62e6e51be4d48e9138d464b9a39febc5c599e83d8e1d30bbdfdf3509252c17a621bfc894adf39a9c4797e310253acff86b9f770aec5"},
+                {"name":"asp-runtime-linux-x64", "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-linux-x64.tar.gz", "hash": "12389d923f71b639cd0f3c5267a06cb65e0f7aae026b545956a6d90ab07e65bee05c18713255fa7de4e910d0ec52de3a4afb40a08545f984415a9690d6adce35"}
+            ]
+        }
+    },
+    {
+        "date": "2018-04-17",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.8.md",
+        "runtime":{
+            "version": "1.1.8",
+            "vs-version": "15.0",
+            "lts": true,
+            "eol":null,
+            "eol-date": null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.8-runtime-sha.txt",
+            "files": [
+                {"name":"runtime-mac-x64", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-osx-x64.1.1.8.tar.gz", "hash": "d45684320e1b4931663045a1c89d39558bb8a66cc1f1ca8f8f3a11ac8943b8c0176bb5485183c79e94eedacf58e65d9422fe7102e2fc02f0f5349b019303d183"},
+                {"name":"runtime-win-x86", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.zip", "hash": "62f3b0d7d2836979c9cd5da7d598354e6c6adb4fd804a3dc378c09e9065c555218beeff2febcfb5f0fd3a08091d2ab4628a769600f4b3d672461ad0dc7af636d"},
+                {"name":"runtime-win-x86.exe", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.exe", "hash": "ad40c463bbec93afd79aaa734482f979251db874a5dc91bb40562ffa4aa45b5823470b5bbeba2db8e669c01add15b762db2ba113a7ffcc10bda0d6cd7a5d3ea8"},
+                {"name":"runtime-win-x64", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.zip", "hash": "81a9e99544efcb14294b267d6605edc07d857575a4ca628eb805adb8fb5c2644be24bbd3c449e3fa7ed8c28f65b15f64531a1885aec9e9898c5e31ea3a197926"},
+                {"name":"runtime-win-x64.exe", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.exe", "hash": "682ad53a66f8a936fa8664a9be7ba6364acd9dd5983a70ded3020a144f8e13c28d3dcb3b2f1328b1003e474b05ef94c10aa90dde22bc23a5ddbf036157515e2b"},
+                {"name":"runtime-centos", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-centos-x64.1.1.8.tar.gz", "hash": "c7221974f522633babe9b3e35bd984c5c65264f56d1ba9d916dd0c3a1193327e2983154b1eff6585b48c8508b4a4c95c0cc59793c7a0efd6db9b28f8f1e91a8b"},
+                {"name":"runtime-debian", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-debian-x64.1.1.8.tar.gz", "hash": "49161d81fb9068ec018dd3bf6f438e838629933245cf88fe08562f8c8726e24523c628ab2a31dcdf5fe32f8496b009fefe275406318c5072cba85bddfe0a7693"},
+                {"name":"runtime-fedora.24", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-fedora.24-x64.1.1.8.tar.gz", "hash": "b0ee8856ec0d18a6d406a3f21372685eec74d22af81e351eecf78413de7c49602006a8492d775530cb72dd35da9f7dd074e1504158821ea6cc5f92b31fee5de3"},
+                {"name":"runtime-opensuse.42.1", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-opensuse.42.1-x64.1.1.8.tar.gz", "hash": "fef9696d73d91ab7e3ea65c6a3c4d5c4fa4f0c219a21fa9f937e9292c261208a53d22173f72371d3cbddf02ea263ced50a90771effcde7ae26487526919ea9ed"},
+                {"name":"runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu-x64.1.1.8.tar.gz", "hash": "f7385d5273c69259fb551adc8b4b6539b858f7f70365c98a6bd181525727cb7330d35716242632e61cf41c015b39ffc1aed8682a11316e77eb90c396b833a68e"},
+                {"name":"runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu.16.04-x64.1.1.8.tar.gz", "hash": "dc9d732ddf5b136c4b1dae873f17d73465b653fd90d97123072541a7d9e243066220e04d204fd5942645f0c06969ad93084dce0400b37018ecc4d6b8131ce3a1"}
+            ]
+        },            
+        "sdk":{
+            "version": "1.1.9",
+            "vs-version": "15.0",
+            "lts": true,
+            "eol":null,
+            "csharp-language": "7.0",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.9-sdk-sha.txt",
+            "files": [
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz", "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg", "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip", "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip", "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"},
+                {"name": "sdk-win-x64.exe", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.exe", "hash": "08f7ffbf28d3a85b3e6e4983bef643a212161271c6ff3956fbdef932038ba240104db6c2deb8b662e5392f1e5b45db2aee2e7da20ee7d800f3b417aabb649d2a"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz", "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz", "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"},
+                {"name": "sdk-fedora.24", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz", "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz", "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz", "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"}
+            ]
+        },
+        "aspnetcore-runtime":{
+            "version": "1.1.8",
+            "vs-version": "15.0",
+            "lts": true,
+            "eol":null,
+            "files":[
+                {"name": "hosting-win-x64.exe", "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/DotNetCore.1.0.11_1.1.8-WindowsHosting.exe", "hash": ""}
+            ]
+
+        }
+    },       
+    {
+        "date": "2018-04-17",
+        "security": false,
+        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.11.md",
+        "runtime":{
+            "version": "1.0.11",
+            "vs-version": "15.0",
+            "lts": true,
+            "eol": null,
+            "eol-date": null,
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.11-runtime-sha.txt",
+            "files":[
+                {"name": "runtime-mac-x64", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-osx-x64.1.0.11.tar.gz", "hash": "7299e31d2c9f57035d3d99338cd583a52c172a60a5e0d27bf3f75cc99ddbfa49d2b66627bd1ea8adffa9ece6e362bf022e12a170e6461569dff33977f5783a87"},
+                {"name": "runtime-win-x86", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.zip", "hash": "8587478c682b06a6c447afc56610a1c07a6943f82c163be9db1d53fc360052f02546234a335d8f47a527048124ef4437f9dbad24060970b1ef0f82e6d2be2416"},
+                {"name": "runtime-win-x86.exe", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.exe", "hash": "7aeadfa40f095e9e284888f7169b0d030446435e37bd0645e8cc713d04985d703fe343ae35c45a50e501c79048e9a009d83eb649d11b1f5e1eaecc24bdd889fb"},
+                {"name": "runtime-win-x64", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.zip", "hash": "51bcb135c1880db365c0c0fc3d2151736a6e3699c40148ce6f11e363e2184982bf71dbb61fe7011688eff6ede5e33126be32af139d516151ae7bab5574ec67ce"},
+                {"name": "runtime-win-x64.exe", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.exe", "hash": "b2cfd380baddeda278e0659e7a5e3706898ed2f8b0f8d4a58f5573815e634ba6910bf668fc9d8dbbd4a63422c6a44e801c63cc9cfed37c198e02f5978d89c305"},
+                {"name": "runtime-centos", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-centos-x64.1.0.11.tar.gz", "hash": "5f9de7f5a678a9211e4e956c11c0638f2cf582d64c3132cb1b73f48c4aad4846c01fa49b26e612d17090e7813449091a206a3abe946394aa6dab15697fca76aa"},
+                {"name": "runtime-debian", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-debian-x64.1.0.11.tar.gz", "hash": "42b3111e4a781ac35b3db33b0d109c653f0962ff70a3b7bc2452eafbe31690852faacd839fa9098117907c8de7663451d51028d201956ce7feb872b6906af513"},
+                {"name": "runtime-ubuntu.14.04", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu-x64.1.0.11.tar.gz", "hash": "4487d360c623953236f9577e48f644ced1bf293b32432fe857d43a62377b0ea22b557aef92eca14cda5a6b055d3697444de457bb7533c1f7dda20eb8554a2699"},
+                {"name": "runtime-ubuntu.16.04", "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu.16.04-x64.1.0.11.tar.gz", "hash": "31dc1e9914df84b32b6641508c657bd9cb5882327af50549100e58d17c2b184dbc20ca1cbdd616bfd8894b1a6fad201a434df5ffc9fb376fbc88a42d7d8eb5c4"}
+            ]
+        },
+        "sdk":{
+            "version": "1.1.9",
+            "vs-version": "15.0",
+            "lts": false,
+            "csharp-language": "7.0",
+            "checksums": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.1.9-sdk-sha.txt",
+            "files":[
+                {"name": "sdk-mac-x64", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz", "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"},
+                {"name": "sdk-mac-x64.pkg", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg", "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"},
+                {"name": "sdk-win-x86", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip", "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"},
+                {"name": "sdk-win-x64", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip", "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"},
+                {"name": "sdk-centos", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz", "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"},
+                {"name": "sdk-debian", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz", "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"},
+                {"name": "sdk-fedora.23", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz", "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"},
+                {"name": "sdk-ubuntu.14.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz", "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"},
+                {"name": "sdk-ubuntu.16.04", "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz", "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"}
+            ]
+        }
+    }
+]


### PR DESCRIPTION
Beginnings of the new releases.json format. Scheduled to be introduced with the August release. The existing json will be maintained for August as well, then deprecated in September. 