### PR TITLE
Improve wording on comment editing

### DIFF
--- a/Documentation/contributing/maintainers.md
+++ b/Documentation/contributing/maintainers.md
@@ -11,7 +11,7 @@ The following two lists summarize how maintainers will act. A more detailed desc
 - Report abusive behavior to the [Code of Conduct review group](mailto:conduct@dotnetfoundation.org).
 
 **Maintainers won't**
-- Edit contributor comments as a general rule. GitHub comments don't provide edit history and therefore don't offer maintainers a transparent and accurate way to describe changes made to contributor comments. Transparency is a cornerstone of effective discourse and its absence undermines trust.
+- Edit contributor comments as a general rule. GitHub provides [edit history](https://blog.github.com/changelog/2018-05-24-comment-edit-history/) which makes editing more acceptable as there is a way to see an audit log. However, contributors might still be surprised when they see statements or phrases under their name that they don't recall making. Transparency is a cornerstone of effective discourse and its absence undermines trust. And a change log doesn't fully eliminate these concerns.
 
 ## Respect your Contributions
 


### PR DESCRIPTION
GitHub supports editing comments now, so need to update our guidance to reflect this. However, we also believe a ful edit log doesn't take away all the concerns that come with editing someone else's comment.

Fixes #1885.