### PR TITLE
Ubuntu 17.10 EOL Update

### DIFF
--- a/release-notes/1.0/1.0-supported-os.md
+++ b/release-notes/1.0/1.0-supported-os.md
@@ -32,7 +32,7 @@ OS                            | Version                        | Architectures| 
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7     | x64          | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 27, 28 (1.1)                   | x64          | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 8.2+                           | x64          | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
-Ubuntu <br> Linux Mint        | 14.04, 16.04, 17.10 (1.1), 18.04 (1.1) <br> 17 | x64    | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases) <br> [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
+Ubuntu <br> Linux Mint        | 14.04, 16.04, 18.04 (1.1) <br> 17 | x64    | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases) <br> [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
 openSUSE                      | 42.3+ (1.1)                    | x64          | [OpenSUSE lifecycle](https://en.opensuse.org/Lifetime)
 
 * \* Supported by the latest patch release of .NET Core 1.1
@@ -51,4 +51,5 @@ Fedora     | 24       | [August 2017](https://fedoramagazine.org/fedora-24-eol/)
 Fedora     | 23       | [December 20, 2016](https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/OHFCBTYXAO6NBH5BZZI3VIMIIL2ODFP5/) | 27+
 openSUSE   | 13.2     | [January 18, 2017](https://lists.opensuse.org/opensuse-security-announce/2017-01/msg00033.html) | 42.3+
 openSUSE   | 42.1     | [May 17, 2017](https://lists.opensuse.org/opensuse-security-announce/2017-05/msg00053.html) | 42.3+
-Ubuntu     | 16.10    | [July 2017](https://lists.ubuntu.com/archives/ubuntu-announce/2017-July/000223.html) | 17.10
+Ubuntu     | 17.10    | [July 2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-July/000232.html) | 18.04
+Ubuntu     | 16.10    | [July 2017](https://lists.ubuntu.com/archives/ubuntu-announce/2017-July/000223.html) | 18.04

--- a/release-notes/2.0/2.0-supported-os.md
+++ b/release-notes/2.0/2.0-supported-os.md
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux      | 6                             | x64            |
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux     | 7                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 27                | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9, 8.7+                   | x64            | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
-Ubuntu                        | 18.04, 17.10, 16.04, 14.04       | x64            | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
+Ubuntu                        | 18.04, 16.04, 14.04       | x64            | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
 Linux Mint                    | 18, 17                    | x64            | [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
 openSUSE                      | 42.3+                         | x64            | [OpenSUSE lifecycle](https://en.opensuse.org/Lifetime)
 SUSE Enterprise Linux (SLES)  | 12 SP2+                   | x64            | [SUSE lifecycle](https://www.suse.com/lifecycle/)
@@ -51,5 +51,6 @@ Fedora     | 25       | [December 2017](https://fedoramagazine.org/fedora-25-end
 Fedora     | 24       | [August 2017](https://fedoramagazine.org/fedora-24-eol/) | 27+
 openSUSE   | 42.2     | [January 2018](https://lists.opensuse.org/opensuse-security-announce/2017-11/msg00066.html)  | 42.3
 openSUSE   | 42.1     | [May 2017](https://lists.opensuse.org/opensuse-security-announce/2017-05/msg00053.html)  | 42.3
-Ubuntu     | 17.04    | [January 2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-January.txt) | 17.10 |
-Ubuntu     | 16.10    | [July 2017](https://lists.ubuntu.com/archives/ubuntu-announce/2017-July/000223.html) | 17.10
+Ubuntu     | 17.10    | [July 2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-July/000232.html) | 18.04
+Ubuntu     | 17.04    | [January 2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-January.txt) | 18.04
+Ubuntu     | 16.10    | [July 2017](https://lists.ubuntu.com/archives/ubuntu-announce/2017-July/000223.html) | 18.04

--- a/release-notes/2.1/2.1-supported-os.md
+++ b/release-notes/2.1/2.1-supported-os.md
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux      | 6                             | x64            |
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 27, 28                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9, 8.7+                       | x64, ARM32\*     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
-Ubuntu                        | 18.04, 17.10, 16.04, 14.04    | x64, ARM32\*    | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
+Ubuntu                        | 18.04, 16.04, 14.04           | x64, ARM32\*   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
 Linux Mint                    | 18, 17                        | x64            | [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
 openSUSE                      | 42.3+                         | x64            | [OpenSUSE lifecycle](https://en.opensuse.org/Lifetime)
 SUSE Enterprise Linux (SLES)  | 12 SP2+                       | x64            | [SUSE lifecycle](https://www.suse.com/lifecycle/)
@@ -49,4 +49,5 @@ Support for the following versions was ended by the distribution owners and are 
 
 |OS         | Version  | End of Life | Supported Version|
 |-----------|----------|-------------|------------------|
-| Fedora       | 26         | 5/29/2018            | 27+  |
+| Fedora    | 26       | [5/29/2018](https://fedoramagazine.org/fedora-26-end-life/)   | 27+  |
+| Ubuntu    | 17.10    | [7/19/2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-July/000232.html) | 18.04 |


### PR DESCRIPTION
[Ubuntu 17.10 (Artful Aardvark) reaches End of Life on July 19 2018](https://lists.ubuntu.com/archives/ubuntu-announce/2018-July/000232.html)

Ubuntu announced its 17.10 (Artful Aardvark) release almost 9 months
ago, on October 19, 2017.  As a non-LTS release, 17.10 has a 9-month
support cycle and, as such, the support period is now nearing its
end and Ubuntu 17.10 will reach end of life on Thursday, July 19th.

At that time, Ubuntu Security Notices will no longer include
information or updated packages for Ubuntu 17.10.

Fixes https://github.com/dotnet/core/issues/1824