### PR TITLE
Removed reference to Red Hat errata policy for RHEL6 from release notes

### DIFF
--- a/release-notes/2.0/2.0-supported-os.md
+++ b/release-notes/2.0/2.0-supported-os.md
@@ -28,7 +28,7 @@ Mac OS X                      | 10.12+                        | x64            |
 
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
-Red Hat Enterprise Linux      | 6                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) 
+Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://www.microsoft.com/net/support/policy) 
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux     | 7                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 27                | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9, 8.7+                   | x64            | [Debian lifecycle](https://wiki.debian.org/DebianReleases)

--- a/release-notes/2.1/2.1-supported-os.md
+++ b/release-notes/2.1/2.1-supported-os.md
@@ -28,7 +28,7 @@ Mac OS X                      | 10.12+                        | x64            |
 
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
-Red Hat Enterprise Linux      | 6                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) 
+Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://www.microsoft.com/net/support/policy)
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 27, 28                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9, 8.7+                       | x64, ARM32\*     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)


### PR DESCRIPTION
I replaced it with Microsoft support policy instead, not sure if that's the right thing to refer to...