### PR TITLE
Updates link for Contributing to proper repo and location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-See [Contributing](https://github.com/dotnet/coreclr/blob/master/CONTRIBUTING.md) for information about coding styles, source structure, making pull requests, and more.
+See [Contributing](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md) for information about coding styles, source structure, making pull requests, and more.
 
 # Repos
 


### PR DESCRIPTION
The original **Contributing** link takes you to: https://github.com/dotnet/coreclr/blob/master/CONTRIBUTING.md

That requires a further click on that repo's  **Contributing** link to go to the proper location, which is https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md.

This PR changes the **Contributing** link to just point to https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md and thus eliminate extra mouse clicks and page loads.