### PR TITLE
fix field inconsistencies and add runtime and sdk versions

### DIFF
--- a/release-notes/1.0/releases.json
+++ b/release-notes/1.0/releases.json
@@ -2,6 +2,8 @@
     "channel-version": "1.0",
     "latest-release": "1.0.13",
     "latest-release-date": "2018-10-09",
+    "latest-runtime": "1.0.13",
+    "latest-sdk": "1.1.11",
     "support-phase": "maintenance",
     "eol-date": "2019-06-27",
     "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
@@ -91,6 +93,9 @@
         "sdk":
         {
             "version": "1.1.11",
+            "version-display":  "1.1.11",
+            "runtime-version": "1.0.13",
+            "vs-version":  "",
             "files":  [
                 {
                     "name":  "dotnet-dev-osx-x64.tar.gz",
@@ -235,6 +240,9 @@
         "sdk":
         {
             "version": "1.1.10",
+            "version-display":  "1.1.10",
+            "runtime-version": "1.0.12",
+            "vs-version":  "",
             "files": 
             [
                 {
@@ -371,6 +379,8 @@
         "sdk":
         {
             "version": "1.1.9",
+            "version-display":  "1.1.9",
+            "runtime-version": "1.0.11",
             "vs-version": "15.0",
             "csharp-language": "7.0",
             "files":
@@ -474,6 +484,9 @@
         "sdk":
         {
             "version": "1.1.8",
+            "version-display":  "1.1.8",
+            "runtime-version": "1.0.10",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -573,6 +586,9 @@
         "sdk":
         {
             "version": "1.1.7",
+            "version-display":  "1.1.7",
+            "runtime-version": "1.0.9",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -668,6 +684,9 @@
         "sdk":
         {
             "version": "1.1.5",
+            "version-display":  "1.1.5",
+            "runtime-version": "1.0.8",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -763,6 +782,9 @@
         "sdk":
         {
             "version": "1.1.4",
+            "version-display":  "1.1.4",
+            "runtime-version": "1.0.7",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -880,6 +902,9 @@
         "sdk":
         {
             "version": "1.0.4",
+            "version-display":  "1.0.4",
+            "runtime-version": "1.0.5",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -990,6 +1015,8 @@
         "sdk":
         {
             "version": "1.0.1",
+            "version-display":  "1.0.1",
+            "runtime-version": "1.0.4",
             "vs-version": "15.0",
             "files":
             [
@@ -1131,6 +1158,9 @@
         "sdk":
         {
             "version": "1.0.0-preview2-003156",
+            "version-display":  "1.0.0-preview2",
+            "runtime-version": "1.0.3",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -1215,6 +1245,9 @@
         "sdk":
         {
             "version": "1.0.0-preview2-003148",
+            "version-display":  "1.0.0-preview2",
+            "runtime-version": "1.0.2",
+            "vs-version":  "",
             "files":
             [
                 {
@@ -1275,6 +1308,9 @@
         "sdk":
         {
             "version": "1.0.0-preview2-003131",
+            "version-display":  "1.0.0-preview2",
+            "runtime-version": "1.0.1",
+            "vs-version":  "",
             "files":
             [
             {
@@ -1380,6 +1416,8 @@
         "sdk":
         {
             "version": "1.0.0-preview2-003121",
+            "version-display":  "1.0.0-preview2",
+            "runtime-version": "1.0.0",
             "files":
             [
             {

--- a/release-notes/1.1/releases.json
+++ b/release-notes/1.1/releases.json
@@ -2,6 +2,8 @@
     "channel-version": "1.1",
     "latest-release": "1.1.10",
     "latest-release-date": "2018-10-09",
+    "latest-runtime": "1.1.10",
+    "latest-sdk": "1.1.11",
     "support-phase": "maintenance",
     "eol-date": "2019-06-27",
     "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
@@ -117,6 +119,7 @@
             "sdk": {
                 "version": "1.1.11",
                 "version-display": "1.1.11",
+                "runtime-version": "1.1.10",
                 "vs-version": "",
                 "files":  [
                     {
@@ -305,6 +308,7 @@
             {
                 "version": "1.1.10",
                 "version-display": "1.1.10",
+                "runtime-version": "1.1.9",
                 "vs-version": "",
                 "files":
                 [
@@ -469,6 +473,8 @@
             "sdk":
             {
                 "version": "1.1.9",
+                "version-display": "1.1.9",
+                "runtime-version": "1.1.8",
                 "vs-version": "15.0",
                 "csharp-language": "7.0",
                 "files": 
@@ -603,7 +609,9 @@
             },
             "sdk":
             {
-                "version-sdk": "1.1.8",
+                "version": "1.1.8",
+                "version-display": "1.1.8",
+                "runtime-version": "1.1.7",
                 "vs-version": "",
                 "files":
                 [
@@ -737,6 +745,9 @@
             "sdk":
             {
                 "version": "1.1.7",
+                "version-display": "1.1.7",
+                "runtime-version": "1.1.6",
+                "vs-version": "",
                 "files":
                 [
                 {
@@ -863,6 +874,9 @@
             "sdk":
             {
                 "version": "1.1.5",
+                "version-display":  "1.1.5",
+                "runtime-version": "1.1.5",
+                "vs-version":  "",
                 "files":
                 [
                 {
@@ -962,7 +976,9 @@
             },
             "sdk":
             {
-                "version-sdk": "1.1.4",
+                "version": "1.1.4",
+                "version-display":  "1.1.4",
+                "runtime-version": "1.1.4",
                 "vs-version": "",
                 "files":
                 [
@@ -1097,6 +1113,8 @@
             "sdk":
             {
                 "version": "1.0.4",
+                "version-display":  "1.0.4",
+                "runtime-version": "1.1.2",
                 "vs-version": "15.2.2",
                 "files":
                 [
@@ -1239,6 +1257,9 @@
             "sdk":
             {
                 "version": "1.0.1",
+                "version-display":  "1.0.1",
+                "runtime-version": "1.1.1",
+                "vs-version":  "",
                 "files":
                 [
                     {
@@ -1380,6 +1401,9 @@
             "sdk":
             {
                 "version": "1.0.0-preview2.1-003177",
+                "version-display":  "1.0.0-preview2",
+                "runtime-version": "1.1.0",
+                "vs-version":  "",
                 "files":
                 [
                     {

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -129,7 +129,8 @@
             "sdk": {
               "version": "2.1.600-preview-009426",
               "version-display": "2.1.600-preview-009426",
-              "vsversion": "16.0-preview-1",
+              "runtime-version": "2.1.6",
+              "vs-version": "16.0-preview-1",
               "csharp-version": "7.3",
               "fsharp-version": "4.5",
               "vb-version": "15.0",
@@ -294,6 +295,7 @@
             {
                 "version":  "2.1.500",
                 "version-display":  "2.1.500",
+                "runtime-version": "2.1.6",
                 "vs-version":  "15.9",
                 "csharp-language":  "7.3",
                 "fsharp-language":  "4.5",
@@ -550,6 +552,7 @@
             {
                 "version":  "2.1.403",
                 "version-display":  "2.1.403",
+                "runtime-version": "2.1.5",
                 "vs-version":  "15.8.6",
                 "csharp-language":  "7.3",
                 "fsharp-language":  "4.5",
@@ -796,6 +799,7 @@
             {
                 "version": "2.1.402",
                 "version-display": "2.1.402",
+                "runtime-version": "2.1.4",
                 "vs-version": "",
                 "csharp-language": "7.3",
                 "fsharp-language":"4.5",
@@ -1004,6 +1008,7 @@
             {
                 "version": "2.1.401",
                 "version-display": "2.1.401",
+                "runtime-version": "2.1.3",
                 "vs-version": "",
                 "csharp-language": "7.3",
                 "fsharp-language":"4.5",
@@ -1208,6 +1213,7 @@
             {
                     "version": "2.1.302",
                     "version-display": "2.1.302",
+                    "runtime-version": "2.1.2",
                     "vs-version": "",
                     "csharp-language": "7.3",
                     "files":
@@ -1411,6 +1417,7 @@
             {
                 "version": "2.1.301",
                 "version-display": "2.1.301",
+                "runtime-version": "2.1.1",
                 "vs-version": "",
                 "csharp-language": "7.3",
                 "files": 
@@ -1614,6 +1621,7 @@
             {
                 "version": "2.1.300-rc1-008673",
                 "version-display": "2.1.300-rc1",
+                "runtime-version": "2.1.0-rc1",
                 "files":
                 [
                     {	
@@ -1734,7 +1742,7 @@
         },
         {
             "release-date": "2018-04-10",
-	    "release-version": "2.1.0-preview2",
+	        "release-version": "2.1.0-preview2",
             "security": false,
             "runtime":
             {
@@ -1783,6 +1791,7 @@
             {
                 "version": "2.1.300-preview2-008533",
                 "version-display": "2.1.300-preview2",
+                "runtime-version": "2.1.0-preview2-26406-04",
                 "csharp-language": "7.3",
                 "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.300-preview2-008533-sdk-sha.txt",
                 "files":
@@ -1930,6 +1939,7 @@
             {
                 "version": "2.1.300-preview1-008174",
                 "version-display": "2.1.300-preview1",
+                "runtime-version": "2.1.0-preview1-26216-03",
                 "files":
                 [
                     {	

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -2,6 +2,8 @@
     "channel-version": "2.2",
     "latest-release": "2.2.101",
     "latest-release-date":"2018-12-11",
+    "latest-runtime": "2.2.0",
+    "latest-sdk": "2.2.101",
     "support-phase": "current",
     "eol-date": "",
     "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
@@ -116,7 +118,8 @@
             "sdk": {
               "version": "2.2.200-preview-009648",
               "version-display": "2.2.200-preview-009648",
-              "vsversion": "16.0-preview-1",
+              "runtime-version": "2.2.0",
+              "vs-version": "16.0-preview-1",
               "csharp-version": "7.3",
               "fsharp-version": "4.5",
               "files": [
@@ -226,7 +229,7 @@
             "runtime": {
               "version": "2.2.0",
               "version-display": "2.2.0",
-              "vsversion": "",
+              "vs-version": "",
               "files": [
                 {
                   "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -299,6 +302,7 @@
             {
                 "version":  "2.2.100",
                 "version-display":  "2.2.100",
+                "runtime-version": "2.2.0",
                 "vs-version":  "",
                 "csharp-language":  "7.3",
                 "fsharp-language":  "4.5",
@@ -380,7 +384,10 @@
             {
                 "version":  "2.2.0",
                 "version-display":  "2.2.0",
-                "version-aspnetcoremodule":  "12.2.18316.0",
+                "version-aspnetcoremodule":  
+                [ 
+                    "12.2.18316.0" 
+                ],
                 "files": [
                     {
                       "name": "aspnetcore-runtime-linux-arm.tar.gz",
@@ -563,6 +570,7 @@
             {
                 "version":  "2.2.100-preview3-009430",
                 "version-display":  "2.2.100-preview3-009430",
+                "runtime-version":  "2.2.0-preview3-27014-02",
                 "vs-version":  "",
                 "csharp-language":  "7.3",
                 "fsharp-language":  "4.5",

--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -16,7 +16,7 @@
         {
           "version": "3.0.0-preview-27122-01",
           "version-display": "3.0.0-preview-27122-01",
-          "vsversion": "",
+          "vs-version": "",
           "files": [
             {
               "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -102,7 +102,7 @@
         {
           "version": "3.0.100-preview-009812",
           "version-display": "3.0.100-preview-009812",
-          "vsversion": "",
+          "vs-version": "",
           "csharp-version": "7.3",
           "fsharp-version": "4.5",
           "vb-version":"15.5",
@@ -203,8 +203,11 @@
         {
           "version": "3.0.0-preview-18579-0056",
           "version-display": "3.0.0-preview-18579-0056",
-          "version-aspnetcoremodule": "13.0.18333.0",
-          "vsversion": "",
+          "version-aspnetcoremodule": 
+          [
+              "13.0.18333.0"
+          ],
+          "vs-version": "",
           "files": [
             {
               "name": "aspnetcore-runtime-linux-arm.tar.gz",


### PR DESCRIPTION
Partially addresses https://github.com/dotnet/core/issues/2139. 

Summary of changes

- added latest-runtime and latest-sdk to the top-level element of each channel releases.json
- added runtime-version to sdk element
- corrected field name inconsistencies where found
- changed all occurrences of version-aspnetcoremodule to an array because multiple versions per release is possible.

cc @tristanbarcelon 