### PR TITLE
WIP: Fixes in the new releases.json format

### DIFF
--- a/release-notes/1.0/releases.json
+++ b/release-notes/1.0/releases.json
@@ -1227,6 +1227,7 @@
     },
     {
         "release-date": "2016-09-13",
+        "release-version": "1.0.1",
         "security": false,
         "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md",
         "runtime":

--- a/release-notes/1.1/releases.json
+++ b/release-notes/1.1/releases.json
@@ -603,7 +603,7 @@
             },
             "sdk":
             {
-                "version-sdk": "1.1.8",
+                "version": "1.1.8",
                 "vs-version": "",
                 "files":
                 [
@@ -962,7 +962,7 @@
             },
             "sdk":
             {
-                "version-sdk": "1.1.4",
+                "version": "1.1.4",
                 "vs-version": "",
                 "files":
                 [

--- a/release-notes/1.1/releases.json
+++ b/release-notes/1.1/releases.json
@@ -673,7 +673,7 @@
             }
         },
         {
-            "release-date": "2017-11-14",
+            "release-date": "2018-01-09",
             "release-version": "1.1.6",
             "security": true,
             "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.6.md",

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -1266,6 +1266,7 @@
     
         {
             "release-date": "2018-04-10",
+            "release-version": "2.1.0-preview2",
             "security": false,
             "runtime":
             {

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -251,6 +251,474 @@
                     }
                  ]
             }
+        },
+        {
+            "release-date":  "2018-09-12",
+            "release-version":  "2.2.0-preview2",
+            "security":  false,
+            "release-notes":  "https://github.com/dotnet/core/blob/master/release-notes/2.2/preview/2.2.0-preview2.md",
+            "runtime":  
+            {
+                "version":  "2.2.0-preview2-26905-02",
+                "version-display":  "2.2.0-preview2-26905-02",
+                "files":  
+                [
+                    {
+                        "name":  "dotnet-runtime-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-linux-arm.tar.gz",
+                        "hash":  "93eb9c831745519f8976c9bf6c02ef4a55cd46f7312330de05602e74ee70bea99f0ff45c93c0fdb4cbcc53ce3f22b8d82a27acc354db5cc1cb8eb4caf1ec6dd2"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-arm64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-linux-arm64.tar.gz",
+                        "hash":  "1c88c7b7284f53be6c978ad5f80d1fb44696c5fd67769f17b5967a8aae1f581185a0401bc593fa3968a30b0fbd320c42741f018fcfd37fe979b3643975683201"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-linux-musl-x64.tar.gz",
+                        "hash":  "ef90cbd272f426bdbf8737a99229ccd0eaf9cc6b0a5a910c28f9a892ce11eacde33b8c74bcd35cd2e458ef811295aa9ca92a4ac28db105a3cfdb9e6d6ad3470b"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-linux-x64.tar.gz",
+                        "hash":  "da47c2f0574ee1e73e68ebebf9132b70f2d6b6ff110e4e09666bf360d8e36840ae91855d46ef471ba249c62955efc134ae802584effa688563026f30560e8730"
+                    },
+                    {
+                        "name":  "dotnet-runtime-osx-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-osx-x64.pkg",
+                        "hash":  "2ddd73819cc73077cce9dff5d8442740c2ad66183bd9dfc20987d2b75c8a8bc2048c75c0470d5f1bbd74d722ce53cfcd7207226531dfa5650d526e00746bea49"
+                    },
+                    {
+                        "name":  "dotnet-runtime-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-osx-x64.tar.gz",
+                        "hash":  "9f48942259d9512c47bcff7f939dcff56818a7afe40dc770c3b7bb0973b141f53b893774545a1dd64fe4ac57fa900fedabab9cc3f9cd379092c25aa5d315fb05"
+                    },
+                    {
+                        "name":  "dotnet-runtime-rhel.6-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-rhel.6-x64.tar.gz",
+                        "hash":  "06bd8753c827dfef54ad17ad9f698bca0a1bfa2d5d64420fd53b2ed0075a8952cd298d5e8059d87917bd3f6df4f1d4750841d13926c82a3a0f2e5f8c205d86ff"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-win-x64.exe",
+                        "hash":  "eca0b684bed858e45a8d04dcf05296e023d4eb4ffa996d2b0970b475944b67c86ac7af05c6673ed1f327e06b1184bb1574528fd5d15296661c47cd5d9ae92602"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-win-x64.zip",
+                        "hash":  "8869b53858dde352d2a1aff369daa2805b412288d0c7e52c79114bad17e7c6ddb97490c3c88b9e3c093c3e07f95945766fb3b009a0dd1364bdaedf536b80650d"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-win-x86.exe",
+                        "hash":  "29611927629370c3659f77ee8004225a1b8d58747431c0e846ea35f2db8f72b4588c7df3f570dcbce130fad5cce73566ab7a816b14dab7f261f8c0ad452d6e98"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-runtime-2.2.0-preview2-26905-02-win-x86.zip",
+                        "hash":  "6f9ce9ffcfdc03a07cd9c29f36bd21a3d49720b198b5b361bf499d9c485d38d438dea076189471dc43839b0b871b67a6ff834f3dff56d0fcbb73123eab696026"
+                    }
+                ]
+            },
+            "sdk":  
+            {
+                "version":  "2.2.100-preview2-009404",
+                "version-display":  "2.2.100-preview2-009404",
+                "vs-version":  "15.8.4",
+                "csharp-language":  "7.3",
+                "fsharp-language":  "4.5",
+                "files":  
+                [
+                    {
+                        "name":  "dotnet-sdk-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-linux-arm.tar.gz",
+                        "hash":  "5544eb753e7bab67d34c1509a37a2af96f97ddbdb32e2c63a5d857b27710f37db63630287550e6b60c76e8c2a6988b8212a69e75d04382b224b5fde51b2aea1d"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-arm64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-linux-arm64.tar.gz",
+                        "hash":  "9cd2f0d9970a205a3b92a19c397139e522c3cb309dff34076f141bbae382651bc57bf91bc54703123af997ed64da3970f289b1fbd49e1ef638b1fe279a4ce545"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-linux-musl-x64.tar.gz",
+                        "hash":  "8c41c9ead676e8b1056868eae3464099d2f238a2a2f8bd7ccefb097bfa3758c18a0047d0de48389d53a662e2799391d8761fdaad288049ce0e61f0fc709ddf03"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-linux-x64.tar.gz",
+                        "hash":  "05c4e4accea5cae674bfde24ac883ba7aa733686479621411a5d8fb9c030e0c053d5c0f2c4a4fb62bc8b0f651987ce0f33628ac8a26af1d5c7a4259b3cba7a21"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-gs-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-osx-gs-x64.pkg",
+                        "hash":  "bab8d830984255f9c3c19b1d70a575f3c1876be5dc537ab50a7be43bea0b0ef19a0e22895deb03e30f3559a849f15c68c8e245af314258d79296fe4b4b8019f9"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-osx-x64.pkg",
+                        "hash":  "bab8d830984255f9c3c19b1d70a575f3c1876be5dc537ab50a7be43bea0b0ef19a0e22895deb03e30f3559a849f15c68c8e245af314258d79296fe4b4b8019f9"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-osx-x64.tar.gz",
+                        "hash":  "91b45bc9f6012afc4fbc0a1a0e3ca91276c6873715811a1ec75e9d593d93c244bf104faa34d23e01608ac5878b9220a7c65b0b1ad1793b31abff3ecea95bda61"
+                    },
+                    {
+                        "name":  "dotnet-sdk-rhel.6-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-rhel.6-x64.tar.gz",
+                        "hash":  "215c66b4826d98c92b09e8186aeed0ecdc2556fbaf53ccc41ee69092e4464a65ffaea02028077efbffad6eb7e8d4c242a8773af148e39f6373e0da464dc2a8d7"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-gs-x64.exe",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-gs-x64.exe",
+                        "hash":  "f3431a4b83d97ec835a4fb9daf1dff421e8693a902aac854da3b1d8652c78a98c9b15174a7734e4bf5942aa425af34f97e1cc4809e40eb418de3d597f4cad0bb"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-gs-x86.exe",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-gs-x86.exe",
+                        "hash":  "64b5173921cdfbdda7657111e4428241e70bd5ad52ba21a36dc1a84f59da00ed1aa3c18570a639d4d2e07f97fb7b0198d89b658c6ceec123abb1b2e22bfa4d1a"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-x64.exe",
+                        "hash":  "f3431a4b83d97ec835a4fb9daf1dff421e8693a902aac854da3b1d8652c78a98c9b15174a7734e4bf5942aa425af34f97e1cc4809e40eb418de3d597f4cad0bb"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-x64.zip",
+                        "hash":  "a56368bcc3cc7d94940d2275c8da57ead08e852c2f45ad16323616e3efd1411bfa557eea50f72dd8895153a8e3fb6b90658220ea4d33cdb278cec60df1ac92a3"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-x86.exe",
+                        "hash":  "64b5173921cdfbdda7657111e4428241e70bd5ad52ba21a36dc1a84f59da00ed1aa3c18570a639d4d2e07f97fb7b0198d89b658c6ceec123abb1b2e22bfa4d1a"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/D/5/9/D593CD8F-04E7-425D-962C-86FF4C90B1DA/dotnet-sdk-2.2.100-preview2-009404-win-x86.zip",
+                        "hash":  "4e0bdb25276c287cb4ed4dc71d0cbddb19f6ef892cc2461bc2738e74dfe528567ea2a49740f0a602da23f2c8e343a73786daeb140500246e5d683978899162a3"
+                    }
+                ]
+            },
+            "aspnetcore-runtime":  
+            {
+                "version":  "2.2.0-preview2-35157",
+                "version-display":  "2.2.0-preview2-35157",
+                "version-aspnetcoremodule":  
+                [
+                    "12.2.18248.0",
+                    "8.2.1991.0"
+                ],
+                "files":  
+                [
+                    {
+                        "name":  "aspnetcore-runtime-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-linux-arm.tar.gz",
+                        "hash":  "736d96512ced3b4d40a85a13fad10fda22f6f9ef49775cbd730a9025b1a97da6b6b6dd7364e331b51283dbc13aed1648f0c41d371d26b2be3aac1b6719acbb5b"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-linux-musl-x64.tar.gz",
+                        "hash":  "bff1d30755a4918d42107248b8fd94d4a0b782d8715ff2c2b5a0a547e5bf88ceace574c354a2ba314390909bc2d915dbb048d3304492685b204a14b1ca2ab6b0"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-linux-x64.tar.gz",
+                        "hash":  "c99cbac87b7904305b4b04df4a48779dd18157d6e7befa6f964317f82133005eff3ec2fbc3f91d3db64d9c3382ebd3903a7918bb424180084fd42933211025c2"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-osx-x64.tar.gz",
+                        "hash":  "edc004bc6e230c2b4220a7489e5a6213812b19895df95239e39291570f7368e8543d9c511953cb24fa209c064825afbde81dafd8f195b61812762a23040719f7"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-win-x64.exe",
+                        "hash":  "fa331f372ec4d3a4de2a6dc9664e39dbbbda017ca1872720ee6257bbf8f9dd0878d4c0aba5d27cd2113ee381756e6482ddef5424362ceb52063c3a4d812d8b8c"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-win-x64.zip",
+                        "hash":  "f90a087ec1f5a36b6012e6b5041c76fff63472dc2c95b7c1f68b979e679aaab55ce855c4c18fe2e38f6671f365e956b25a1ae977e7dffe914b0d27477ab67839"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-win-x86.exe",
+                        "hash":  "69eafe97f6c0e5286c923ca681268c03b00f0e1e5c89f5cb5f177ee093056e4d81dfd82b0221713fe486119e4db81c75cef3eb0505d2a12332163e5bbde78e22"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnetcore-runtime-2.2.0-preview2-35157-win-x86.zip",
+                        "hash":  "86282ab1adb588314446382012c0730d66622160442be91dd6764ac2cb60117e81ece542ba352ddd72b9a2041e5c21cc147163fcc378e1d634d68c33ef6585a9"
+                    },
+                    {
+                        "name":  "dotnet-hosting-win.exe",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/dotnet-hosting-2.2.0-preview2-35157-win.exe",
+                        "hash":  "37c88e69165ac1116991027b74434fad47a61affb80bea759b79b98bdd2afe82b0a2e0cd62d5d09189a796453ada711f4aaf109cff89fd9878e1faadbf31b5fb"
+                    }
+                ]
+            },
+            "symbols":  
+            {
+                "version":  "2.2.0-preview2",
+                "files":  
+                [
+                    {
+                        "name":  "aspnet-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/aspnet-2.2.0-preview2-symbols.zip",
+                        "hash":  "f2cf90c7d0c513945c04555043e7bd2461a4432154a961c99ff4710acb0f941a944c26710e7ca94e6c3a0edd4824df73eaa5bcd9c5bcb490bcec5719c2819fa3"
+                    },
+                    {
+                        "name":  "coreclr-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/coreclr-2.2.0-preview2-symbols.zip",
+                        "hash":  "7e1bf8ad862320b4e77978f670cf890ac13ffdfa4a5bc454110d783d317bea01aa225bb9a6692cb34d2989a53fcc99125906e7081d6dbe10f3d27a2921639531"
+                    },
+                    {
+                        "name":  "corefx-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/corefx-2.2.0-preview2-symbols.zip",
+                        "hash":  "58c3a7beff06c5421d19f173666889ddbfccf66b91d656cfbc4b3207a645214be8d89d2654cd80f37272c45148e4aed9a4425d7a64af849460eaf75bdedbd8dc"
+                    },
+                    {
+                        "name":  "core-setup-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/5/B/A/5BA1012E-5112-45C2-8369-152B49A6AA3B/core-setup-2.2.0-preview2-symbols.zip",
+                        "hash":  "e022ec37fc972d970bd56ea8d2985c7d7c158be45da3bd60c725040f4ae0da948b837632cd81fb3455c5be315b48c023c4695487a5625a9b986193dea4a3f4e2"
+                    }
+                 ]
+            }
+        },
+        {
+            "release-date":  "2018-08-22",
+            "release-version":  "2.2.0-preview1",
+            "security":  false,
+            "release-notes":  "https://github.com/dotnet/core/blob/master/release-notes/2.2/preview/2.2.0-preview1.md",
+            "runtime":  
+            {
+                "version":  "2.2.0-preview-26820-02",
+                "version-display":  "2.2.0-preview-26820-02",
+                "files":  
+                [
+                    {
+                        "name":  "dotnet-runtime-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-linux-arm.tar.gz",
+                        "hash":  "33a4fda6cda60352195fd4cc4c214c1e565628d6ffa9b2582e105e49c8886ea143ab50479fb129b22ee87fbdfcc6e99714aae465a111954f5c529c5b5e5b8b54"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-arm64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-linux-arm64.tar.gz",
+                        "hash":  "81fd36b2209446823a39f89ac93db7c566b531897bbcdcb26abde09b95e6d36838d62ed1b2a95339c5f6944ead830c1ebffe9e0d0d28c53ef9d594d8f25df8e6"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-linux-musl-x64.tar.gz",
+                        "hash":  "e260a28512dae88e677aaff8e2f4eae26274a15fd459a63c2ebb03c4f39d6a55451e44612e07ed0dafd2410112a0b21fa32941d13888d70475defc0309ecb910"
+                    },
+                    {
+                        "name":  "dotnet-runtime-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-linux-x64.tar.gz",
+                        "hash":  "6fc7e1a39707f2909699c5b1af470a01b6f0908e169db5b83425f3a5498597850ecdb0c78c60f64205bd68aa9822025a1579a004e3d48128dee59f272d4bd10c"
+                    },
+                    {
+                        "name":  "dotnet-runtime-osx-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-osx-x64.pkg",
+                        "hash":  "b0ce07e2294dfb613d5aa3d81e02c6af30716613900da8d0e54015ca3fd60dae05ceec7351400559a2c619e99c1fc8199feee57b3cfb25453b03e9ca0dda43ca"
+                    },
+                    {
+                        "name":  "dotnet-runtime-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-osx-x64.tar.gz",
+                        "hash":  "870dea28301ca7a402184f14e956fa23756b60458afcedc0475b2bf2ccdba19c6ab6592f8a2e612b52312ad47c364362f065fa8cc67757970001ee7f5d8dc770"
+                    },
+                    {
+                        "name":  "dotnet-runtime-rhel.6-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-rhel.6-x64.tar.gz",
+                        "hash":  "945ee583ce4d58334049ed73de4e20da6c8043a33d8950d229584c368be03d90da9389b3ae328c471cce9b47ebbba806c5393130b05677c6c53be00177f56631"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-win-x64.exe",
+                        "hash":  "968fd684c65314634338f6d3fc7e5336d97303eb7a2e0149a5fb94fd105b14b9b3f146a572849e843dd8656aef16444c69cb6630ea4cbedd1d1ed637bbc15058"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-win-x64.zip",
+                        "hash":  "1c8be0ae874a4daab7a6558a18c4bdf8c2702a93946c0cf3c1b5b6d4ea2cb090880a9e76c139a68e518904016fe37e9dbfb90d471fcc351f7947b7921b7880ae"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-win-x86.exe",
+                        "hash":  "fab1f877448002bb7cd509ec309978baca2322f2c9c29d91eaf54a0b4310079ad7f55449da5ddc8cd5a29c67e05d262bbb1b96325258c123642c77c874fa8eed"
+                    },
+                    {
+                        "name":  "dotnet-runtime-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-win-x86.zip",
+                        "hash":  "9a857b5b22c579a7a55354076b81bea38c61ed70425fb33094762180e10e9c5f06fc9dd436484b1de0bc854f93a282f8c8beeaad1f1f01dd68de9a613ab9ae51"
+                    }
+                ]
+            },
+            "sdk":  
+            {
+                "version":  "2.2.100-preview1-009349",
+                "version-display":  "2.2.100-preview1-009349",
+                "csharp-language":  "7.3",
+                "files":  
+                [
+                    {
+                        "name":  "dotnet-sdk-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-linux-arm.tar.gz",
+                        "hash":  "2f1b84cc88a2098b30ae4b560e6af93b4299990dae8c5939e8aedabcf08931ac37e5af330467aff9ec998cfaada3b0dc76eeea667ce4398a6423b36546737741"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-arm64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-runtime-2.2.0-preview-26820-02-linux-arm64.tar.gz",
+                        "hash":  "705d876fee32e28c49fbcf15f1ee42c4708d9006bf28f5ea2499634e92d86ddb643fe213530b14545f27fa94a1187d79cdc6f9abdc31482f35a4ab896f4cf831"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-linux-musl-x64.tar.gz",
+                        "hash":  "ea1bcf0c2f9f91ea3296667d2b95b07ae4080625d14fdd06f353ac6f02336c26f1ca9d85ae904aebf717b8fb065c86b4eb3a06e643cde746b1bbcfaec1ddadb0"
+                    },
+                    {
+                        "name":  "dotnet-sdk-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-linux-x64.tar.gz",
+                        "hash":  "0584ff770e1e8808126c74cd36c6014cbc95320ff797a79159e809aac72dc6a84bde932dcc4fbb4b281fa253302d4979ce2bd709647fe1f4dfa1e47799ef7184"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-gs-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-osx-gs-x64.pkg",
+                        "hash":  "a2f65c0d5eb09bff9d630a9f4bebaeca82e319bb01b8489e728f144020831736818c59de0a52d0796f059aaeb8a6d758b501b8301911ef74c747b12d63a56fab"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-x64.pkg",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-osx-x64.pkg",
+                        "hash":  "a2f65c0d5eb09bff9d630a9f4bebaeca82e319bb01b8489e728f144020831736818c59de0a52d0796f059aaeb8a6d758b501b8301911ef74c747b12d63a56fab"
+                    },
+                    {
+                        "name":  "dotnet-sdk-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-osx-x64.tar.gz",
+                        "hash":  "edcc36f939689ffb6a16c0ddc43c73da5cf69abf7c1b86a1b7ded9f382e0c7f5c8cada0d2f2fa5e81ca6d93fa7186215625e0433ab6d4721842ea7d7653d6efc"
+                    },
+                    {
+                        "name":  "dotnet-sdk-rhel.6-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-rhel.6-x64.tar.gz",
+                        "hash":  "bedd1485f677c955288f3e1d41c065cb91704d2f346f478f3946040f32b6f9c67eeda5c0a902618ff65f47327b8475bf702c1ee50a738238f1c40cdf685dd6f0"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-gs-x64.exe",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-gs-x64.exe",
+                        "hash":  "91fe61cfb0f76757ae025d77cdd8cd3ecbef14f3708aa742f1a86650323f38fac490e9cc6ab180769bcd3ca1f470ea5b3291726633a6675a33af442307c7dd27"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-gs-x86.exe",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-gs-x86.exe",
+                        "hash":  "47cd97836615c73dfb1f10e9b0d10c36c4e0def770564f8f5ed1e162c8d33d5cbb54cb25ebea4d2e87d1955ffa93756709d2c61c5568b7886c9b97f148a5ff93"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-x64.exe",
+                        "hash":  "91fe61cfb0f76757ae025d77cdd8cd3ecbef14f3708aa742f1a86650323f38fac490e9cc6ab180769bcd3ca1f470ea5b3291726633a6675a33af442307c7dd27"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-x64.zip",
+                        "hash":  "98c799cf1effe00f86ffbcff016f01f7a749289b51a96f310040db713140a4a8e5202aa6e9b2a92e22a0aeb183503a5fd6e733b6853835b4fd83a10b9b5449b0"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-x86.exe",
+                        "hash":  "47cd97836615c73dfb1f10e9b0d10c36c4e0def770564f8f5ed1e162c8d33d5cbb54cb25ebea4d2e87d1955ffa93756709d2c61c5568b7886c9b97f148a5ff93"
+                    },
+                    {
+                        "name":  "dotnet-sdk-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/5/9/2/592E5073-8394-4A95-8F48-54080F0F1555/dotnet-sdk-2.2.100-preview1-009349-win-x86.zip",
+                        "hash":  "d1975ddd41a4dd0b9cd97c818d192a6343d4090d1a9c941714d9a8eb2e2dc6a3bc9c2dd49a6b19ed2d702913546be12b88f22aa4ed13d4dcc7693a9f5fbf92e0"
+                    }
+                ]
+            },
+            "aspnetcore-runtime":  
+            {
+                "version":  "2.2.0-preview1-35029",
+                "version-display":  "2.2.0-preview1-35029",
+                "version-aspnetcoremodule":  
+                [
+                    "12.2.18248.0",
+                    "8.2.1991.0"
+                ],
+                "files":  
+                [
+                    {
+                        "name":  "aspnetcore-runtime-linux-arm.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-linux-arm.tar.gz",
+                        "hash":  "f033ef30ef5a48c4a6fa281865dd4062416e668d1b019fefb8a630c20ada7b4d762e045f6b16b1bf36bb21096d783a14b8fa0cea0ae7b6d78ae118ff769efb84"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-linux-musl-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-linux-musl-x64.tar.gz",
+                        "hash":  "b86908f2c5fc72267520e6b35929d6e8551df7b1f8292c6179c4af09efaffc868574563148868c4ae48ecb45a5c4b95648c33a6b3601024c9db388ecb1a8e938"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-linux-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-linux-x64.tar.gz",
+                        "hash":  "5513145c0d6344af6858fc94f2aa9a78dc2d8abcd35a9db7d10ff01b97a89221cd8534eaebad59b9d548af2233e4d075a8bc254ff0934d0f66a71d83507c03a0"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-osx-x64.tar.gz",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-osx-x64.tar.gz",
+                        "hash":  "16ee2abe50d22332098b371baefdc84313ac7728eba5199243b5755f2f6ce1ab9cb4f32356d53b4402baf38a8b7e0aaf1e583a9cd7de1d7eaef37068de27fec6"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x64.exe",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-win-x64.exe",
+                        "hash":  "867cb2efefcbf0cfcb68ecf92bcb42eb72c9c1fd11be1c0934c51f50c14d907d97b4c8efc3f91e9d2e0682e5c35a7e161f6c30f936c820add142ae902084835f"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x64.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-win-x64.zip",
+                        "hash":  "c923f4e4537642d2ff431d3e5478edcab0cdb3122103d7aeb3844a027de7fb605849b46910a3165047a6ae5d57686fdd914a7f34c9bbb960c912852503206f42"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x86.exe",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-win-x86.exe",
+                        "hash":  "a838ee412c12eecebb50ab05b7de6bb6034420ae1b69b58639aceccd13c6189aa5ffa3d3b37963f623cc8a242b874c79ff41fd08a02e16999681d81cc7f1860c"
+                    },
+                    {
+                        "name":  "aspnetcore-runtime-win-x86.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnetcore-runtime-2.2.0-preview1-35029-win-x86.zip",
+                        "hash":  "38d42d7deb948160a969495bda3f12a4bff6d603ca1ecf657bd128e66ae5b9fe04b3bdd2903e41fb35c75bdb6478075889159c0dd22270596c5ac7a663aee35b"
+                    },
+                    {
+                        "name":  "dotnet-hosting-win.exe",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/dotnet-hosting-2.2.0-preview1-35029-win.exe",
+                        "hash":  "ea347dccf2e62476b151e8d2f9d0cb3bd5523c1830f0f19cef778d63abc05553f380c513325b719239667afe7743d03b4a6dd405a5d94bede2ae53a7abeb480b"
+                    }
+                ]
+            },
+            "symbols":  
+            {
+                "version":  "2.2.0-preview1",
+                "files":  
+                [
+                    {
+                        "name":  "aspnet-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/aspnet-2.2.0-preview1-symbols.zip",
+                        "hash":  "6960afaa7b5dc2446c3adfbcb6c352409241298c9114aa7be9390a0af0126dab0a06f39e82f27f3e35aa3340becf5291f54cec4cdc73831550177e26d7433518"
+                    },
+                    {
+                        "name":  "coreclr-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/coreclr-2.2.0-preview1-symbols.zip",
+                        "hash":  "2d2d9ead71b13aee5d1bc89b0e947ef6fcb4be7bcfcdaebf325051dc21cd0a1c2a7d20c105d500af7454ff4b09d04f6359315f6da39063eeb4484590848a21fb"
+                    },
+                    {
+                        "name":  "corefx-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/corefx-2.2.0-preview1-symbols.zip",
+                        "hash":  "1eb028e621ec0febd4fef4aa787c2ecf8563733bfe95ffa02ac8bd3c39898b5e91fc19ba78a5bf9c545a825e36adaa8138d94872abda0968f0b12ec3f0695770"
+                    },
+                    {
+                        "name":  "core-setup-symbols.zip",
+                        "url":  "https://download.microsoft.com/download/1/9/F/19FEB118-A1D8-4B0E-B74C-D155FC5D297E/core-setup-2.2.0-preview1-symbols.zip",
+                        "hash":  "493804a96e01e2d9c63458f81fe2b0c253e1479286b60318050aeaa041497e293247b8b92316f829f0cab567c8c6521b0a5dc76ff81e4959080478044840c227"
+                    }
+                 ]
+            }
         }
     ]
 }

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -1,6 +1,15 @@
 {
     "releases-index": [
         {
+            "channel-version": "2.2",
+            "latest-release": "2.2.0-preview3",
+            "latest-release-date":"2018-10-17",
+            "product": ".NET Core",
+            "support-phase": "preview",
+            "eol-date": "",
+            "releases.json": "https://github.com/dotnet/core/blob/master/release-notes/2.2/releases.json"
+        },
+        {
             "channel-version": "2.1",
             "latest-release": "2.1.5",
             "latest-release-date":"2018-10-02",


### PR DESCRIPTION
Fixes for the issues I raised in #1986.

Note that for 2.2.0-preview1 and 2.2.0-preview2 I could not find some of the symbol files that are listed for preview3, so I removed those entries.

TODO:
- [ ] Add SDK release 2.1.400