### PR TITLE
Fix link to latest .NET Core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The dotnet/core repository is a good starting point for .NET Core.
 
-The latest major release is [.NET Core 2.1](release-notes/2.1/2.1.3/2.1.3.md). The latest patch updates are listed in [.NET Core release notes](release-notes/README.md)
+The latest major release is [.NET Core 2.1](release-notes/2.1). The latest patch updates are listed in [.NET Core release notes](release-notes/README.md)
 
 ## Download the latest .NET Core SDK
 


### PR DESCRIPTION
2.1.3 is not the latest - replace it with general 2.1 link.