### PR TITLE
Remove broken link in 2.1.3 release notes

### DIFF
--- a/release-notes/2.1/2.1.3/2.1.3-download.md
+++ b/release-notes/2.1/2.1.3/2.1.3-download.md
@@ -6,8 +6,6 @@
 * ASP.NET Core 2.1.3
 * .NET Core SDK 2.1.401
 
-See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.3.md) for details about what is included in this update.
-
 |           | SDK Installer<sup>1</sup>                        | SDK Binaries<sup>1</sup>                 | Runtime Installer                                        | Runtime Binaries                                 | ASP.NET Core Runtime           |
 | --------- | :------------------------------------------:     | :----------------------:                 | :---------------------------:                            | :-------------------------:                      | :-----------------:            |
 | Windows   | [x86][sdk-win-x86.exe] \| [x64][sdk-win-x64.exe] | [x86][sdk-win-x86] \| [x64][sdk-win-x64] | [x86][runtime-win-x86.exe] \| [x64][runtime-win-x64.exe] | [x86][runtime-win-x86] \| [x64][runtime-win-x64] | [x86][asp-runtime-win-x86.exe] \| [x64][asp-runtime-win-x64.exe] <br> [Hosting Bundle][hosting-win-x64.exe]<sup>2</sup> |


### PR DESCRIPTION
The release notes are already linked 2 lines up, and this link was broken.