### PR TITLE
Make wget slightly more verbose

### DIFF
--- a/Documentation/linux-setup.md
+++ b/Documentation/linux-setup.md
@@ -21,34 +21,34 @@ Open a command prompt and run the commands below that match your distro:
 
 ```bash
 # Debian 8 - .NET Core 2.0 and newer
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
+wget -nv -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-wget -q https://packages.microsoft.com/config/debian/8/prod.list
+wget -nv https://packages.microsoft.com/config/debian/8/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 
 # Debian 9 - .NET Core 2.0 and newer
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
+wget -nv -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-wget -q https://packages.microsoft.com/config/debian/9/prod.list
+wget -nv https://packages.microsoft.com/config/debian/9/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 
 # Ubuntu 14.04 - .NET Core 1.0 and newer
-wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+wget -nv https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get install apt-transport-https
 
 
 # Ubuntu 16.04 - .NET Core 2.0 and newer
-wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+wget -nv https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get install apt-transport-https
 
 # Ubuntu 18.04 -  - .NET Core 2.0 and newer
-wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+wget -nv https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get install apt-transport-https
 ```


### PR DESCRIPTION
`wget -q` is completeley quiet and doesn't even report any errors.
This can lead to a situation where the subsequent command fails but
the user is not made aware of that issue (like with a 404 error,...).

Therefore I propose `wget -nv` which prevents `wget` from being verbose
but reports errors.