### PR TITLE
backfill json updates to previous channels

### DIFF
--- a/release-notes/1.0/releases.json
+++ b/release-notes/1.0/releases.json
@@ -1,1467 +1,1762 @@
 {
-    "channel-version": "1.0",
-    "latest-release": "1.0.13",
-    "latest-release-date": "2018-10-09",
-    "latest-runtime": "1.0.13",
-    "latest-sdk": "1.1.11",
-    "support-phase": "maintenance",
-    "eol-date": "2019-06-27",
-    "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
-    "releases": 
-    [
+  "channel-version": "1.0",
+  "latest-release": "1.0.13",
+  "latest-release-date": "2018-10-09",
+  "latest-runtime": "1.0.13",
+  "latest-sdk": "1.1.11",
+  "support-phase": "maintenance",
+  "eol-date": "2019-06-27",
+  "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+  "releases": [
     {
-        "release-date": "2018-10-09",
-        "release-version": "1.0.13",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.13.md",
-        "runtime":
-        {
-            "version": "1.0.13",
-            "files":  [
-                {
-                    "name":  "dotnet-win-x86.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/bf245f8d-baac-40c1-8e71-cbbba707567a/1409618b28f28081543611fc6b3975b2/dotnet-win-x86.1.0.13.zip",
-                    "hash":  "8def96db00781c198a15302ac7bb3d81808f79c0656f24ecb40408989735aee1579e9761a4969011f554faa42180d85fd609b132e8a7bf9293bc2b5c833988d3"
-                },
-                {
-                    "name":  "dotnet-win-x86.exe",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/cb053d14-47f0-4b44-be07-10a8498c6e43/085f44c92dcc8f37f041362789d64652/dotnet-win-x86.1.0.13.exe",
-                    "hash":  "0b9b3819f42605d6a4d8f6125456b8c14a861af242d4fce93675731adff0df7487875247558b6aa12df89f3907b8855434ee964976f70766df86bf1eeff9e4d3"
-                },
-                {
-                    "name":  "dotnet-win-x64.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/9912c80e-d5cb-4444-ad0f-14c7d8be9934/6d84e4c1b52854fd3348b61a8f35390c/dotnet-win-x64.1.0.13.zip",
-                    "hash":  "2959a7fd9e5a3d043721eade277e3d7172782776e7988323d1b3e072cbb2283f3b0c75c2971d13c5139e3b90d0c5de06aa1e3f48aeb325f3eabab8568d14d5dc"
-                },
-                {
-                    "name":  "dotnet-win-x64.exe",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/ca708427-f409-4c58-ba6c-8e4181165ca7/302fb8001cd5a43e1a2b3b298f178421/dotnet-win-x64.1.0.13.exe",
-                    "hash":  "ec36957a4c2b9b5afad5a47c8d8e2c49091515f40e79f74b9dd63e9933943256f4d4af773e00e6d69a6dcd5a9512941867b0bb93c854595237f7fd9f58e29a31"
-                },
-                {
-                    "name":  "dotnet-osx-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/e0c8ff7d-f5bc-45f0-91a6-d498ca19ecdb/5a4c140f88ee9411c8c3422bbd3c21fb/dotnet-osx-x64.1.0.13.tar.gz",
-                    "hash":  "aa3d13c821ae29488cd528cdeec8e4758c1213c9cf412305b3d78c2a884aa25f1bf831f99a431f68a5b6127845f6195c9379bc2198bbabbfe053ff2c011ca4f0"
-                },
-                {
-                    "name":  "dotnet-osx-x64.pkg",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/f1abb833-4b3e-4c97-a1ef-5e8258a5bdf8/8e05b692b4e50005288c0712fc20ed9d/dotnet-osx-x64.1.0.13.pkg",
-                    "hash":  "f8a44b733740b6fd041f3fbfd96e47b9aa164c0a5b6cf3e02d9bdbaa1624669a7f4a7a0c50aab32cb6c3c001c368e968b7df0f68977e7766f47a5cb5f2ffcbf0"
-                },
-                {
-                    "name":  "dotnet-centos-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/239e6fa0-ad82-4536-a48e-655dd0ccab1a/89fcb7d66660bec8259c97cd1d554d88/dotnet-centos-x64.1.0.13.tar.gz",
-                    "hash":  "3a04df57beda49ab7da450a59658f43d7289edcb4810c041e9b1d5f366b7fe7b499a259452d59b42180cde005ad4caa7e039aaa997bf098cbaca2035288a91f8"
-                },
-                {
-                    "name":  "dotnet-debian-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/0459a9f3-c263-4086-b7e3-a846183f2132/c2f1813dd266658dd76628daba5806c3/dotnet-debian-x64.1.0.13.tar.gz",
-                    "hash":  "2e1b823f9e4af9d3da1741ab21cc9f5eaf5b9267690d63528a1fde53a2d841490dc8c83ade0ac365acb3383b1ef435d2c7213d0e320a461d77596fb9858722b5"
-                },
-                {
-                    "name":  "dotnet-ubuntu-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/9892faa7-c699-461d-afeb-dcd0869f544b/76cd9455b6623e390c4f61ca73d7701e/dotnet-ubuntu-x64.1.0.13.tar.gz",
-                    "hash":  "e4df72a4e8a3d78a12cae60e1cec37c52f18640276e720bb6da83b44931f172066c0b9716cb2871b3d1a29537b635e9348b8c2f0601a38f532f071626af2d01b"
-                },
-                {
-                    "name":  "dotnet-ubuntu.16.04-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/30bac15b-7bca-4aa5-8981-bd71e171f3b0/ee84e87162dd3e344609faec9802cbde/dotnet-ubuntu.16.04-x64.1.0.13.tar.gz",
-                    "hash":  "28415fb271d62dc5a889884149e9a03ed845644b1b7f4fcaf264d3bc53b790821dbff861de3df02bd1160a7969a8321b62816ddc4987efd3e014b1012e545199"
-                },
-                {
-                    "name":  "dotnet-rhel-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/632f280e-9f27-495f-bbe4-ccd17cde70ac/df8a4b586e8d7caa9ac6133e68aa41fe/dotnet-rhel-x64.1.0.13.tar.gz",
-                    "hash":  "1e39bfc22254ec7660dae50fdcf0cd1eaf9be58797732107b5ce4fa3c035a8fa66d55f3acf0af27193176480bd94829c152621eccbb906672a6fd1397376b269"
-                },
-                {
-                    "name":  "core-setup-symbols.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/8b10e003-60e0-43de-80c8-1a1c93b0c9f8/fd1f4c730b2b2a808521686a470cd17b/core-setup-1.0.13-symbols.zip",
-                    "hash":  "aadb261a541b0994079c571ae776819197fb18a9518d61fc0b891cdc7e40e0592a2e3a72efc4944a2f70b4cfd7e281852a53dc4ea254346c2cee29c17f3ec25f"
-                },
-                {
-                    "name":  "corefx-symbols.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/c8437415-67ab-4a52-b9e2-cb2d873818cb/756c1aec8815d1d23852ee91a769739e/corefx-1.0.13-symbols.zip",
-                    "hash":  "5227344287216e0c86e2b8d18a6fabef049abc831e52664a653ea5a55e6ab9717d53c43f6e400b869b8a6557356937d85f443c09adb7ab371a2789f3242ca58e"
-                },
-                {
-                    "name":  "coreclr-symbols.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/94463197-e5ce-4780-a3e3-824b593984a4/6c8ccf14c6d7c48f2abe97f35e3349a4/coreclr-1.0.13-symbols.zip",
-                    "hash":  "30eb24a28de0a5bf28983570eb52568728ec432405a3b73ca4e7f968068336f81ec24d717587c6ecc4a2195b949f4e212d5a84913388beb55c28ccf59260042d"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.11",
-            "version-display":  "1.1.11",
-            "runtime-version": "1.0.13",
-            "vs-version":  "",
-            "files":  [
-                {
-                    "name":  "dotnet-dev-osx-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/15a05546-15df-488f-adcf-0e77e86dbefb/1f902e78cfea6209c387adce764a88bc/dotnet-dev-osx-x64.1.1.11.tar.gz",
-                    "hash":  "b827b192398af01bf917a5fc0255616a82f04a95dac8154e681398e7e3ef549d701376bb1c9018dea37269e0406f065fb8e2958e652dfabaf86d5e0bb68b0840"
-                },
-                {
-                    "name":  "dotnet-dev-osx-x64.pkg",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/3c23a7aa-eecd-461b-ad45-979c4c684917/1b464bd34c763e664f7eed6006889d87/dotnet-dev-osx-x64.1.1.11.pkg",
-                    "hash":  "1b8ba4f003fda6725c6c27787f6b750064fa7522d0adb0bbbb1717286b2083550da68a242b840dc9505ca68775785935b0428933eb8b0e89f31e698e41618989"
-                },
-                {
-                    "name":  "dotnet-dev-win-x86.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/db408c7b-ef37-4374-b33b-a5b286adaa53/be0f0df977501c4df71ac3f04b9ce35e/dotnet-dev-win-x86.1.1.11.zip",
-                    "hash":  "29a97f3e5e2e8465e4b0c7628a9a02baa0148bfe1a960f58dcdb08b3ad65702cf5367c3f776f47b4df5ce2487955831ed5ab330d4eeabea28ab4f25edb051be8"
-                },
-                {
-                    "name":  "dotnet-dev-win-x86.exe",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/9386d3bc-6799-4cc5-8288-c807674c72ed/b585db316f0d1c4cad749c247ef21b59/dotnet-dev-win-x86.1.1.11.exe",
-                    "hash":  "88778c12aa4e3bdb696da31d5ae1a03441fc6d0d1860bada75bc604692e3f8c240941a10b8a99eaace2b5a6957bcdafa158f2cfb533d122bffcb2c55b25f351d"
-                },
-                {
-                    "name":  "dotnet-dev-win-x64.zip",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/a298f85a-bc4c-4019-842e-021e397e3437/5c95727dfe79b600834291a8983b9507/dotnet-dev-win-x64.1.1.11.zip",
-                    "hash":  "cbf96efd9f6119cad96041e3c55099b98f82252a60a93bbba5f93289bf600c5146402046c3ac79c6e927291e40cb5222171c3ee8cfbc086e635968dfed6e269e"
-                },
-                {
-                    "name":  "dotnet-dev-win-x64.exe",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/baf5a5a7-68d6-4cf1-afdf-47968b5f91e7/05e6dfe191607ef6135a34215464f600/dotnet-dev-win-x64.1.1.11.exe",
-                    "hash":  "6e15fa8c9d5b10cc3edb353c5e1ece01a29f7d00ff853cc12f84e33a776df8062c07febbd9659ca46c2adeb005036c231fd7a7592591b6e28c643bdc45084778"
-                },
-                {
-                    "name":  "dotnet-dev-centos-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/116bc57f-a6d6-474f-aca7-58c18fe0fac4/aa324344fc9c36623fb4a7c7e5bece0c/dotnet-dev-centos-x64.1.1.11.tar.gz",
-                    "hash":  "8665733eba5af02f8af5420bc858ffc4ef73281fb518c0736458f9f1f666f65e57c6a8e2efac5d3e6aca56ac8942a25d1d805ce392fd6f751fb3f0ce821b20c4"
-                },
-                {
-                    "name":  "dotnet-dev-debian-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/1ef84426-c1d0-4e3b-86a4-7fce48baecb8/a47dbe0cd3bc1eefdabbf9354f60004b/dotnet-dev-debian-x64.1.1.11.tar.gz",
-                    "hash":  "14f48469ebbc171d111369ea0dbe88ee9aeb74193aabd6e123c97e54ad81fd6352e86c446f8fe68e2db93793de86fbf89a9c682dd7d1d226169e788cd1f3f6a2"
-                },
-                {
-                    "name":  "dotnet-dev-debian.9-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/b5c87053-99b4-4c91-af5b-69a1c0e2c91e/ab8882f283fb7206d0f1ee965faa4288/dotnet-dev-debian.9-x64.1.1.11.tar.gz",
-                    "hash":  "23e1d3d1863ae8f6bfd450ff238ad7d5929722df6a0492597089c992aa1b223af294386718a711040a4e5f77bd3af97e7924d344e1535d4bc36c640dc6b73869"
-                },
-                {
-                    "name":  "dotnet-dev-fedora.27-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/98eb7365-0ca8-4e29-b455-b165e583d0de/3a1da729266cb9b885f6747b376a0f7c/dotnet-dev-fedora.27-x64.1.1.11.tar.gz",
-                    "hash":  "ed2cad6ef471dd787086a249b932569840cabc7d48aa6920ce2d85e2d364a880f1d4c63e1014016a0fd19f8e8f1f93526fa2d710a587fcb27616bfd27844dc57"
-                },
-                {
-                    "name":  "dotnet-dev-fedora.28-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/b3e55604-5a36-412d-ada3-9a46bba55fd0/473cb6db3926c04b7598d750f1d30731/dotnet-dev-fedora.28-x64.1.1.11.tar.gz",
-                    "hash":  "50ba2fa6a319de00857f847c6dbaf49bb4b93a0e7f73824ff47bdabc6862b45f0349c9c95b11dd2caec6fd4ef5ba3e89ad1c5a44e6a66cf600bc906327805a7f"
-                },
-                {
-                    "name":  "dotnet-dev-opensuse.42.3-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/3b5e416e-1359-4638-b1f3-e0ac378d3550/13ee9ae8dd5bdd11a11abe1934542920/dotnet-dev-opensuse.42.3-x64.1.1.11.tar.gz",
-                    "hash":  "13163a1573c1f95ed45a5b445488080cd619693ac7ce8705e13ccfb605ae89d959a82bf42d633a6e65d5242eb508840e9f521bcfb6f30623a6575bfa701e6532"
-                },
-                {
-                    "name":  "dotnet-dev-ubuntu-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/c0957a2b-cac6-44d8-b1cc-0dad4420c825/8dc69e33f8cf44152fdf173d3bf0b746/dotnet-dev-ubuntu-x64.1.1.11.tar.gz",
-                    "hash":  "a7743d00fad50ec1c9f27ac5b09d1b9d787ac9d4d600179d1d4a5ebb636438dda45ecc85b1a246fd2eed6455dfdcf764165428af38f83a524b4ea0aee82a3366"
-                },
-                {
-                    "name":  "dotnet-dev-ubuntu.16.04-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/c9f432a7-11fd-48a8-adef-fa95bc24a9ad/85a7293b69d07d5ed678ea21f6082539/dotnet-dev-ubuntu.16.04-x64.1.1.11.tar.gz",
-                    "hash":  "60906a50e01420c0603127041b5fc628cb064169ed03b6c9727857695021d2713d92cdec322d97340d9e525a1f2f3c727b7125ca07c0d04057196e0e7cf791b2"
-                },
-                {
-                    "name":  "dotnet-dev-ubuntu.18.04-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/aeac042a-cfef-4064-b914-7419f13c20ae/be14353986c2fbb2259064bcd2cc522a/dotnet-dev-ubuntu.18.04-x64.1.1.11.tar.gz",
-                    "hash":  "d96adb429e00052e331215438d0f1f244c830f633f9bd0dcf817f02a2211028ee4ac02e585be440863bdc6afc54fabe3539188c6f5f7086d8a0ced624fb05697"
-                },
-                {
-                    "name":  "dotnet-dev-rhel-x64.tar.gz",
-                    "url":  "https://download.visualstudio.microsoft.com/download/pr/e461be2e-e14f-4a78-b987-351da98fb9ab/dc2c11f04a967d3d5c15a9a47b2d9fcc/dotnet-dev-rhel-x64.1.1.11.tar.gz",
-                    "hash":  "c79e40710dbf5e0f22d54ebeef4e08ce459a83dd58a9d7a2e56ebb480c780e912d4c8ee643df7f7717bb8544955bb154ca9aa88ec610eccd0d2f712b74668be3"
-                }
-            ]    
-        }
+      "release-date": "2018-10-09",
+      "release-version": "1.0.13",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.13.md",
+      "runtime": {
+        "version": "1.0.13",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf245f8d-baac-40c1-8e71-cbbba707567a/1409618b28f28081543611fc6b3975b2/dotnet-win-x86.1.0.13.zip",
+            "hash": "8def96db00781c198a15302ac7bb3d81808f79c0656f24ecb40408989735aee1579e9761a4969011f554faa42180d85fd609b132e8a7bf9293bc2b5c833988d3"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cb053d14-47f0-4b44-be07-10a8498c6e43/085f44c92dcc8f37f041362789d64652/dotnet-win-x86.1.0.13.exe",
+            "hash": "0b9b3819f42605d6a4d8f6125456b8c14a861af242d4fce93675731adff0df7487875247558b6aa12df89f3907b8855434ee964976f70766df86bf1eeff9e4d3"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9912c80e-d5cb-4444-ad0f-14c7d8be9934/6d84e4c1b52854fd3348b61a8f35390c/dotnet-win-x64.1.0.13.zip",
+            "hash": "2959a7fd9e5a3d043721eade277e3d7172782776e7988323d1b3e072cbb2283f3b0c75c2971d13c5139e3b90d0c5de06aa1e3f48aeb325f3eabab8568d14d5dc"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca708427-f409-4c58-ba6c-8e4181165ca7/302fb8001cd5a43e1a2b3b298f178421/dotnet-win-x64.1.0.13.exe",
+            "hash": "ec36957a4c2b9b5afad5a47c8d8e2c49091515f40e79f74b9dd63e9933943256f4d4af773e00e6d69a6dcd5a9512941867b0bb93c854595237f7fd9f58e29a31"
+          },
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e0c8ff7d-f5bc-45f0-91a6-d498ca19ecdb/5a4c140f88ee9411c8c3422bbd3c21fb/dotnet-osx-x64.1.0.13.tar.gz",
+            "hash": "aa3d13c821ae29488cd528cdeec8e4758c1213c9cf412305b3d78c2a884aa25f1bf831f99a431f68a5b6127845f6195c9379bc2198bbabbfe053ff2c011ca4f0"
+          },
+          {
+            "name": "dotnet-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f1abb833-4b3e-4c97-a1ef-5e8258a5bdf8/8e05b692b4e50005288c0712fc20ed9d/dotnet-osx-x64.1.0.13.pkg",
+            "hash": "f8a44b733740b6fd041f3fbfd96e47b9aa164c0a5b6cf3e02d9bdbaa1624669a7f4a7a0c50aab32cb6c3c001c368e968b7df0f68977e7766f47a5cb5f2ffcbf0"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/239e6fa0-ad82-4536-a48e-655dd0ccab1a/89fcb7d66660bec8259c97cd1d554d88/dotnet-centos-x64.1.0.13.tar.gz",
+            "hash": "3a04df57beda49ab7da450a59658f43d7289edcb4810c041e9b1d5f366b7fe7b499a259452d59b42180cde005ad4caa7e039aaa997bf098cbaca2035288a91f8"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0459a9f3-c263-4086-b7e3-a846183f2132/c2f1813dd266658dd76628daba5806c3/dotnet-debian-x64.1.0.13.tar.gz",
+            "hash": "2e1b823f9e4af9d3da1741ab21cc9f5eaf5b9267690d63528a1fde53a2d841490dc8c83ade0ac365acb3383b1ef435d2c7213d0e320a461d77596fb9858722b5"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9892faa7-c699-461d-afeb-dcd0869f544b/76cd9455b6623e390c4f61ca73d7701e/dotnet-ubuntu-x64.1.0.13.tar.gz",
+            "hash": "e4df72a4e8a3d78a12cae60e1cec37c52f18640276e720bb6da83b44931f172066c0b9716cb2871b3d1a29537b635e9348b8c2f0601a38f532f071626af2d01b"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30bac15b-7bca-4aa5-8981-bd71e171f3b0/ee84e87162dd3e344609faec9802cbde/dotnet-ubuntu.16.04-x64.1.0.13.tar.gz",
+            "hash": "28415fb271d62dc5a889884149e9a03ed845644b1b7f4fcaf264d3bc53b790821dbff861de3df02bd1160a7969a8321b62816ddc4987efd3e014b1012e545199"
+          },
+          {
+            "name": "dotnet-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/632f280e-9f27-495f-bbe4-ccd17cde70ac/df8a4b586e8d7caa9ac6133e68aa41fe/dotnet-rhel-x64.1.0.13.tar.gz",
+            "hash": "1e39bfc22254ec7660dae50fdcf0cd1eaf9be58797732107b5ce4fa3c035a8fa66d55f3acf0af27193176480bd94829c152621eccbb906672a6fd1397376b269"
+          },
+          {
+            "name": "core-setup-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8b10e003-60e0-43de-80c8-1a1c93b0c9f8/fd1f4c730b2b2a808521686a470cd17b/core-setup-1.0.13-symbols.zip",
+            "hash": "aadb261a541b0994079c571ae776819197fb18a9518d61fc0b891cdc7e40e0592a2e3a72efc4944a2f70b4cfd7e281852a53dc4ea254346c2cee29c17f3ec25f"
+          },
+          {
+            "name": "corefx-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c8437415-67ab-4a52-b9e2-cb2d873818cb/756c1aec8815d1d23852ee91a769739e/corefx-1.0.13-symbols.zip",
+            "hash": "5227344287216e0c86e2b8d18a6fabef049abc831e52664a653ea5a55e6ab9717d53c43f6e400b869b8a6557356937d85f443c09adb7ab371a2789f3242ca58e"
+          },
+          {
+            "name": "coreclr-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94463197-e5ce-4780-a3e3-824b593984a4/6c8ccf14c6d7c48f2abe97f35e3349a4/coreclr-1.0.13-symbols.zip",
+            "hash": "30eb24a28de0a5bf28983570eb52568728ec432405a3b73ca4e7f968068336f81ec24d717587c6ecc4a2195b949f4e212d5a84913388beb55c28ccf59260042d"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.11",
+        "version-display": "1.1.11",
+        "runtime-version": "1.0.13",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/15a05546-15df-488f-adcf-0e77e86dbefb/1f902e78cfea6209c387adce764a88bc/dotnet-dev-osx-x64.1.1.11.tar.gz",
+            "hash": "b827b192398af01bf917a5fc0255616a82f04a95dac8154e681398e7e3ef549d701376bb1c9018dea37269e0406f065fb8e2958e652dfabaf86d5e0bb68b0840"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3c23a7aa-eecd-461b-ad45-979c4c684917/1b464bd34c763e664f7eed6006889d87/dotnet-dev-osx-x64.1.1.11.pkg",
+            "hash": "1b8ba4f003fda6725c6c27787f6b750064fa7522d0adb0bbbb1717286b2083550da68a242b840dc9505ca68775785935b0428933eb8b0e89f31e698e41618989"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db408c7b-ef37-4374-b33b-a5b286adaa53/be0f0df977501c4df71ac3f04b9ce35e/dotnet-dev-win-x86.1.1.11.zip",
+            "hash": "29a97f3e5e2e8465e4b0c7628a9a02baa0148bfe1a960f58dcdb08b3ad65702cf5367c3f776f47b4df5ce2487955831ed5ab330d4eeabea28ab4f25edb051be8"
+          },
+          {
+            "name": "dotnet-dev-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9386d3bc-6799-4cc5-8288-c807674c72ed/b585db316f0d1c4cad749c247ef21b59/dotnet-dev-win-x86.1.1.11.exe",
+            "hash": "88778c12aa4e3bdb696da31d5ae1a03441fc6d0d1860bada75bc604692e3f8c240941a10b8a99eaace2b5a6957bcdafa158f2cfb533d122bffcb2c55b25f351d"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a298f85a-bc4c-4019-842e-021e397e3437/5c95727dfe79b600834291a8983b9507/dotnet-dev-win-x64.1.1.11.zip",
+            "hash": "cbf96efd9f6119cad96041e3c55099b98f82252a60a93bbba5f93289bf600c5146402046c3ac79c6e927291e40cb5222171c3ee8cfbc086e635968dfed6e269e"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/baf5a5a7-68d6-4cf1-afdf-47968b5f91e7/05e6dfe191607ef6135a34215464f600/dotnet-dev-win-x64.1.1.11.exe",
+            "hash": "6e15fa8c9d5b10cc3edb353c5e1ece01a29f7d00ff853cc12f84e33a776df8062c07febbd9659ca46c2adeb005036c231fd7a7592591b6e28c643bdc45084778"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/116bc57f-a6d6-474f-aca7-58c18fe0fac4/aa324344fc9c36623fb4a7c7e5bece0c/dotnet-dev-centos-x64.1.1.11.tar.gz",
+            "hash": "8665733eba5af02f8af5420bc858ffc4ef73281fb518c0736458f9f1f666f65e57c6a8e2efac5d3e6aca56ac8942a25d1d805ce392fd6f751fb3f0ce821b20c4"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1ef84426-c1d0-4e3b-86a4-7fce48baecb8/a47dbe0cd3bc1eefdabbf9354f60004b/dotnet-dev-debian-x64.1.1.11.tar.gz",
+            "hash": "14f48469ebbc171d111369ea0dbe88ee9aeb74193aabd6e123c97e54ad81fd6352e86c446f8fe68e2db93793de86fbf89a9c682dd7d1d226169e788cd1f3f6a2"
+          },
+          {
+            "name": "dotnet-dev-debian.9-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b5c87053-99b4-4c91-af5b-69a1c0e2c91e/ab8882f283fb7206d0f1ee965faa4288/dotnet-dev-debian.9-x64.1.1.11.tar.gz",
+            "hash": "23e1d3d1863ae8f6bfd450ff238ad7d5929722df6a0492597089c992aa1b223af294386718a711040a4e5f77bd3af97e7924d344e1535d4bc36c640dc6b73869"
+          },
+          {
+            "name": "dotnet-dev-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/98eb7365-0ca8-4e29-b455-b165e583d0de/3a1da729266cb9b885f6747b376a0f7c/dotnet-dev-fedora.27-x64.1.1.11.tar.gz",
+            "hash": "ed2cad6ef471dd787086a249b932569840cabc7d48aa6920ce2d85e2d364a880f1d4c63e1014016a0fd19f8e8f1f93526fa2d710a587fcb27616bfd27844dc57"
+          },
+          {
+            "name": "dotnet-dev-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b3e55604-5a36-412d-ada3-9a46bba55fd0/473cb6db3926c04b7598d750f1d30731/dotnet-dev-fedora.28-x64.1.1.11.tar.gz",
+            "hash": "50ba2fa6a319de00857f847c6dbaf49bb4b93a0e7f73824ff47bdabc6862b45f0349c9c95b11dd2caec6fd4ef5ba3e89ad1c5a44e6a66cf600bc906327805a7f"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3b5e416e-1359-4638-b1f3-e0ac378d3550/13ee9ae8dd5bdd11a11abe1934542920/dotnet-dev-opensuse.42.3-x64.1.1.11.tar.gz",
+            "hash": "13163a1573c1f95ed45a5b445488080cd619693ac7ce8705e13ccfb605ae89d959a82bf42d633a6e65d5242eb508840e9f521bcfb6f30623a6575bfa701e6532"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0957a2b-cac6-44d8-b1cc-0dad4420c825/8dc69e33f8cf44152fdf173d3bf0b746/dotnet-dev-ubuntu-x64.1.1.11.tar.gz",
+            "hash": "a7743d00fad50ec1c9f27ac5b09d1b9d787ac9d4d600179d1d4a5ebb636438dda45ecc85b1a246fd2eed6455dfdcf764165428af38f83a524b4ea0aee82a3366"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c9f432a7-11fd-48a8-adef-fa95bc24a9ad/85a7293b69d07d5ed678ea21f6082539/dotnet-dev-ubuntu.16.04-x64.1.1.11.tar.gz",
+            "hash": "60906a50e01420c0603127041b5fc628cb064169ed03b6c9727857695021d2713d92cdec322d97340d9e525a1f2f3c727b7125ca07c0d04057196e0e7cf791b2"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aeac042a-cfef-4064-b914-7419f13c20ae/be14353986c2fbb2259064bcd2cc522a/dotnet-dev-ubuntu.18.04-x64.1.1.11.tar.gz",
+            "hash": "d96adb429e00052e331215438d0f1f244c830f633f9bd0dcf817f02a2211028ee4ac02e585be440863bdc6afc54fabe3539188c6f5f7086d8a0ced624fb05697"
+          },
+          {
+            "name": "dotnet-dev-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e461be2e-e14f-4a78-b987-351da98fb9ab/dc2c11f04a967d3d5c15a9a47b2d9fcc/dotnet-dev-rhel-x64.1.1.11.tar.gz",
+            "hash": "c79e40710dbf5e0f22d54ebeef4e08ce459a83dd58a9d7a2e56ebb480c780e912d4c8ee643df7f7717bb8544955bb154ca9aa88ec610eccd0d2f712b74668be3"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2018-07-10",
-        "release-version": "1.0.12",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.12.md",
-        "runtime":
-        {
-            "version": "1.0.12",
-            "files": 
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-osx-x64.1.0.12.tar.gz", 
-                    "hash": "6d69022219c117f2db307884daf225fc01c09b9e8f0b2a4f72c10a4ee6fedf54060643f0221857279687a0c417507a53b142b64f691d425cd94576852513be91"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.zip", 
-                    "hash": "26debb4b4a75be877e55ebde22badec0e6acd8aa83800056132c83d3492bf92f0e5fcac98e947a685a744aef1b3ef843f4109404b97061b532cc411c19dd2f3d"
-                },
-                {
-                    "name": "dotnet-win-x86.exe", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.exe", 
-                    "hash": "b2a55df7716677c5b9ac33b33686b07617fa9a97f0629b23e9869cb2db4ff9004b472aff09857921290853d56672e4c6da4eda7c4dcfe55c734ba5de3fe22ab3"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.zip", 
-                    "hash": "43c22c1273c1055cda580e7bcec4274c8f40a40bacab07107899679afb12ddb6cdbaa544d778c65c593e3e65395d50c42a2f1d71dc10a60436437c709a126ef3"
-                },
-                {
-                    "name": "dotnet-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.exe", 
-                    "hash": "0eedfca647ef551b19243eaec5417393562f5b1c9bbc920d91db8cc0a192543c59237980f0b2c5d388ffc89c4cb121b2acd75c1e21c2bdf9daafeeb9780b28f4"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-centos-x64.1.0.12.tar.gz", 
-                    "hash": "3758c4a1b3e853864ef955ad9cee5f852e484f896d7a05c3994bb6f9b2b487c248577c3fd30c35eed674de649c1c8d0de709e432b0b2a7ccda9b81ed1f1c4f22"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-debian-x64.1.0.12.tar.gz", 
-                    "hash": "a69bfa909454b5de50cb177f00528a7f05641f823e1aa30569fc9357d50cc3cc22a2dae6ca806fb8300345765cb4873b9884fd42807d922a4a2476f1b8cc72ea"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu-x64.1.0.12.tar.gz", 
-                    "hash": "338c1dbd127205d6e10dccf51ca4ac00685a3062aaf2297bac6b78771a0dad37bd7da0d9991e14c09ca90ff6066c00584d90848eeaf816ab6cb5a871956410e9"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu.16.04-x64.1.0.12.tar.gz", 
-                    "hash": "e0122f97adfde7a30ce1c251e7ec62700e7e02083ac94b445d5708b924bec99304f280068c345f9352f0ed20ceb83f77fee05553264e2768d669dc63c6872b76"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.10",
-            "version-display":  "1.1.10",
-            "runtime-version": "1.0.12",
-            "vs-version":  "",
-            "files": 
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.tar.gz", 
-                    "hash": "bf3bf5f22c70c944a9459565626ef935cd15465a189ef9dd65d18560f7e71e44e2ac93552999774eb9a6672530a99baa30347bf3ea1cc7f4ac4d583e1f0e60b9"
-                },
-                {
-                    "name": "dotnet-dev-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.pkg", 
-                    "hash": "990d54a53702f5314ad06aab3fa7b6ad0944f2d8863d5ba99f9e86a660fc542378e0fa2cf9aebbd44bdee71bdd37d287409ded40f98d4a43f77e613a3d84fee3"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.zip", 
-                    "hash": "f46778149a785c0ffed4611966c07668061bd07dcf0c4ebb42e68461aa9dc5a8fe5bcd0d99f1ebb279a7f8269d84dd7f34e34b6c953d63ce1acbc85c4c88b743"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.exe", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.exe", 
-                    "hash": "871baf6e9e7ca12a222ad0c9eb6060b933448c58f289defe1723934c66c07b2da6bd6f3495878afb280f188e64fd6200ed18b59ea5659e62be538956cb502a5a"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.zip", 
-                    "hash": "d0b01871251265b9a07c24e94e2e33f4a5d96ec6165ec0f60b032ce5c35895985e37cc01f73134fc8802a442eeb243b1d1403ebe898d6455907095e5b6b854c1"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.exe", 
-                    "hash": "d686d2514f45df597791d4fb60ccc272f5d42239e21803dbbf050891f79dbc7c0c8a72623606f312fd0aed0eef7ec5270c4adcfba105e3ec635d27729ff5c4af"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-centos-x64.1.1.10.tar.gz", 
-                    "hash": "30af1b4c9d8bd46bc48a52c9a9bee9e3a9a750ffd2308236458acd4cc3b313b8a4ca6259b34422caabd47540e30f5467b8f9237595e49be963d29abbdbfbd0e9"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-debian-x64.1.1.10.tar.gz", 
-                    "hash": "f4ac12ff20db06a7c6232c2645f35486d5369201429e3aa9c89a65a3e5f53957cd6ab612c225cc1dd6afebd4dd28695ca5a1f9cbcc812d8fa08635d6cedb1dff"
-                },
-                {
-                    "name": "dotnet-dev-fedora.27-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.27-x64.1.1.10.tar.gz", 
-                    "hash": "89cb369e8205224db77e314b6e236570e94b1d351689dddab5c4fbd63f444389e9745b84c57f855ddef9d693866b1103af6b8d889d6626ccc5c08c6783185d6d"
-                },
-                {
-                    "name": "dotnet-dev-fedora.28-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.28-x64.1.1.10.tar.gz", 
-                    "hash": "91e3bd421cadaf3a3a3e65486a088d9d4b0aaab9f35757068f6f09736cacbe498fc9469aaab9a4d5c209074af253761a8325adf525e991e40c5ffc10acd8ba93"
-                },
-                {
-                    "name": "dotnet-dev-opensuse.42.3-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz", 
-                    "hash": "227928df186dbd0fcc152f602383efcb66c45e467e5b88e135c725a53f69fbba26debbcb0536629e53b15e0caac65ef3af8db9b242195f3bf517d2f629125439"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu-x64.1.1.10.tar.gz", 
-                    "hash": "21bb88c12a094aced52d5161dee6d345698210ddc942a597e489c167fdeef4a1ebab90f7bd4bc0c23fba1c912d24e73b333635b70f7571b4ab5d8d8d1ce4b713"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz", 
-                    "hash": "89300ca6c519ba17eebe0e425f332bd457c0af49d9ba0cd00f4df14be471bb6d5a0207486e484b106a6b1071fb140b0738f752475dd88d8d7f833e8b8e26da58"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz", 
-                    "hash": "38a3cd266f3b1f680e878c981adca1cebe81fbfd161ce4ea083ea4c7809c0a92e03ac33d292e29f43b5ebae18622ea83360c6b07186a6fa35ca6b2ad8450d140"
-                } 
-            ]       
-        }
+      "release-date": "2018-07-10",
+      "release-version": "1.0.12",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.12.md",
+      "runtime": {
+        "version": "1.0.12",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-osx-x64.1.0.12.tar.gz",
+            "hash": "6d69022219c117f2db307884daf225fc01c09b9e8f0b2a4f72c10a4ee6fedf54060643f0221857279687a0c417507a53b142b64f691d425cd94576852513be91"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.zip",
+            "hash": "26debb4b4a75be877e55ebde22badec0e6acd8aa83800056132c83d3492bf92f0e5fcac98e947a685a744aef1b3ef843f4109404b97061b532cc411c19dd2f3d"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x86.1.0.12.exe",
+            "hash": "b2a55df7716677c5b9ac33b33686b07617fa9a97f0629b23e9869cb2db4ff9004b472aff09857921290853d56672e4c6da4eda7c4dcfe55c734ba5de3fe22ab3"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.zip",
+            "hash": "43c22c1273c1055cda580e7bcec4274c8f40a40bacab07107899679afb12ddb6cdbaa544d778c65c593e3e65395d50c42a2f1d71dc10a60436437c709a126ef3"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-win-x64.1.0.12.exe",
+            "hash": "0eedfca647ef551b19243eaec5417393562f5b1c9bbc920d91db8cc0a192543c59237980f0b2c5d388ffc89c4cb121b2acd75c1e21c2bdf9daafeeb9780b28f4"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-centos-x64.1.0.12.tar.gz",
+            "hash": "3758c4a1b3e853864ef955ad9cee5f852e484f896d7a05c3994bb6f9b2b487c248577c3fd30c35eed674de649c1c8d0de709e432b0b2a7ccda9b81ed1f1c4f22"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-debian-x64.1.0.12.tar.gz",
+            "hash": "a69bfa909454b5de50cb177f00528a7f05641f823e1aa30569fc9357d50cc3cc22a2dae6ca806fb8300345765cb4873b9884fd42807d922a4a2476f1b8cc72ea"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu-x64.1.0.12.tar.gz",
+            "hash": "338c1dbd127205d6e10dccf51ca4ac00685a3062aaf2297bac6b78771a0dad37bd7da0d9991e14c09ca90ff6066c00584d90848eeaf816ab6cb5a871956410e9"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/f/1/0f1a7818-dae3-437f-a063-3cc62b840927/dotnet-ubuntu.16.04-x64.1.0.12.tar.gz",
+            "hash": "e0122f97adfde7a30ce1c251e7ec62700e7e02083ac94b445d5708b924bec99304f280068c345f9352f0ed20ceb83f77fee05553264e2768d669dc63c6872b76"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.10",
+        "version-display": "1.1.10",
+        "runtime-version": "1.0.12",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.tar.gz",
+            "hash": "bf3bf5f22c70c944a9459565626ef935cd15465a189ef9dd65d18560f7e71e44e2ac93552999774eb9a6672530a99baa30347bf3ea1cc7f4ac4d583e1f0e60b9"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.pkg",
+            "hash": "990d54a53702f5314ad06aab3fa7b6ad0944f2d8863d5ba99f9e86a660fc542378e0fa2cf9aebbd44bdee71bdd37d287409ded40f98d4a43f77e613a3d84fee3"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.zip",
+            "hash": "f46778149a785c0ffed4611966c07668061bd07dcf0c4ebb42e68461aa9dc5a8fe5bcd0d99f1ebb279a7f8269d84dd7f34e34b6c953d63ce1acbc85c4c88b743"
+          },
+          {
+            "name": "dotnet-dev-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.exe",
+            "hash": "871baf6e9e7ca12a222ad0c9eb6060b933448c58f289defe1723934c66c07b2da6bd6f3495878afb280f188e64fd6200ed18b59ea5659e62be538956cb502a5a"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.zip",
+            "hash": "d0b01871251265b9a07c24e94e2e33f4a5d96ec6165ec0f60b032ce5c35895985e37cc01f73134fc8802a442eeb243b1d1403ebe898d6455907095e5b6b854c1"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.exe",
+            "hash": "d686d2514f45df597791d4fb60ccc272f5d42239e21803dbbf050891f79dbc7c0c8a72623606f312fd0aed0eef7ec5270c4adcfba105e3ec635d27729ff5c4af"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-centos-x64.1.1.10.tar.gz",
+            "hash": "30af1b4c9d8bd46bc48a52c9a9bee9e3a9a750ffd2308236458acd4cc3b313b8a4ca6259b34422caabd47540e30f5467b8f9237595e49be963d29abbdbfbd0e9"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-debian-x64.1.1.10.tar.gz",
+            "hash": "f4ac12ff20db06a7c6232c2645f35486d5369201429e3aa9c89a65a3e5f53957cd6ab612c225cc1dd6afebd4dd28695ca5a1f9cbcc812d8fa08635d6cedb1dff"
+          },
+          {
+            "name": "dotnet-dev-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.27-x64.1.1.10.tar.gz",
+            "hash": "89cb369e8205224db77e314b6e236570e94b1d351689dddab5c4fbd63f444389e9745b84c57f855ddef9d693866b1103af6b8d889d6626ccc5c08c6783185d6d"
+          },
+          {
+            "name": "dotnet-dev-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.28-x64.1.1.10.tar.gz",
+            "hash": "91e3bd421cadaf3a3a3e65486a088d9d4b0aaab9f35757068f6f09736cacbe498fc9469aaab9a4d5c209074af253761a8325adf525e991e40c5ffc10acd8ba93"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz",
+            "hash": "227928df186dbd0fcc152f602383efcb66c45e467e5b88e135c725a53f69fbba26debbcb0536629e53b15e0caac65ef3af8db9b242195f3bf517d2f629125439"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu-x64.1.1.10.tar.gz",
+            "hash": "21bb88c12a094aced52d5161dee6d345698210ddc942a597e489c167fdeef4a1ebab90f7bd4bc0c23fba1c912d24e73b333635b70f7571b4ab5d8d8d1ce4b713"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz",
+            "hash": "89300ca6c519ba17eebe0e425f332bd457c0af49d9ba0cd00f4df14be471bb6d5a0207486e484b106a6b1071fb140b0738f752475dd88d8d7f833e8b8e26da58"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz",
+            "hash": "38a3cd266f3b1f680e878c981adca1cebe81fbfd161ce4ea083ea4c7809c0a92e03ac33d292e29f43b5ebae18622ea83360c6b07186a6fa35ca6b2ad8450d140"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2018-04-17",
-        "release-version": "1.0.11",
-        "security": false,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.11.md",
-        "runtime":
-        {
-            "version": "1.0.11",
-            "vs-version": "15.0",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-osx-x64.1.0.11.tar.gz", 
-                    "hash": "7299e31d2c9f57035d3d99338cd583a52c172a60a5e0d27bf3f75cc99ddbfa49d2b66627bd1ea8adffa9ece6e362bf022e12a170e6461569dff33977f5783a87"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.zip", 
-                    "hash": "8587478c682b06a6c447afc56610a1c07a6943f82c163be9db1d53fc360052f02546234a335d8f47a527048124ef4437f9dbad24060970b1ef0f82e6d2be2416"
-                },
-                {
-                    "name": "dotnet-win-x86.exe", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.exe", 
-                    "hash": "7aeadfa40f095e9e284888f7169b0d030446435e37bd0645e8cc713d04985d703fe343ae35c45a50e501c79048e9a009d83eb649d11b1f5e1eaecc24bdd889fb"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.zip", 
-                    "hash": "51bcb135c1880db365c0c0fc3d2151736a6e3699c40148ce6f11e363e2184982bf71dbb61fe7011688eff6ede5e33126be32af139d516151ae7bab5574ec67ce"
-                },
-                {
-                    "name": "dotnet-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.exe", 
-                    "hash": "b2cfd380baddeda278e0659e7a5e3706898ed2f8b0f8d4a58f5573815e634ba6910bf668fc9d8dbbd4a63422c6a44e801c63cc9cfed37c198e02f5978d89c305"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-centos-x64.1.0.11.tar.gz", 
-                    "hash": "5f9de7f5a678a9211e4e956c11c0638f2cf582d64c3132cb1b73f48c4aad4846c01fa49b26e612d17090e7813449091a206a3abe946394aa6dab15697fca76aa"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-debian-x64.1.0.11.tar.gz", 
-                    "hash": "42b3111e4a781ac35b3db33b0d109c653f0962ff70a3b7bc2452eafbe31690852faacd839fa9098117907c8de7663451d51028d201956ce7feb872b6906af513"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu-x64.1.0.11.tar.gz", 
-                    "hash": "4487d360c623953236f9577e48f644ced1bf293b32432fe857d43a62377b0ea22b557aef92eca14cda5a6b055d3697444de457bb7533c1f7dda20eb8554a2699"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu.16.04-x64.1.0.11.tar.gz", 
-                    "hash": "31dc1e9914df84b32b6641508c657bd9cb5882327af50549100e58d17c2b184dbc20ca1cbdd616bfd8894b1a6fad201a434df5ffc9fb376fbc88a42d7d8eb5c4"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.9",
-            "version-display":  "1.1.9",
-            "runtime-version": "1.0.11",
-            "vs-version": "15.0",
-            "csharp-language": "7.0",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz", 
-                    "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"
-                },
-                {
-                    "name": "dotnet-dev-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg", 
-                    "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip", 
-                    "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip", 
-                    "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz", 
-                    "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz", 
-                    "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz", 
-                    "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz", 
-                    "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz", 
-                    "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"
-                }
-            ]
-        }
+      "release-date": "2018-04-17",
+      "release-version": "1.0.11",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.11.md",
+      "runtime": {
+        "version": "1.0.11",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-osx-x64.1.0.11.tar.gz",
+            "hash": "7299e31d2c9f57035d3d99338cd583a52c172a60a5e0d27bf3f75cc99ddbfa49d2b66627bd1ea8adffa9ece6e362bf022e12a170e6461569dff33977f5783a87"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.zip",
+            "hash": "8587478c682b06a6c447afc56610a1c07a6943f82c163be9db1d53fc360052f02546234a335d8f47a527048124ef4437f9dbad24060970b1ef0f82e6d2be2416"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x86.1.0.11.exe",
+            "hash": "7aeadfa40f095e9e284888f7169b0d030446435e37bd0645e8cc713d04985d703fe343ae35c45a50e501c79048e9a009d83eb649d11b1f5e1eaecc24bdd889fb"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.zip",
+            "hash": "51bcb135c1880db365c0c0fc3d2151736a6e3699c40148ce6f11e363e2184982bf71dbb61fe7011688eff6ede5e33126be32af139d516151ae7bab5574ec67ce"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-win-x64.1.0.11.exe",
+            "hash": "b2cfd380baddeda278e0659e7a5e3706898ed2f8b0f8d4a58f5573815e634ba6910bf668fc9d8dbbd4a63422c6a44e801c63cc9cfed37c198e02f5978d89c305"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-centos-x64.1.0.11.tar.gz",
+            "hash": "5f9de7f5a678a9211e4e956c11c0638f2cf582d64c3132cb1b73f48c4aad4846c01fa49b26e612d17090e7813449091a206a3abe946394aa6dab15697fca76aa"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-debian-x64.1.0.11.tar.gz",
+            "hash": "42b3111e4a781ac35b3db33b0d109c653f0962ff70a3b7bc2452eafbe31690852faacd839fa9098117907c8de7663451d51028d201956ce7feb872b6906af513"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu-x64.1.0.11.tar.gz",
+            "hash": "4487d360c623953236f9577e48f644ced1bf293b32432fe857d43a62377b0ea22b557aef92eca14cda5a6b055d3697444de457bb7533c1f7dda20eb8554a2699"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/E/7/BE70BFBD-9AB4-48F8-A696-013ACA8720D5/dotnet-ubuntu.16.04-x64.1.0.11.tar.gz",
+            "hash": "31dc1e9914df84b32b6641508c657bd9cb5882327af50549100e58d17c2b184dbc20ca1cbdd616bfd8894b1a6fad201a434df5ffc9fb376fbc88a42d7d8eb5c4"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.9",
+        "version-display": "1.1.9",
+        "runtime-version": "1.0.11",
+        "vs-version": "15.0",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz",
+            "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg",
+            "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip",
+            "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip",
+            "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz",
+            "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz",
+            "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz",
+            "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz",
+            "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz",
+            "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2018-03-13",
-        "release-version": "1.0.10",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.10.md",
-        "runtime":
-        {
-            "version": "1.0.10",
-            "checksums-": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/1.0.10-runtime-sha.txt",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-osx-x64.1.0.10.tar.gz", 
-                    "hash": "326cdd0bad8529a954ff407b8387eb054b97af739b1203a559a9433220fb988b1ef120bbf0abcfc953d9bd5304b8fe0115c6e0d181e7518be948500c5e89d6c9"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x86.1.0.10.zip", 
-                    "hash": "5a0a281e4e65d4ae08eacbb8bb57f1431992e5de1be1028f9bd1b7dffd124d424b4d0521a0bb606f5bbf9e77dd658868ac9c7c848d591d14a2d5852cc1a8bb8f"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x64.1.0.10.zip", 
-                    "hash": "3e31fc8ee712184707c5a811944aad444019cb71b3feced22aa96ad0cf9a6e2bc31a36271414202b24d1039c5ea3058ef7e6274775df6dedc95fa249651e277b"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-centos-x64.1.0.10.tar.gz", 
-                    "hash": "ea6ca96aeb2940937ea88815f061f3721cc04a1335228984476d5f2e46037136b07abf1241a7ffaff69b0ae5dab6627f9c22ab778c92361687d330fe0da786a3"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-debian-x64.1.0.10.tar.gz", 
-                    "hash": "21e57ed1934a12c44cc0de17cf212dadc07654e398df85ef9a79e233e1095c086eff2d28a9e3129c4f93a979237be72fa5a7934f04217fad2d0a487470dc167b"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu-x64.1.0.10.tar.gz", 
-                    "hash": "87e0df0cac7a3700fc80801b8220f77fedae464b925ebeb83e8059c61258ca8a0ac0b46463b1e0fa0727a75c371b0f1a0dfe30ad7fe164cc4f06e9e38c349781"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu.16.04-x64.1.0.10.tar.gz", 
-                    "hash": "979e24f6b1416157290e7fe983d28325a9d1954366625ebaffb167901ba68bd68ce5d2e76ba5c8e147a2c6a303e5bd922ac9f2175a452e0c2a190d28eb3040e3"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.8",
-            "version-display":  "1.1.8",
-            "runtime-version": "1.0.10",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz", 
-                    "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"
-                },
-                {
-                    "name": "dotnet-dev-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.pkg", 
-                    "hash": "f1d438376839cb9343b2a893608a482d91134e4fa4aa1bc015b50ca58e9aea419043da134102496f13c9a90302abeaf9cb7b07df4e2dfaf528b3614f84847ea2"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip", 
-                    "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip", 
-                    "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz", 
-                    "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz", 
-                    "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz", 
-                    "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz", 
-                    "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz","hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"
-                }
-            ]            
-        }
+      "release-date": "2018-03-13",
+      "release-version": "1.0.10",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.10.md",
+      "runtime": {
+        "version": "1.0.10",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-osx-x64.1.0.10.tar.gz",
+            "hash": "326cdd0bad8529a954ff407b8387eb054b97af739b1203a559a9433220fb988b1ef120bbf0abcfc953d9bd5304b8fe0115c6e0d181e7518be948500c5e89d6c9"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x86.1.0.10.zip",
+            "hash": "5a0a281e4e65d4ae08eacbb8bb57f1431992e5de1be1028f9bd1b7dffd124d424b4d0521a0bb606f5bbf9e77dd658868ac9c7c848d591d14a2d5852cc1a8bb8f"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-win-x64.1.0.10.zip",
+            "hash": "3e31fc8ee712184707c5a811944aad444019cb71b3feced22aa96ad0cf9a6e2bc31a36271414202b24d1039c5ea3058ef7e6274775df6dedc95fa249651e277b"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-centos-x64.1.0.10.tar.gz",
+            "hash": "ea6ca96aeb2940937ea88815f061f3721cc04a1335228984476d5f2e46037136b07abf1241a7ffaff69b0ae5dab6627f9c22ab778c92361687d330fe0da786a3"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-debian-x64.1.0.10.tar.gz",
+            "hash": "21e57ed1934a12c44cc0de17cf212dadc07654e398df85ef9a79e233e1095c086eff2d28a9e3129c4f93a979237be72fa5a7934f04217fad2d0a487470dc167b"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu-x64.1.0.10.tar.gz",
+            "hash": "87e0df0cac7a3700fc80801b8220f77fedae464b925ebeb83e8059c61258ca8a0ac0b46463b1e0fa0727a75c371b0f1a0dfe30ad7fe164cc4f06e9e38c349781"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/1/2E1D70C2-F74D-4024-B14D-3F30330450A8/dotnet-ubuntu.16.04-x64.1.0.10.tar.gz",
+            "hash": "979e24f6b1416157290e7fe983d28325a9d1954366625ebaffb167901ba68bd68ce5d2e76ba5c8e147a2c6a303e5bd922ac9f2175a452e0c2a190d28eb3040e3"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.8",
+        "version-display": "1.1.8",
+        "runtime-version": "1.0.10",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz",
+            "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.pkg",
+            "hash": "f1d438376839cb9343b2a893608a482d91134e4fa4aa1bc015b50ca58e9aea419043da134102496f13c9a90302abeaf9cb7b07df4e2dfaf528b3614f84847ea2"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip",
+            "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip",
+            "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz",
+            "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz",
+            "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz",
+            "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz",
+            "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz",
+            "hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2017-11-14",
-        "release-version": "1.0.9",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.9.md",
-        "runtime":
-        {
-            "version": "1.0.9",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-osx-x64.1.0.9.tar.gz", 
-                    "hash": "f1f0210f9517e274b13d33c49ec3641b8d3248874f28b00d278faeb792ff88cee431d43af300ef7423122776aecdb63155d1a2f84d31deb7c9baa16237109d78"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x86.1.0.9.zip", 
-                    "hash": "f10a3d1ddb7b7302e73314c47bc9075a3ab2a8c3072f4bbd95a5340b7a1798a1964e798cec0f528ec64ce3ae947563b46b145f5da8b2a3f50d30cf0770c84a2a"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x64.1.0.9.zip", 
-                    "hash": "1d632c7392c35677c9e549e3559bd31e1c203d0523d502109429cb89512a6dc755030ded4f30964a48a59ac636ef1fda3617ea62b34204b586309b18f0109ecd"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-centos-x64.1.0.9.tar.gz", 
-                    "hash": "bbdc00f11b391e6e89818e74a32cb3a9ae13eb9e9acae5409a2a4b00986fe4968be9e325638adba4b119cc82cb33111fa36445c2beff07f098233b22b752bddc"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-debian-x64.1.0.9.tar.gz", 
-                    "hash": "3d11fb2881fde022dba3453816192e10845f09fb6d5f7cb83d8f2691161e73cc3b459516cd0ba5e425c430844d733f4b61bdcd3f0a3b9ac4bdb5d0b06ce91438"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu-x64.1.0.9.tar.gz", 
-                    "hash": "9dd1de2f20b278bf9ad8b7204fee67e2597ba03afd20a16e667430b1c89ac69101df54ef04b7d4dc9600eca558f868ad3b8189ea8f0e2ef359b05a8c2ef4e9d1"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu.16.04-x64.1.0.9.tar.gz", 
-                    "hash": "65e85314ed2085f1e5a4ba641174c7120002cdedc5abab673e87606beffa842a5ab9f378992a9a7358ffea2104d084b7f90a822d80990a8e492fa24563b4fa5d"
-                }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.7",
-            "version-display":  "1.1.7",
-            "runtime-version": "1.0.9",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz", 
-                    "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip", 
-                    "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip", 
-                    "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz", 
-                    "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz", 
-                    "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"
-                },
-                {
-                    "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz", 
-                    "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz", 
-                    "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz", 
-                    "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"
-                }                
-            ]            
-        }
+      "release-date": "2017-11-14",
+      "release-version": "1.0.9",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.9.md",
+      "runtime": {
+        "version": "1.0.9",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-osx-x64.1.0.9.tar.gz",
+            "hash": "f1f0210f9517e274b13d33c49ec3641b8d3248874f28b00d278faeb792ff88cee431d43af300ef7423122776aecdb63155d1a2f84d31deb7c9baa16237109d78"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x86.1.0.9.zip",
+            "hash": "f10a3d1ddb7b7302e73314c47bc9075a3ab2a8c3072f4bbd95a5340b7a1798a1964e798cec0f528ec64ce3ae947563b46b145f5da8b2a3f50d30cf0770c84a2a"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-win-x64.1.0.9.zip",
+            "hash": "1d632c7392c35677c9e549e3559bd31e1c203d0523d502109429cb89512a6dc755030ded4f30964a48a59ac636ef1fda3617ea62b34204b586309b18f0109ecd"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-centos-x64.1.0.9.tar.gz",
+            "hash": "bbdc00f11b391e6e89818e74a32cb3a9ae13eb9e9acae5409a2a4b00986fe4968be9e325638adba4b119cc82cb33111fa36445c2beff07f098233b22b752bddc"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-debian-x64.1.0.9.tar.gz",
+            "hash": "3d11fb2881fde022dba3453816192e10845f09fb6d5f7cb83d8f2691161e73cc3b459516cd0ba5e425c430844d733f4b61bdcd3f0a3b9ac4bdb5d0b06ce91438"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu-x64.1.0.9.tar.gz",
+            "hash": "9dd1de2f20b278bf9ad8b7204fee67e2597ba03afd20a16e667430b1c89ac69101df54ef04b7d4dc9600eca558f868ad3b8189ea8f0e2ef359b05a8c2ef4e9d1"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/1/D/A1D5F1B5-A7B0-432B-A354-FCDC4B059149/dotnet-ubuntu.16.04-x64.1.0.9.tar.gz",
+            "hash": "65e85314ed2085f1e5a4ba641174c7120002cdedc5abab673e87606beffa842a5ab9f378992a9a7358ffea2104d084b7f90a822d80990a8e492fa24563b4fa5d"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.7",
+        "version-display": "1.1.7",
+        "runtime-version": "1.0.9",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz",
+            "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip",
+            "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip",
+            "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz",
+            "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz",
+            "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz",
+            "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz",
+            "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz",
+            "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2017-11-14",
-        "release-version": "1.0.8",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.8.md",
-        "runtime":
-        {
-            "version": "1.0.8",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-osx-x64.1.0.8.tar.gz", 
-                    "hash": "1e513f3f41518aa6f37ad138d711d32dd1031ec37f2e8c98835c7aa65425af9a95e153eecd18600a8fa4207c898d23721cca36c16006d538f3eb3e5b3872242e"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x86.1.0.8.zip", 
-                    "hash": "2761942eebc13152d79fd697e361bdea711c04668b7587d89360972fadedefa55eba2fbeffc580d10d191cd3b3fde7a4fa6a99522af5278b1dace16d57967298"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x64.1.0.8.zip", 
-                    "hash": "63af1fb406ba14b75fb9386036ed129a96bdba8f4bf3d7e3410c33e723163116c63062130113441fac4aeb7c343f24b20eb785a2c82d0d1b162dbf516f287ad1"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-centos-x64.1.0.8.tar.gz", 
-                    "hash": "f3cf87b89f5daa364268e4ec3000dc20d7aac4d0b056cceb65ea1faed5ab55d9df1b3bc23fe01b32cb67cbb407e1056ffb664eb3b5b7dc30a907e9057cad3c44"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-debian-x64.1.0.8.tar.gz", 
-                    "hash": "e663014f763efccadf5b5868a286bc56a432e6349042e4ab3816e3cc0a05d9e67b05113d6dfe55260cfb1c3e1a554c235813bafe2cbc2debb75c638e0c77d02d"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu-x64.1.0.8.tar.gz", 
-                    "hash": "c639b2a21337dc5120a9d7d768057ab38eda5bf7c7cc6a307821096e7b09c136786be13278bbcdc3fa30acf0d21cd28201b6e25a1cd001ddb20709020517bef9"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu.16.04-x64.1.0.8.tar.gz", 
-                    "hash": "43ef03e5598d5ed080331f91bfe543795635e15fc19060f954d8b4ad4c8ebd1a50c92527c30d73d14ea3dda332cbb8fa8ec89210beb152d5de9be2120d1892d7"
-                }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.5",
-            "version-display":  "1.1.5",
-            "runtime-version": "1.0.8",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz", 
-                    "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip", 
-                    "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip", 
-                    "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz", 
-                    "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz", 
-                    "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz", 
-                    "hash": "e0e3e3c54cbd81bd3b2e1d16776e1b597415307e06c2415438ad482c315191d87ba99b6c4981b0e077449dbb5f453bd3facf814b4818f14e3fd9b35fcd95de8f"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz", 
-                    "hash": "ef32e224fdffe7d4fced2b576fa94bb3738a19ed76d01d9cf3fa67a3bc0a74d80bdb6e35a554b8a89810e17a9a3d67ebc7e1b4f1a0ac3604510d62a4f363d90c"
-                }                
-            ]            
-        }
+      "release-date": "2017-11-14",
+      "release-version": "1.0.8",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.8.md",
+      "runtime": {
+        "version": "1.0.8",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-osx-x64.1.0.8.tar.gz",
+            "hash": "1e513f3f41518aa6f37ad138d711d32dd1031ec37f2e8c98835c7aa65425af9a95e153eecd18600a8fa4207c898d23721cca36c16006d538f3eb3e5b3872242e"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x86.1.0.8.zip",
+            "hash": "2761942eebc13152d79fd697e361bdea711c04668b7587d89360972fadedefa55eba2fbeffc580d10d191cd3b3fde7a4fa6a99522af5278b1dace16d57967298"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-win-x64.1.0.8.zip",
+            "hash": "63af1fb406ba14b75fb9386036ed129a96bdba8f4bf3d7e3410c33e723163116c63062130113441fac4aeb7c343f24b20eb785a2c82d0d1b162dbf516f287ad1"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-centos-x64.1.0.8.tar.gz",
+            "hash": "f3cf87b89f5daa364268e4ec3000dc20d7aac4d0b056cceb65ea1faed5ab55d9df1b3bc23fe01b32cb67cbb407e1056ffb664eb3b5b7dc30a907e9057cad3c44"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-debian-x64.1.0.8.tar.gz",
+            "hash": "e663014f763efccadf5b5868a286bc56a432e6349042e4ab3816e3cc0a05d9e67b05113d6dfe55260cfb1c3e1a554c235813bafe2cbc2debb75c638e0c77d02d"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu-x64.1.0.8.tar.gz",
+            "hash": "c639b2a21337dc5120a9d7d768057ab38eda5bf7c7cc6a307821096e7b09c136786be13278bbcdc3fa30acf0d21cd28201b6e25a1cd001ddb20709020517bef9"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/0/B/50B3563D-0109-4975-B1FC-F3F31DE3CC82/dotnet-ubuntu.16.04-x64.1.0.8.tar.gz",
+            "hash": "43ef03e5598d5ed080331f91bfe543795635e15fc19060f954d8b4ad4c8ebd1a50c92527c30d73d14ea3dda332cbb8fa8ec89210beb152d5de9be2120d1892d7"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.5",
+        "version-display": "1.1.5",
+        "runtime-version": "1.0.8",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz",
+            "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip",
+            "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip",
+            "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz",
+            "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz",
+            "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz",
+            "hash": "e0e3e3c54cbd81bd3b2e1d16776e1b597415307e06c2415438ad482c315191d87ba99b6c4981b0e077449dbb5f453bd3facf814b4818f14e3fd9b35fcd95de8f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz",
+            "hash": "ef32e224fdffe7d4fced2b576fa94bb3738a19ed76d01d9cf3fa67a3bc0a74d80bdb6e35a554b8a89810e17a9a3d67ebc7e1b4f1a0ac3604510d62a4f363d90c"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2017-09-21",
-        "release-version": "1.0.7",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.7.md",
-        "runtime":
-        {
-            "version": "1.0.7",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-osx-x64.1.0.7.tar.gz", 
-                    "hash": "b5ec0b5d86814989c21398084fc3ee4d64d334aa9ccc34cd9300a1527d5f173f"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x86.1.0.7.zip", 
-                    "hash": "a8bd2c4babda3ed2fe870f40e178e139cd75dd32489e76ecd4ed73295a117138"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x64.1.0.7.zip", 
-                    "hash": "c4d338c3382507e52641d9509b2fb44b287ac11ad2f3c33b94592a09723784d1"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-centos-x64.1.0.7.tar.gz", 
-                    "hash": "dc7bc1b69729e801141daac7fd6a21b9ff46be6459a7acfb63b32544d566a036"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-debian-x64.1.0.7.tar.gz", 
-                    "hash": "fe8da8515029e00415b3675903fde02dade148ba44540745de3ebc6f0e0c83c2"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu-x64.1.0.7.tar.gz", 
-                    "hash": "f4ffe75aa180bc609f573478e3e6a4be6ae4bd32ff1eb2aadca44141463c1f16"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu.16.04-x64.1.0.7.tar.gz", 
-                    "hash": "4b12c5c5317d68922af2e93a4771186b497f5c82f00498df9d8e685ef9757658"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.1.4",
-            "version-display":  "1.1.4",
-            "runtime-version": "1.0.7",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz", 
-                    "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip", 
-                    "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip", 
-                    "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz", 
-                    "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz", 
-                    "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz", 
-                    "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz", 
-                    "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz", 
-                    "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"
-                }
-            ]            
-        },
-        "aspnetcore-runtime":
-        {
-            "version": "1.0.7",
-            "files":
-            [
-                {
-                    "name": "hosting-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe", 
-                    "hash": ""
-                }
-            ]
-        }
+      "release-date": "2017-09-21",
+      "release-version": "1.0.7",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.7.md",
+      "runtime": {
+        "version": "1.0.7",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-osx-x64.1.0.7.tar.gz",
+            "hash": "b5ec0b5d86814989c21398084fc3ee4d64d334aa9ccc34cd9300a1527d5f173f"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x86.1.0.7.zip",
+            "hash": "a8bd2c4babda3ed2fe870f40e178e139cd75dd32489e76ecd4ed73295a117138"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-win-x64.1.0.7.zip",
+            "hash": "c4d338c3382507e52641d9509b2fb44b287ac11ad2f3c33b94592a09723784d1"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-centos-x64.1.0.7.tar.gz",
+            "hash": "dc7bc1b69729e801141daac7fd6a21b9ff46be6459a7acfb63b32544d566a036"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-debian-x64.1.0.7.tar.gz",
+            "hash": "fe8da8515029e00415b3675903fde02dade148ba44540745de3ebc6f0e0c83c2"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu-x64.1.0.7.tar.gz",
+            "hash": "f4ffe75aa180bc609f573478e3e6a4be6ae4bd32ff1eb2aadca44141463c1f16"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/D/B0D6D983-3188-4008-A852-94BCED5355E6/dotnet-ubuntu.16.04-x64.1.0.7.tar.gz",
+            "hash": "4b12c5c5317d68922af2e93a4771186b497f5c82f00498df9d8e685ef9757658"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.4",
+        "version-display": "1.1.4",
+        "runtime-version": "1.0.7",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz",
+            "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip",
+            "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip",
+            "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz",
+            "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz",
+            "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz",
+            "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz",
+            "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz",
+            "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.0.7",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "hosting-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
     },
     {
-        "release-date": "2017-05-09",
-        "release-version": "1.0.5",
-        "security": true,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.5.md",
-        "runtime":
-        {
-            "version": "1.0.5",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-osx-x64.1.0.5.tar.gz", 
-                    "hash": "86228ed7ba5f4eb14565104e85f30a3ccc01c544865cdf573b3edfba1cd3bf80"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x86.1.0.5.zip", 
-                    "hash": "e34a62fa697f778c90732f552aefc161f425ae735a20dd66ea5e772cdef7496b"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x64.1.0.5.zip", 
-                    "hash": "c930b72b6510b916423ab93a6a4c19b334b9c2215ec2abbe446e4e2defc76177"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-centos-x64.1.0.5.tar.gz", 
-                    "hash": "b4e8adebada8e140e0e5fbaaedd459bf090a2fd521dfb7c98adbb6b02daf13b9"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-debian-x64.1.0.5.tar.gz", 
-                    "hash": "55481b0254a72d8c342ba6ccca3908ffb5c99d7eeb54f83dec6cc93c6b4cc3ae"
-                },
-                {
-                    "name": "dotnet-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-fedora.23-x64.1.0.5.tar.gz", 
-                    "hash": "aaa236d77d1ec4d8bef85761e578a59bbd5153d3af8744407605de940509ebce"
-                },
-                {
-                    "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-opensuse.13.2-x64.1.0.5.tar.gz", 
-                    "hash": "5d43aaab95262cd44a017b4dc95226b1249dcd95547721eb3565599a404af439"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu-x64.1.0.5.tar.gz", 
-                    "hash": "860a22f2adc783a1ab10cb373109682d32435c76b9045bc9966d097512bec937"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu.16.04-x64.1.0.5.tar.gz", 
-                    "hash": "cec3ed3464a0982b92d92d46088039f302c5b861c8dd13db90d2d99eb9e7fa96"
-                }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.4",
-            "version-display":  "1.0.4",
-            "runtime-version": "1.0.5",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz", 
-                    "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip", 
-                    "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip", 
-                    "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz", 
-                    "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz", 
-                    "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz", 
-                    "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"
-                },
-                {
-                    "name": "dotnet-dev-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz", 
-                    "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz", 
-                    "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz", 
-                    "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"
-                }                
-            ]            
-        }
+      "release-date": "2017-05-09",
+      "release-version": "1.0.5",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.5.md",
+      "runtime": {
+        "version": "1.0.5",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-osx-x64.1.0.5.tar.gz",
+            "hash": "86228ed7ba5f4eb14565104e85f30a3ccc01c544865cdf573b3edfba1cd3bf80"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x86.1.0.5.zip",
+            "hash": "e34a62fa697f778c90732f552aefc161f425ae735a20dd66ea5e772cdef7496b"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-win-x64.1.0.5.zip",
+            "hash": "c930b72b6510b916423ab93a6a4c19b334b9c2215ec2abbe446e4e2defc76177"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-centos-x64.1.0.5.tar.gz",
+            "hash": "b4e8adebada8e140e0e5fbaaedd459bf090a2fd521dfb7c98adbb6b02daf13b9"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-debian-x64.1.0.5.tar.gz",
+            "hash": "55481b0254a72d8c342ba6ccca3908ffb5c99d7eeb54f83dec6cc93c6b4cc3ae"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-fedora.23-x64.1.0.5.tar.gz",
+            "hash": "aaa236d77d1ec4d8bef85761e578a59bbd5153d3af8744407605de940509ebce"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-opensuse.13.2-x64.1.0.5.tar.gz",
+            "hash": "5d43aaab95262cd44a017b4dc95226b1249dcd95547721eb3565599a404af439"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu-x64.1.0.5.tar.gz",
+            "hash": "860a22f2adc783a1ab10cb373109682d32435c76b9045bc9966d097512bec937"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/4/A/24A06858-E8AC-469B-8AE6-D0CEC9BA982A/dotnet-ubuntu.16.04-x64.1.0.5.tar.gz",
+            "hash": "cec3ed3464a0982b92d92d46088039f302c5b861c8dd13db90d2d99eb9e7fa96"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.4",
+        "version-display": "1.0.4",
+        "runtime-version": "1.0.5",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz",
+            "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip",
+            "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip",
+            "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz",
+            "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz",
+            "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz",
+            "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz",
+            "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz",
+            "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz",
+            "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2017-03-07",
-        "release-version": "1.0.4",
-        "security": false,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.4.md",
-        "runtime":
-        {
-            "version": "1.0.4",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-osx-x64.1.0.4.tar.gz", 
-                    "hash": "7f999ad206b9da7f2e41e0657d4c4827e8863628a97036efa34ff74914338c2b"
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x86.1.0.4.zip", 
-                    "hash": "caa47a54f25145c680f0da1dad54f39443bf3db3b561ba84754f411cfdf874ce"
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x64.1.0.4.zip", 
-                    "hash": "35eaf27e9643679ad53b3db94bee1b7fe56d35eb4a09afbf22b64ef63381bc9f"
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-centos-x64.1.0.4.tar.gz", 
-                    "hash": "c73de2a339508ee5ddcd3ac2fe524c3ab012b872ac5ad8b27d8c396d8d41925f"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-debian-x64.1.0.4.tar.gz", 
-                    "hash": "1223e8456789125b0fb4113ab87c46ae58f214dec59b1c28fd2a851bfbf6762a"
-                },
-                {
-                    "name": "dotnet-fedora.23-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-fedora.23-x64.1.0.4.tar.gz", 
-                    "hash": "70b17dc13cf87f9c51f772a7c85c03f1530e608389a7c0e090d8a8534c14a6c2"
-                },
-                {
-                    "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-opensuse.13.2-x64.1.0.4.tar.gz", 
-                    "hash": "a23c49d83b83d797b1fc9da0ab9d6be8026fcee26896afddbedb088a66424f30"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu-x64.1.0.4.tar.gz", 
-                    "hash": "309296da11b302c48a035fadc1e6cade3aa68b2263af69f4038053db8be56526"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu.16.04-x64.1.0.4.tar.gz", 
-                    "hash": "d9af9252e5987e7fa4acdc1cdd13c7a22e09336389a3429015737dca0124bc70"
-                }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.1",
-            "version-display":  "1.0.1",
-            "runtime-version": "1.0.4",
-            "vs-version": "15.0",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz", 
-                    "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip", 
-                    "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip", 
-                    "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz", 
-                    "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz", 
-                    "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz", 
-                    "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"
-                },
-                {
-                    "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz", 
-                    "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"
-                },
-                {
-                    "name": "dotnet-dev-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz", 
-                    "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"
-                },
-                {
-                    "name": "dotnet-dev-opensuse.42.1-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz", 
-                    "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz", 
-                    "hash": "d85dc4043049ff6ccf45282b6dda5484d8cd3b49554a8f18e2c45b7a0fdb24f5"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz", 
-                    "hash": "2f89e03968d44824278e62f8b8b1e720a2bd0ede4be32da095a748336528551a"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz", 
-                    "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz", 
-                    "hash": "2450b62653ccc6d6c0b5f0c454a1563d659e20c19159d9e8b59a71c744adfa9f"
-                }
-            ]            
-        }
+      "release-date": "2017-03-07",
+      "release-version": "1.0.4",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.4.md",
+      "runtime": {
+        "version": "1.0.4",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-osx-x64.1.0.4.tar.gz",
+            "hash": "7f999ad206b9da7f2e41e0657d4c4827e8863628a97036efa34ff74914338c2b"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x86.1.0.4.zip",
+            "hash": "caa47a54f25145c680f0da1dad54f39443bf3db3b561ba84754f411cfdf874ce"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-win-x64.1.0.4.zip",
+            "hash": "35eaf27e9643679ad53b3db94bee1b7fe56d35eb4a09afbf22b64ef63381bc9f"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-centos-x64.1.0.4.tar.gz",
+            "hash": "c73de2a339508ee5ddcd3ac2fe524c3ab012b872ac5ad8b27d8c396d8d41925f"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-debian-x64.1.0.4.tar.gz",
+            "hash": "1223e8456789125b0fb4113ab87c46ae58f214dec59b1c28fd2a851bfbf6762a"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-fedora.23-x64.1.0.4.tar.gz",
+            "hash": "70b17dc13cf87f9c51f772a7c85c03f1530e608389a7c0e090d8a8534c14a6c2"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-opensuse.13.2-x64.1.0.4.tar.gz",
+            "hash": "a23c49d83b83d797b1fc9da0ab9d6be8026fcee26896afddbedb088a66424f30"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu-x64.1.0.4.tar.gz",
+            "hash": "309296da11b302c48a035fadc1e6cade3aa68b2263af69f4038053db8be56526"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/1.0.4/dotnet-ubuntu.16.04-x64.1.0.4.tar.gz",
+            "hash": "d9af9252e5987e7fa4acdc1cdd13c7a22e09336389a3429015737dca0124bc70"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.1",
+        "version-display": "1.0.1",
+        "runtime-version": "1.0.4",
+        "vs-version": "15.0",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz",
+            "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip",
+            "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip",
+            "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz",
+            "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz",
+            "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz",
+            "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz",
+            "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz",
+            "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.1-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz",
+            "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz",
+            "hash": "d85dc4043049ff6ccf45282b6dda5484d8cd3b49554a8f18e2c45b7a0fdb24f5"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz",
+            "hash": "2f89e03968d44824278e62f8b8b1e720a2bd0ede4be32da095a748336528551a"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz",
+            "hash": "2450b62653ccc6d6c0b5f0c454a1563d659e20c19159d9e8b59a71c744adfa9f"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2016-12-13",
-        "release-version": "1.0.3",
-        "security": false,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md",
-        "runtime":
-        {
-            "version": "1.0.3",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-osx-x64.1.0.3.tar.gz", 
-                    "hash": "7355f4a6d2b07e373a6e86d196d134a9c4167e40915e9ae9515fd36af6376923"
-                },
-                {
-                    "name": "dotnet-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-osx-x64.1.0.3.pkg", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-win-x86.1.0.3.zip", 
-                    "hash": "135cdad343d18343386f41163462ef8755568f2bfcc31809c5d5d0c58b9358fa"
-                },
-                {
-                    "name": "dotnet-win-x86.exe", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x86.1.0.3.exe", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-win-x64.1.0.3.zip", 
-                    "hash": "4f984e8ca364f8524f00551f1cc7fc8caf8483b9165596538027f5112e066884"
-                },
-                {
-                    "name": "dotnet-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x64.1.0.3.exe", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-centos-x64.1.0.3.tar.gz", 
-                    "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"
-                },
-                {
-                    "name": "dotnet-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-debian-x64.1.0.3.tar.gz", 
-                    "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"
-                },
-                {
-                    "name": "dotnet-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-fedora.23-x64.1.0.3.tar.gz", 
-                    "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"
-                },
-                {
-                    "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-opensuse.13.2-x64.1.0.3.tar.gz", 
-                    "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"
-                },
-                {
-                    "name": "dotnet-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-ubuntu-x64.1.0.3.tar.gz", 
-                    "hash": "d48aa0ffc135b89838777124844df06deb12b480fa0e6acb9b4a29804e91b0cf"
-                },
-                {
-                    "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-ubuntu.16.04-x64.1.0.3.tar.gz", 
-                    "hash": "7193d0f922208bca47ea4e43ace662774514624e377dbe034b59a061c9808afa"
-                }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.0-preview2-003156",
-            "version-display":  "1.0.0-preview2",
-            "runtime-version": "1.0.3",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-osx-x64.1.0.0-preview2-003156.pkg", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-dev-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x64.1.0.0-preview2-003156.exe", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-dev-win-x86.exe", 
-                    "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x86.1.0.0-preview2-003156.exe", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-osx-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "8923307b4c17262dab995171733a05b2f6ec9c166b31f6971795e219a789fd24"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-win-x86.1.0.0-preview2-003156.zip", 
-                    "hash": "7cf1891e6129a357cdaf0410b0f3de27ffd3b67473ac124d586d6df75cf8f235"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-win-x64.1.0.0-preview2-003156.zip", 
-                    "hash": "ebef0a9b8055d70c5ab27d5a06b933f31650e43696740c8989b877145a158aa0"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-centos-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-debian-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"
-                },
-                {
-                    "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-fedora.23-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"
-                },
-                {
-                    "name": "dotnet-dev-opensuse.13.2-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-ubuntu-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003156.tar.gz", 
-                    "hash": "701173691ab79f85a071163e33309da89f7ede008804a73d36d2042487b7cc98"
-                }                
-            ]            
-        }
+      "release-date": "2016-12-13",
+      "release-version": "1.0.3",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.3.md",
+      "runtime": {
+        "version": "1.0.3",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-osx-x64.1.0.3.tar.gz",
+            "hash": "7355f4a6d2b07e373a6e86d196d134a9c4167e40915e9ae9515fd36af6376923"
+          },
+          {
+            "name": "dotnet-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-osx-x64.1.0.3.pkg",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-win-x86.1.0.3.zip",
+            "hash": "135cdad343d18343386f41163462ef8755568f2bfcc31809c5d5d0c58b9358fa"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x86.1.0.3.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-win-x64.1.0.3.zip",
+            "hash": "4f984e8ca364f8524f00551f1cc7fc8caf8483b9165596538027f5112e066884"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sharedfx/dotnet-win-x64.1.0.3.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-centos-x64.1.0.3.tar.gz",
+            "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-debian-x64.1.0.3.tar.gz",
+            "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-fedora.23-x64.1.0.3.tar.gz",
+            "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-opensuse.13.2-x64.1.0.3.tar.gz",
+            "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-ubuntu-x64.1.0.3.tar.gz",
+            "hash": "d48aa0ffc135b89838777124844df06deb12b480fa0e6acb9b4a29804e91b0cf"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sharedfx/dotnet-ubuntu.16.04-x64.1.0.3.tar.gz",
+            "hash": "7193d0f922208bca47ea4e43ace662774514624e377dbe034b59a061c9808afa"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.0-preview2-003156",
+        "version-display": "1.0.0-preview2",
+        "runtime-version": "1.0.3",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-osx-x64.1.0.0-preview2-003156.pkg",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x64.1.0.0-preview2-003156.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/F/F/AFF54A80-A370-4595-B22C-2575C10F5F4F/sdk/dotnet-dev-win-x86.1.0.0-preview2-003156.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-osx-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "8923307b4c17262dab995171733a05b2f6ec9c166b31f6971795e219a789fd24"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-win-x86.1.0.0-preview2-003156.zip",
+            "hash": "7cf1891e6129a357cdaf0410b0f3de27ffd3b67473ac124d586d6df75cf8f235"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-win-x64.1.0.0-preview2-003156.zip",
+            "hash": "ebef0a9b8055d70c5ab27d5a06b933f31650e43696740c8989b877145a158aa0"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-centos-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "df72591c1008e95629d8f86c30d2be69c6c33eacceb4722905bc97f13a6e3145"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-debian-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "d61f2732930c050a1e2cc1270dc86829f496f3611dba4a5cb2409ceb1b821699"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-fedora.23-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "cc36f1e6c39629a7e8d7c33becc286e4b5b111451b47819db909ab44391aa647"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "24b2aa95a32cf4162b592980bcb80c1b5abd5adb95e7f466091f59e2f4e79397"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-ubuntu-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/0/3/0/030449F5-F093-44A6-9889-E19B50A59777/sdk/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003156.tar.gz",
+            "hash": "701173691ab79f85a071163e33309da89f7ede008804a73d36d2042487b7cc98"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2016-10-17",
-        "release-version": "1.0.2",
-        "security": false,
-        "runtime":
-        {
-            "version": "1.0.2",
-            "files":
-            [
-                {
-                    "name": "dotnet-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-osx-x64.1.0.2.pkg", 
-                    "hash": "c05310b26134fb0fcbcdc42b7b34d75a6b9185838bb27329e089bf3626c47bae33426c5840cc9ce2e47799a25d3f49414b6988a80d6b48528d4c0fe3c2c2eb8f"
-                }
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.0-preview2-003148",
-            "version-display":  "1.0.0-preview2",
-            "runtime-version": "1.0.2",
-            "vs-version":  "",
-            "files":
-            [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.1.0.0-preview2-003148.pkg", 
-                    "hash": "8523e2249665b081d2a90de07f146d5dd3cba43c40ca65038b1095db4357cbc37425e424f652f3662cdebf2db090929a7e8677bf3b9bbd921af626bd72111627"
-                }
-            ]            
-        }
+      "release-date": "2016-10-17",
+      "release-version": "1.0.2",
+      "security": false,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "1.0.2",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-osx-x64.1.0.2.pkg",
+            "hash": "c05310b26134fb0fcbcdc42b7b34d75a6b9185838bb27329e089bf3626c47bae33426c5840cc9ce2e47799a25d3f49414b6988a80d6b48528d4c0fe3c2c2eb8f"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.0-preview2-003148",
+        "version-display": "1.0.0-preview2",
+        "runtime-version": "1.0.2",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.1.0.0-preview2-003148.pkg",
+            "hash": "8523e2249665b081d2a90de07f146d5dd3cba43c40ca65038b1095db4357cbc37425e424f652f3662cdebf2db090929a7e8677bf3b9bbd921af626bd72111627"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2016-09-13",
-        "security": false,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md",
-        "runtime":
-        {
-            "version": "1.0.1",
-            "files":
-            [
-            {
-                "name": "dotnet-osx-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-osx-x64.1.0.1.tar.gz", "hash" : "45a06f7eec05b32b511cd42074708bbb03a4c16d74b576b31ee282019f7a1149"
-            },
-            {
-                "name": "dotnet-win-x86.zip", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x86.1.0.1.zip", "hash" : "10d76abf6a5bebe57a9dd7bd6b112501d4bfee7eeb649e581c287713746814f9"
-            },
-            {
-                "name": "dotnet-win-x64.zip", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x64.1.0.1.zip", "hash" : "86b9a242e14296d266697c7a1004ef379ea7f3faed231fbe196561d6f9591868"
-            },
-            {
-                "name": "dotnet-centos-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-centos-x64.1.0.1.tar.gz", "hash" : "4e35226bcc6006c46c0ecbe6b16b8c879d9d30fd5e9250d238e025b7357bee0b"
-            },
-            {
-                "name": "dotnet-debian-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-debian-x64.1.0.1.tar.gz", "hash" : "aab094ab47d266b11194caa285c0adef3bf311ac48cdb17e4a6e0d1de0365543"
-            },
-            {
-                "name": "dotnet-fedora.23-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-fedora.23-x64.1.0.1.tar.gz", "hash" : "a61fa03d5519e029f59addf9dd740a2e8fb834ff2cfab2856d7052fd9dbbb7ce"
-            },
-            {
-                "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-opensuse.13.2-x64.1.0.1.tar.gz", "hash" : "8b50b6c920eb38e7e2b6e686d85f8d1ff56c357f630c6a3d26e943913134a9e3"
-            },
-            {
-                "name": "dotnet-ubuntu-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu-x64.1.0.1.tar.gz", "hash" : "d462661db3f8b9a8b4435b03114c90190b3f5bb30fa02617c5c6f99af5b3d458"
-            },
-            {
-                "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu.16.04-x64.1.0.1.tar.gz", "hash" : "ad4d4a8ebae995410667fa598a9afb0f5a273f08b7d57d7b7b2256c350943aed"
-            }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.0-preview2-003131",
-            "version-display":  "1.0.0-preview2",
-            "runtime-version": "1.0.1",
-            "vs-version":  "",
-            "files":
-            [
-            {
-                "name": "dotnet-dev-osx-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "36629fbad1dc1609360482140de3e5c074fcab538c2f2ce67ff6e246375ecd2b"
-            },
-            {
-                "name": "dotnet-dev-win-x86.zip", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003131.zip", 
-                "hash": "93a67a5b8cc8aaba5f33e297a524fdff3098442b84232b1a85160f455369ee68"
-            },
-            {
-                "name": "dotnet-dev-win-x64.zip", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003131.zip", 
-                "hash": "392f494301427f4d1172f60efa61be6f25f016aa2ff6e6fa2ad4137fa184eb5c"
-            },
-            {
-                "name": "dotnet-dev-centos-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "c51797746b5ce338e74e85f6cc43a5201db1af50247d47c28c9cb25f6a37833d"
-            },
-            {
-                "name": "dotnet-dev-debian-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "bb3458b0e771182e1387ca5d9fa5946fc775b77ec55a2501fb3f75ddf29f8124"
-            },
-            {
-                "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "8cd233fdf2d12eca47d558e70e90000aee34a75c718fc9f22d8680e6cb688047"
-            },
-            {
-                "name": "dotnet-dev-opensuse.13.2-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "d52077e0401a9cd39faaaa90e9003d32e765b0294d30eabc418ba76386766428"
-            },
-            {
-                "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"
-            },
-            {
-                "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003131.tar.gz", 
-                "hash": "ba36382d95307a6526d675bba4160f8035e9a5b9b1c2295fb1e6e752be337298"
-            }                
-            ]            
-        }
+      "release-date": "2016-09-13",
+      "release-version": null,
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md",
+      "runtime": {
+        "version": "1.0.1",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-osx-x64.1.0.1.tar.gz",
+            "hash": "45a06f7eec05b32b511cd42074708bbb03a4c16d74b576b31ee282019f7a1149"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x86.1.0.1.zip",
+            "hash": "10d76abf6a5bebe57a9dd7bd6b112501d4bfee7eeb649e581c287713746814f9"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-win-x64.1.0.1.zip",
+            "hash": "86b9a242e14296d266697c7a1004ef379ea7f3faed231fbe196561d6f9591868"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-centos-x64.1.0.1.tar.gz",
+            "hash": "4e35226bcc6006c46c0ecbe6b16b8c879d9d30fd5e9250d238e025b7357bee0b"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-debian-x64.1.0.1.tar.gz",
+            "hash": "aab094ab47d266b11194caa285c0adef3bf311ac48cdb17e4a6e0d1de0365543"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-fedora.23-x64.1.0.1.tar.gz",
+            "hash": "a61fa03d5519e029f59addf9dd740a2e8fb834ff2cfab2856d7052fd9dbbb7ce"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-opensuse.13.2-x64.1.0.1.tar.gz",
+            "hash": "8b50b6c920eb38e7e2b6e686d85f8d1ff56c357f630c6a3d26e943913134a9e3"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu-x64.1.0.1.tar.gz",
+            "hash": "d462661db3f8b9a8b4435b03114c90190b3f5bb30fa02617c5c6f99af5b3d458"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/0/0/B00543E8-54D9-4D4A-826B-84348956AA75/dotnet-ubuntu.16.04-x64.1.0.1.tar.gz",
+            "hash": "ad4d4a8ebae995410667fa598a9afb0f5a273f08b7d57d7b7b2256c350943aed"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.0-preview2-003131",
+        "version-display": "1.0.0-preview2",
+        "runtime-version": "1.0.1",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "36629fbad1dc1609360482140de3e5c074fcab538c2f2ce67ff6e246375ecd2b"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003131.zip",
+            "hash": "93a67a5b8cc8aaba5f33e297a524fdff3098442b84232b1a85160f455369ee68"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003131.zip",
+            "hash": "392f494301427f4d1172f60efa61be6f25f016aa2ff6e6fa2ad4137fa184eb5c"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "c51797746b5ce338e74e85f6cc43a5201db1af50247d47c28c9cb25f6a37833d"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "bb3458b0e771182e1387ca5d9fa5946fc775b77ec55a2501fb3f75ddf29f8124"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "8cd233fdf2d12eca47d558e70e90000aee34a75c718fc9f22d8680e6cb688047"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "d52077e0401a9cd39faaaa90e9003d32e765b0294d30eabc418ba76386766428"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "5566872fbe47910df57ec8a93b8b7a69ea904e4ba24d8ff05498657c4079df5b"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-003131.tar.gz",
+            "hash": "ba36382d95307a6526d675bba4160f8035e9a5b9b1c2295fb1e6e752be337298"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     },
     {
-        "release-date": "2016-06-27",
-        "release-version": "1.0.0",
-        "security": false,
-        "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0.md",
-        "runtime":
-        {
-            "version": "1.0.0",
-            "files":
-            [
-            {
-                "name": "dotnet-osx-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-osx-x64.1.0.0.tar.gz", 
-                "hash": ""
-            },
-            {
-                "name": "dotnet-win-x86.zip", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x86.1.0.0.zip", 
-                "hash": ""
-            },
-            {
-                "name": "dotnet-win-x64.zip", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x64.1.0.0.zip", 
-                "hash": ""
-            },
-            {
-                "name": "dotnet-centos-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-centos-x64.1.0.0.tar.gz", 
-                "hash": "c01e6a474e95a02c38f327dc5b7830b7a31109f87563d735a6e272008726f262"
-            },
-            {
-                "name": "dotnet-debian-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-debian-x64.1.0.0.tar.gz", 
-                "hash": "df8b71809626960c26a632e8c1801973ff9f1b8fa4fdeaa51a27bc070ce3f03a"
-            },
-            {
-                "name": "dotnet-fedora.23-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-fedora.23-x64.1.0.0.tar.gz", 
-                "hash": "49b4f9037e2c75b0abc1c364dc67c15125fcb5d353c6935ff487e6aefec86353"
-            },
-            {
-                "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-opensuse.13.2-x64.1.0.0.tar.gz", 
-                "hash": "a4bc924aa0ebfc4d6123baad15e270bbcb99ce25fbe7ea8f0fd721cb8ad725ba"
-            },
-            {
-                "name": "dotnet-ubuntu-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-ubuntu-x64.1.0.0.tar.gz", 
-                "hash": "304165580cf2eeac1ba8db994ec9cd7c83084c9a4a094387d180400ce2fdd1aa"
-            }                
-            ]
-        },
-        "sdk":
-        {
-            "version": "1.0.0-preview2-003121",
-            "version-display":  "1.0.0-preview2",
-            "runtime-version": "1.0.0",
-            "files":
-            [
-            {
-                "name": "dotnet-dev-osx-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": "1df92ad4eb117e717acbd68c46b06df4a677f590652099d0cc0982253bdf4534"
-            },
-            {
-                "name": "dotnet-dev-win-x86.zip", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003121.zip", 
-                "hash": "107a27f5c1dec01932f26bcbd2640ae2d098266f05fafe1ab6c6ada7a5f43a27"
-            },
-            {
-                "name": "dotnet-dev-win-x64.zip", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003121.zip", 
-                "hash": "a7ab3ad9c28c9952a9f6e1fee158c337b82aac3ba502e742a92d23bab258e621"
-            },
-            {
-                "name": "dotnet-dev-centos-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": ""
-            },
-            {
-                "name": "dotnet-dev-debian-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": "204ceab7bc92c17d17691b0d5c1d54992fc78a969fc217a8423045875a4c63ed"
-            },
-            {
-                "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": "dde9f8326583f351a89e57095dc523ba92560896cd1d4b8e0ca5ac7fd8499138"
-            },
-            {
-                "name": "dotnet-dev-opensuse.13.2-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": "293aa02e528d6c4621b4dda859caf14d670ab212a497945ef5ea17cca31f4ac8"
-            },
-            {
-                "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003121.tar.gz", 
-                "hash": "02aa1990cf130ea7d772baee6e066bfe249c914c881f5e2cb8e482f524cdb54d"
-            }                
-            ]            
-        }
+      "release-date": "2016-06-27",
+      "release-version": "1.0.0",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0.md",
+      "runtime": {
+        "version": "1.0.0",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-osx-x64.1.0.0.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x86.1.0.0.zip",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-win-x64.1.0.0.zip",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-centos-x64.1.0.0.tar.gz",
+            "hash": "c01e6a474e95a02c38f327dc5b7830b7a31109f87563d735a6e272008726f262"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-debian-x64.1.0.0.tar.gz",
+            "hash": "df8b71809626960c26a632e8c1801973ff9f1b8fa4fdeaa51a27bc070ce3f03a"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-fedora.23-x64.1.0.0.tar.gz",
+            "hash": "49b4f9037e2c75b0abc1c364dc67c15125fcb5d353c6935ff487e6aefec86353"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-opensuse.13.2-x64.1.0.0.tar.gz",
+            "hash": "a4bc924aa0ebfc4d6123baad15e270bbcb99ce25fbe7ea8f0fd721cb8ad725ba"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/4/E/84EA9F4F-0E3A-4B41-A18A-36D51B06CBED/dotnet-ubuntu-x64.1.0.0.tar.gz",
+            "hash": "304165580cf2eeac1ba8db994ec9cd7c83084c9a4a094387d180400ce2fdd1aa"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.0-preview2-003121",
+        "version-display": "1.0.0-preview2",
+        "runtime-version": "1.0.0",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-osx-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": "1df92ad4eb117e717acbd68c46b06df4a677f590652099d0cc0982253bdf4534"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x86.1.0.0-preview2-003121.zip",
+            "hash": "107a27f5c1dec01932f26bcbd2640ae2d098266f05fafe1ab6c6ada7a5f43a27"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-win-x64.1.0.0-preview2-003121.zip",
+            "hash": "a7ab3ad9c28c9952a9f6e1fee158c337b82aac3ba502e742a92d23bab258e621"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-centos-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": "204ceab7bc92c17d17691b0d5c1d54992fc78a969fc217a8423045875a4c63ed"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-fedora.23-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": "dde9f8326583f351a89e57095dc523ba92560896cd1d4b8e0ca5ac7fd8499138"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": "293aa02e528d6c4621b4dda859caf14d670ab212a497945ef5ea17cca31f4ac8"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-ubuntu-x64.1.0.0-preview2-003121.tar.gz",
+            "hash": "02aa1990cf130ea7d772baee6e066bfe249c914c881f5e2cb8e482f524cdb54d"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
     }
-    ]
+  ]
 }

--- a/release-notes/1.1/releases.json
+++ b/release-notes/1.1/releases.json
@@ -1,1473 +1,1746 @@
 {
-    "channel-version": "1.1",
-    "latest-release": "1.1.10",
-    "latest-release-date": "2018-10-09",
-    "latest-runtime": "1.1.10",
-    "latest-sdk": "1.1.11",
-    "support-phase": "maintenance",
-    "eol-date": "2019-06-27",
-    "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
-    "releases": 
-    [
-        {
-            "release-date": "2018-10-09",
-            "release-version": "1.1.10",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.10.md",
-            "runtime": {
-                "version": "1.1.10",
-                "version-display": "1.1.10",
-                "vs-version": "",
-                "files": [
-                    {
-                        "name":  "coreclr-symbols.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/373f14c7-c48f-4812-aacd-36d0a264679c/44e2497391796c22f2123e763e288c0b/coreclr-1.1.10-symbols.zip",
-                        "hash":  "930734cf9816d9996363bcc1811e05c626cac8875f9335e86a2d2bd2fc47af9c2880769cbf725ec5ec8641f7a9ac754d141d874298fc22fc5d933ed68060fcf2"
-                    },
-                    {
-                        "name":  "corefx-symbols.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/aaddf89a-b6b9-425b-85f0-ca6777d82960/e8f560ab2700dc7a36e8ceaff71f0f1b/corefx-1.1.10-symbols.zip",
-                        "hash":  "1f6fdc3acaf68922a3c83618385341a81aa1c7c981a705f93371ac01ac2c08760c767b67a098900e5eccc403e8c503bf49f9a20203415767a5a45851b07b96e8"
-                    },
-                    {
-                        "name":  "core-setup-symbols.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/f02b2b5c-35f9-4c7f-b1af-d701bceeb18a/adcd583ab241afac1aef59bf13a4a683/core-setup-1.1.10-symbols.zip",
-                        "hash":  "4051672a0d4fc98577896d30fbeae9b8d7ef7d9411c57e7c90d21b1a032ff69f53a89c6bbfc7cc84b3760cb2bab02efdead6e5baa6d37bece906b9d284c274a7"
-                    },
-                    {
-                        "name":  "dotnet-centos-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/dcd0be0c-bcd7-44ba-a2b9-81a311a3cdb3/b0ca72ea9b995994d6e54ac242928ede/dotnet-centos-x64.1.1.10.tar.gz",
-                        "hash":  "18f8fed7d7fa8d54cdceebac4f2528d7a90b32c66be1a98ebcafbbaa7b0c9f4aa412da6e66893bb21bdfedf37fce196b24eb76e5ba4405e5fd352aa80f25fcb0"
-                    },
-                    {
-                        "name":  "dotnet-debian.9-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/1fe343e6-f55f-4b70-a3c8-1c9439a7c905/07dcc830b9ed0a2c2feead85a5209b92/dotnet-debian.9-x64.1.1.10.tar.gz",
-                        "hash":  "fe3ea31831444bcd4f77ae0b05e217c8f1efaf175605667a76615223b8efbc728a77411c67cc096168881030d7f3c4ab387a2d2633177cf635e9543ac837f01b"
-                    },
-                    {
-                        "name":  "dotnet-debian-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/8543193c-3c50-4709-90d6-632e3c37ae2b/c8919995f8eda0b236d91459b3ab4f4b/dotnet-debian-x64.1.1.10.tar.gz",
-                        "hash":  "a89e1a06ac23a0fd51fa6ab8f35b792499af9601c67b6f5ed2334d357ffb1bb811ed94d9e8f297b351b0f1470fbbc0e15d8da87010c11cf9fcc0b91d7b0262e3"
-                    },
-                    {
-                        "name":  "dotnet-fedora.27-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/24786c9f-d752-4d7d-9891-b4500507281f/147128999e7bb01117796de87c542516/dotnet-fedora.27-x64.1.1.10.tar.gz",
-                        "hash":  "84a47b8dbd8ab0c3badea337d8a0df22af1c9da7f65b3272488fcb6506eb29924573c4970606bc3df36cd45f4363ef1b4f518a6648a9fa559b1a49abaf460871"
-                    },
-                    {
-                        "name":  "dotnet-fedora.28-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/a5c06c72-a6c1-4624-8ab6-ce2d5ec78e6a/6afd58fbd5aee8d97f3340f94eeecad0/dotnet-fedora.28-x64.1.1.10.tar.gz",
-                        "hash":  "47845a9a7985e916c0f8bc266c20f87b4cfaa2b61becfa7c9ecfaa5056bcfb147d057038797787ea3f612a520484bfc1131636375a6fd56088c05452acbfc3ed"
-                    },
-                    {
-                        "name":  "dotnet-opensuse.42.3-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/c36cfeaa-2310-4b15-84eb-634e39cc67c4/f409e955512078bfd4424b44dbc6c05b/dotnet-opensuse.42.3-x64.1.1.10.tar.gz",
-                        "hash":  "99f1ada1b8ebfc9c5bb84c524235fa61fa421b4758adf46e70bfbf13c730f82eab4d934ea86e810392891d7d45d5caf43bfeb685410a380b4ea2b4719fea0659"
-                    },
-                    {
-                        "name":  "dotnet-osx-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/196e2703-a697-4eef-b647-36430cd66b47/6d490df0fe97b97a118302b8ea7a29db/dotnet-osx-x64.1.1.10.pkg",
-                        "hash":  "035e86ba27bd094f419a8032af1608d1c756c7cb6df3f34b7be4423e9c0fcb5f1b35e823a184086e53fa1f1f1c0dc209acbe2ef1aa2cdd608e3a4cc0f423ff3f"
-                    },
-                    {
-                        "name":  "dotnet-osx-x64.pkg",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/d6e2e0f4-36e4-4f02-bc9a-18554377cb1a/6024c1292306c11fbf879293329dec42/dotnet-osx-x64.1.1.10.tar.gz",
-                        "hash":  "fbb3dc3e35cf17e95ad54cf38339a9fc2dc11f650f6a22de52658e2f6dfdbad2b39bce42badd76a7a941d105a343d9c2232dcbbc0b64cef2e3656ff65a59a4f9"
-                    },
-                    {
-                        "name":  "dotnet-rhel-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/950bcacb-cd3b-40bd-8a21-e22fc25f850c/935f5844d8af2132e71c4a1a88dee0d0/dotnet-rhel-x64.1.1.10.tar.gz",
-                        "hash":  "40029e8f7c06fdb797683edf6e472f87a48c0d776bafbea3ac6ad03561d9cbf94d011999968a102135b87651a819b27af13ea1c8d05780c8cc3b577411cdc71b"
-                    },
-                    {
-                        "name":  "dotnet-ubuntu.16.04-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/6d8ce8f5-173b-471f-bf83-6d21b6f7924c/7e7b983ed52f1f0eb937bffb8d3ab1e2/dotnet-ubuntu.16.04-x64.1.1.10.tar.gz",
-                        "hash":  "e39f0fe332d26d42a1f7517ceb2624e17cb825aa6c85ddb8b19d5ec79f885b1a343ce28a139a9e863cb6fdd103434e857914003e5716f5aeb3b7d05002daa3ee"
-                    },
-                    {
-                        "name":  "dotnet-ubuntu.18.04-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/b25b5650-0cb8-4699-a347-48d73650da0b/920966211e9bb1907232bbda1faa895a/dotnet-ubuntu.18.04-x64.1.1.10.tar.gz",
-                        "hash":  "5008d2b2f4ad0c0c8dc7e109ebba4b83b897e8e35d7c925754b99879673de811e44deb77051f5f22eb0df016992c02c2c4c6c4bea14ca77cafcaae79fe0f4404"
-                    },
-                    {
-                        "name":  "dotnet-ubuntu-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/e436ca0b-f286-4d5a-b07d-41855d4c1e83/f169eac4a2b1449055cc804a345f1413/dotnet-ubuntu-x64.1.1.10.tar.gz",
-                        "hash":  "0f75dcd87af64960ff154657f1afac7f4cb5d09b2eab472472dd320b01b5efdb2d7ff48b49cc0a933213647cd16392e13e71a3e9c82edc9d561d483a427814f8"
-                    },
-                    {
-                        "name":  "dotnet-win-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/f2c70fc3-d08f-41d0-80cd-851530acb391/6f5c6c2715f92c4aa3c45616c0419125/dotnet-win-x64.1.1.10.exe",
-                        "hash":  "0653d989fd88ec8d94e66825c70134476f405da4e00fa850b42a597fd8faeb72fd389f947444d7bdddf30e600a3d7398f607aaee2e63047c25d620f46f2d39db"
-                    },
-                    {
-                        "name":  "dotnet-win-x64.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/2b67f7b6-3178-4405-98fa-529a0ee63ec7/e422f43e67412f1b2619dc297cd4da6a/dotnet-win-x64.1.1.10.zip",
-                        "hash":  "92b2779f9b84b23f9f317c3f5bd2b4c6263b0b99683a696d2637718b79eea0d5468bb836d5b14b37a04f7f44fa2717f3d9e94c69dd969d4a70538f9ab595c9a8"
-                    },
-                    {
-                        "name":  "dotnet-win-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/69d04e62-57d7-481e-9441-3b45ac73cf3b/040505f07aba828c022ed9cf43488dd5/dotnet-win-x86.1.1.10.exe",
-                        "hash":  "67e07ddb58f26166633b1db45db2ad73a98cd68f3ac0cd48eff3823da0ae31883fea64e9b4aa39141c83c41fa70085e4d333402f6dbec1f6f794f972efbfb483"
-                    },
-                    {
-                        "name":  "dotnet-win-x86.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/2424cd3a-e84d-4e0b-bebf-57e0e52185ce/52b1b575a2dfb1731ede85fd4d3b7fcf/dotnet-win-x86.1.1.10.zip",
-                        "hash":  "56de3d4a6145defb859dad2e9623ca7f2fbd990c2a24fdbfc962a78c54df27003b459152d9b631f9330ece90c65e178e3792e80966031476b1f9449815a5fad8"
-                    }
-                ]
-            },
-            "sdk": {
-                "version": "1.1.11",
-                "version-display": "1.1.11",
-                "runtime-version": "1.1.10",
-                "vs-version": "",
-                "files":  [
-                    {
-                        "name":  "dotnet-dev-osx-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/15a05546-15df-488f-adcf-0e77e86dbefb/1f902e78cfea6209c387adce764a88bc/dotnet-dev-osx-x64.1.1.11.tar.gz",
-                        "hash":  "b827b192398af01bf917a5fc0255616a82f04a95dac8154e681398e7e3ef549d701376bb1c9018dea37269e0406f065fb8e2958e652dfabaf86d5e0bb68b0840"
-                    },
-                    {
-                        "name":  "dotnet-dev-osx-x64.pkg",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/3c23a7aa-eecd-461b-ad45-979c4c684917/1b464bd34c763e664f7eed6006889d87/dotnet-dev-osx-x64.1.1.11.pkg",
-                        "hash":  "1b8ba4f003fda6725c6c27787f6b750064fa7522d0adb0bbbb1717286b2083550da68a242b840dc9505ca68775785935b0428933eb8b0e89f31e698e41618989"
-                    },
-                    {
-                        "name":  "dotnet-dev-win-x86.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/db408c7b-ef37-4374-b33b-a5b286adaa53/be0f0df977501c4df71ac3f04b9ce35e/dotnet-dev-win-x86.1.1.11.zip",
-                        "hash":  "29a97f3e5e2e8465e4b0c7628a9a02baa0148bfe1a960f58dcdb08b3ad65702cf5367c3f776f47b4df5ce2487955831ed5ab330d4eeabea28ab4f25edb051be8"
-                    },
-                    {
-                        "name":  "dotnet-dev-win-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/9386d3bc-6799-4cc5-8288-c807674c72ed/b585db316f0d1c4cad749c247ef21b59/dotnet-dev-win-x86.1.1.11.exe",
-                        "hash":  "88778c12aa4e3bdb696da31d5ae1a03441fc6d0d1860bada75bc604692e3f8c240941a10b8a99eaace2b5a6957bcdafa158f2cfb533d122bffcb2c55b25f351d"
-                    },
-                    {
-                        "name":  "dotnet-dev-win-x64.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/a298f85a-bc4c-4019-842e-021e397e3437/5c95727dfe79b600834291a8983b9507/dotnet-dev-win-x64.1.1.11.zip",
-                        "hash":  "cbf96efd9f6119cad96041e3c55099b98f82252a60a93bbba5f93289bf600c5146402046c3ac79c6e927291e40cb5222171c3ee8cfbc086e635968dfed6e269e"
-                    },
-                    {
-                        "name":  "dotnet-dev-win-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/baf5a5a7-68d6-4cf1-afdf-47968b5f91e7/05e6dfe191607ef6135a34215464f600/dotnet-dev-win-x64.1.1.11.exe",
-                        "hash":  "6e15fa8c9d5b10cc3edb353c5e1ece01a29f7d00ff853cc12f84e33a776df8062c07febbd9659ca46c2adeb005036c231fd7a7592591b6e28c643bdc45084778"
-                    },
-                    {
-                        "name":  "dotnet-dev-centos-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/116bc57f-a6d6-474f-aca7-58c18fe0fac4/aa324344fc9c36623fb4a7c7e5bece0c/dotnet-dev-centos-x64.1.1.11.tar.gz",
-                        "hash":  "8665733eba5af02f8af5420bc858ffc4ef73281fb518c0736458f9f1f666f65e57c6a8e2efac5d3e6aca56ac8942a25d1d805ce392fd6f751fb3f0ce821b20c4"
-                    },
-                    {
-                        "name":  "dotnet-dev-debian-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/1ef84426-c1d0-4e3b-86a4-7fce48baecb8/a47dbe0cd3bc1eefdabbf9354f60004b/dotnet-dev-debian-x64.1.1.11.tar.gz",
-                        "hash":  "14f48469ebbc171d111369ea0dbe88ee9aeb74193aabd6e123c97e54ad81fd6352e86c446f8fe68e2db93793de86fbf89a9c682dd7d1d226169e788cd1f3f6a2"
-                    },
-                    {
-                        "name":  "dotnet-dev-debian.9-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/b5c87053-99b4-4c91-af5b-69a1c0e2c91e/ab8882f283fb7206d0f1ee965faa4288/dotnet-dev-debian.9-x64.1.1.11.tar.gz",
-                        "hash":  "23e1d3d1863ae8f6bfd450ff238ad7d5929722df6a0492597089c992aa1b223af294386718a711040a4e5f77bd3af97e7924d344e1535d4bc36c640dc6b73869"
-                    },
-                    {
-                        "name":  "dotnet-dev-fedora.27-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/98eb7365-0ca8-4e29-b455-b165e583d0de/3a1da729266cb9b885f6747b376a0f7c/dotnet-dev-fedora.27-x64.1.1.11.tar.gz",
-                        "hash":  "ed2cad6ef471dd787086a249b932569840cabc7d48aa6920ce2d85e2d364a880f1d4c63e1014016a0fd19f8e8f1f93526fa2d710a587fcb27616bfd27844dc57"
-                    },
-                    {
-                        "name":  "dotnet-dev-fedora.28-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/b3e55604-5a36-412d-ada3-9a46bba55fd0/473cb6db3926c04b7598d750f1d30731/dotnet-dev-fedora.28-x64.1.1.11.tar.gz",
-                        "hash":  "50ba2fa6a319de00857f847c6dbaf49bb4b93a0e7f73824ff47bdabc6862b45f0349c9c95b11dd2caec6fd4ef5ba3e89ad1c5a44e6a66cf600bc906327805a7f"
-                    },
-                    {
-                        "name":  "dotnet-dev-opensuse.42.3-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/3b5e416e-1359-4638-b1f3-e0ac378d3550/13ee9ae8dd5bdd11a11abe1934542920/dotnet-dev-opensuse.42.3-x64.1.1.11.tar.gz",
-                        "hash":  "13163a1573c1f95ed45a5b445488080cd619693ac7ce8705e13ccfb605ae89d959a82bf42d633a6e65d5242eb508840e9f521bcfb6f30623a6575bfa701e6532"
-                    },
-                    {
-                        "name":  "dotnet-dev-ubuntu-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/c0957a2b-cac6-44d8-b1cc-0dad4420c825/8dc69e33f8cf44152fdf173d3bf0b746/dotnet-dev-ubuntu-x64.1.1.11.tar.gz",
-                        "hash":  "a7743d00fad50ec1c9f27ac5b09d1b9d787ac9d4d600179d1d4a5ebb636438dda45ecc85b1a246fd2eed6455dfdcf764165428af38f83a524b4ea0aee82a3366"
-                    },
-                    {
-                        "name":  "dotnet-dev-ubuntu.16.04-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/c9f432a7-11fd-48a8-adef-fa95bc24a9ad/85a7293b69d07d5ed678ea21f6082539/dotnet-dev-ubuntu.16.04-x64.1.1.11.tar.gz",
-                        "hash":  "60906a50e01420c0603127041b5fc628cb064169ed03b6c9727857695021d2713d92cdec322d97340d9e525a1f2f3c727b7125ca07c0d04057196e0e7cf791b2"
-                    },
-                    {
-                        "name":  "dotnet-dev-ubuntu.18.04-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/aeac042a-cfef-4064-b914-7419f13c20ae/be14353986c2fbb2259064bcd2cc522a/dotnet-dev-ubuntu.18.04-x64.1.1.11.tar.gz",
-                        "hash":  "d96adb429e00052e331215438d0f1f244c830f633f9bd0dcf817f02a2211028ee4ac02e585be440863bdc6afc54fabe3539188c6f5f7086d8a0ced624fb05697"
-                    },
-                    {
-                        "name":  "dotnet-dev-rhel-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/e461be2e-e14f-4a78-b987-351da98fb9ab/dc2c11f04a967d3d5c15a9a47b2d9fcc/dotnet-dev-rhel-x64.1.1.11.tar.gz",
-                        "hash":  "c79e40710dbf5e0f22d54ebeef4e08ce459a83dd58a9d7a2e56ebb480c780e912d4c8ee643df7f7717bb8544955bb154ca9aa88ec610eccd0d2f712b74668be3"
-                    }
-                ]
-            },
-            "aspnetcore-runtime": {
-                "version": "1.1.10",
-                "files": [
-                    {
-                        "name":  "DotNetCore-WindowsHosting.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/b84d0334-d56b-47b3-9da4-c48a553ce286/5079d35485214be3fbd72a4fdf21a655/dotnetcore.1.0.13_1.1.10-windowshosting.exe",
-                        "hash":  "a653ae9b309baa4918b1b0c70b2b73dc4b5cf5cca0a6756273c924051973dd354b6748d72177937f851c1f7b2d16aa4d67920294ea2bf98a11768cab04d2f764"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-07-10",
-            "release-version": "1.1.9",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.9.md",
-            "runtime":
-            {
-                "version": "1.1.9",
-                "version-display": "1.1.9",
-                "vs-version": "",            
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-osx-x64.1.1.9.tar.gz", 
-                        "hash": "ff3fed1cda60e82de53de0c95b3ebb97e64f398f54d36aacc52d21f5859d4ab016e81c502c68e511ff2bfa5f97645e7c04eb7b8e66cf2b173419c009492bef03"
-                    },
-                    {
-                        "name": "dotnet-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-osx-x64.1.1.9.pkg", 
-                        "hash": "e3ed92c005ce1d819f140e22a2e4c46e49d53f073d31eab0a3b883006f77a69b960fe97ef0931fd10bad8aff511dfee020af7a305b573436fee7a2067eb076fb"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.zip", 
-                        "hash": "8c98407232539275bf14960f2e9dc6623aef129e2960a2feda9ae35087f3dd0a3688f54c31ec79d99e7dc233165eff458deaebd6db0e2b0396cbec1b94d5bd38"
-                    },
-                    {
-                        "name": "dotnet-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.exe", 
-                        "hash": "cbea84c048d9f83e218b57bdc4ee770127e2402ab63f7ba072f3420556722d891226f2826164980a5c72672b25beb62de7eb4c38082184fd1c81624f240a28e1"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.zip", 
-                        "hash": "6de9e8db06131f0a77b78ff755350304dd7ae57a8861646bf0abca824689de2e29936667932d1cad025b062b1c818bc5a036d4326f65095448e664a5badc6d5a"
-                    },
-                    {
-                        "name": "dotnet-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.exe", 
-                        "hash": "c2016e5afd5e76b2a0735474d067323a1e701a6a4aa99e8dead4155edc98c80ceb36ba643941e0bb4723be0b0c34eb401ad3c8784493c6f14a6c3b4ac49df6e1"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-centos-x64.1.1.9.tar.gz", 
-                        "hash": "8be4dbeb3c801d219e68f8cf93400126034c4da37ae28856e690021522a0eff392264f2c44653724f6e8562a7efcfe86f96ea3bf7289c0d6e4ce64ca4cde4560"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-debian-x64.1.1.9.tar.gz", 
-                        "hash": "7cc5b2eaa20c1541be3b1affad8b839b1fd9fa97cf3cde5f9e13077581ade08c02f1aa89fce81cfe3fcb143b5207b3fbd71f1a7c0e9a7ac1d7eec5a66bdc3e33"
-                    },
-                    {
-                        "name": "dotnet-fedora.27-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.27-x64.1.1.9.tar.gz", 
-                        "hash": "2e7646554c8903f6446e07f4b7a6593ee67031c00a65f0ad7aaaba7e21d287dd3fab7609234bae78941861b870701b83c99119af259e6c249530c62f1dad8dc0"
-                    },
-                    {
-                        "name": "dotnet-fedora.28-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.28-x64.1.1.9.tar.gz", 
-                        "hash": "5e657a221841e220a7601c60ec0ba2436abd442db8d83cc79adc49c67937439c69e9cebf0b7e17073ef3f4585bdbaf21d619db2dd5694c8630a9aa0427b6c057"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-opensuse.42.3-x64.1.1.9.tar.gz", 
-                        "hash": "f7919d8d68b10ab00168ad2a82f69fbd661f803bfc941e9ad75037afd02d1b783bb812ed5032ef0350b9fcd0cbbf2219b293a340ffb51cd8f40485a85a3b2a29"
-                    },
-                    {
-                        "name": "dotnet-rhel-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-rhel-x64.1.1.9.tar.gz", 
-                        "hash": "3d36fbafbb573dc29533209a6f463bb7e69790b93635854d9862c31c3c991ebf3ec3385b00423eb2fb4a3112ba967b5e18275acfc37a46c8063aab5e3bc2b092"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu-x64.1.1.9.tar.gz", 
-                        "hash": "e64753b4f81106c6d692c45a51abc45bd700ee52390f56090ab61e25b2811c484bdd87c434e7ca4fe1f0d187d9469c207fe94694ee1d848a72cd1cff01fb01ca"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.16.04-x64.1.1.9.tar.gz", 
-                        "hash": "95e050b3faf98e1391605a69353d708231641d69a4f8cac6b0f11bf1736f09a69dfb4b2f8e446a39a22e8141c35a609130870c485af85e7089c109c313f0248c"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.18.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.18.04-x64.1.1.9.tar.gz", 
-                        "hash": "fb3ee217813b099f651ef8ded1adc5bbece731ed61add842cc488c5a70dbee50877f4defec71c0089c1c90f3e580e0ea3c3f4d4006c03ecdd568787542d16728"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.1.10",
-                "version-display": "1.1.10",
-                "runtime-version": "1.1.9",
-                "vs-version": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.tar.gz", 
-                        "hash": "bf3bf5f22c70c944a9459565626ef935cd15465a189ef9dd65d18560f7e71e44e2ac93552999774eb9a6672530a99baa30347bf3ea1cc7f4ac4d583e1f0e60b9"
-                    },
-                    {
-                        "name": "dotnet-dev-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.pkg", 
-                        "hash": "990d54a53702f5314ad06aab3fa7b6ad0944f2d8863d5ba99f9e86a660fc542378e0fa2cf9aebbd44bdee71bdd37d287409ded40f98d4a43f77e613a3d84fee3"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.zip", 
-                        "hash": "f46778149a785c0ffed4611966c07668061bd07dcf0c4ebb42e68461aa9dc5a8fe5bcd0d99f1ebb279a7f8269d84dd7f34e34b6c953d63ce1acbc85c4c88b743"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.exe", 
-                        "hash": "871baf6e9e7ca12a222ad0c9eb6060b933448c58f289defe1723934c66c07b2da6bd6f3495878afb280f188e64fd6200ed18b59ea5659e62be538956cb502a5a"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.zip", 
-                        "hash": "d0b01871251265b9a07c24e94e2e33f4a5d96ec6165ec0f60b032ce5c35895985e37cc01f73134fc8802a442eeb243b1d1403ebe898d6455907095e5b6b854c1"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.exe", 
-                        "hash": "d686d2514f45df597791d4fb60ccc272f5d42239e21803dbbf050891f79dbc7c0c8a72623606f312fd0aed0eef7ec5270c4adcfba105e3ec635d27729ff5c4af"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-centos-x64.1.1.10.tar.gz", 
-                        "hash": "30af1b4c9d8bd46bc48a52c9a9bee9e3a9a750ffd2308236458acd4cc3b313b8a4ca6259b34422caabd47540e30f5467b8f9237595e49be963d29abbdbfbd0e9"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-debian-x64.1.1.10.tar.gz", 
-                        "hash": "f4ac12ff20db06a7c6232c2645f35486d5369201429e3aa9c89a65a3e5f53957cd6ab612c225cc1dd6afebd4dd28695ca5a1f9cbcc812d8fa08635d6cedb1dff"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.27-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.27-x64.1.1.10.tar.gz", 
-                        "hash": "89cb369e8205224db77e314b6e236570e94b1d351689dddab5c4fbd63f444389e9745b84c57f855ddef9d693866b1103af6b8d889d6626ccc5c08c6783185d6d"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.28-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.28-x64.1.1.10.tar.gz", 
-                        "hash": "91e3bd421cadaf3a3a3e65486a088d9d4b0aaab9f35757068f6f09736cacbe498fc9469aaab9a4d5c209074af253761a8325adf525e991e40c5ffc10acd8ba93"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz", 
-                        "hash": "227928df186dbd0fcc152f602383efcb66c45e467e5b88e135c725a53f69fbba26debbcb0536629e53b15e0caac65ef3af8db9b242195f3bf517d2f629125439"
-                    },
-                    {
-                        "name": "dotnet-dev-rhel-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-rhel-x64.1.1.10.tar.gz", 
-                        "hash": "717c07603009c52f996c3e5a90292022ecf0f7d787bd3de202a68b8eb4273b947ee2832aa93a9c9636e8b05f5e65d2051cb4ea1f0a5d4bf9f5d167e732a8c0c4"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu-x64.1.1.10.tar.gz", 
-                        "hash": "21bb88c12a094aced52d5161dee6d345698210ddc942a597e489c167fdeef4a1ebab90f7bd4bc0c23fba1c912d24e73b333635b70f7571b4ab5d8d8d1ce4b713"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz", 
-                        "hash": "89300ca6c519ba17eebe0e425f332bd457c0af49d9ba0cd00f4df14be471bb6d5a0207486e484b106a6b1071fb140b0738f752475dd88d8d7f833e8b8e26da58"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz", 
-                        "hash": "38a3cd266f3b1f680e878c981adca1cebe81fbfd161ce4ea083ea4c7809c0a92e03ac33d292e29f43b5ebae18622ea83360c6b07186a6fa35ca6b2ad8450d140"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "1.1.9",            
-                "files": 
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/DotNetCore.1.0.12_1.1.9-WindowsHosting.exe", 
-                        "hash": "4d8f7cd4f2f647312d4615d951242cc5d36cbad3ffea48643abd4a9015494e635f7379eb1b46b0384c6a7facbe1b18fe8946fcdf277715d18c270f91d61e9e18"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-04-17",
-            "release-version": "1.1.8",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.8.md",
-            "runtime":
-            {
-                "version": "1.1.8",
-                "vs-version": "15.0",
-                "files": 
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-osx-x64.1.1.8.tar.gz", 
-                        "hash": "d45684320e1b4931663045a1c89d39558bb8a66cc1f1ca8f8f3a11ac8943b8c0176bb5485183c79e94eedacf58e65d9422fe7102e2fc02f0f5349b019303d183"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.zip", 
-                        "hash": "62f3b0d7d2836979c9cd5da7d598354e6c6adb4fd804a3dc378c09e9065c555218beeff2febcfb5f0fd3a08091d2ab4628a769600f4b3d672461ad0dc7af636d"
-                    },
-                    {
-                        "name": "dotnet-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.exe", 
-                        "hash": "ad40c463bbec93afd79aaa734482f979251db874a5dc91bb40562ffa4aa45b5823470b5bbeba2db8e669c01add15b762db2ba113a7ffcc10bda0d6cd7a5d3ea8"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.zip", 
-                        "hash": "81a9e99544efcb14294b267d6605edc07d857575a4ca628eb805adb8fb5c2644be24bbd3c449e3fa7ed8c28f65b15f64531a1885aec9e9898c5e31ea3a197926"
-                    },
-                    {
-                        "name": "dotnet-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.exe", 
-                        "hash": "682ad53a66f8a936fa8664a9be7ba6364acd9dd5983a70ded3020a144f8e13c28d3dcb3b2f1328b1003e474b05ef94c10aa90dde22bc23a5ddbf036157515e2b"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-centos-x64.1.1.8.tar.gz", 
-                        "hash": "c7221974f522633babe9b3e35bd984c5c65264f56d1ba9d916dd0c3a1193327e2983154b1eff6585b48c8508b4a4c95c0cc59793c7a0efd6db9b28f8f1e91a8b"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-debian-x64.1.1.8.tar.gz", 
-                        "hash": "49161d81fb9068ec018dd3bf6f438e838629933245cf88fe08562f8c8726e24523c628ab2a31dcdf5fe32f8496b009fefe275406318c5072cba85bddfe0a7693"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-fedora.24-x64.1.1.8.tar.gz", 
-                        "hash": "b0ee8856ec0d18a6d406a3f21372685eec74d22af81e351eecf78413de7c49602006a8492d775530cb72dd35da9f7dd074e1504158821ea6cc5f92b31fee5de3"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-opensuse.42.1-x64.1.1.8.tar.gz", 
-                        "hash": "fef9696d73d91ab7e3ea65c6a3c4d5c4fa4f0c219a21fa9f937e9292c261208a53d22173f72371d3cbddf02ea263ced50a90771effcde7ae26487526919ea9ed"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu-x64.1.1.8.tar.gz", 
-                        "hash": "f7385d5273c69259fb551adc8b4b6539b858f7f70365c98a6bd181525727cb7330d35716242632e61cf41c015b39ffc1aed8682a11316e77eb90c396b833a68e"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu.16.04-x64.1.1.8.tar.gz", 
-                        "hash": "dc9d732ddf5b136c4b1dae873f17d73465b653fd90d97123072541a7d9e243066220e04d204fd5942645f0c06969ad93084dce0400b37018ecc4d6b8131ce3a1"
-                    }
-                ]
-            },            
-            "sdk":
-            {
-                "version": "1.1.9",
-                "version-display": "1.1.9",
-                "runtime-version": "1.1.8",
-                "vs-version": "15.0",
-                "csharp-language": "7.0",
-                "files": 
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz", 
-                        "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"
-                    },
-                    {
-                        "name": "dotnet-dev-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg", 
-                        "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip", 
-                        "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip", 
-                        "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.exe", 
-                        "hash": "08f7ffbf28d3a85b3e6e4983bef643a212161271c6ff3956fbdef932038ba240104db6c2deb8b662e5392f1e5b45db2aee2e7da20ee7d800f3b417aabb649d2a"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz", 
-                        "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz", 
-                        "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz", 
-                        "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz", 
-                        "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz", 
-                        "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "1.1.8",
-                "vs-version": "15.0",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/DotNetCore.1.0.11_1.1.8-WindowsHosting.exe", 
-                        "hash": ""
-                    }
-                ]
-            }
-        },      
-        {
-            "release-date": "2018-03-13",
-            "release-version": "1.1.7",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.7.md",
-            "runtime":
-            {
-                "version-runtime": "1.1.7",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-osx-x64.1.1.7.tar.gz", 
-                        "hash": "b4068d5551017208879f6e9fcb887d630b13e5bca992478fb543a291f42d3bfc6071f8821aabcd0baa1f9ef4d18f22dadfb9218f8eba98c63c01bbd70339a7d6"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x86.1.1.7.zip", 
-                        "hash": "623dd7438b925c7063820a60e1fbe09011cc429ee325e519462fd537dfb17b53402b896aa89ffa09f695866166a410ea28cf1a8e92a9749ffc924c64034ca804"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.zip", 
-                        "hash": "43a414489f2bcc492a7b8874e0bf8d2693cf2b2bbe0720bf9e574f81e2537b1c509a801b56a6e49d755a9ee67da0d18a10a303a1acb23b69819898238c9ad2c8"
-                    },
-                    {
-                        "name": "dotnet-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.exe", 
-                        "hash": "16c1356c809059a767f17156fa2529cdf1ccddee0d6d18b3a10899e7c4de6a843fd4f1ef553297a329a6c76b8c22c9335a47c32072e8ef4860f5e9c627b003d6"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-centos-x64.1.1.7.tar.gz", 
-                        "hash": "cd99355697c5afeab3974b6b1a4ddf49ea74a4a8b08efc54ed9b6a561b665a6d1c59254965cfe59f8f5eea00d93bfeaf9684efc70dc4e339d6976e11f6104a6c"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-debian-x64.1.1.7.tar.gz", 
-                        "hash": "08e26b44547025e6b3edc75e6ad75c5a81eb4f6dcb0eda0452edaee1e66d04d2fa84914842f495d978cb9b8917eda192d0041e0548232a014e0e919e21d7d1a6"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-fedora.24-x64.1.1.7.tar.gz", 
-                        "hash": "22d2d6b1d3ee21ecfb256a0fa257d1a14a83689b63f0560ec58c88ddfa33aeff9800c5c62dda03abeff4966247d50a80b76db5ed3b6930448fd576b85e36f229"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-opensuse.42.1-x64.1.1.7.tar.gz", 
-                        "hash": "945abd08d56e1f81bd162af8ddf881a920a3f6d42790d5536cc6763dd82b8b0320125b9970ddc4d866657f2d07461b744b830f2d09ecc57d0bf0c120455e5206"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu-x64.1.1.7.tar.gz", 
-                        "hash": "621158af199e26c6fe9eba69dc934397b644db58ee63dd815634fc6b7bbba38b244ecce957aced307547df8e4725a6aa7a3039ee2e1eac8974c0248f662892f8"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu.16.04-x64.1.1.7.tar.gz", 
-                        "hash": "6e43dec9222b2d72e9ab763ee00e6f0244b73e9d02d129846afae00a474cf93656e85c5434c69b580015661f9bc5cb8fbfe09bb1f98d9df9dc6c5cc5921f3359"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.1.8",
-                "version-display": "1.1.8",
-                "runtime-version": "1.1.7",
-                "vs-version": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz", 
-                        "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"
-                    },
-                    {
-                        "name": "dotnet-dev-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-sdk-osx-x64.1.1.8.pkg", 
-                        "hash": "39f04d5bb258915794b91f0c39486f8a405fbff3bcd54524243f6685822824a605da9f2c694c0a966b5f27cc567346af57ba25d5381ea9fcbee3ddb7273a7f8b"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip", 
-                        "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip", 
-                        "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.exe", 
-                        "hash": "278304c8ef455e3c0d24d5b9dc3c2d0019b1a429d968e4a39f499b8e63636685ef6cfef38a50b954fa24189c3421f9a3d157a0113064af09bc55f66f391a0b8f"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz", 
-                        "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz", 
-                        "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz", 
-                        "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz", 
-                        "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz", 
-                        "hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"
-                    }
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "1.1.7",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/DotNetCore.1.0.10_1.1.7-WindowsHosting.exe", 
-                        "hash": ""
-                    }
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-11-14",
-            "release-version": "1.1.6",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.6.md",
-            "runtime":
-            {
-                "version": "1.1.6",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-osx-x64.1.1.6.tar.gz", 
-                        "hash": "216d4489d6d0f6cb5c1fc08e36fbf07ec051760abdeed4027dc3a21239424f54a958ae46d0e2428418a57a0cd5273adac46d63725369a8b9a0ea99a32589c90b"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x86.1.1.6.zip", 
-                        "hash": "03809a2c1ef3b75e3753e92c82063304915132991f42f2ad3576e2076fd3b56dbfa586896b6539bdf1c3667f09a32fc745df683b3fa38636d3027642b082d45a"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.zip", 
-                        "hash": "d1562159c16764d8313cf039e8fb59aa777acf9a479cc34db9665022053765f4608e6633d6fddb490aa40e2fdfe6248fc4d29265958648029d07a5bd27fe4a80"
-                    },
-                    {
-                        "name": "dotnet-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.exe", 
-                        "hash": "57a4beaf70dcf38c055013a9595970c1e5a997f48a8091553c5cd69e3b7cfeddd3d2f2848007e0319ba546c97a5e211c46a59421c6e8f0964b8db1d9523ce9e5"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-centos-x64.1.1.6.tar.gz", 
-                        "hash": "e5cf8a038a613241426a878751fef23fefac674206153fc9e7cf12e5f063eae2916e74a9a9a51b18075aeabca62f4651d6ac5b466cd60feaeae6a721eb6de3d6"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-debian-x64.1.1.6.tar.gz", 
-                        "hash": "54c1d4a3a0125f177f4e61e4a3c4d447cf2ee18e436e2e62bc435d081b6cd9d9255be7130a792d4a667e2fa8940f8e33ad9596f1c08cf8f02340aa6cd3d4c361"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-fedora.24-x64.1.1.6.tar.gz", 
-                        "hash": "bcc570398f9a3148dff1da6627cc4b6ca397806db74b80881c4719ff815ac09a35298eee59c19b8bdfce05c8ce6c71ac4ed172558127eade4c680f6f58755243"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-opensuse.42.1-x64.1.1.6.tar.gz", 
-                        "hash": "83a282254ca690de5e10e230614e28b48a18b58ba0ff390ca15d06b88bde5ea786c1915055e3d78d2a9e10c9164dbc4562d4a0ca650a24591435e8c584900505"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu-x64.1.1.6.tar.gz", 
-                        "hash": "503e3d9e3adc87e90114e2e54fab7cc14c94f9df68961e77da996f293da8c8f50cb5b9a089ba7cddd2cd09eed3c3c357e4a8b52eda0f0d7f5e220fcfe41df140"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu.16.04-x64.1.1.6.tar.gz", 
-                        "hash": "bc8aa9990a99df631338af0d796ca0e51e452001e0593e22d3835621a45f7e3404f1214395e36cf64793d829702dddd4724c66ad841069dcac495ea4b57375db"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.1.7",
-                "version-display": "1.1.7",
-                "runtime-version": "1.1.6",
-                "vs-version": "",
-                "files":
-                [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz", 
-                    "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"
-                },
-                {
-                    "name": "dotnet-dev-osx-x64.pkg", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.pkg", 
-                    "hash": "080313d0b501502829e043f417fb2ebcced2aeba7640b84d83175dba25faea7219ee2f301aed7e5db857300e600e2d6b42a35cacb5d7bebf7569df193318666f"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip", 
-                    "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip", 
-                    "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.exe", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.exe", 
-                    "hash": "94daa61ccebed6925f94b921af74ca3fd62c086f4680116fb4ca97c03c79b50910dfff5a7f4e957d72fd8f6d27bf07223cb29588b107181adbe3e9ec641186db"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz", 
-                    "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz", 
-                    "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"
-                },
-                {
-                    "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz", 
-                    "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz", 
-                    "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz", 
-                    "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"
-                }
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "1.1.6",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/DotNetCore.1.0.9_1.1.6-WindowsHosting.exe", 
-                        "hash": ""
-                    }
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-11-14",
-            "release-version": "1.1.5",
-            "security": true,
-            "runtime":
-            {
-                "version": "1.1.5",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-osx-x64.1.1.5.tar.gz", 
-                        "hash": "ac538259ec3ac7cad13f9b4d3e1303e70b5a641d197e4bddbcccc4b91ca170fbdb0cc17fd9224efdb14c767b94d3c37997440e3e51750b8bdfb88060d4532516"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x86.1.1.5.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x64.1.1.5.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-centos-x64.1.1.5.tar.gz", 
-                        "hash": "d32e844c01fea03cb1906fd9d00b91a64f21646993748f8569d02ffeed28dc89a1eedcff60eeaf1ebbb5c7b0176ce360b929582f48725c13415b0a8f37d992b6"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-debian-x64.1.1.5.tar.gz", 
-                        "hash": "2d8e2a4f17f6986d1d1cf5f8191aa94f858e2121efa9283a97ac5ee6c8b2ed8c169f0312c6797e1fbcfdb981f501f38dc710ca95898d63a859597081523df095"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-fedora.24-x64.1.1.5.tar.gz", 
-                        "hash": "2d813462072ad7cf31529835d6be9afa55cc47c08b3fa749de337f5f214eda520d9b071aa67a2325c9f16711366a58380caee5c76372a747b4fda550df6dfaef"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-opensuse.42.1-x64.1.1.5.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu-x64.1.1.5.tar.gz", 
-                        "hash": "9c3d08ad516ad85ce9f5ce0118b550232d5b67f8466715ccfda8b98ab350e5535d66573525691a58dd2499bfb32446cc689d713efb05ddf672af18b862ecab84"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu.16.04-x64.1.1.5.tar.gz", 
-                        "hash": ""
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.1.5",
-                "version-display":  "1.1.5",
-                "runtime-version": "1.1.5",
-                "vs-version":  "",
-                "files":
-                [
-                {
-                    "name": "dotnet-dev-osx-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz", 
-                    "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"
-                },
-                {
-                    "name": "dotnet-dev-win-x86.zip", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip", 
-                    "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"
-                },
-                {
-                    "name": "dotnet-dev-win-x64.zip", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip", 
-                    "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"
-                },
-                {
-                    "name": "dotnet-dev-centos-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz", 
-                    "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"
-                },
-                {
-                    "name": "dotnet-dev-debian-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz", 
-                    "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"
-                },
-                {
-                    "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz", 
-                    "hash": ""
-                },
-                {
-                    "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz", 
-                    "hash": "6024e9e5ca8a986c6a63ba1d4d89234b682157f2814b379cd8d2890699f5d4acc197a5ae7204f136fd1bc2bad15c9896be99df6648a863dd1fb8e4758ba0daf5"
-                },
-                {
-                    "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                    "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz", 
-                    "hash": "0f666b7cf806cde0c5d93788bbf6dd4d808417aa0c1bdbdb1453d8046262188f8e5dabf593076d296e60ad77f34d858efd3137045943cec54e6d61ccf2556ec0"
-                }
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-09-21",
-            "release-version": "1.1.4",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.4.md",
-            "runtime":
-            {
-                "version-runtime": "1.1.4",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-osx-x64.1.1.4.tar.gz", 
-                        "hash": "58e93d00ddcaa14d58150f923b700c6190c87b1609d59040a262625853eae136"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x86.1.1.4.zip", 
-                        "hash": "265ec7d4b178e5c03e4b8250d0f368de714e3205c90180de71a3c514251d8eaf"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x64.1.1.4.zip", 
-                        "hash": "51a363fb5378f461e67793954e452cbdda4fbf825e7718e286c5ac4250c48b77"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-centos-x64.1.1.4.tar.gz", 
-                        "hash": "4b35bacfbf56c22e389739a4750b4773e51907944d4e24e4f5fca0b8355a83c4"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-debian-x64.1.1.4.tar.gz", 
-                        "hash": "8b3f0cd9a100a41436f316952128c0bfbd9bafc2808734599c643345de2e5304"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-fedora.24-x64.1.1.4.tar.gz", 
-                        "hash": "1897ef8729d3356b6f3b19b20ccdb744d49c78f2b05014282b98e7ce53e0a3e2"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu-x64.1.1.4.tar.gz", 
-                        "hash": "7948d90eac05b56a7c37a8ac37a5c83012843feeaa0194dfb079a90db9717e6c"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu.16.04-x64.1.1.4.tar.gz", 
-                        "hash": "fe412836910718d3f91ea5ba815a116f5fa872ac0a9ff683db2d8670aceb9b56"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.1.4",
-                "version-display":  "1.1.4",
-                "runtime-version": "1.1.4",
-                "vs-version": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz", 
-                        "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip", 
-                        "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip", 
-                        "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz", 
-                        "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz", 
-                        "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz", 
-                        "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz", 
-                        "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz", 
-                        "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"
-                    }
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "1.1.4",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe", 
-                        "hash": ""
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2017-05-09",
-            "release-version": "1.1.2",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.2.md",
-            "runtime":
-            {
-                "version": "1.1.2",
-                "support-phase": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-osx-x64.1.1.2.tar.gz", 
-                        "hash": "620a98213e423301fa44abfc1ca0b15e0bc538e676cbf0344c711abef5ed4231"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x86.1.1.2.zip", 
-                        "hash": "31e49e6ae491795c99221307dc829bbb57e645d568a94820a031688b6d8df4c6"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x64.1.1.2.zip", 
-                        "hash": "a4ccb23a6cf2ddf9894cb178ce8e69b5788880a1e3d9d659f26fb914a4bc2988"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-centos-x64.1.1.2.tar.gz", 
-                        "hash": "49c54129b39a4a873074b80691733d68ba596782f411cc6565d601aeb6229d1e"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-debian-x64.1.1.2.tar.gz", 
-                        "hash": "26f6a2e247dd0b9ac4003d12cf1bd8647985255fdd7659b60e36a7a26fce15de"
-                    },
-                    {
-                        "name": "dotnet-fedora.23-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.23-x64.1.1.2.tar.gz", 
-                        "hash": "5cb04a3a7f8fd780af87cc6e3273ade1fe9803b7518228999649fcbc95528278"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.24-x64.1.1.2.tar.gz", 
-                        "hash": "96204460bd7998e78ad2e84b1eb6821bff97c4a3dc2bb7a79cf828c5b6dfa37f"
-                    },
-                    {
-                        "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.13.2-x64.1.1.2.tar.gz", 
-                        "hash": "24be24522531d560513c54fe4b08116a48b81be27e0a43c39f150b8e71a816d3"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.42.1-x64.1.1.2.tar.gz", 
-                        "hash": "4112308f5e4bbbf38051140ee7bd47df79d4eee40d65f67a0fd1b14782da8166"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu-x64.1.1.2.tar.gz", 
-                        "hash": "9032e88d43d28004ac10618ef0abac502cdeb02228297d1b51dd67c7e40cd3d1"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.04-x64.1.1.2.tar.gz", 
-                        "hash": "c003ccc3942e327aed42c395bdcfacfc703f5adc5ec69246588a8aaab52b1513"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.10-x64.1.1.2.tar.gz", 
-                        "hash": "0a4d4061931e0154c9186446dbc8d4c3e69ba49537699be98185d55fc24a1b56"
-                    }                
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.0.4",
-                "version-display":  "1.0.4",
-                "runtime-version": "1.1.2",
-                "vs-version": "15.2.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz", 
-                        "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip", 
-                        "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip", 
-                        "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz", 
-                        "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz", 
-                        "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz", 
-                        "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.24-x64.1.0.4.tar.gz", 
-                        "hash": "f3f049e099c4ea73342ec6448cb0eef61d81cfca7c476b989fcb0f09d918c31c"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.13.2-x64..tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz", 
-                        "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.42.1-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.42.1-x64.1.0.4.tar.gz", 
-                        "hash": "91f133a77ba5ba9cd3ec5b243ce6c69ceb5ec164b2ff1fd256a28fbb73d6991e"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz", 
-                        "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz", 
-                        "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.10-x64.1.0.4.tar.gz", 
-                        "hash": "9e784b554a9cb68df9ce541cc220dafcb71b185837e05420c182e4a496b68f47"
-                    }                
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-03-07",
-            "release-version": "1.1.1",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.1.md",
-            "runtime":
-            {
-                "version": "1.1.1",
-                "support-phase": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-osx-x64.1.1.1.tar.gz", 
-                        "hash": "a809eb4f47a8468edacfab8dfd9ddc1015a2e4ec3643fdcedd4d7c9ab3f028f6"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x86.1.1.1.zip", 
-                        "hash": "0c69428e55782603982b173bc66eb24fbf80f9b01ffdf8a00f012beaab3c4653"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x64.1.1.1.zip", 
-                        "hash": "b0f7fc902308b98fa8e202081884d310a94a93264a1f5beeb4632acccf2c0bb2"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-centos-x64.1.1.1.tar.gz", 
-                        "hash": "2eca7129424c50bd4a312bf519e5f3add2398cc11f53e4032e233b787528c3e4"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-debian-x64.1.1.1.tar.gz", 
-                        "hash": "6359fcd443c686476c6b55bfcd5fdc214a64f8f399bfc1801e4d841c4ca163de"
-                    },
-                    {
-                        "name": "dotnet-fedora.23-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.23-x64.1.1.1.tar.gz", 
-                        "hash": "f5813c020d0b5c507ab857a168f7faea54f745ff8b34404b85f8dc5c03aa3537"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.24-x64.1.1.1.tar.gz", 
-                        "hash": "060d05dc338cb722cad94e379e354cca174309b789b686cf4e2cdfed2c238503"
-                    },
-                    {
-                        "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.13.2-x64.1.1.1.tar.gz", 
-                        "hash": "86180fb3d67293be760abbe6a28d73a7717a2910852e8b047ba771d0fecd3430"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.42.1-x64.1.1.1.tar.gz", 
-                        "hash": "97535294b174d09d685f46687d30ebc7d929afa11ed99fcc1645954b1cdeecb3"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu-x64.1.1.1.tar.gz", 
-                        "hash": "bd2807bf3d5b316bf7360bddab276bc4af13106de406491a41a4fae522d1c0be"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.04-x64.1.1.1.tar.gz", 
-                        "hash": "e1737cfc3df8336d7469e1c3df431abcb56f94d021a941dc33af9a0d090f512c"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.10-x64.1.1.1.tar.gz", 
-                        "hash": "d2d439fd7e544e120db4fb7246ec99cad199ad8d827a78e3e4157f8e331aa066"
-                    }                
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.0.1",
-                "version-display":  "1.0.1",
-                "runtime-version": "1.1.1",
-                "vs-version":  "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz", 
-                        "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip", 
-                        "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip", 
-                        "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz", 
-                        "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz", 
-                        "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz", 
-                        "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz", 
-                        "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.13.2-x64..tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz", 
-                        "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.42.1-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz", 
-                        "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz", 
-                        "hash": "4d4399e090c436e7037dc393373345aa0521b2acfa325dec80771f7adb448daf"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz", 
-                        "hash": "4a59413a0b2ba8914ceecb4a505dae4f93ede10cae4246d714178b11cbe32a2f"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz", 
-                        "hash": "828af612b3e691f27d93153c3c7fd561e041535e907e9823f206ccab51030ecf"
-                    }
-                ]            
-            }
-        },
-        {
-            "release-date": "2016-11-16",
-            "release-version": "1.1.0",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.md",
-            "runtime":
-            {
-                "version": "1.1.0",
-                "support-phase": "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-osx-x64.1.1.0.tar.gz", 
-                        "hash": "b8c28c32ca6bf677982999543feec0cea4e7275ed034e1b503451de0744d13f2"
-                    },
-                    {
-                        "name": "dotnet-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x86.1.1.0.zip", 
-                        "hash": "6e08a9753f96ed2087d189dd1adea7611e90bd88614157c1fe51cf397a967ed9"
-                    },
-                    {
-                        "name": "dotnet-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x64.1.1.0.zip", 
-                        "hash": "cc66a190edc10866494df9e72dbaf4b872c83045e26431161131459ab413a08c"
-                    },
-                    {
-                        "name": "dotnet-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-centos-x64.1.1.0.tar.gz", 
-                        "hash": "6f2a99f2aba9afd4c8470d5c423d06eec8e7dc9b2c6d2521216eefcceccdd254"
-                    },
-                    {
-                        "name": "dotnet-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-debian-x64.1.1.0.tar.gz", 
-                        "hash": "91acd357628a3ae510e6f9ff2f912fb69b7a477125a66dca8f8cf3015d87df19"
-                    },
-                    {
-                        "name": "dotnet-fedora.23-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.23-x64.1.1.0.tar.gz", 
-                        "hash": "de34ecd0bae6865d5ff15898415517892caf1894301a9368c7b68a62b9e188b4"
-                    },
-                    {
-                        "name": "dotnet-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.24-x64.1.1.0.tar.gz", 
-                        "hash": "4bf2fed6c9607cfb19c8b80cce74a99aee3f7549b644841d46ea47238d39feee"
-                    },
-                    {
-                        "name": "dotnet-opensuse.13.2-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.13.2-x64.1.1.0.tar.gz", 
-                        "hash": "97b98c12693683bd5bb5e3b1745f72b8e5a4e50ed72dbfe0155749135bc09b84"
-                    },
-                    {
-                        "name": "dotnet-opensuse.42.3-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.42.1-x64.1.1.0.tar.gz", 
-                        "hash": "f1b5055ffd1e8df4bcfbdbee8c99ff81315d493d2e24ebfbcab5b324e9bb7671"
-                    },
-                    {
-                        "name": "dotnet-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu-x64.1.1.0.tar.gz", 
-                        "hash": "1c067b32dd40dd2b88a6d25c8634c94f37399a590b5036e609550de7f5fda935"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.04-x64.1.1.0.tar.gz", 
-                        "hash": "917fa16e95fe9d2434134e09025c23b766387c67e91f5f88947ccd6b5e3032e2"
-                    },
-                    {
-                        "name": "dotnet-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.10-x64.1.1.0.tar.gz", 
-                        "hash": "48243753a3b4429b51e1c919955f40c977886849aacc03a2a207f472d78bfae9"
-                    }                
-                ]
-            },
-            "sdk":
-            {
-                "version": "1.0.0-preview2.1-003177",
-                "version-display":  "1.0.0-preview2",
-                "runtime-version": "1.1.0",
-                "vs-version":  "",
-                "files":
-                [
-                    {
-                        "name": "dotnet-dev-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-osx-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "8f1ffef37aa9da7273674185dab3b78feb44082d3a9d3156dfc20329acfe7e0d"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x86.1.0.0-preview2-1-003177.zip", 
-                        "hash": "38a451069f6bc1d2e226218f260b19fc1a2aca775fbd88c083b2d23d5a3af737"
-                    },
-                    {
-                        "name": "dotnet-dev-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x64.1.0.0-preview2-1-003177.zip", 
-                        "hash": "d4056a91f83699894c9f9fbac1b8965597ded079b0d8848dacc7505f372f85a0"
-                    },
-                    {
-                        "name": "dotnet-dev-centos-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-centos-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "168099d73a4be8dacf148a4c9300602a4a74e78fa86495a6d819a2ecca2db406"
-                    },
-                    {
-                        "name": "dotnet-dev-debian-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-debian-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "a2f228dc79501ee85ac5fcdf771886d8f84409bacfd3f9b3ba4225663cbfa3ef"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.23-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.23-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "9802a59b2e68c1fd2c91648503302066bf0ab09b1d286dd6264e2ccc75f50b09"
-                    },
-                    {
-                        "name": "dotnet-dev-fedora.24-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.24-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "4ff0b843f00f89b4391cb2b442f973117d676c56b571b40c9ffa49af3740f717"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.13.2-x64..tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "a46585f907b73336878076ab9942db6565445b8b7a435f85537fece4ae4456a0"
-                    },
-                    {
-                        "name": "dotnet-dev-opensuse.42.1-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.42.1-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "b9bec78bbb710a47baa79e2af65b5dc0242bbc7850571d67f8153f6d6cb3f542"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "9f6f72c581534ec4367bc3952fe3bfe7649179d86c55b31371b4294edc96d1d1"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "4fdae55113557171a0898b283eef13669a7d722fb2b918a595eb2ab70db1d8a8"
-                    },
-                    {
-                        "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.10-x64.1.0.0-preview2-1-003177.tar.gz", 
-                        "hash": "835bfcb0cf56457a7c5f953f5fd7d6a37b7a68eb23dc0fb3d9161def833345ea"
-                    }                
-                ]            
-            }
-        }
-    ]
+  "channel-version": "1.1",
+  "latest-release": "1.1.10",
+  "latest-release-date": "2018-10-09",
+  "latest-runtime": "1.1.10",
+  "latest-sdk": "1.1.11",
+  "support-phase": "maintenance",
+  "eol-date": "2019-06-27",
+  "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+  "releases": [
+    {
+      "release-date": "2018-10-09",
+      "release-version": "1.1.10",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.10.md",
+      "runtime": {
+        "version": "1.1.10",
+        "version-display": "1.1.10",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "coreclr-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/373f14c7-c48f-4812-aacd-36d0a264679c/44e2497391796c22f2123e763e288c0b/coreclr-1.1.10-symbols.zip",
+            "hash": "930734cf9816d9996363bcc1811e05c626cac8875f9335e86a2d2bd2fc47af9c2880769cbf725ec5ec8641f7a9ac754d141d874298fc22fc5d933ed68060fcf2"
+          },
+          {
+            "name": "corefx-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aaddf89a-b6b9-425b-85f0-ca6777d82960/e8f560ab2700dc7a36e8ceaff71f0f1b/corefx-1.1.10-symbols.zip",
+            "hash": "1f6fdc3acaf68922a3c83618385341a81aa1c7c981a705f93371ac01ac2c08760c767b67a098900e5eccc403e8c503bf49f9a20203415767a5a45851b07b96e8"
+          },
+          {
+            "name": "core-setup-symbols.zip",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f02b2b5c-35f9-4c7f-b1af-d701bceeb18a/adcd583ab241afac1aef59bf13a4a683/core-setup-1.1.10-symbols.zip",
+            "hash": "4051672a0d4fc98577896d30fbeae9b8d7ef7d9411c57e7c90d21b1a032ff69f53a89c6bbfc7cc84b3760cb2bab02efdead6e5baa6d37bece906b9d284c274a7"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dcd0be0c-bcd7-44ba-a2b9-81a311a3cdb3/b0ca72ea9b995994d6e54ac242928ede/dotnet-centos-x64.1.1.10.tar.gz",
+            "hash": "18f8fed7d7fa8d54cdceebac4f2528d7a90b32c66be1a98ebcafbbaa7b0c9f4aa412da6e66893bb21bdfedf37fce196b24eb76e5ba4405e5fd352aa80f25fcb0"
+          },
+          {
+            "name": "dotnet-debian.9-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1fe343e6-f55f-4b70-a3c8-1c9439a7c905/07dcc830b9ed0a2c2feead85a5209b92/dotnet-debian.9-x64.1.1.10.tar.gz",
+            "hash": "fe3ea31831444bcd4f77ae0b05e217c8f1efaf175605667a76615223b8efbc728a77411c67cc096168881030d7f3c4ab387a2d2633177cf635e9543ac837f01b"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8543193c-3c50-4709-90d6-632e3c37ae2b/c8919995f8eda0b236d91459b3ab4f4b/dotnet-debian-x64.1.1.10.tar.gz",
+            "hash": "a89e1a06ac23a0fd51fa6ab8f35b792499af9601c67b6f5ed2334d357ffb1bb811ed94d9e8f297b351b0f1470fbbc0e15d8da87010c11cf9fcc0b91d7b0262e3"
+          },
+          {
+            "name": "dotnet-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/24786c9f-d752-4d7d-9891-b4500507281f/147128999e7bb01117796de87c542516/dotnet-fedora.27-x64.1.1.10.tar.gz",
+            "hash": "84a47b8dbd8ab0c3badea337d8a0df22af1c9da7f65b3272488fcb6506eb29924573c4970606bc3df36cd45f4363ef1b4f518a6648a9fa559b1a49abaf460871"
+          },
+          {
+            "name": "dotnet-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a5c06c72-a6c1-4624-8ab6-ce2d5ec78e6a/6afd58fbd5aee8d97f3340f94eeecad0/dotnet-fedora.28-x64.1.1.10.tar.gz",
+            "hash": "47845a9a7985e916c0f8bc266c20f87b4cfaa2b61becfa7c9ecfaa5056bcfb147d057038797787ea3f612a520484bfc1131636375a6fd56088c05452acbfc3ed"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c36cfeaa-2310-4b15-84eb-634e39cc67c4/f409e955512078bfd4424b44dbc6c05b/dotnet-opensuse.42.3-x64.1.1.10.tar.gz",
+            "hash": "99f1ada1b8ebfc9c5bb84c524235fa61fa421b4758adf46e70bfbf13c730f82eab4d934ea86e810392891d7d45d5caf43bfeb685410a380b4ea2b4719fea0659"
+          },
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/196e2703-a697-4eef-b647-36430cd66b47/6d490df0fe97b97a118302b8ea7a29db/dotnet-osx-x64.1.1.10.pkg",
+            "hash": "035e86ba27bd094f419a8032af1608d1c756c7cb6df3f34b7be4423e9c0fcb5f1b35e823a184086e53fa1f1f1c0dc209acbe2ef1aa2cdd608e3a4cc0f423ff3f"
+          },
+          {
+            "name": "dotnet-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d6e2e0f4-36e4-4f02-bc9a-18554377cb1a/6024c1292306c11fbf879293329dec42/dotnet-osx-x64.1.1.10.tar.gz",
+            "hash": "fbb3dc3e35cf17e95ad54cf38339a9fc2dc11f650f6a22de52658e2f6dfdbad2b39bce42badd76a7a941d105a343d9c2232dcbbc0b64cef2e3656ff65a59a4f9"
+          },
+          {
+            "name": "dotnet-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/950bcacb-cd3b-40bd-8a21-e22fc25f850c/935f5844d8af2132e71c4a1a88dee0d0/dotnet-rhel-x64.1.1.10.tar.gz",
+            "hash": "40029e8f7c06fdb797683edf6e472f87a48c0d776bafbea3ac6ad03561d9cbf94d011999968a102135b87651a819b27af13ea1c8d05780c8cc3b577411cdc71b"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d8ce8f5-173b-471f-bf83-6d21b6f7924c/7e7b983ed52f1f0eb937bffb8d3ab1e2/dotnet-ubuntu.16.04-x64.1.1.10.tar.gz",
+            "hash": "e39f0fe332d26d42a1f7517ceb2624e17cb825aa6c85ddb8b19d5ec79f885b1a343ce28a139a9e863cb6fdd103434e857914003e5716f5aeb3b7d05002daa3ee"
+          },
+          {
+            "name": "dotnet-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b25b5650-0cb8-4699-a347-48d73650da0b/920966211e9bb1907232bbda1faa895a/dotnet-ubuntu.18.04-x64.1.1.10.tar.gz",
+            "hash": "5008d2b2f4ad0c0c8dc7e109ebba4b83b897e8e35d7c925754b99879673de811e44deb77051f5f22eb0df016992c02c2c4c6c4bea14ca77cafcaae79fe0f4404"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e436ca0b-f286-4d5a-b07d-41855d4c1e83/f169eac4a2b1449055cc804a345f1413/dotnet-ubuntu-x64.1.1.10.tar.gz",
+            "hash": "0f75dcd87af64960ff154657f1afac7f4cb5d09b2eab472472dd320b01b5efdb2d7ff48b49cc0a933213647cd16392e13e71a3e9c82edc9d561d483a427814f8"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2c70fc3-d08f-41d0-80cd-851530acb391/6f5c6c2715f92c4aa3c45616c0419125/dotnet-win-x64.1.1.10.exe",
+            "hash": "0653d989fd88ec8d94e66825c70134476f405da4e00fa850b42a597fd8faeb72fd389f947444d7bdddf30e600a3d7398f607aaee2e63047c25d620f46f2d39db"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b67f7b6-3178-4405-98fa-529a0ee63ec7/e422f43e67412f1b2619dc297cd4da6a/dotnet-win-x64.1.1.10.zip",
+            "hash": "92b2779f9b84b23f9f317c3f5bd2b4c6263b0b99683a696d2637718b79eea0d5468bb836d5b14b37a04f7f44fa2717f3d9e94c69dd969d4a70538f9ab595c9a8"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/69d04e62-57d7-481e-9441-3b45ac73cf3b/040505f07aba828c022ed9cf43488dd5/dotnet-win-x86.1.1.10.exe",
+            "hash": "67e07ddb58f26166633b1db45db2ad73a98cd68f3ac0cd48eff3823da0ae31883fea64e9b4aa39141c83c41fa70085e4d333402f6dbec1f6f794f972efbfb483"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2424cd3a-e84d-4e0b-bebf-57e0e52185ce/52b1b575a2dfb1731ede85fd4d3b7fcf/dotnet-win-x86.1.1.10.zip",
+            "hash": "56de3d4a6145defb859dad2e9623ca7f2fbd990c2a24fdbfc962a78c54df27003b459152d9b631f9330ece90c65e178e3792e80966031476b1f9449815a5fad8"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.11",
+        "version-display": "1.1.11",
+        "runtime-version": "1.1.10",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/15a05546-15df-488f-adcf-0e77e86dbefb/1f902e78cfea6209c387adce764a88bc/dotnet-dev-osx-x64.1.1.11.tar.gz",
+            "hash": "b827b192398af01bf917a5fc0255616a82f04a95dac8154e681398e7e3ef549d701376bb1c9018dea37269e0406f065fb8e2958e652dfabaf86d5e0bb68b0840"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3c23a7aa-eecd-461b-ad45-979c4c684917/1b464bd34c763e664f7eed6006889d87/dotnet-dev-osx-x64.1.1.11.pkg",
+            "hash": "1b8ba4f003fda6725c6c27787f6b750064fa7522d0adb0bbbb1717286b2083550da68a242b840dc9505ca68775785935b0428933eb8b0e89f31e698e41618989"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db408c7b-ef37-4374-b33b-a5b286adaa53/be0f0df977501c4df71ac3f04b9ce35e/dotnet-dev-win-x86.1.1.11.zip",
+            "hash": "29a97f3e5e2e8465e4b0c7628a9a02baa0148bfe1a960f58dcdb08b3ad65702cf5367c3f776f47b4df5ce2487955831ed5ab330d4eeabea28ab4f25edb051be8"
+          },
+          {
+            "name": "dotnet-dev-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9386d3bc-6799-4cc5-8288-c807674c72ed/b585db316f0d1c4cad749c247ef21b59/dotnet-dev-win-x86.1.1.11.exe",
+            "hash": "88778c12aa4e3bdb696da31d5ae1a03441fc6d0d1860bada75bc604692e3f8c240941a10b8a99eaace2b5a6957bcdafa158f2cfb533d122bffcb2c55b25f351d"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a298f85a-bc4c-4019-842e-021e397e3437/5c95727dfe79b600834291a8983b9507/dotnet-dev-win-x64.1.1.11.zip",
+            "hash": "cbf96efd9f6119cad96041e3c55099b98f82252a60a93bbba5f93289bf600c5146402046c3ac79c6e927291e40cb5222171c3ee8cfbc086e635968dfed6e269e"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/baf5a5a7-68d6-4cf1-afdf-47968b5f91e7/05e6dfe191607ef6135a34215464f600/dotnet-dev-win-x64.1.1.11.exe",
+            "hash": "6e15fa8c9d5b10cc3edb353c5e1ece01a29f7d00ff853cc12f84e33a776df8062c07febbd9659ca46c2adeb005036c231fd7a7592591b6e28c643bdc45084778"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/116bc57f-a6d6-474f-aca7-58c18fe0fac4/aa324344fc9c36623fb4a7c7e5bece0c/dotnet-dev-centos-x64.1.1.11.tar.gz",
+            "hash": "8665733eba5af02f8af5420bc858ffc4ef73281fb518c0736458f9f1f666f65e57c6a8e2efac5d3e6aca56ac8942a25d1d805ce392fd6f751fb3f0ce821b20c4"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1ef84426-c1d0-4e3b-86a4-7fce48baecb8/a47dbe0cd3bc1eefdabbf9354f60004b/dotnet-dev-debian-x64.1.1.11.tar.gz",
+            "hash": "14f48469ebbc171d111369ea0dbe88ee9aeb74193aabd6e123c97e54ad81fd6352e86c446f8fe68e2db93793de86fbf89a9c682dd7d1d226169e788cd1f3f6a2"
+          },
+          {
+            "name": "dotnet-dev-debian.9-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b5c87053-99b4-4c91-af5b-69a1c0e2c91e/ab8882f283fb7206d0f1ee965faa4288/dotnet-dev-debian.9-x64.1.1.11.tar.gz",
+            "hash": "23e1d3d1863ae8f6bfd450ff238ad7d5929722df6a0492597089c992aa1b223af294386718a711040a4e5f77bd3af97e7924d344e1535d4bc36c640dc6b73869"
+          },
+          {
+            "name": "dotnet-dev-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/98eb7365-0ca8-4e29-b455-b165e583d0de/3a1da729266cb9b885f6747b376a0f7c/dotnet-dev-fedora.27-x64.1.1.11.tar.gz",
+            "hash": "ed2cad6ef471dd787086a249b932569840cabc7d48aa6920ce2d85e2d364a880f1d4c63e1014016a0fd19f8e8f1f93526fa2d710a587fcb27616bfd27844dc57"
+          },
+          {
+            "name": "dotnet-dev-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b3e55604-5a36-412d-ada3-9a46bba55fd0/473cb6db3926c04b7598d750f1d30731/dotnet-dev-fedora.28-x64.1.1.11.tar.gz",
+            "hash": "50ba2fa6a319de00857f847c6dbaf49bb4b93a0e7f73824ff47bdabc6862b45f0349c9c95b11dd2caec6fd4ef5ba3e89ad1c5a44e6a66cf600bc906327805a7f"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3b5e416e-1359-4638-b1f3-e0ac378d3550/13ee9ae8dd5bdd11a11abe1934542920/dotnet-dev-opensuse.42.3-x64.1.1.11.tar.gz",
+            "hash": "13163a1573c1f95ed45a5b445488080cd619693ac7ce8705e13ccfb605ae89d959a82bf42d633a6e65d5242eb508840e9f521bcfb6f30623a6575bfa701e6532"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0957a2b-cac6-44d8-b1cc-0dad4420c825/8dc69e33f8cf44152fdf173d3bf0b746/dotnet-dev-ubuntu-x64.1.1.11.tar.gz",
+            "hash": "a7743d00fad50ec1c9f27ac5b09d1b9d787ac9d4d600179d1d4a5ebb636438dda45ecc85b1a246fd2eed6455dfdcf764165428af38f83a524b4ea0aee82a3366"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c9f432a7-11fd-48a8-adef-fa95bc24a9ad/85a7293b69d07d5ed678ea21f6082539/dotnet-dev-ubuntu.16.04-x64.1.1.11.tar.gz",
+            "hash": "60906a50e01420c0603127041b5fc628cb064169ed03b6c9727857695021d2713d92cdec322d97340d9e525a1f2f3c727b7125ca07c0d04057196e0e7cf791b2"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aeac042a-cfef-4064-b914-7419f13c20ae/be14353986c2fbb2259064bcd2cc522a/dotnet-dev-ubuntu.18.04-x64.1.1.11.tar.gz",
+            "hash": "d96adb429e00052e331215438d0f1f244c830f633f9bd0dcf817f02a2211028ee4ac02e585be440863bdc6afc54fabe3539188c6f5f7086d8a0ced624fb05697"
+          },
+          {
+            "name": "dotnet-dev-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e461be2e-e14f-4a78-b987-351da98fb9ab/dc2c11f04a967d3d5c15a9a47b2d9fcc/dotnet-dev-rhel-x64.1.1.11.tar.gz",
+            "hash": "c79e40710dbf5e0f22d54ebeef4e08ce459a83dd58a9d7a2e56ebb480c780e912d4c8ee643df7f7717bb8544955bb154ca9aa88ec610eccd0d2f712b74668be3"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.10",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b84d0334-d56b-47b3-9da4-c48a553ce286/5079d35485214be3fbd72a4fdf21a655/dotnetcore.1.0.13_1.1.10-windowshosting.exe",
+            "hash": "a653ae9b309baa4918b1b0c70b2b73dc4b5cf5cca0a6756273c924051973dd354b6748d72177937f851c1f7b2d16aa4d67920294ea2bf98a11768cab04d2f764"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-07-10",
+      "release-version": "1.1.9",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.9.md",
+      "runtime": {
+        "version": "1.1.9",
+        "version-display": "1.1.9",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-osx-x64.1.1.9.tar.gz",
+            "hash": "ff3fed1cda60e82de53de0c95b3ebb97e64f398f54d36aacc52d21f5859d4ab016e81c502c68e511ff2bfa5f97645e7c04eb7b8e66cf2b173419c009492bef03"
+          },
+          {
+            "name": "dotnet-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-osx-x64.1.1.9.pkg",
+            "hash": "e3ed92c005ce1d819f140e22a2e4c46e49d53f073d31eab0a3b883006f77a69b960fe97ef0931fd10bad8aff511dfee020af7a305b573436fee7a2067eb076fb"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.zip",
+            "hash": "8c98407232539275bf14960f2e9dc6623aef129e2960a2feda9ae35087f3dd0a3688f54c31ec79d99e7dc233165eff458deaebd6db0e2b0396cbec1b94d5bd38"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x86.1.1.9.exe",
+            "hash": "cbea84c048d9f83e218b57bdc4ee770127e2402ab63f7ba072f3420556722d891226f2826164980a5c72672b25beb62de7eb4c38082184fd1c81624f240a28e1"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.zip",
+            "hash": "6de9e8db06131f0a77b78ff755350304dd7ae57a8861646bf0abca824689de2e29936667932d1cad025b062b1c818bc5a036d4326f65095448e664a5badc6d5a"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-win-x64.1.1.9.exe",
+            "hash": "c2016e5afd5e76b2a0735474d067323a1e701a6a4aa99e8dead4155edc98c80ceb36ba643941e0bb4723be0b0c34eb401ad3c8784493c6f14a6c3b4ac49df6e1"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-centos-x64.1.1.9.tar.gz",
+            "hash": "8be4dbeb3c801d219e68f8cf93400126034c4da37ae28856e690021522a0eff392264f2c44653724f6e8562a7efcfe86f96ea3bf7289c0d6e4ce64ca4cde4560"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-debian-x64.1.1.9.tar.gz",
+            "hash": "7cc5b2eaa20c1541be3b1affad8b839b1fd9fa97cf3cde5f9e13077581ade08c02f1aa89fce81cfe3fcb143b5207b3fbd71f1a7c0e9a7ac1d7eec5a66bdc3e33"
+          },
+          {
+            "name": "dotnet-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.27-x64.1.1.9.tar.gz",
+            "hash": "2e7646554c8903f6446e07f4b7a6593ee67031c00a65f0ad7aaaba7e21d287dd3fab7609234bae78941861b870701b83c99119af259e6c249530c62f1dad8dc0"
+          },
+          {
+            "name": "dotnet-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-fedora.28-x64.1.1.9.tar.gz",
+            "hash": "5e657a221841e220a7601c60ec0ba2436abd442db8d83cc79adc49c67937439c69e9cebf0b7e17073ef3f4585bdbaf21d619db2dd5694c8630a9aa0427b6c057"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-opensuse.42.3-x64.1.1.9.tar.gz",
+            "hash": "f7919d8d68b10ab00168ad2a82f69fbd661f803bfc941e9ad75037afd02d1b783bb812ed5032ef0350b9fcd0cbbf2219b293a340ffb51cd8f40485a85a3b2a29"
+          },
+          {
+            "name": "dotnet-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-rhel-x64.1.1.9.tar.gz",
+            "hash": "3d36fbafbb573dc29533209a6f463bb7e69790b93635854d9862c31c3c991ebf3ec3385b00423eb2fb4a3112ba967b5e18275acfc37a46c8063aab5e3bc2b092"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu-x64.1.1.9.tar.gz",
+            "hash": "e64753b4f81106c6d692c45a51abc45bd700ee52390f56090ab61e25b2811c484bdd87c434e7ca4fe1f0d187d9469c207fe94694ee1d848a72cd1cff01fb01ca"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.16.04-x64.1.1.9.tar.gz",
+            "hash": "95e050b3faf98e1391605a69353d708231641d69a4f8cac6b0f11bf1736f09a69dfb4b2f8e446a39a22e8141c35a609130870c485af85e7089c109c313f0248c"
+          },
+          {
+            "name": "dotnet-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/dotnet-ubuntu.18.04-x64.1.1.9.tar.gz",
+            "hash": "fb3ee217813b099f651ef8ded1adc5bbece731ed61add842cc488c5a70dbee50877f4defec71c0089c1c90f3e580e0ea3c3f4d4006c03ecdd568787542d16728"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.10",
+        "version-display": "1.1.10",
+        "runtime-version": "1.1.9",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.tar.gz",
+            "hash": "bf3bf5f22c70c944a9459565626ef935cd15465a189ef9dd65d18560f7e71e44e2ac93552999774eb9a6672530a99baa30347bf3ea1cc7f4ac4d583e1f0e60b9"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-osx-x64.1.1.10.pkg",
+            "hash": "990d54a53702f5314ad06aab3fa7b6ad0944f2d8863d5ba99f9e86a660fc542378e0fa2cf9aebbd44bdee71bdd37d287409ded40f98d4a43f77e613a3d84fee3"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.zip",
+            "hash": "f46778149a785c0ffed4611966c07668061bd07dcf0c4ebb42e68461aa9dc5a8fe5bcd0d99f1ebb279a7f8269d84dd7f34e34b6c953d63ce1acbc85c4c88b743"
+          },
+          {
+            "name": "dotnet-dev-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x86.1.1.10.exe",
+            "hash": "871baf6e9e7ca12a222ad0c9eb6060b933448c58f289defe1723934c66c07b2da6bd6f3495878afb280f188e64fd6200ed18b59ea5659e62be538956cb502a5a"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.zip",
+            "hash": "d0b01871251265b9a07c24e94e2e33f4a5d96ec6165ec0f60b032ce5c35895985e37cc01f73134fc8802a442eeb243b1d1403ebe898d6455907095e5b6b854c1"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-win-x64.1.1.10.exe",
+            "hash": "d686d2514f45df597791d4fb60ccc272f5d42239e21803dbbf050891f79dbc7c0c8a72623606f312fd0aed0eef7ec5270c4adcfba105e3ec635d27729ff5c4af"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-centos-x64.1.1.10.tar.gz",
+            "hash": "30af1b4c9d8bd46bc48a52c9a9bee9e3a9a750ffd2308236458acd4cc3b313b8a4ca6259b34422caabd47540e30f5467b8f9237595e49be963d29abbdbfbd0e9"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-debian-x64.1.1.10.tar.gz",
+            "hash": "f4ac12ff20db06a7c6232c2645f35486d5369201429e3aa9c89a65a3e5f53957cd6ab612c225cc1dd6afebd4dd28695ca5a1f9cbcc812d8fa08635d6cedb1dff"
+          },
+          {
+            "name": "dotnet-dev-fedora.27-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.27-x64.1.1.10.tar.gz",
+            "hash": "89cb369e8205224db77e314b6e236570e94b1d351689dddab5c4fbd63f444389e9745b84c57f855ddef9d693866b1103af6b8d889d6626ccc5c08c6783185d6d"
+          },
+          {
+            "name": "dotnet-dev-fedora.28-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-fedora.28-x64.1.1.10.tar.gz",
+            "hash": "91e3bd421cadaf3a3a3e65486a088d9d4b0aaab9f35757068f6f09736cacbe498fc9469aaab9a4d5c209074af253761a8325adf525e991e40c5ffc10acd8ba93"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-opensuse.42.3-x64.1.1.10.tar.gz",
+            "hash": "227928df186dbd0fcc152f602383efcb66c45e467e5b88e135c725a53f69fbba26debbcb0536629e53b15e0caac65ef3af8db9b242195f3bf517d2f629125439"
+          },
+          {
+            "name": "dotnet-dev-rhel-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-rhel-x64.1.1.10.tar.gz",
+            "hash": "717c07603009c52f996c3e5a90292022ecf0f7d787bd3de202a68b8eb4273b947ee2832aa93a9c9636e8b05f5e65d2051cb4ea1f0a5d4bf9f5d167e732a8c0c4"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu-x64.1.1.10.tar.gz",
+            "hash": "21bb88c12a094aced52d5161dee6d345698210ddc942a597e489c167fdeef4a1ebab90f7bd4bc0c23fba1c912d24e73b333635b70f7571b4ab5d8d8d1ce4b713"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.16.04-x64.1.1.10.tar.gz",
+            "hash": "89300ca6c519ba17eebe0e425f332bd457c0af49d9ba0cd00f4df14be471bb6d5a0207486e484b106a6b1071fb140b0738f752475dd88d8d7f833e8b8e26da58"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.18.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/e/6/9e6e1700-f682-4e4c-9e02-583f102cb048/dotnet-dev-ubuntu.18.04-x64.1.1.10.tar.gz",
+            "hash": "38a3cd266f3b1f680e878c981adca1cebe81fbfd161ce4ea083ea4c7809c0a92e03ac33d292e29f43b5ebae18622ea83360c6b07186a6fa35ca6b2ad8450d140"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.9",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/f/37f3cf83-bed5-4ef1-bcd5-f24f7aef7c56/DotNetCore.1.0.12_1.1.9-WindowsHosting.exe",
+            "hash": "4d8f7cd4f2f647312d4615d951242cc5d36cbad3ffea48643abd4a9015494e635f7379eb1b46b0384c6a7facbe1b18fe8946fcdf277715d18c270f91d61e9e18"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-04-17",
+      "release-version": "1.1.8",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.8.md",
+      "runtime": {
+        "version": "1.1.8",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-osx-x64.1.1.8.tar.gz",
+            "hash": "d45684320e1b4931663045a1c89d39558bb8a66cc1f1ca8f8f3a11ac8943b8c0176bb5485183c79e94eedacf58e65d9422fe7102e2fc02f0f5349b019303d183"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.zip",
+            "hash": "62f3b0d7d2836979c9cd5da7d598354e6c6adb4fd804a3dc378c09e9065c555218beeff2febcfb5f0fd3a08091d2ab4628a769600f4b3d672461ad0dc7af636d"
+          },
+          {
+            "name": "dotnet-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x86.1.1.8.exe",
+            "hash": "ad40c463bbec93afd79aaa734482f979251db874a5dc91bb40562ffa4aa45b5823470b5bbeba2db8e669c01add15b762db2ba113a7ffcc10bda0d6cd7a5d3ea8"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.zip",
+            "hash": "81a9e99544efcb14294b267d6605edc07d857575a4ca628eb805adb8fb5c2644be24bbd3c449e3fa7ed8c28f65b15f64531a1885aec9e9898c5e31ea3a197926"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-win-x64.1.1.8.exe",
+            "hash": "682ad53a66f8a936fa8664a9be7ba6364acd9dd5983a70ded3020a144f8e13c28d3dcb3b2f1328b1003e474b05ef94c10aa90dde22bc23a5ddbf036157515e2b"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-centos-x64.1.1.8.tar.gz",
+            "hash": "c7221974f522633babe9b3e35bd984c5c65264f56d1ba9d916dd0c3a1193327e2983154b1eff6585b48c8508b4a4c95c0cc59793c7a0efd6db9b28f8f1e91a8b"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-debian-x64.1.1.8.tar.gz",
+            "hash": "49161d81fb9068ec018dd3bf6f438e838629933245cf88fe08562f8c8726e24523c628ab2a31dcdf5fe32f8496b009fefe275406318c5072cba85bddfe0a7693"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-fedora.24-x64.1.1.8.tar.gz",
+            "hash": "b0ee8856ec0d18a6d406a3f21372685eec74d22af81e351eecf78413de7c49602006a8492d775530cb72dd35da9f7dd074e1504158821ea6cc5f92b31fee5de3"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-opensuse.42.1-x64.1.1.8.tar.gz",
+            "hash": "fef9696d73d91ab7e3ea65c6a3c4d5c4fa4f0c219a21fa9f937e9292c261208a53d22173f72371d3cbddf02ea263ced50a90771effcde7ae26487526919ea9ed"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu-x64.1.1.8.tar.gz",
+            "hash": "f7385d5273c69259fb551adc8b4b6539b858f7f70365c98a6bd181525727cb7330d35716242632e61cf41c015b39ffc1aed8682a11316e77eb90c396b833a68e"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/dotnet-ubuntu.16.04-x64.1.1.8.tar.gz",
+            "hash": "dc9d732ddf5b136c4b1dae873f17d73465b653fd90d97123072541a7d9e243066220e04d204fd5942645f0c06969ad93084dce0400b37018ecc4d6b8131ce3a1"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.9",
+        "version-display": "1.1.9",
+        "runtime-version": "1.1.8",
+        "vs-version": "15.0",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.tar.gz",
+            "hash": "c6e74231bdfd9d02dee203e37eafa4bd3a99645fdd982aa319800136b3ee9f4d90769095d05337f80ef50722e16d6c66eac87d83154055bd085d84bed31d50aa"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-osx-x64.1.1.9.pkg",
+            "hash": "002eaebff614b5ce20472e1247cf980c6659ff03913cf1d7fadf675ada651e1fc35caa55fe8d2b0ede6b250adac85bc41378c331088d853f4decd009bf7ee2b0"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x86.1.1.9.zip",
+            "hash": "3fc2052aaf1cc48b6510dc93fe80207be61eb2a3d86d4032135d00b2feee90999e741ce02367fedadbfc8d630809f32e36fbdf2423ce1b1efaca11f2deb98fc9"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.zip",
+            "hash": "93c4d9113ab25e18428b46fea75573a876f258daa1fe432e167ffaa49ac33c87dde744820ea31c605c94af948787b019048076c6eb879b515b16f9cce9ee5fff"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-win-x64.1.1.9.exe",
+            "hash": "08f7ffbf28d3a85b3e6e4983bef643a212161271c6ff3956fbdef932038ba240104db6c2deb8b662e5392f1e5b45db2aee2e7da20ee7d800f3b417aabb649d2a"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-centos-x64.1.1.9.tar.gz",
+            "hash": "259a7dd766a70175634559d08805cbf6c82ee40038ab822ccd8262549591f5492d89467f1d7ac77bfb73dc848c7b68297935b6679aa0a662dd7d8d307631d88a"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-debian-x64.1.1.9.tar.gz",
+            "hash": "1a50849d5660f8e592ee2c1eadd9aaf1af20f98977edec9a200cb04c652b4f5931d42ce618546229ab67037937802f720d784a015a7658bc765300789843065c"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-fedora.24-x64.1.1.9.tar.gz",
+            "hash": "e63da30afacf314989fff957ad7fca196651464ec5d7f50c4df8fcce396d76194d949d19a3bb4158d88777ff356a9b3617d95fe4d3ed8455486f4cb2800aac19"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu-x64.1.1.9.tar.gz",
+            "hash": "874295a7daff58ef0e7a06aa63a9f04a344b8588888b09c50ee25266e9092a87f618ef99c8d26defe1a44e1c883bd4debf7cb52e0a5fd361cb5a296da3fb688c"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/0/2/4022CFC7-5061-4762-B9BA-48B35632572D/dotnet-dev-ubuntu.16.04-x64.1.1.9.tar.gz",
+            "hash": "5c1df91d95f23c1b9891f8f6c7e0a7745010287fdc3a4c18122f0d922261cc53f9040eac682b639f9267026490d522af33298d32519282e23ce59f9a7db2a25c"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.8",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/B/8/1B80E25B-316E-4DFB-9707-DB758681F175/DotNetCore.1.0.11_1.1.8-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-03-13",
+      "release-version": "1.1.7",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.7.md",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-osx-x64.1.1.7.tar.gz",
+            "hash": "b4068d5551017208879f6e9fcb887d630b13e5bca992478fb543a291f42d3bfc6071f8821aabcd0baa1f9ef4d18f22dadfb9218f8eba98c63c01bbd70339a7d6"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x86.1.1.7.zip",
+            "hash": "623dd7438b925c7063820a60e1fbe09011cc429ee325e519462fd537dfb17b53402b896aa89ffa09f695866166a410ea28cf1a8e92a9749ffc924c64034ca804"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.zip",
+            "hash": "43a414489f2bcc492a7b8874e0bf8d2693cf2b2bbe0720bf9e574f81e2537b1c509a801b56a6e49d755a9ee67da0d18a10a303a1acb23b69819898238c9ad2c8"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-win-x64.1.1.7.exe",
+            "hash": "16c1356c809059a767f17156fa2529cdf1ccddee0d6d18b3a10899e7c4de6a843fd4f1ef553297a329a6c76b8c22c9335a47c32072e8ef4860f5e9c627b003d6"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-centos-x64.1.1.7.tar.gz",
+            "hash": "cd99355697c5afeab3974b6b1a4ddf49ea74a4a8b08efc54ed9b6a561b665a6d1c59254965cfe59f8f5eea00d93bfeaf9684efc70dc4e339d6976e11f6104a6c"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-debian-x64.1.1.7.tar.gz",
+            "hash": "08e26b44547025e6b3edc75e6ad75c5a81eb4f6dcb0eda0452edaee1e66d04d2fa84914842f495d978cb9b8917eda192d0041e0548232a014e0e919e21d7d1a6"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-fedora.24-x64.1.1.7.tar.gz",
+            "hash": "22d2d6b1d3ee21ecfb256a0fa257d1a14a83689b63f0560ec58c88ddfa33aeff9800c5c62dda03abeff4966247d50a80b76db5ed3b6930448fd576b85e36f229"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-opensuse.42.1-x64.1.1.7.tar.gz",
+            "hash": "945abd08d56e1f81bd162af8ddf881a920a3f6d42790d5536cc6763dd82b8b0320125b9970ddc4d866657f2d07461b744b830f2d09ecc57d0bf0c120455e5206"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu-x64.1.1.7.tar.gz",
+            "hash": "621158af199e26c6fe9eba69dc934397b644db58ee63dd815634fc6b7bbba38b244ecce957aced307547df8e4725a6aa7a3039ee2e1eac8974c0248f662892f8"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/dotnet-ubuntu.16.04-x64.1.1.7.tar.gz",
+            "hash": "6e43dec9222b2d72e9ab763ee00e6f0244b73e9d02d129846afae00a474cf93656e85c5434c69b580015661f9bc5cb8fbfe09bb1f98d9df9dc6c5cc5921f3359"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.8",
+        "version-display": "1.1.8",
+        "runtime-version": "1.1.7",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.tar.gz",
+            "hash": "99ab5361d7f082e269c4262acf56e851932cf45ad2dd7077a4759817c627392917900d15455dd4c51d44c341e40a3cf5e9e52b0f8e7736e58345d5a6fcda3d41"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-sdk-osx-x64.1.1.8.pkg",
+            "hash": "39f04d5bb258915794b91f0c39486f8a405fbff3bcd54524243f6685822824a605da9f2c694c0a966b5f27cc567346af57ba25d5381ea9fcbee3ddb7273a7f8b"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x86.1.1.8.zip",
+            "hash": "d1acec19ef873b1b11c19412396e6f9b6388a072f3639091629966b1b28622558498786a547ca8ecf262f61868ce1f028e8308f0b18cdca20d174942c317c1e9"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.zip",
+            "hash": "151ade63c624d2c34b095ea19c382b20cc746efa5f41fc0feca2239896ca877b7fd8b1677ebf49aca750a07d5d0a4a5091649a70851d03657590c6f6f110434c"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-win-x64.1.1.8.exe",
+            "hash": "278304c8ef455e3c0d24d5b9dc3c2d0019b1a429d968e4a39f499b8e63636685ef6cfef38a50b954fa24189c3421f9a3d157a0113064af09bc55f66f391a0b8f"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-centos-x64.1.1.8.tar.gz",
+            "hash": "2c81764aa67f29c7eb9577f38b2dce4fbf356805a6b652bbc45e7f869b9fce63a474c0f5d806df229b9d77525b0b4709ced67a3a9b88b9e985490f25ea49caee"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-debian-x64.1.1.8.tar.gz",
+            "hash": "c669b96f35082df356673bd602e71eacd95282dd036755be9682be3b3ef96b4ef69026d16c981122d6b382c517ed7739a339eac040064a7d4dd3403306faedbe"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-fedora.24-x64.1.1.8.tar.gz",
+            "hash": "961b48edb6fed6fd8fa9eb8cb4a384c6549c896316bbbd38911a50fdbe4bfa98b53c4a107e7eee1712b556f51d60bd4844d314bab31c3cf70760b4ce83a71a26"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu-x64.1.1.8.tar.gz",
+            "hash": "640165e75f1f042e5f5ec9d13a7a28464703bcabe4e46683d5909eebeb2bc8cd4227f652ca66d6e7b3d8287718f1a1f6dcfdd5b94c371114817ea481f4aa4b3f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-ubuntu.16.04-x64.1.1.8.tar.gz",
+            "hash": "b80c9298366f01e2472de8d11094c52e5c2a197aa4b50e1ead83e6a60e58aafda652ff5afbd0178b8c57e98c2e27c2dba432ec41ba115b61be3e9a43bdfbc6e6"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.7",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/4/1/1416E22E-A1C5-48E3-81EF-AFE86CDA9C78/DotNetCore.1.0.10_1.1.7-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-11-14",
+      "release-version": "1.1.6",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.6.md",
+      "runtime": {
+        "version": "1.1.6",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-osx-x64.1.1.6.tar.gz",
+            "hash": "216d4489d6d0f6cb5c1fc08e36fbf07ec051760abdeed4027dc3a21239424f54a958ae46d0e2428418a57a0cd5273adac46d63725369a8b9a0ea99a32589c90b"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x86.1.1.6.zip",
+            "hash": "03809a2c1ef3b75e3753e92c82063304915132991f42f2ad3576e2076fd3b56dbfa586896b6539bdf1c3667f09a32fc745df683b3fa38636d3027642b082d45a"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.zip",
+            "hash": "d1562159c16764d8313cf039e8fb59aa777acf9a479cc34db9665022053765f4608e6633d6fddb490aa40e2fdfe6248fc4d29265958648029d07a5bd27fe4a80"
+          },
+          {
+            "name": "dotnet-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-win-x64.1.1.6.exe",
+            "hash": "57a4beaf70dcf38c055013a9595970c1e5a997f48a8091553c5cd69e3b7cfeddd3d2f2848007e0319ba546c97a5e211c46a59421c6e8f0964b8db1d9523ce9e5"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-centos-x64.1.1.6.tar.gz",
+            "hash": "e5cf8a038a613241426a878751fef23fefac674206153fc9e7cf12e5f063eae2916e74a9a9a51b18075aeabca62f4651d6ac5b466cd60feaeae6a721eb6de3d6"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-debian-x64.1.1.6.tar.gz",
+            "hash": "54c1d4a3a0125f177f4e61e4a3c4d447cf2ee18e436e2e62bc435d081b6cd9d9255be7130a792d4a667e2fa8940f8e33ad9596f1c08cf8f02340aa6cd3d4c361"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-fedora.24-x64.1.1.6.tar.gz",
+            "hash": "bcc570398f9a3148dff1da6627cc4b6ca397806db74b80881c4719ff815ac09a35298eee59c19b8bdfce05c8ce6c71ac4ed172558127eade4c680f6f58755243"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-opensuse.42.1-x64.1.1.6.tar.gz",
+            "hash": "83a282254ca690de5e10e230614e28b48a18b58ba0ff390ca15d06b88bde5ea786c1915055e3d78d2a9e10c9164dbc4562d4a0ca650a24591435e8c584900505"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu-x64.1.1.6.tar.gz",
+            "hash": "503e3d9e3adc87e90114e2e54fab7cc14c94f9df68961e77da996f293da8c8f50cb5b9a089ba7cddd2cd09eed3c3c357e4a8b52eda0f0d7f5e220fcfe41df140"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/dotnet-ubuntu.16.04-x64.1.1.6.tar.gz",
+            "hash": "bc8aa9990a99df631338af0d796ca0e51e452001e0593e22d3835621a45f7e3404f1214395e36cf64793d829702dddd4724c66ad841069dcac495ea4b57375db"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.7",
+        "version-display": "1.1.7",
+        "runtime-version": "1.1.6",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.tar.gz",
+            "hash": "9f5430391f664c942d49d7d1371bdeedad1bf41a21fb9d9afeb5557ce518a494634b750631dbe019e8128296e6d0ffa438853561919566451f42744a53e0b6b7"
+          },
+          {
+            "name": "dotnet-dev-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-osx-x64.1.1.7.pkg",
+            "hash": "080313d0b501502829e043f417fb2ebcced2aeba7640b84d83175dba25faea7219ee2f301aed7e5db857300e600e2d6b42a35cacb5d7bebf7569df193318666f"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x86.1.1.7.zip",
+            "hash": "f465d15d914fd2daa30f5a5fd9725d94c664f5bac47779151ae54e5f9d9b61f49fa95dbb16317b137a06e80b42bf766f89051fe9ca332567bc94c08a1868d381"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.zip",
+            "hash": "c79605ced9c80e21609faf9622766b31a49462b06a43dde9907ca56bc1aa7e37ee5cf48cd8bafc561cb3edff5ff6be97af2fb0f138cf22c94f97e587e8f94c7d"
+          },
+          {
+            "name": "dotnet-dev-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-win-x64.1.1.7.exe",
+            "hash": "94daa61ccebed6925f94b921af74ca3fd62c086f4680116fb4ca97c03c79b50910dfff5a7f4e957d72fd8f6d27bf07223cb29588b107181adbe3e9ec641186db"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-centos-x64.1.1.7.tar.gz",
+            "hash": "1b42158cfb4555f271e5fed62d62678cfea56c32604c8bbb8b7841723c6a5d48100bab27328d38ec6c92bb779099cc4ed5b05294c00830a95037be9a628e3ba2"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-debian-x64.1.1.7.tar.gz",
+            "hash": "5cb00f5bfc4175533956faf7bfebc08917466ec8912c23d6a57a23634b1a950df1f82587daf9a9859f6fb6f3273614990f499e81be117f460dd60b297d628c52"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-fedora.24-x64.1.1.7.tar.gz",
+            "hash": "f667a5b377d94a00020fdc547ec6cdce62cddeb4ecd1134bddc34ee10acbead588862a7c4ba25deecbde7cb7bf8daaa90a9d2891213a862cd011f68579fca6b7"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu-x64.1.1.7.tar.gz",
+            "hash": "73b59f2d247ca7960360fdc5c849dfd641ae8c8a5314d18c0a972fe9480e64bc2faf9051deee7d8568bc4cf073ea9e48cff88ca3fb2d76a8c7a10f9fb5ccf5bd"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/4/E/6/4E64A465-F02E-43AD-9A86-A08A223A82C3/dotnet-dev-ubuntu.16.04-x64.1.1.7.tar.gz",
+            "hash": "743b6fcca6a5831ea31710ef75136188385b5780b6e5eded24ad48c424ec13070713831c32c9b451174bacc27f012d7c90f8492c745894c0b3fda3aff5c11396"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.6",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/E/A7EF2AFF-F77B-4F77-A21B-0F7BD09A4065/DotNetCore.1.0.9_1.1.6-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-11-14",
+      "release-version": "1.1.5",
+      "security": true,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "1.1.5",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-osx-x64.1.1.5.tar.gz",
+            "hash": "ac538259ec3ac7cad13f9b4d3e1303e70b5a641d197e4bddbcccc4b91ca170fbdb0cc17fd9224efdb14c767b94d3c37997440e3e51750b8bdfb88060d4532516"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x86.1.1.5.zip",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-win-x64.1.1.5.zip",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-centos-x64.1.1.5.tar.gz",
+            "hash": "d32e844c01fea03cb1906fd9d00b91a64f21646993748f8569d02ffeed28dc89a1eedcff60eeaf1ebbb5c7b0176ce360b929582f48725c13415b0a8f37d992b6"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-debian-x64.1.1.5.tar.gz",
+            "hash": "2d8e2a4f17f6986d1d1cf5f8191aa94f858e2121efa9283a97ac5ee6c8b2ed8c169f0312c6797e1fbcfdb981f501f38dc710ca95898d63a859597081523df095"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-fedora.24-x64.1.1.5.tar.gz",
+            "hash": "2d813462072ad7cf31529835d6be9afa55cc47c08b3fa749de337f5f214eda520d9b071aa67a2325c9f16711366a58380caee5c76372a747b4fda550df6dfaef"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-opensuse.42.1-x64.1.1.5.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu-x64.1.1.5.tar.gz",
+            "hash": "9c3d08ad516ad85ce9f5ce0118b550232d5b67f8466715ccfda8b98ab350e5535d66573525691a58dd2499bfb32446cc689d713efb05ddf672af18b862ecab84"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/A/2/6A21C555-B042-46EA-BBB4-368AACCB3E25/dotnet-ubuntu.16.04-x64.1.1.5.tar.gz",
+            "hash": ""
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.5",
+        "version-display": "1.1.5",
+        "runtime-version": "1.1.5",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-osx-x64.1.1.5.tar.gz",
+            "hash": "075daf8361e6d7dbbf079b71b2b2a804a96dbde9fe63a665afd02a5e4f1fc67dc7d37e8edd83766535f8f34ec5bb2ad82ef96effb3568d24d25ea3074068bf5c"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x86.1.1.5.zip",
+            "hash": "88d69079274fbd88fdc9b6bbc7042d0be06f225370d42ed82ec73cf97521515a18631cc4b4b9dc8283a4d3e886de5dc438966e23a22ffead175815541a638f91"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-win-x64.1.1.5.zip",
+            "hash": "c8df85c9c073aaa1e7a57ad6d56c190869466587991e1620cefb203482de09a298ca0bee34446dfc42fd51c6f1990173aa280b57cad2ee40db03c71ea199dc75"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-centos-x64.1.1.5.tar.gz",
+            "hash": "083a326668530e7f380246314b33d4a08df6921b9e8e5251d26f97c073f86f6128ad6f0b56b8e7ae3f0677e4aa2c4fdafc6a68a5ef6fea5c5fcff1f20982f788"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-debian-x64.1.1.5.tar.gz",
+            "hash": "15b177092aa44584e2ffed9a5650c4bddf5938ac958f25d156689eeb1927745d52aafaec79d3a2ace9bf9fb85d9295dd59fe81beab1b787acfa5a7c380ef8016"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-fedora.24-x64.1.1.5.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu-x64.1.1.5.tar.gz",
+            "hash": "6024e9e5ca8a986c6a63ba1d4d89234b682157f2814b379cd8d2890699f5d4acc197a5ae7204f136fd1bc2bad15c9896be99df6648a863dd1fb8e4758ba0daf5"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/5/5/C55807F5-601C-49B1-B9BB-1BE03EB83E0A/dotnet-dev-ubuntu.16.04-x64.1.1.5.tar.gz",
+            "hash": "0f666b7cf806cde0c5d93788bbf6dd4d808417aa0c1bdbdb1453d8046262188f8e5dabf593076d296e60ad77f34d858efd3137045943cec54e6d61ccf2556ec0"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2017-09-21",
+      "release-version": "1.1.4",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.4.md",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-osx-x64.1.1.4.tar.gz",
+            "hash": "58e93d00ddcaa14d58150f923b700c6190c87b1609d59040a262625853eae136"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x86.1.1.4.zip",
+            "hash": "265ec7d4b178e5c03e4b8250d0f368de714e3205c90180de71a3c514251d8eaf"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-win-x64.1.1.4.zip",
+            "hash": "51a363fb5378f461e67793954e452cbdda4fbf825e7718e286c5ac4250c48b77"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-centos-x64.1.1.4.tar.gz",
+            "hash": "4b35bacfbf56c22e389739a4750b4773e51907944d4e24e4f5fca0b8355a83c4"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-debian-x64.1.1.4.tar.gz",
+            "hash": "8b3f0cd9a100a41436f316952128c0bfbd9bafc2808734599c643345de2e5304"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-fedora.24-x64.1.1.4.tar.gz",
+            "hash": "1897ef8729d3356b6f3b19b20ccdb744d49c78f2b05014282b98e7ce53e0a3e2"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu-x64.1.1.4.tar.gz",
+            "hash": "7948d90eac05b56a7c37a8ac37a5c83012843feeaa0194dfb079a90db9717e6c"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu.16.04-x64.1.1.4.tar.gz",
+            "hash": "fe412836910718d3f91ea5ba815a116f5fa872ac0a9ff683db2d8670aceb9b56"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.1.4",
+        "version-display": "1.1.4",
+        "runtime-version": "1.1.4",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.tar.gz",
+            "hash": "fee47d9c7d1b3674e61e586ba81f982c2b039f427b41852e11241ea1781c964e"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x86.1.1.4.zip",
+            "hash": "a7512497ca34fa81c2c7049db3722b950ecf56fa224562cfcddcf53d4a6d84e5"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-win-x64.1.1.4.zip",
+            "hash": "c8227d50379eb8617dbd1a647a6c888e1e6674cd46b88e4d44997fecfaf671c7"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-centos-x64.1.1.4.tar.gz",
+            "hash": "3598ec336712b4265ccfa7574bed0d3966f0e747fafa6e5602d0ceb2dd587af8"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-debian-x64.1.1.4.tar.gz",
+            "hash": "fa05f30c5a95e2aadaf76e1a402c157b5ce4e8f102fb00a2f8652869a146379d"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-fedora.24-x64.1.1.4.tar.gz",
+            "hash": "682ca1f5d772adc93248c644019aa84f4baa9c7589ebf2dd07d5cbca8f708581"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu-x64.1.1.4.tar.gz",
+            "hash": "9ac4b6d9f163c02d8ab4b3c1e86fd52b9cc01fb560f976cd61f0664a3c9fef3f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-ubuntu.16.04-x64.1.1.4.tar.gz",
+            "hash": "e806a106ef671efdbc0d3fda3218560a72293e3160e4384523914219937301ed"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "1.1.4",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/DotNetCore.1.0.7_1.1.4-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-05-09",
+      "release-version": "1.1.2",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.2.md",
+      "runtime": {
+        "version": "1.1.2",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-osx-x64.1.1.2.tar.gz",
+            "hash": "620a98213e423301fa44abfc1ca0b15e0bc538e676cbf0344c711abef5ed4231"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x86.1.1.2.zip",
+            "hash": "31e49e6ae491795c99221307dc829bbb57e645d568a94820a031688b6d8df4c6"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-win-x64.1.1.2.zip",
+            "hash": "a4ccb23a6cf2ddf9894cb178ce8e69b5788880a1e3d9d659f26fb914a4bc2988"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-centos-x64.1.1.2.tar.gz",
+            "hash": "49c54129b39a4a873074b80691733d68ba596782f411cc6565d601aeb6229d1e"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-debian-x64.1.1.2.tar.gz",
+            "hash": "26f6a2e247dd0b9ac4003d12cf1bd8647985255fdd7659b60e36a7a26fce15de"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.23-x64.1.1.2.tar.gz",
+            "hash": "5cb04a3a7f8fd780af87cc6e3273ade1fe9803b7518228999649fcbc95528278"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-fedora.24-x64.1.1.2.tar.gz",
+            "hash": "96204460bd7998e78ad2e84b1eb6821bff97c4a3dc2bb7a79cf828c5b6dfa37f"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.13.2-x64.1.1.2.tar.gz",
+            "hash": "24be24522531d560513c54fe4b08116a48b81be27e0a43c39f150b8e71a816d3"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-opensuse.42.1-x64.1.1.2.tar.gz",
+            "hash": "4112308f5e4bbbf38051140ee7bd47df79d4eee40d65f67a0fd1b14782da8166"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu-x64.1.1.2.tar.gz",
+            "hash": "9032e88d43d28004ac10618ef0abac502cdeb02228297d1b51dd67c7e40cd3d1"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.04-x64.1.1.2.tar.gz",
+            "hash": "c003ccc3942e327aed42c395bdcfacfc703f5adc5ec69246588a8aaab52b1513"
+          },
+          {
+            "name": "dotnet-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/7/A/D7A9E4E9-5D25-4F0C-B071-210CB8267943/dotnet-ubuntu.16.10-x64.1.1.2.tar.gz",
+            "hash": "0a4d4061931e0154c9186446dbc8d4c3e69ba49537699be98185d55fc24a1b56"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.4",
+        "version-display": "1.0.4",
+        "runtime-version": "1.1.2",
+        "vs-version": "15.2.2",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-osx-x64.1.0.4.tar.gz",
+            "hash": "79ad510280c3e6bdf67c3164c9cf6cdc7536d809d584e471688400b1fb3bea2e"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip",
+            "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip",
+            "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-centos-x64.1.0.4.tar.gz",
+            "hash": "8e952982414e192cff5980a6190cfdcfef543b59c0be65e5c9d86dc7d4a8ea4b"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-debian-x64.1.0.4.tar.gz",
+            "hash": "eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.23-x64.1.0.4.tar.gz",
+            "hash": "46fca05c426e0d13cb2ad5eb5cbe268c2a469cf574e6731d9cc8dacac9c02b79"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-fedora.24-x64.1.0.4.tar.gz",
+            "hash": "f3f049e099c4ea73342ec6448cb0eef61d81cfca7c476b989fcb0f09d918c31c"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64..tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.13.2-x64.1.0.4.tar.gz",
+            "hash": "49d599df1f2b6b173e4943a3aafb0456c95086ad2bca143c346fa28fe87d30bb"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.1-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-opensuse.42.1-x64.1.0.4.tar.gz",
+            "hash": "91f133a77ba5ba9cd3ec5b243ce6c69ceb5ec164b2ff1fd256a28fbb73d6991e"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu-x64.1.0.4.tar.gz",
+            "hash": "e3823b9f964d27d1434f0e52b93fb1b6a65e83fb275e01f65ecbe63a4242fbe5"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.04-x64.1.0.4.tar.gz",
+            "hash": "6fb4ec609b00bd65881f864249741d6486ba19da5b76cfcb60d03df8799b6ab7"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-ubuntu.16.10-x64.1.0.4.tar.gz",
+            "hash": "9e784b554a9cb68df9ce541cc220dafcb71b185837e05420c182e4a496b68f47"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2017-03-07",
+      "release-version": "1.1.1",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.1.md",
+      "runtime": {
+        "version": "1.1.1",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-osx-x64.1.1.1.tar.gz",
+            "hash": "a809eb4f47a8468edacfab8dfd9ddc1015a2e4ec3643fdcedd4d7c9ab3f028f6"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x86.1.1.1.zip",
+            "hash": "0c69428e55782603982b173bc66eb24fbf80f9b01ffdf8a00f012beaab3c4653"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x64.1.1.1.zip",
+            "hash": "b0f7fc902308b98fa8e202081884d310a94a93264a1f5beeb4632acccf2c0bb2"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-centos-x64.1.1.1.tar.gz",
+            "hash": "2eca7129424c50bd4a312bf519e5f3add2398cc11f53e4032e233b787528c3e4"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-debian-x64.1.1.1.tar.gz",
+            "hash": "6359fcd443c686476c6b55bfcd5fdc214a64f8f399bfc1801e4d841c4ca163de"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.23-x64.1.1.1.tar.gz",
+            "hash": "f5813c020d0b5c507ab857a168f7faea54f745ff8b34404b85f8dc5c03aa3537"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-fedora.24-x64.1.1.1.tar.gz",
+            "hash": "060d05dc338cb722cad94e379e354cca174309b789b686cf4e2cdfed2c238503"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.13.2-x64.1.1.1.tar.gz",
+            "hash": "86180fb3d67293be760abbe6a28d73a7717a2910852e8b047ba771d0fecd3430"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-opensuse.42.1-x64.1.1.1.tar.gz",
+            "hash": "97535294b174d09d685f46687d30ebc7d929afa11ed99fcc1645954b1cdeecb3"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu-x64.1.1.1.tar.gz",
+            "hash": "bd2807bf3d5b316bf7360bddab276bc4af13106de406491a41a4fae522d1c0be"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.04-x64.1.1.1.tar.gz",
+            "hash": "e1737cfc3df8336d7469e1c3df431abcb56f94d021a941dc33af9a0d090f512c"
+          },
+          {
+            "name": "dotnet-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-ubuntu.16.10-x64.1.1.1.tar.gz",
+            "hash": "d2d439fd7e544e120db4fb7246ec99cad199ad8d827a78e3e4157f8e331aa066"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.1",
+        "version-display": "1.0.1",
+        "runtime-version": "1.1.1",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-osx-x64.1.0.1.tar.gz",
+            "hash": "f030188673ebb71fc3bb3a089504c2079cd8176e669575b5992664b405194366"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x86.1.0.1.zip",
+            "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-win-x64.1.0.1.zip",
+            "hash": "e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-centos-x64.1.0.1.tar.gz",
+            "hash": "08759c53aaf335bab14f5bbca89836bd9d4350c1b6392d32e51b37d00dba9eeb"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-debian-x64.1.0.1.tar.gz",
+            "hash": "84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.23-x64.1.0.1.tar.gz",
+            "hash": "dc6a70d11a574f9745b52a5392c384453ffdadd799ee59c417c308bdc63e86c3"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-fedora.24-x64.1.0.1.tar.gz",
+            "hash": "e98ffe4443bed058eaaeba7190b3f136128757799d28ffe8ad985aeae92970b5"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64..tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.13.2-x64.1.0.1.tar.gz",
+            "hash": "2dff951b2db33145ba51e2310e85dd4ffad83a501eb6750365f77ddf7d3d8b5f"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.1-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-opensuse.42.1-x64.1.0.1.tar.gz",
+            "hash": "4c9d4eae74f04acf563da9ee3f1e846e9f2547ebd552ae874d90e897caf85e21"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu-x64.1.0.1.tar.gz",
+            "hash": "4d4399e090c436e7037dc393373345aa0521b2acfa325dec80771f7adb448daf"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.04-x64.1.0.1.tar.gz",
+            "hash": "4a59413a0b2ba8914ceecb4a505dae4f93ede10cae4246d714178b11cbe32a2f"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/1.0.1/dotnet-dev-ubuntu.16.10-x64.1.0.1.tar.gz",
+            "hash": "828af612b3e691f27d93153c3c7fd561e041535e907e9823f206ccab51030ecf"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2016-11-16",
+      "release-version": "1.1.0",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.md",
+      "runtime": {
+        "version": "1.1.0",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-osx-x64.1.1.0.tar.gz",
+            "hash": "b8c28c32ca6bf677982999543feec0cea4e7275ed034e1b503451de0744d13f2"
+          },
+          {
+            "name": "dotnet-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x86.1.1.0.zip",
+            "hash": "6e08a9753f96ed2087d189dd1adea7611e90bd88614157c1fe51cf397a967ed9"
+          },
+          {
+            "name": "dotnet-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-win-x64.1.1.0.zip",
+            "hash": "cc66a190edc10866494df9e72dbaf4b872c83045e26431161131459ab413a08c"
+          },
+          {
+            "name": "dotnet-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-centos-x64.1.1.0.tar.gz",
+            "hash": "6f2a99f2aba9afd4c8470d5c423d06eec8e7dc9b2c6d2521216eefcceccdd254"
+          },
+          {
+            "name": "dotnet-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-debian-x64.1.1.0.tar.gz",
+            "hash": "91acd357628a3ae510e6f9ff2f912fb69b7a477125a66dca8f8cf3015d87df19"
+          },
+          {
+            "name": "dotnet-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.23-x64.1.1.0.tar.gz",
+            "hash": "de34ecd0bae6865d5ff15898415517892caf1894301a9368c7b68a62b9e188b4"
+          },
+          {
+            "name": "dotnet-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-fedora.24-x64.1.1.0.tar.gz",
+            "hash": "4bf2fed6c9607cfb19c8b80cce74a99aee3f7549b644841d46ea47238d39feee"
+          },
+          {
+            "name": "dotnet-opensuse.13.2-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.13.2-x64.1.1.0.tar.gz",
+            "hash": "97b98c12693683bd5bb5e3b1745f72b8e5a4e50ed72dbfe0155749135bc09b84"
+          },
+          {
+            "name": "dotnet-opensuse.42.3-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-opensuse.42.1-x64.1.1.0.tar.gz",
+            "hash": "f1b5055ffd1e8df4bcfbdbee8c99ff81315d493d2e24ebfbcab5b324e9bb7671"
+          },
+          {
+            "name": "dotnet-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu-x64.1.1.0.tar.gz",
+            "hash": "1c067b32dd40dd2b88a6d25c8634c94f37399a590b5036e609550de7f5fda935"
+          },
+          {
+            "name": "dotnet-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.04-x64.1.1.0.tar.gz",
+            "hash": "917fa16e95fe9d2434134e09025c23b766387c67e91f5f88947ccd6b5e3032e2"
+          },
+          {
+            "name": "dotnet-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-ubuntu.16.10-x64.1.1.0.tar.gz",
+            "hash": "48243753a3b4429b51e1c919955f40c977886849aacc03a2a207f472d78bfae9"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "1.0.0-preview2.1-003177",
+        "version-display": "1.0.0-preview2",
+        "runtime-version": "1.1.0",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-dev-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-osx-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "8f1ffef37aa9da7273674185dab3b78feb44082d3a9d3156dfc20329acfe7e0d"
+          },
+          {
+            "name": "dotnet-dev-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x86.1.0.0-preview2-1-003177.zip",
+            "hash": "38a451069f6bc1d2e226218f260b19fc1a2aca775fbd88c083b2d23d5a3af737"
+          },
+          {
+            "name": "dotnet-dev-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-win-x64.1.0.0-preview2-1-003177.zip",
+            "hash": "d4056a91f83699894c9f9fbac1b8965597ded079b0d8848dacc7505f372f85a0"
+          },
+          {
+            "name": "dotnet-dev-centos-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-centos-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "168099d73a4be8dacf148a4c9300602a4a74e78fa86495a6d819a2ecca2db406"
+          },
+          {
+            "name": "dotnet-dev-debian-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-debian-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "a2f228dc79501ee85ac5fcdf771886d8f84409bacfd3f9b3ba4225663cbfa3ef"
+          },
+          {
+            "name": "dotnet-dev-fedora.23-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.23-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "9802a59b2e68c1fd2c91648503302066bf0ab09b1d286dd6264e2ccc75f50b09"
+          },
+          {
+            "name": "dotnet-dev-fedora.24-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-fedora.24-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "4ff0b843f00f89b4391cb2b442f973117d676c56b571b40c9ffa49af3740f717"
+          },
+          {
+            "name": "dotnet-dev-opensuse.13.2-x64..tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.13.2-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "a46585f907b73336878076ab9942db6565445b8b7a435f85537fece4ae4456a0"
+          },
+          {
+            "name": "dotnet-dev-opensuse.42.1-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-opensuse.42.1-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "b9bec78bbb710a47baa79e2af65b5dc0242bbc7850571d67f8153f6d6cb3f542"
+          },
+          {
+            "name": "dotnet-dev-ubuntu-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "9f6f72c581534ec4367bc3952fe3bfe7649179d86c55b31371b4294edc96d1d1"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.04-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.04-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "4fdae55113557171a0898b283eef13669a7d722fb2b918a595eb2ab70db1d8a8"
+          },
+          {
+            "name": "dotnet-dev-ubuntu.16.10-x64.tar.gz",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/F/6/AF610E6A-1D2D-47D8-80B8-F178951A0C72/Binaries/dotnet-dev-ubuntu.16.10-x64.1.0.0-preview2-1-003177.tar.gz",
+            "hash": "835bfcb0cf56457a7c5f953f5fd7d6a37b7a68eb23dc0fb3d9161def833345ea"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    }
+  ]
 }

--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -1,1495 +1,1866 @@
 {
-    "channel-version": "2.0",
-    "latest-release": "2.0.9",
-    "latest-release-date":"2018-07-10",
-    "support-phase": "eol",
-    "eol-date": "2018-10-01",
-    "lifecycle-policy": "https://www.microsoft.com/net/support/policy", 
-    "releases": 
-    [
-        {
-            "release-date": "2018-07-10",
-            "release-version": "2.0.9",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.9.md",
-            "runtime": 
-            {
-                "version": "2.0.9",
-                "version-display":"2.0.9",
-                "vs-version":"15.7",
-                "files": 
-                [
-                    {   
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-linux-x64.tar.gz", 
-                        "hash": "2b49b24ef712fbfc056e0fda95ff18037b4ec938ca8bb41f4c336b6a50870e922f5093684ac92c4bb8e1155b03c36d132d7f90817793f31c9ade5267fff6629a"
-                    },
-                    {   
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.tar.gz", 
-                        "hash": "b59fdfd1763420ae39c2984cb72b122fd0118dee77d7a4ceaac1683fc6b86345f80a9c6974b34254b523a418da518f448cba8ade54b3443b923f590107ce3dfb"
-                    },
-                    {   
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.pkg", 
-                        "hash": "fd1f5e4e6ed08f47e87b907d1c28adcfb983b53822614a01fe23a8d1d81862e2b75b7ebfc4e28770f7486080d72e81179ebb05b569be5d7c2410bf52bf1270c2"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x86.zip", 
-                        "hash": "e73a78ee66f872678594d01720849a3b95a4911ded6700a55b2dbc35fa54a42aeadeeb3de0706a1b96c7b2ed383bc431b8c6e36ce8082bb673132b3d80c7d441"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.zip", 
-                        "hash": "4e03072925ca65f350112916eac8f442ee86f84de5fd8643d6db9eb96e2175351fdee0fb8ebed6a508b5ce2a3f73bdd4b7a084adc0c765c5249c019f601179f4"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x86.exe", 
-                        "hash": "159faebadf18cd2e06b3ca1b71f28a65ad6c3a4be78a090fb1f0947951d392d5bbd9bca9055610658c4e16dab66bc1e13200ac869b88725f6e4ba91de2f62822"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.exe", 
-                        "hash": "9d8ba6ae17a5519a8a4ed043919114d98cf36595c5c3fc82ed699c225b56e07d782680e4a57b1a83f4c9073b75045c89770ee4b0d997a8c19776d1e946bde478"}
-                ]
-            },
-            "sdk": 
-            {
-                "version": "2.1.202",
-                "version-display":"2.1.202",
-                "vs-version":"15.7",
-                "csharp-language": "7.2",
-                "files":
-                [
-                    {   
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz", 
-                        "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"
-                    },
-                    {   
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.tar.gz", 
-                        "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"
-                    },
-                    {   
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.pkg", 
-                        "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
-                    },
-                    {   
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-gs-x64.pkg", 
-                        "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
-                    },
-                    {   
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.zip", 
-                        "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"
-                    },
-                    {   
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.zip", 
-                        "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"
-                    },
-                    {   
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.exe", 
-                        "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"
-                    },
-                    {   
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.exe", 
-                        "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
-                    },
-                    {   
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-gs-x64.exe", 
-                        "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"}
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version":"2.0.9",
-                "version-display":"2.0.9",
-                "vs-version": "15.7",
-                "files": 
-                [
-                    {   
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/DotNetCore.2.0.9-WindowsHosting.exe", 
-                        "hash": "bea34b32752c1a9ab589b43df68fbb90fc63c34564603619a4ac516d8732f37d4867f07602c4ce0c276ebe133a64bbcabe4586cb89459bb2b8929ef848e3b450"
-                    },
-                    {   
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-hosting-2.0.9-linux-x64.tar.gz", 
-                        "hash": "9d99d6a44ec5ce01f994d770195d4ff602116c7c79a183e6077fc6837bedafd1353668fb8f3912caaf04413887a42359f4b1b9eec89d992b97cf1a4ea7fa1f43"
-                    },
-                    {   
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/AspNetCore.2.0.9.RuntimePackageStore_x64.exe", 
-                        "hash": "7f562a2c5171f86ba4278e899d4bce29a4844cfbe13825d524c2b6b28ddb94d9fb2da87dd7da43e7e8c0951d8d6f6f7fa511dea769c8eee035c872982c00b341"
-                    },
-                    {   
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/AspNetCore.2.0.9.RuntimePackageStore_x86.exe", 
-                        "hash": "fb59a3b70373a22241fa6f753c72c1ac726784e66a7685b5cff42a90be82a8034346875a443cda20d25e95016e071c4b27e2d60809d0527b20c64f86dbe3b585"
-                    },
-                    {   
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-win7-x64.zip", 
-                        "hash": "876278b13fa35320a5402016e8bf07f51a316c9ba9a0ddf24aeae68f25f17ad07aa87942e0e802d7ff04a1c685db1e3964f5ed2dcd4bb9764d1bd0fa097c566d"
-                    },
-                    {   
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-win7-x86.zip", 
-                        "hash": "0245852f8b813af572f5725bc19a6e083928aee5ff7afb421cabdf79baa5451008da43a633a599a89e213eff5e5a08fd0330180ea26fcbd3b7a502fe3c7a0f28"
-                    },
-                    {   
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-osx-x64.tar.gz", 
-                        "hash": "1554182e202b5d5bfb2d2fea367ee6efbc996dc1ace65568f81784a5b920dbb0efaec29f35f208899477252d2cf0704ca9934178890b0d9776d14952c8b69014"
-                    },
-                    {   
-                        "name": "aspnetcore-store-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-linux-x64.tar.gz", 
-                        "hash": "7724637f1c37a0ab6b3535acdb38583e248fb06f59e25630f45107c6affd32b1397db2f6e3a91a7ab07a42c3d7e4ff45cd50bf9c406029ca50f07491007b64e2"}
-                ]
-            }
-        },
-
-        {
-            "release-date": "2018-05-21",
-            "release-version": "2.1.201",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.201-sdk.md",
-            "sdk":
-            {
-                "version": "2.1.201",
-                "version-display": "2.1.201",
-                "vs-version": "15.7",
-                "csharp-language":"7.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-linux-x64.tar.gz", 
-                        "hash": "3c456d5f564e7c56a8b33f4116ba79f5ec1c5f6ee87494532efb68f407f25deae1d075c83e6f86624e51b99b090c7d3f1fd6ecd812808aede9017a8877782358"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.tar.gz", 
-                        "hash": "3d2d49f6b6b22e777e80d3ea396ee28e4e71d133478d5aa3e118ed48d3933071d4abc108ea6fded410b218ed9e15b05e99f52f6741af5d102aa0323a01a795b7"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.pkg", 
-                        "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-gs-x64.pkg", 
-                        "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.zip", 
-                        "hash": "08ec5d4e913f973aaebbe34fc34bfc1671a60dd132b2a2323ca48be3af71482d17e6347d72f164ac509d0d6aaaee5ee5f841ab4244ba6eaf49ac1fb424dffe79"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.zip", 
-                        "hash": "34c4c7a48ee9b88cf2c523d615816b1c597f0187e716271926e7fbe478b92f6d6c0faab4884cc897309f38168a033039a8315a395e887a4c90dddb1791f7d2a0"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe", 
-                        "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe", 
-                        "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.exe", 
-                        "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-gs-x64.exe", 
-                        "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"}
-                ]
-            }
-        },
-        {
-            "release-date": "2018-05-08",
-            "release-version": "2.0.8",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.200-sdk.md",
-            "runtime": 
-            {
-                "version": "2.0.8",
-                "version-display":"2.0.8",
-                "vs-version":"15.7",
-                "files": 
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-linux-x64.tar.gz", 
-                        "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.tar.gz", 
-                        "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.pkg", 
-                        "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.zip", 
-                        "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.zip", 
-                        "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.exe", 
-                        "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.exe", 
-                        "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"}
-                ]
-            },
-            "sdk": 
-            {
-                "version": "2.1.200",
-                "version-display":"2.1.200",
-                "vs-version":"15.7",
-                "csharp-language": "7.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-linux-x64.tar.gz", 
-                        "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.tar.gz", 
-                        "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.pkg", 
-                        "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-gs-x64.pkg", 
-                        "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.zip", 
-                        "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.zip", 
-                        "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.exe", 
-                        "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.exe", 
-                        "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-gs-x64.exe", 
-                        "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"}
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version":"2.0.8",
-                "version-display":"2.0.8",
-                "vs-version": "15.7",
-                "files": 
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/DotNetCore.2.0.8-WindowsHosting.exe", 
-                        "hash": "393346d9668b4cfb4d520bc198fdff43d3137ef35a512b5ca4c8c7607c99e08c0ea173bb478ec5a8b75c7e719425abc224c2dd88ddf46b92bafec4a9e3f0bd6a"
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-hosting-2.0.8-linux-x64.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x64.exe", 
-                        "hash": "8c9199f6ede36c24c9d5350e5b71401d2154ecb37e641c0fac9c53055235a4e4844a37369255c59926924f3d4f96868affe47fbb9fef8b96fc5f658cf7dc5cca"
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x86.exe", 
-                        "hash": "1c943c82451bdda0bc3526bd3471010ab5a9a508ff07396888986e05b55218fea8c89eb6ba504c300b438a68b100d0198549ff3ad0546280d0be15db50150279"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x64.zip", 
-                        "hash": "c739e056f62391c8d2b8d3348c0116a54b13c1d81ba938b8ce84897289f2ac2f81ce4539599e6014389e67feead27fcea2ec09e72cd920dbf5405b9c5ec13624"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x86.zip", 
-                        "hash": "89e63e53f0b903de59ba0174128b7baeba4a1ce6f2c95732916e50b65fc405a601d05cfe0c018db809fdd890cd24ec65ced3ce77989cc4da37433f2236a07e03"
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-osx-x64.tar.gz", 
-                        "hash": "045034f21790e92f493ce62e6e51be4d48e9138d464b9a39febc5c599e83d8e1d30bbdfdf3509252c17a621bfc894adf39a9c4797e310253acff86b9f770aec5"
-                    },
-                    {
-                        "name": "aspnetcore-store-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-linux-x64.tar.gz", 
-                        "hash": "12389d923f71b639cd0f3c5267a06cb65e0f7aae026b545956a6d90ab07e65bee05c18713255fa7de4e910d0ec52de3a4afb40a08545f984415a9690d6adce35"}
-                ]
-            }
-        },
-        {
-            "release-date": "2018-04-17",
-            "release-version": "2.0.7",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.7.md",
-            "runtime":
-            {
-                "version": "2.0.7",
-                "version-display": "2.0.7",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-linux-x64.tar.gz", 
-                        "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.tar.gz", 
-                        "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.pkg", 
-                        "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.zip", 
-                        "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.zip", 
-                        "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.exe", 
-                        "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.exe", 
-                        "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"}                
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.105",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-linux-x64.tar.gz", 
-                        "hash": "b5e71dee8720595b0eff7518cca49854ed183e7ca68b98e2ca0580be3f6893f25a1bb267367601f575529a0fd8c94bb379a1411564ed5beaa340a54f37a5e16a"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.tar.gz", 
-                        "hash": "68b060271e5e5d8257a9f87d55c6e9386fa72bec2fa6d9d37d5634837f1a2ccfe4a09934988e4f41aa4efa131708bf5cc1dac2c0609edcd86b966edf2319cae7"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.pkg", 
-                        "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-gs-x64.pkg", 
-                        "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-nj-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-nj-x64.pkg", 
-                        "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.zip", 
-                        "hash": "0e027eda462877d2aa2bbe9b763e2494a01c1a739190e317cde3dd7a905e7cb5c20036ef90e846ba2c9e251386859e4b0600016a536da1b392ef12eb04236236"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.zip", 
-                        "hash": "9e902468b1f40434092d0100dd0054344f085d5d64a325d1e27c86fb2f54cccddda615bc119e3cffa357b8d9ffad455ba6ea9739ac592795d3499d0f1fe498d5"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.exe", 
-                        "hash": "a06393e1030e88f39628e070c6743745d142c754f0a604d26f33a35a5635ad6622f2994db719fa566352c1d0dc1f97a58dcf2792e80e6529359ae1e5454ee2a6"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.exe", 
-                        "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-gs-x64.exe", 
-                        "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-nj-x64.exe", 
-                        "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-nj-x64.exe", 
-                        "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"}
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.7",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/DotNetCore.2.0.7-WindowsHosting.exe", 
-                        "hash": "83f7c2607a0ad97800d2302cd6b9462b623cc66960974bdb1c404eff89eedb0d1f876a957a671b885f7ac81584bc9fd97a34231c342fa19affa38fa603c4974e"
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-hosting-2.0.7-linux-x64.tar.gz", 
-                        "hash": "44cfe2404f5fe87e6381d039ae1a4f6de4935d5564be073f1ebf2624c62a97a35f35862730ab03f38e71ce64e0921444c3058a8aae5564915b18b848fd8e08a3"
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x64.exe", 
-                        "hash": "81d8bb363a7d8b517027229fce7d60800902b84921dbf926582213e3b0f9b856daeba4cfed8f6ab52974f04752722303a09e2370a9cb3dae2c443fad188dbe05"
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x86.exe", 
-                        "hash": "071d19f2d897a0fcd6d61e1ea8c418b305ece143eaf1c0ad03af9de03cf49084d17408f2edb3e950b9ac3bff24638638865e88a6e149bf6f7d37f8d5f9ec22d6"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x64.zip", 
-                        "hash": "12f4035ceab8385849c60ae9883ce68b8350de0a20100a9a5f91176a5bb52a2bd7b677fbddc1bc2f3f30a3b1926693c1eec801fe044d3b93f0dde4861d816c48"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x86.zip", 
-                        "hash": "d145bb1ec3ba95166c46b22e29271476d215561ac93f866f155d8016bec0cad2a8f8645f0f7e09365fb49dee966446cbdfb058f49ef3a023a0d4a47492fd09ce"
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-osx-x64.tar.gz", 
-                        "hash": "6cf6d3fca8401944b28d8da5cd82ed09a1187196289d7a142ee5a48194ed74c7df55881cb54b99235dfe20d8914c2bdb29e7bc1fc5bbb349d5a78650aecea765"
-                    },
-                    {
-                        "name": "aspnetcore-store-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-linux-x64.tar.gz", 
-                        "hash": "422d6fd1598628d72bf5687582c90b2178bb0c0485d2df224af7b0cedea09b9768408c6940cb60c09fee1cd36e064fa013d79dd417104ae8a42b428a2b0d395a"}                
-                ]            
-            }
-        },
-        {
-            "release-date": "2018-04-04",
-            "release-version": "2.1.104",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.104",
-            "sdk":
-            {
-                "version": "2.1.104",
-                "vs-version": "",
-                "csharp-language": "7.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-linux-x64.tar.gz", 
-                        "hash": "813334694667f8c1389d88cd3128a7749f4f65b13a0a8e2cb47380823849b8fe7f4816ab66c2d77e589fac9cb5748390b262beae9673aef86cad5a3d8f24986e"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.tar.gz", 
-                        "hash": "625aa1e52f9a03cf0ed0bc2ede40f94749f35ecf142a655f8d353c6d8223f8f7e6e715f46d6bd546dec9d888a8ae75ccf9d79e91b5b92b7ee633a92d6ae82e53"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.pkg", 
-                        "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-gs-x64.pkg", 
-                        "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.zip", 
-                        "hash": "0d4fa339d125f780bf293ad566f5127b602c228fa3312bc0c02d455499797114aea1cb27de6b187c18908ae8a4358e7b6c91a596219f572e08ec091cadb4cba8"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.zip", 
-                        "hash": "f3a46570f220cafbdb2f7d40cddd09a8f718b62f02fbea79fdf8e48ac1871a20d2e79191b037a559b7f2bd88064e1ec70d2c68988312a7ee23d34dc757b9981b"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.exe", 
-                        "hash": "4462a33130b09ba6b9d5f8b579b91ff797f4081717ccc4ecde507bfd2c774985e73458716b6b1f3ea714b020d0607d99c9a013629497c26e89b3424e1713ab97"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.exe", 
-                        "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-gs-x64.exe", 
-                        "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"}
-                ]            
-            }
-        },
-        {
-            "release-date": "2018-03-22",
-            "release-version": "2.1.103",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.103",
-            "sdk":
-            {
-                "version": "2.1.103",
-                "vs-version": "15.6.6",
-                "csharp-language": "7.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-linux-x64.tar.gz", 
-                        "hash": "5252ece4fa8eefdd401ef90cc1fcaecaaa6ad71ae5e25351578c7f497488039b0aa334b5c6481c6c839a95dbf9ab4aec89404dc760cfbcd06564ef5869dd9377"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.tar.gz", 
-                        "hash": "1ad9f16fc72362fa810951bf0f129ea48c4c0f10d465eed73b4706066956c063a41964bcf84fb7f7590c3c90f31261bd33162cb2aa8348bcb5c96d75473a610d"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.pkg", 
-                        "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-gs-x64.pkg", 
-                        "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.zip", 
-                        "hash": "61ee3cb4e12e435e9b3ead8426c2ae528dcf9c77de0878e51e7e3baa04b3928a83cd60f5822e785302884f5f034723a6c45599cb2eabd8c03e3f525f3cc0f1cc"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.zip", 
-                        "hash": "8166b0f2fda1533df4397209616754b5255fb1ee5a775d581640b99158adf371538dd373001c2431f6d12abcc9648b325f88653b9891c8eaf9f50c9e2e1b4b1e"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.exe", 
-                        "hash": "ba0f0f9519a6c5a3bcd8325034f466212797e820e7671b019eec199c8ab9ffb2f3543eb5594c76f2374459e5c0e175bc8604b67f7de3c7505959c4e209d6d835"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.exe", 
-                        "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe", 
-                        "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"}                
-                ]
-            }
-        },
-        {
-            "release-date": "2018-03-19",
-            "release-version": "2.1.102",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.102",
-            "sdk":
-            {
-                "version": "2.1.102",
-                "csharp-language": "7.2",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-linux-x64.tar.gz", 
-                        "hash": "39bcc14c6453552ea5f400aac7b5838a0361dd15cc2ed9d2794f1185ac2e38c82478e32712e1ad483eeb4edf4b485bb799de26368fccacd98e6c0819f8ff7eef"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.tar.gz", 
-                        "hash": "a3f3acb6be30047970764dd657353262822addeb669b6179336b83c6bcf4d97faf2c9bfda3ef07fbe56630d7083de04fdb49c5d9b4c03ec9e8090c9f5ab0c4ae"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.pkg", 
-                        "hash": "982522821d3d6ab7f98810ab70084eb1c10381326bd91237bc9de9821e8434803f76d3231ab8b1762f2598cde48d5ebb1b53a84da3e28424f6c7ce946fa5e859"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.zip", 
-                        "hash": "642162de05c3d7265da4fb644a9fb6c965788bea93adc2ee381ccab4992dd15dd7ffb02cf8a54485391943627533ea496ec8799d4850b6922f196e3c7cabdeb4"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.zip", 
-                        "hash": "c1e169cac4200b944d708c46712389f0cadf3eb319f1b6f6f90eb2a8c3e01b18a569acacabb4b7985c9c54165a63e3ca9dc8f1ce7170db650442052d35fbe310"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.exe", 
-                        "hash": "3850b7ed490d64599f7aa592ab1cc59609c77f5f131e04c81cdc47b884db521b4ff421c25730907694b6107573c0fbc38765f6417b0ad5a1bbbd915765d8d617"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.exe", 
-                        "hash": "ee698f7a3d88d22c344f3bf692a671c03abed634250a58c55de7eba33135df6d26315bf75caf8de5dd614900e51b3f602a07a0acbcee9ecc22ba9e323c5d0cdb"}
-                ]            
-            }
-        },
-        {
-            "release-date": "2018-03-13",
-            "release-version": "2.0.6",
-            "security": true,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.6.md",
-            "runtime":
-            {
-                "version": "2.0.6",
-                "lts-sdk": false,
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-linux-x64.tar.gz", 
-                        "hash": "b8a00bbac9b0f4f9cf03785afa2aa71e6e5d24c1035ad9865e14c259eb06b3d98a524c1f2bb1567810a556a5c2380252642b7b43d919982c89962707e5361383"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.tar.gz", 
-                        "hash": "b9ccb006c62cc9ac717d9b5894b3fc1dad5713c9b870a134b3232aa803c8239a05d10826458205b52207b525b75109963aedfe12a2d280e491d5ea0437152276"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.pkg", 
-                        "hash": "6fc023b8c03c049b57597122ccd4c471924986c8962b903ebf296be394013fb18222deba5ea1dab0663d5c064640e6b11c46b89dc68452a8a34384bf84b74f41"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.zip", 
-                        "hash": "ba29f7386f4d4adfd81649798cca730e4e8d40c4cf041e084bcfb3ee8823a789d4fada73c6ff1e323d376cf8cc3704a8b0c3d18515445b1246a98c99a1c9c087"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.zip", 
-                        "hash": "c139ee4f8f65581d908efad230111948abb29431c26d058995386d796c71890423ef0654fbc6791ac6e1a889ba2c0bb755c58ac08232d9d009da3e7d55da60d1"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.exe", 
-                        "hash": "a74bab1888f6ae973c35d78c21f382c5945a0f1d6ecce10f2d8e9219b8e400f4db7600f3a6f8d580e0b0ed853a40b9f8d81a77492e30d21188f793841be62aea"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.exe", 
-                        "hash": "d5c185982e31fe6dd5baa01c45fe2e75d36a962b189511a69591639da9501a9ba9ac9a8e6b94160a06acb22953e235c5fb14b4a120e62537272fda872482fc4e"}
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.101",
-                "vs-version": "15.6.6",
-                "csharp-language": "7.2",            
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-linux-x64.tar.gz", 
-                        "hash": "d231ac3562f025b848497eddbcb254cfd547bd622b35dc4b1ed5bcd29153f832610b77cf7edf15d9f05c707d4d06abecbdcd7633fa721246d6d7ba61d78eea81"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.tar.gz", 
-                        "hash": "d8465acf3a0410ca6a35847e79d8063aaa46cb6d3704ef53f9257e49eaa0242aa2b7ba64eeb625ef984a7109b733988b3b400816bfa0ea09c6db9ba5a7d3de30"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.pkg", 
-                        "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-gs-x64.pkg", 
-                        "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-nj-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-nj-x64.pkg", 
-                        "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.zip", 
-                        "hash": "7973c10b7cf32d71a1e564967f85e00f293f948d4f3ff58bc0a3ebdb4b936b1e5d2e247166f40e6f82cb4ba3d9fabc3d72ea78e145f76789c6f26ae5550acdf6"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.zip", 
-                        "hash": "794901f629921c2ef8db9de9ef984725a3b7f7b165289294593f4add34a5abb456d1165b90cf63df287d22ba21d06a136086e4db37a63c74196332608f18b0e8"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.exe", 
-                        "hash": "22527e8d3ce51189707c411bf67a23d3745bd39f994b67d2a5004f3c143439d3583d7df3935b89f5a3d58ac5a51970c2ee61043897258d45c3fff74e95091fe0"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.exe", 
-                        "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-gs-x64.exe", 
-                        "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-nj-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-nj-x64.exe", 
-                        "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"}
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.6",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/DotNetCore.2.0.6-1-WindowsHosting.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-hosting-2.0.6-linux-x64.tar.gz", 
-                        "hash": "f70d88731859d63b632851c0a2214a6dc6c041fadfa291c97ecc5a84b4ffcd3fda89d7304fcb79392c5bbb354d98cd03bb83d4c523ce4b404bf429fdac016dc1"
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x64.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x86.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x64.zip", 
-                        "hash": "6dd368be3c46e920aca55a982866a77b6d599daa74b29b87db4a3346d5d05515c3f9f6d7bff501ec0afbd7f7edfd95a8bc47c5166486c5e57fe6642e86259a01"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x86.zip", 
-                        "hash": "4f12f9fe3007691cfc98bf8d7026b4c0fb1785ac5fe95af692c5355275d0ba0d4a3b4b5088c587b1ae815b46b881c63a8164ef61c45d52dddc2613bcccd67e61"
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-osx-x64.tar.gz", 
-                        "hash": "29a4b4905866d6cffb314122902cd78886deac91a6348256b45f625f8461c006b790daac2318e58393280c164ce80e5a92c083123cca54859a785c23e2b1fc6e"
-                    },
-                    {
-                        "name": "aspnetcore-store-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-linux-x64.tar.gz", 
-                        "hash": "178f9384a4010daec34a9846fe2dc597e3dffc7170ffb889cc82f6ae6bf9aa2e93254c64af90a3ee3f8f9e024d6615f1f1857eacded6ef1bffd7601ad32eff5f"}
-                ]            
-            }
-        },
-        {
-            "release-date": "2018-03-13",
-            "release-version": "2.1.100",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.100",
-            "sdk":
-            {
-                "version": "2.1.100",
-                "vs-version":"15.6.1",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-linux-x64.tar.gz", 
-                        "hash": "71b55610baa809017ccf2c133b3238344e6e238128ea3c6302e3d57ccdf88629e70f48e5cf086ed62c72101d224e94092d8776fcd42528014951dc49f578e72d"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.tar.gz", 
-                        "hash": "f0ea5bd796f58fe2544b00331cc88cf54639560135107409cacbebe8ce8ee1fce2c905379368433c4b275080a72526df087df61837d3150c6feae5e7fff68b87"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.pkg", 
-                        "hash": "1d60d14e201727681d3206286fef873e613590c51b6cfa6ea4db23c1444b89aebeaff6c7a1619dade2a0cb6ab5b5f8bed28f92b73b6d6051fc3b113251d9081b"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.zip", 
-                        "hash": "7d221f9f194154410ab8be064e2bbc02d84c3067bb511cba78b4a2b57b378a10860fb0a2d0fa75e4ff992d9f76fe132df7afde056ab8e78b2038aba1fd3cfdd6"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.zip", 
-                        "hash": "dbed1bde38f5ff5b97d75c7bb45a84dfc6270093f8e8bce124f2318e28b9dbd60c21b373e7862007bff28fe7b21a45a3cd754f4fede4ad70cce070dc7a2fd14d"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.exe", 
-                        "hash": "1826f5ab39efad23e1c7aef844d6e5d2d0aef5bc2bb0c708b4e3dfe577fe4b8d715cce2d754cb5774c15eea888ad260f83e4f6018092f4ceb327eb68910bb63e"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.exe", 
-                        "hash": "7fff3190e67f70792009ff9f15999757f769182ef7256bbb5133382f139ef5cdea86c724dbdcfd7763dd48f9619e39778238502b59d5cc4f05af4e055a1b789e"}
-                ]            
-            }
-        },
-        {
-            "release-date": "2018-01-09",
-            "release-version": "2.0.5",
-            "security": true,
-            "runtime":
-            {
-                "version": "2.0.5",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-linux-x64.tar.gz", 
-                        "hash": "21d54e559c5130bb3f8c38eadacb7833ec90943f71c4e9c8fa2d53192313505311230b96f1afeb52d74d181d49ce736b83521754e55f15d96a8756921783cd33"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-osx-x64.tar.gz", 
-                        "hash": "993dab75a25b961b474f147bf42273b86b561c1823cb53458aa864599003f131880b54c5f31241bcbcee7b89b9a21bdd90d0f43fb440e2b9b5a1266f624e2e45"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-osx-x64.pkg", 
-                        "hash": "94de569a3124ab1de8b52d82dfa48bf58bfb85cac532a20b1111704d31bb0c8e361f4074d7ca3cca7d0e21a7e90cbcbd2a95361cf62b2cd4cb74424c83f16bee"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.zip", 
-                        "hash": "671fde7ff5a64738de7863feb8501692f4b62c2496acea9e3c47c381f14e51805f9e7237002ae63bc71189431411de0e051ab1e23200bfbe830a254ec5f7fa8e"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.zip", 
-                        "hash": "5a4381d01d7b7769254aff980bb4a333aec41fdfe92e74bca95147931f1500a1d391ae8da873bc802524a83899e270e24e30faf3759a121505aef110fe9902dd"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.exe", 
-                        "hash": "84dc1b30e36dc0aef5cc7294aeb43963570bf4bd6fd824ff9c9ae9fe5c7bb574b9b2a48d299d526097732879317ce92e76f9ac1b034b8c14eaebb27297b4401b"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.exe", 
-                        "hash": "dc6c0f438258e8a5ea825809cc5d7e3f0e69d6aa233894086ffafafe8e539d707aac1abcf4f56ea324fc54f578b52d7796c2b828c26bb838b9b94299bf754c20"}                
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.4",
-                "vs-version": "15.5.5",
-                "csharp-language": "7.1",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-linux-x64.tar.gz", 
-                        "hash": "05fe90457a8b77ad5a5eb2f22348f53e962012a55077ac4ad144b279f6cad69740e57f165820bfd6104e88b30e93684bde3e858f781541d4f110f28cd52ce2b7"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.tar.gz", 
-                        "hash": "1b08705b8679bf1800d40908408e0d8c1fac7963f6ce508710cf6425cdc1663fd46526e8b6ba8a67d6d327e6bbc143797aa7be4acfdb5205d4d3143de3951849"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.pkg", 
-                        "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-gs-x64.pkg", 
-                        "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-nj-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-nj-x64.pkg", 
-                        "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.zip", 
-                        "hash": "e4d4872733710ddb93bb00fe724a63be4c7fb352d120841c255a89fc42c3e81da8749c201f63ecfc0e86cb473c9854da719e92a3e665f0c380c3e7cf862b1db3"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.zip", 
-                        "hash": "955e20434007592f77fb866aa8543ef13efdc0b1cb91f0c946824f60d8726db5227d1245fbeb7409f93293cf918d50b99f96b0d4512b62a70577e69874f8c777"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.exe", 
-                        "hash": "57703986a5c7eea8ceee265ce206a047e85dec5c698ad570df74b68cbfed36026bf70aa454924ec94be4d37ff492c76716beb23e12ed98816e5cb8e25eeeff0b"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.exe", 
-                        "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-gs-x64.exe", 
-                        "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-nj-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-nj-x64.exe", 
-                        "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"}                
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.5",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/DotNetCore.2.0.5-WindowsHosting.exe", 
-                        "hash": "98a577cfee15a521484972fc7b6f212ccc37141502b417fcb003b29e67af732b6018b01dbe7b3eca22dcad7ec4e6fbb4f01898a15ffcf8342d7f4f5712eaee1c"
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-hosting-2.0.5-linux-x64.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x64.exe", 
-                        "hash": "df4576532b715c9a8b7a6797458982d156a05acd3f676a9261886f892a98ba3fb71db17027c8ef065ae9792beedd4f4bd82f3791fce497ed9cff38f4139d978b"
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x86.exe", 
-                        "hash": "c5df5b0b2f1848c9a797d44cb464061c99c367ecdd6f05cc93aa82b49b2191f7122043bfa34349673d5b2af7018f7062c6be2e0f3fb1e63afad34d2ffa7030fa"
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x64.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x86.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-osx-x64.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-linux-x64.tar.gz", 
-                        "hash": ""}                
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-12-04",
-            "release-version": "2.0.3",       
-            "security": true,
-            "runtime":
-            {
-                "version": "2.0.3",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz", 
-                        "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz", 
-                        "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip", 
-                        "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip", 
-                        "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"}
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.2",
-                "vs-version": "15.5.5",
-                "csharp-language": "7.1",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-linux-x64.tar.gz", 
-                        "hash": "0f1006a5844f860242abb42c8d930f50dc5116ff5a3282b3cdae01ed9ac75dbfc6c74dc3d201358832082d7b6d0aa29b55043afa0493f61892e748c1cfbd0afa"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.tar.gz", 
-                        "hash": "078df91dff760652dddb8090967a59f552959f8b2cf217188793eb8dc21a47c797f22f334f8d958959a0184e0cf4ec2648549478188f8d32e4686cce7c87d699"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.pkg", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x86.zip", 
-                        "hash": "db638b7dff1f384f136da9358a57393b2a5f0365a663beda08130a3fd5694ac8660f8a02823f39490b435d9c96e45a475e848448fffef0b52824f7e54d08cf76"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x64.zip", 
-                        "hash": "1b0988b048cc0d4aa7f6335a35e873d343546d1f11e2c19e323138205cdeefa8e0961390fb9477e750a46ec244ef9886ac83b6127ddcdfd77a75550d4aeeab27"}
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.3",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz", 
-                        "hash": ""}
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-11-14",
-            "release-version": "2.0.3",
-            "security": true,
-            "runtime":
-            {
-                "version": "2.0.3",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz", 
-                        "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz", 
-                        "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip", 
-                        "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip", 
-                        "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"}                
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.0.3",
-                "vs-version": "15.5.4",
-                "csharp-language": "7.1",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-linux-x64.tar.gz", 
-                        "hash": "74a0741d4261d6769f29a5f1ba3e8ff44c79f17bbfed5e240c59c0aa104f92e93f5e76b1a262bdfab3769f3366e33ea47603d9d725617a75cad839274ebc5f2b"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.tar.gz", 
-                        "hash": "f3f78ed62c1c7b996a62e591843bc34be5d76d083d257c8a839049964c35d3054d56437ebf0f4890c96396d8f230a91ae8e9c64f030ccd3b62c8e18032081c1c"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.pkg", 
-                        "hash": "052f42870a42f97a3f25863386d7337ff176258e775787ab0f567231337ebc62eec1f5ce7cf7adaf31b377aec7942be52a024bc9c2572dac69501c046b5a7ceb"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x86.zip", 
-                        "hash": "37deddbfc1a8ea72da4e864343bb4374bd50d744e1621910de30f8d83eaa3860b14f262750810a7ff66f8ab05a587cd71a935a130acf499257d8d4509e0b3cb2"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x64.zip", 
-                        "hash": "8b4bd2174f413f9043374d0cfa7d4061f0aeedc28c16257e66b99f28454bc0a898c6f52d4cf8349413ae222b21e6f594a8f70c1892844a0416e2be2994af13f1"}                
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.3",
-                "files":
-                [
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "dotnet-hosting-linux-x64.tar.gz", 
-                        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-win7-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "aspnetcore-store-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz", 
-                        "hash": ""}                
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-08-14",
-            "release-version": "2.0.0",
-            "security": false,
-            "runtime":
-            {
-                "version": "2.0.0",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-linux-x64.tar.gz", 
-                        "hash": "69ecad24bce4f2132e0db616b49e2c35487d13e3c379dabc3ec860662467b714"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-osx-x64.tar.gz", 
-                        "hash": "b92e6cff9e4f40d4d5126d0896d632951bc9a339dbc7b032098bf5ab76d571a0"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.pkg", 
-                        "hash": "a70cffe0bb2b73a77c59c9de6c7080510a67cff56e519bed77055353e7f90104"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x64.exe", 
-                        "hash": "ea7f9fce864932b25b6c709d3fe9e4432cb6d119658d1dafcafaac59b75066a1"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x86.exe", 
-                        "hash": "e2c57d314bbba4c2ebbfb18a75a41e7948ec913e0bd24a2cae21f361b2f96849"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-win-x86.zip", 
-                        "hash": "f6f595a8f842a73c7176a16ce9c4568af756894cd67a1870c245216e4990587e"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-win-x64.zip", 
-                        "hash": "750cee101278cb3d521447a0a2ed11a779a42ee680baa32cd7a6cb5ceb8d08a6"}
-
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.0.0",
-                "vs-version": "15.3.3",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-linux-x64.tar.gz", 
-                        "hash": "6059a6f72fb7aa6205ef4b52583e9c041fd128e768870a0fc4a33ed84c98ca6b"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-osx-x64.tar.gz", 
-                        "hash": "6e87270e72b5a02ea4e3c4b2266d079366e0e55d6892f9dad5f64dee3f8a341b"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x86.zip", 
-                        "hash": "5eaa475a12843cfff9a97f4b7d3b205eb169fd372ddfc9ddde92225e9e4c1c7c"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip", 
-                        "hash": "541d4dd17023aff14a0aeb6505b200ccabffffc34ab2f629caeb994cedf8afd9"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-osx-x64.pkg", 
-                        "hash": "69300051d696f5ae8e42bd79e5aa13a08116723d79c324fd248df7ead2869291"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x64.exe", 
-                        "hash": "cc490d28f55b67185688ff51dc6274aea6a582e47a07e9d084437e940c69f7a0"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x86.exe", 
-                        "hash": "af488629001e60d50bd0ca268de28b2ab97f6c20213be007dda763b93d51c3d4"}
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.0.0",
-                "files":
-                [
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x64.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x64.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "AspNetCore.RuntimePackageStore_x86.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x86.exe", 
-                        "hash": ""
-                    },
-                    {
-                        "name": "DotNetCore-WindowsHosting.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/DotNetCore.2.0.0-WindowsHosting.exe", 
-                        "hash": ""}
-                ]            
-            }
-
-        },
-        {
-            "release-date": "2017-06-28",
-            "release-version": "2.0.0-preview2",
-            "security": false,
-            "runtime":
-            {
-                "version": "2.0.0-preview2-25407-01",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-linux-x64.tar.gz", 
-                        "hash": "1fe615f179fef606b97d43ce07a491da9067716ff594f929b82d8772d461c027"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.tar.gz", 
-                        "hash": "3b09436c2e03e81da9d08ddd32334d1d50906e9e03cfa94831a8cc6f6fbfeb70"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x86.zip", 
-                        "hash": "e4f7630d7f4ac1a9510ce60bee712b94712b76f5581fa278b75bc7ba8ba3d810"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x64.zip", 
-                        "hash": "807e1361c628f43e395f349b9e921f7340aba9a2f699142791ed5330c0918491"}
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.0.0-preview2-006497",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-linux-x64.tar.gz", 
-                        "hash": "f70b6dfc4e46230001ef863b54992b32bb04c998b098ad58dd47152f348a0997"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-osx-x64.tar.gz", 
-                        "hash": "97dfd57b1e3f3c6ae365654141d3670619699449cca76c3d7ef13a9f0b967ad5"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x86.zip", 
-                        "hash": "2a804fcb5d7502cc6d6fe0b2fc17676c96002d64075b32ea0e3eb6240812b863"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x64.zip", 
-                        "hash": "c9b0205f24d310204dde39e80b996f98b6d546ad4507723cceb2578a208e507f"}
-                ]            
-            }
-        },
-        {
-            "release-date": "2017-05-10",
-            "release-version": "2.0.0-preview1",
-            "security": false,        
-            "runtime":
-            {
-                "version": "2.0.0-preview1-002111-00",
-                "files":
-                [
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-linux-x64.2.0.0-preview1-002111-00.tar.gz", 
-                        "hash": "421ab6b516f68e6302878750d565a48ed7a41d6f04eedca7b03e0a8ac55cc5ba"
-                    }, 
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-osx-x64.2.0.0-preview1-002111-00.tar.gz", 
-                        "hash": "10f37ee22e6c0495a91b0aaac7978305b223258e81bd4c5997046325db90a55a"
-                    }, 
-                    {
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-win-x86.2.0.0-preview1-002111-00.exe", 
-                        "hash": "da1cc72c84e79f1e2aef0c334535f5170339108fc07a3b026d835300370ca55a"
-                    }, 
-                    {
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-win-x64.2.0.0-preview1-002111-00.zip", 
-                        "hash": "df73f34c35a0ed5286e2dc0f5db545502d917221aacf04cdeab266eb013936e1"}                
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.0.0-preview1-005977",
-                "files":
-                [
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-linux-x64.2.0.0-preview1-005977.tar.gz", 
-                        "hash": "1774a15ae12dd1786d14397c691411e936cb0937d59add08cc16c89e80aa65c1"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-osx-x64.2.0.0-preview1-005977.tar.gz", 
-                        "hash": "b3394f082f4aa00a25e2ef5a18b067fdd84faccb40f0863509f29dce496643e9"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x86.2.0.0-preview1-005977.exe", 
-                        "hash": "44e03bb1b703745b07316980bcc7ce86792cd33865fca6e932f96a3da001fdf9"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x64.2.0.0-preview1-005977.exe", 
-                        "hash": "ba2a47e5e63f2e695317dfcee928f5655ce87b2956a4de9e31d9a7a57e0618fd"}                
-                ]            
-            }
-        }
-    ]
+  "channel-version": "2.0",
+  "latest-release": "2.0.9",
+  "latest-release-date": "2018-07-10",
+  "latest-runtime": "2.0.9",
+  "latest-sdk": "2.1.202",
+  "support-phase": "eol",
+  "eol-date": "2018-10-01",
+  "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+  "releases": [
+    {
+      "release-date": "2018-07-10",
+      "release-version": "2.0.9",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.9.md",
+      "runtime": {
+        "version": "2.0.9",
+        "version-display": "2.0.9",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-linux-x64.tar.gz",
+            "hash": "2b49b24ef712fbfc056e0fda95ff18037b4ec938ca8bb41f4c336b6a50870e922f5093684ac92c4bb8e1155b03c36d132d7f90817793f31c9ade5267fff6629a"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.tar.gz",
+            "hash": "b59fdfd1763420ae39c2984cb72b122fd0118dee77d7a4ceaac1683fc6b86345f80a9c6974b34254b523a418da518f448cba8ade54b3443b923f590107ce3dfb"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.pkg",
+            "hash": "fd1f5e4e6ed08f47e87b907d1c28adcfb983b53822614a01fe23a8d1d81862e2b75b7ebfc4e28770f7486080d72e81179ebb05b569be5d7c2410bf52bf1270c2"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x86.zip",
+            "hash": "e73a78ee66f872678594d01720849a3b95a4911ded6700a55b2dbc35fa54a42aeadeeb3de0706a1b96c7b2ed383bc431b8c6e36ce8082bb673132b3d80c7d441"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.zip",
+            "hash": "4e03072925ca65f350112916eac8f442ee86f84de5fd8643d6db9eb96e2175351fdee0fb8ebed6a508b5ce2a3f73bdd4b7a084adc0c765c5249c019f601179f4"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x86.exe",
+            "hash": "159faebadf18cd2e06b3ca1b71f28a65ad6c3a4be78a090fb1f0947951d392d5bbd9bca9055610658c4e16dab66bc1e13200ac869b88725f6e4ba91de2f62822"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.exe",
+            "hash": "9d8ba6ae17a5519a8a4ed043919114d98cf36595c5c3fc82ed699c225b56e07d782680e4a57b1a83f4c9073b75045c89770ee4b0d997a8c19776d1e946bde478"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.202",
+        "version-display": "2.1.202",
+        "runtime-version": "2.0.9",
+        "vs-version": "15.7",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz",
+            "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.tar.gz",
+            "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.pkg",
+            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-gs-x64.pkg",
+            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.zip",
+            "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.zip",
+            "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.exe",
+            "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.exe",
+            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-gs-x64.exe",
+            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.9",
+        "version-display": "2.0.9",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/DotNetCore.2.0.9-WindowsHosting.exe",
+            "hash": "bea34b32752c1a9ab589b43df68fbb90fc63c34564603619a4ac516d8732f37d4867f07602c4ce0c276ebe133a64bbcabe4586cb89459bb2b8929ef848e3b450"
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-hosting-2.0.9-linux-x64.tar.gz",
+            "hash": "9d99d6a44ec5ce01f994d770195d4ff602116c7c79a183e6077fc6837bedafd1353668fb8f3912caaf04413887a42359f4b1b9eec89d992b97cf1a4ea7fa1f43"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/AspNetCore.2.0.9.RuntimePackageStore_x64.exe",
+            "hash": "7f562a2c5171f86ba4278e899d4bce29a4844cfbe13825d524c2b6b28ddb94d9fb2da87dd7da43e7e8c0951d8d6f6f7fa511dea769c8eee035c872982c00b341"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/AspNetCore.2.0.9.RuntimePackageStore_x86.exe",
+            "hash": "fb59a3b70373a22241fa6f753c72c1ac726784e66a7685b5cff42a90be82a8034346875a443cda20d25e95016e071c4b27e2d60809d0527b20c64f86dbe3b585"
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-win7-x64.zip",
+            "hash": "876278b13fa35320a5402016e8bf07f51a316c9ba9a0ddf24aeae68f25f17ad07aa87942e0e802d7ff04a1c685db1e3964f5ed2dcd4bb9764d1bd0fa097c566d"
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-win7-x86.zip",
+            "hash": "0245852f8b813af572f5725bc19a6e083928aee5ff7afb421cabdf79baa5451008da43a633a599a89e213eff5e5a08fd0330180ea26fcbd3b7a502fe3c7a0f28"
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-osx-x64.tar.gz",
+            "hash": "1554182e202b5d5bfb2d2fea367ee6efbc996dc1ace65568f81784a5b920dbb0efaec29f35f208899477252d2cf0704ca9934178890b0d9776d14952c8b69014"
+          },
+          {
+            "name": "aspnetcore-store-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/aspnetcore-store-2.0.9-linux-x64.tar.gz",
+            "hash": "7724637f1c37a0ab6b3535acdb38583e248fb06f59e25630f45107c6affd32b1397db2f6e3a91a7ab07a42c3d7e4ff45cd50bf9c406029ca50f07491007b64e2"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-05-21",
+      "release-version": "2.1.201",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.201-sdk.md",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.201",
+        "version-display": "2.1.201",
+        "runtime-version": "2.0.8",
+        "vs-version": "15.7",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-linux-x64.tar.gz",
+            "hash": "3c456d5f564e7c56a8b33f4116ba79f5ec1c5f6ee87494532efb68f407f25deae1d075c83e6f86624e51b99b090c7d3f1fd6ecd812808aede9017a8877782358"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.tar.gz",
+            "hash": "3d2d49f6b6b22e777e80d3ea396ee28e4e71d133478d5aa3e118ed48d3933071d4abc108ea6fded410b218ed9e15b05e99f52f6741af5d102aa0323a01a795b7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-x64.pkg",
+            "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-osx-gs-x64.pkg",
+            "hash": "071d07df85ba1f497b0cc13787fcbdc77c4c62c0f3e76214242ef2b4dc4f2166cc28041be040c50c83010852f9c8516aed34e3f2bbcf5111a4fa41058f3042ce"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.zip",
+            "hash": "08ec5d4e913f973aaebbe34fc34bfc1671a60dd132b2a2323ca48be3af71482d17e6347d72f164ac509d0d6aaaee5ee5f841ab4244ba6eaf49ac1fb424dffe79"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.zip",
+            "hash": "34c4c7a48ee9b88cf2c523d615816b1c597f0187e716271926e7fbe478b92f6d6c0faab4884cc897309f38168a033039a8315a395e887a4c90dddb1791f7d2a0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe",
+            "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe",
+            "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.exe",
+            "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-gs-x64.exe",
+            "hash": "20ff0401d31efe31829c4915b802de41ba6ea06f474ab8e89d63dd75f27ee0fea7613f02db539e28224941706c56cc82bdcc1ef6e899ee98d4a79d364291967d"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-05-08",
+      "release-version": "2.0.8",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.1.200-sdk.md",
+      "runtime": {
+        "version": "2.0.8",
+        "version-display": "2.0.8",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-linux-x64.tar.gz",
+            "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.tar.gz",
+            "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-osx-x64.pkg",
+            "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.zip",
+            "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.zip",
+            "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x86.exe",
+            "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.exe",
+            "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.200",
+        "version-display": "2.1.200",
+        "runtime-version": "2.0.8",
+        "vs-version": "15.7",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-linux-x64.tar.gz",
+            "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.tar.gz",
+            "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.pkg",
+            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-gs-x64.pkg",
+            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.zip",
+            "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.zip",
+            "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x86.exe",
+            "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.exe",
+            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-gs-x64.exe",
+            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.8",
+        "version-display": "2.0.8",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/DotNetCore.2.0.8-WindowsHosting.exe",
+            "hash": "393346d9668b4cfb4d520bc198fdff43d3137ef35a512b5ca4c8c7607c99e08c0ea173bb478ec5a8b75c7e719425abc224c2dd88ddf46b92bafec4a9e3f0bd6a"
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-hosting-2.0.8-linux-x64.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x64.exe",
+            "hash": "8c9199f6ede36c24c9d5350e5b71401d2154ecb37e641c0fac9c53055235a4e4844a37369255c59926924f3d4f96868affe47fbb9fef8b96fc5f658cf7dc5cca"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/AspNetCore.2.0.8.RuntimePackageStore_x86.exe",
+            "hash": "1c943c82451bdda0bc3526bd3471010ab5a9a508ff07396888986e05b55218fea8c89eb6ba504c300b438a68b100d0198549ff3ad0546280d0be15db50150279"
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x64.zip",
+            "hash": "c739e056f62391c8d2b8d3348c0116a54b13c1d81ba938b8ce84897289f2ac2f81ce4539599e6014389e67feead27fcea2ec09e72cd920dbf5405b9c5ec13624"
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-win7-x86.zip",
+            "hash": "89e63e53f0b903de59ba0174128b7baeba4a1ce6f2c95732916e50b65fc405a601d05cfe0c018db809fdd890cd24ec65ced3ce77989cc4da37433f2236a07e03"
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-osx-x64.tar.gz",
+            "hash": "045034f21790e92f493ce62e6e51be4d48e9138d464b9a39febc5c599e83d8e1d30bbdfdf3509252c17a621bfc894adf39a9c4797e310253acff86b9f770aec5"
+          },
+          {
+            "name": "aspnetcore-store-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/aspnetcore-store-2.0.8-linux-x64.tar.gz",
+            "hash": "12389d923f71b639cd0f3c5267a06cb65e0f7aae026b545956a6d90ab07e65bee05c18713255fa7de4e910d0ec52de3a4afb40a08545f984415a9690d6adce35"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-04-17",
+      "release-version": "2.0.7",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.7.md",
+      "runtime": {
+        "version": "2.0.7",
+        "version-display": "2.0.7",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-linux-x64.tar.gz",
+            "hash": "d8f6035a591b5500a8b81188d834ed4153c4f44f1618e18857c610d0b332d636970fd8a980af7ae3fbff84b9f1da53aa2f45d8d305827ea88992195cd5643027"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.tar.gz",
+            "hash": "0fd31dab707f4c143a382474b93f872c2d1c3dd88fadc882e5fb5958c35c41d9ff150841efcfedf2b4eff0a9af8d76b2ad672df98572f9c10d58b4be2303e8c5"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-osx-x64.pkg",
+            "hash": "2913259f616c30750296311262fa044982a701f07fff9359026514e7f399c3a5261de019cc6ea0e8b167a41d0de5c177e9439faa0c82e0ae5e31d3de5bc656d5"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.zip",
+            "hash": "facbe62fe77499544aa06125278b5a3e2b668d58ffbb5d9028c629ed93f05a664b2f2778100457aa47654219af124dfeaffec896c7ad684b525c7d3860e64551"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.zip",
+            "hash": "9e6bae56c972858721119eb42e294092d2a203c554e72d9c42091af8ec81bb632750e054c044c56ef821a58e45fb462d1184d199d9bb36db119982c4a8fd4588"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x86.exe",
+            "hash": "2875841cad57b7424769974769cde87bba34ad9eb9f174a40c21bc45b94a1c6e5efb6b7d2a80d6bab76cf8b1199220736d744de2ffccb9c4b67f79c3295e506e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.exe",
+            "hash": "596347e65aea327d14de5c30aadc04bddf3443f471a96619a498614c66a2629f707fa6d03a7225d1e924316217200d34154e8c07c92f80f993a2df6b70593e16"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.105",
+        "version-display": null,
+        "runtime-version": "2.0.7",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-linux-x64.tar.gz",
+            "hash": "b5e71dee8720595b0eff7518cca49854ed183e7ca68b98e2ca0580be3f6893f25a1bb267367601f575529a0fd8c94bb379a1411564ed5beaa340a54f37a5e16a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.tar.gz",
+            "hash": "68b060271e5e5d8257a9f87d55c6e9386fa72bec2fa6d9d37d5634837f1a2ccfe4a09934988e4f41aa4efa131708bf5cc1dac2c0609edcd86b966edf2319cae7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-x64.pkg",
+            "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-gs-x64.pkg",
+            "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
+          },
+          {
+            "name": "dotnet-sdk-osx-nj-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-osx-nj-x64.pkg",
+            "hash": "16b994d8b7f73f5146c5deba3880fd29482a3c807e86fc2d74b5c5a09a02dc728c395ebf6b1b8680fdbc357954cc441a1c76158bdd9897cba1e5e5a116b75cad"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.zip",
+            "hash": "0e027eda462877d2aa2bbe9b763e2494a01c1a739190e317cde3dd7a905e7cb5c20036ef90e846ba2c9e251386859e4b0600016a536da1b392ef12eb04236236"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.zip",
+            "hash": "9e902468b1f40434092d0100dd0054344f085d5d64a325d1e27c86fb2f54cccddda615bc119e3cffa357b8d9ffad455ba6ea9739ac592795d3499d0f1fe498d5"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x86.exe",
+            "hash": "a06393e1030e88f39628e070c6743745d142c754f0a604d26f33a35a5635ad6622f2994db719fa566352c1d0dc1f97a58dcf2792e80e6529359ae1e5454ee2a6"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-x64.exe",
+            "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-gs-x64.exe",
+            "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"
+          },
+          {
+            "name": "dotnet-sdk-win-nj-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/2/E/C/2EC018A0-A0FC-40A2-849D-AA692F68349E/dotnet-sdk-2.1.105-win-nj-x64.exe",
+            "hash": "35b64e8fc1ed63778880790fcb59d2e92176e1673753b5b9c9c1e0eb1b87353eb940453abdff51457467f98a0c49a574feff1301536410ba036dc3d63affd439"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.7",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/DotNetCore.2.0.7-WindowsHosting.exe",
+            "hash": "83f7c2607a0ad97800d2302cd6b9462b623cc66960974bdb1c404eff89eedb0d1f876a957a671b885f7ac81584bc9fd97a34231c342fa19affa38fa603c4974e"
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-hosting-2.0.7-linux-x64.tar.gz",
+            "hash": "44cfe2404f5fe87e6381d039ae1a4f6de4935d5564be073f1ebf2624c62a97a35f35862730ab03f38e71ce64e0921444c3058a8aae5564915b18b848fd8e08a3"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x64.exe",
+            "hash": "81d8bb363a7d8b517027229fce7d60800902b84921dbf926582213e3b0f9b856daeba4cfed8f6ab52974f04752722303a09e2370a9cb3dae2c443fad188dbe05"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/AspNetCore.2.0.7.RuntimePackageStore_x86.exe",
+            "hash": "071d19f2d897a0fcd6d61e1ea8c418b305ece143eaf1c0ad03af9de03cf49084d17408f2edb3e950b9ac3bff24638638865e88a6e149bf6f7d37f8d5f9ec22d6"
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x64.zip",
+            "hash": "12f4035ceab8385849c60ae9883ce68b8350de0a20100a9a5f91176a5bb52a2bd7b677fbddc1bc2f3f30a3b1926693c1eec801fe044d3b93f0dde4861d816c48"
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-win7-x86.zip",
+            "hash": "d145bb1ec3ba95166c46b22e29271476d215561ac93f866f155d8016bec0cad2a8f8645f0f7e09365fb49dee966446cbdfb058f49ef3a023a0d4a47492fd09ce"
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-osx-x64.tar.gz",
+            "hash": "6cf6d3fca8401944b28d8da5cd82ed09a1187196289d7a142ee5a48194ed74c7df55881cb54b99235dfe20d8914c2bdb29e7bc1fc5bbb349d5a78650aecea765"
+          },
+          {
+            "name": "aspnetcore-store-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/aspnetcore-store-2.0.7-linux-x64.tar.gz",
+            "hash": "422d6fd1598628d72bf5687582c90b2178bb0c0485d2df224af7b0cedea09b9768408c6940cb60c09fee1cd36e064fa013d79dd417104ae8a42b428a2b0d395a"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-04-04",
+      "release-version": "2.1.104",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.104",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.104",
+        "version-display": null,
+        "runtime-version": "2.0.6",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-linux-x64.tar.gz",
+            "hash": "813334694667f8c1389d88cd3128a7749f4f65b13a0a8e2cb47380823849b8fe7f4816ab66c2d77e589fac9cb5748390b262beae9673aef86cad5a3d8f24986e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.tar.gz",
+            "hash": "625aa1e52f9a03cf0ed0bc2ede40f94749f35ecf142a655f8d353c6d8223f8f7e6e715f46d6bd546dec9d888a8ae75ccf9d79e91b5b92b7ee633a92d6ae82e53"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-x64.pkg",
+            "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-osx-gs-x64.pkg",
+            "hash": "3474f0dab1bd5cdc41a41f59ae2cab5ed213c7e81009ff97c8b014d2b2176d7370134253cec1cd6a4967f1c9d746be6d3a4badf901e80999d1fe006aa2f7e4ed"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.zip",
+            "hash": "0d4fa339d125f780bf293ad566f5127b602c228fa3312bc0c02d455499797114aea1cb27de6b187c18908ae8a4358e7b6c91a596219f572e08ec091cadb4cba8"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.zip",
+            "hash": "f3a46570f220cafbdb2f7d40cddd09a8f718b62f02fbea79fdf8e48ac1871a20d2e79191b037a559b7f2bd88064e1ec70d2c68988312a7ee23d34dc757b9981b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x86.exe",
+            "hash": "4462a33130b09ba6b9d5f8b579b91ff797f4081717ccc4ecde507bfd2c774985e73458716b6b1f3ea714b020d0607d99c9a013629497c26e89b3424e1713ab97"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-x64.exe",
+            "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/8/1/D8131218-F121-4E13-8C5F-39B09A36E406/dotnet-sdk-2.1.104-win-gs-x64.exe",
+            "hash": "90402af6694fe7fd5af65b25afd94538133d3f15fa52cf2c8bc86c7b8d32f8ec347788e0d69b51026d1927f3c734ffc6e0bf87380846a37676a7f6dcd97798f7"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-03-22",
+      "release-version": "2.1.103",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.103",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.103",
+        "version-display": null,
+        "runtime-version": "2.0.6",
+        "vs-version": "15.6.6",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-linux-x64.tar.gz",
+            "hash": "5252ece4fa8eefdd401ef90cc1fcaecaaa6ad71ae5e25351578c7f497488039b0aa334b5c6481c6c839a95dbf9ab4aec89404dc760cfbcd06564ef5869dd9377"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.tar.gz",
+            "hash": "1ad9f16fc72362fa810951bf0f129ea48c4c0f10d465eed73b4706066956c063a41964bcf84fb7f7590c3c90f31261bd33162cb2aa8348bcb5c96d75473a610d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-x64.pkg",
+            "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-osx-gs-x64.pkg",
+            "hash": "463486a94ebcb79e9812fcd058e839db3a97f599641eb9390718f110d837d59b838899334c9e2b548e9c9ebaae1d6d4f1eed2c0fbf55f9b0a53b6d6e4eda4cea"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.zip",
+            "hash": "61ee3cb4e12e435e9b3ead8426c2ae528dcf9c77de0878e51e7e3baa04b3928a83cd60f5822e785302884f5f034723a6c45599cb2eabd8c03e3f525f3cc0f1cc"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.zip",
+            "hash": "8166b0f2fda1533df4397209616754b5255fb1ee5a775d581640b99158adf371538dd373001c2431f6d12abcc9648b325f88653b9891c8eaf9f50c9e2e1b4b1e"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x86.exe",
+            "hash": "ba0f0f9519a6c5a3bcd8325034f466212797e820e7671b019eec199c8ab9ffb2f3543eb5594c76f2374459e5c0e175bc8604b67f7de3c7505959c4e209d6d835"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-x64.exe",
+            "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe",
+            "hash": "909f178a98e1742e965d005187a6121dda71c224d8bfd018b07d8ec66591cc19906825e674e9f012f422d21a2929e67b15ff79d4c1ab3e72602b5b27e9ad4cbd"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-03-19",
+      "release-version": "2.1.102",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.102",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.102",
+        "version-display": null,
+        "runtime-version": "2.0.6",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-linux-x64.tar.gz",
+            "hash": "39bcc14c6453552ea5f400aac7b5838a0361dd15cc2ed9d2794f1185ac2e38c82478e32712e1ad483eeb4edf4b485bb799de26368fccacd98e6c0819f8ff7eef"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.tar.gz",
+            "hash": "a3f3acb6be30047970764dd657353262822addeb669b6179336b83c6bcf4d97faf2c9bfda3ef07fbe56630d7083de04fdb49c5d9b4c03ec9e8090c9f5ab0c4ae"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-osx-x64.pkg",
+            "hash": "982522821d3d6ab7f98810ab70084eb1c10381326bd91237bc9de9821e8434803f76d3231ab8b1762f2598cde48d5ebb1b53a84da3e28424f6c7ce946fa5e859"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.zip",
+            "hash": "642162de05c3d7265da4fb644a9fb6c965788bea93adc2ee381ccab4992dd15dd7ffb02cf8a54485391943627533ea496ec8799d4850b6922f196e3c7cabdeb4"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.zip",
+            "hash": "c1e169cac4200b944d708c46712389f0cadf3eb319f1b6f6f90eb2a8c3e01b18a569acacabb4b7985c9c54165a63e3ca9dc8f1ce7170db650442052d35fbe310"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x86.exe",
+            "hash": "3850b7ed490d64599f7aa592ab1cc59609c77f5f131e04c81cdc47b884db521b4ff421c25730907694b6107573c0fbc38765f6417b0ad5a1bbbd915765d8d617"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-2.1.102-win-x64.exe",
+            "hash": "ee698f7a3d88d22c344f3bf692a671c03abed634250a58c55de7eba33135df6d26315bf75caf8de5dd614900e51b3f602a07a0acbcee9ecc22ba9e323c5d0cdb"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-03-13",
+      "release-version": "2.0.6",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0.6.md",
+      "runtime": {
+        "version": "2.0.6",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-linux-x64.tar.gz",
+            "hash": "b8a00bbac9b0f4f9cf03785afa2aa71e6e5d24c1035ad9865e14c259eb06b3d98a524c1f2bb1567810a556a5c2380252642b7b43d919982c89962707e5361383"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.tar.gz",
+            "hash": "b9ccb006c62cc9ac717d9b5894b3fc1dad5713c9b870a134b3232aa803c8239a05d10826458205b52207b525b75109963aedfe12a2d280e491d5ea0437152276"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-osx-x64.pkg",
+            "hash": "6fc023b8c03c049b57597122ccd4c471924986c8962b903ebf296be394013fb18222deba5ea1dab0663d5c064640e6b11c46b89dc68452a8a34384bf84b74f41"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.zip",
+            "hash": "ba29f7386f4d4adfd81649798cca730e4e8d40c4cf041e084bcfb3ee8823a789d4fada73c6ff1e323d376cf8cc3704a8b0c3d18515445b1246a98c99a1c9c087"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.zip",
+            "hash": "c139ee4f8f65581d908efad230111948abb29431c26d058995386d796c71890423ef0654fbc6791ac6e1a889ba2c0bb755c58ac08232d9d009da3e7d55da60d1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x86.exe",
+            "hash": "a74bab1888f6ae973c35d78c21f382c5945a0f1d6ecce10f2d8e9219b8e400f4db7600f3a6f8d580e0b0ed853a40b9f8d81a77492e30d21188f793841be62aea"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-2.0.6-win-x64.exe",
+            "hash": "d5c185982e31fe6dd5baa01c45fe2e75d36a962b189511a69591639da9501a9ba9ac9a8e6b94160a06acb22953e235c5fb14b4a120e62537272fda872482fc4e"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.101",
+        "version-display": null,
+        "runtime-version": "2.0.6",
+        "vs-version": "15.6.6",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-linux-x64.tar.gz",
+            "hash": "d231ac3562f025b848497eddbcb254cfd547bd622b35dc4b1ed5bcd29153f832610b77cf7edf15d9f05c707d4d06abecbdcd7633fa721246d6d7ba61d78eea81"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.tar.gz",
+            "hash": "d8465acf3a0410ca6a35847e79d8063aaa46cb6d3704ef53f9257e49eaa0242aa2b7ba64eeb625ef984a7109b733988b3b400816bfa0ea09c6db9ba5a7d3de30"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-x64.pkg",
+            "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-gs-x64.pkg",
+            "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
+          },
+          {
+            "name": "dotnet-sdk-osx-nj-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-osx-nj-x64.pkg",
+            "hash": "448978a821903f45f6630419e5cb784c99182495ceae1d5583384df88fb7f197695c3b737004d1a2928b04c310869896417ff3c4f1528065a7387fa34d531809"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.zip",
+            "hash": "7973c10b7cf32d71a1e564967f85e00f293f948d4f3ff58bc0a3ebdb4b936b1e5d2e247166f40e6f82cb4ba3d9fabc3d72ea78e145f76789c6f26ae5550acdf6"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.zip",
+            "hash": "794901f629921c2ef8db9de9ef984725a3b7f7b165289294593f4add34a5abb456d1165b90cf63df287d22ba21d06a136086e4db37a63c74196332608f18b0e8"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x86.exe",
+            "hash": "22527e8d3ce51189707c411bf67a23d3745bd39f994b67d2a5004f3c143439d3583d7df3935b89f5a3d58ac5a51970c2ee61043897258d45c3fff74e95091fe0"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-x64.exe",
+            "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-gs-x64.exe",
+            "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"
+          },
+          {
+            "name": "dotnet-sdk-win-nj-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/C/F/DCFA73BE-93CE-4DA0-AB76-98972FD6E475/dotnet-sdk-2.1.101-win-nj-x64.exe",
+            "hash": "c7fb50ca82acba7e9454d53bf9c47a240611f731ea4a095957dfe58ab0404d4f98585951258fb353b5ff16a808dc89931f30b6b8a0ea6e1c967f2e84ba6ee101"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.6",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/DotNetCore.2.0.6-1-WindowsHosting.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-hosting-2.0.6-linux-x64.tar.gz",
+            "hash": "f70d88731859d63b632851c0a2214a6dc6c041fadfa291c97ecc5a84b4ffcd3fda89d7304fcb79392c5bbb354d98cd03bb83d4c523ce4b404bf429fdac016dc1"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x64.exe",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/AspNetCore.2.0.6.RuntimePackageStore_x86.exe",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x64.zip",
+            "hash": "6dd368be3c46e920aca55a982866a77b6d599daa74b29b87db4a3346d5d05515c3f9f6d7bff501ec0afbd7f7edfd95a8bc47c5166486c5e57fe6642e86259a01"
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-win7-x86.zip",
+            "hash": "4f12f9fe3007691cfc98bf8d7026b4c0fb1785ac5fe95af692c5355275d0ba0d4a3b4b5088c587b1ae815b46b881c63a8164ef61c45d52dddc2613bcccd67e61"
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-osx-x64.tar.gz",
+            "hash": "29a4b4905866d6cffb314122902cd78886deac91a6348256b45f625f8461c006b790daac2318e58393280c164ce80e5a92c083123cca54859a785c23e2b1fc6e"
+          },
+          {
+            "name": "aspnetcore-store-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/aspnetcore-store-2.0.6-linux-x64.tar.gz",
+            "hash": "178f9384a4010daec34a9846fe2dc597e3dffc7170ffb889cc82f6ae6bf9aa2e93254c64af90a3ee3f8f9e024d6615f1f1857eacded6ef1bffd7601ad32eff5f"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-03-13",
+      "release-version": "2.1.100",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/cli/releases/tag/v2.1.100",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.100",
+        "version-display": null,
+        "runtime-version": null,
+        "vs-version": "15.6.1",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-linux-x64.tar.gz",
+            "hash": "71b55610baa809017ccf2c133b3238344e6e238128ea3c6302e3d57ccdf88629e70f48e5cf086ed62c72101d224e94092d8776fcd42528014951dc49f578e72d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.tar.gz",
+            "hash": "f0ea5bd796f58fe2544b00331cc88cf54639560135107409cacbebe8ce8ee1fce2c905379368433c4b275080a72526df087df61837d3150c6feae5e7fff68b87"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-osx-x64.pkg",
+            "hash": "1d60d14e201727681d3206286fef873e613590c51b6cfa6ea4db23c1444b89aebeaff6c7a1619dade2a0cb6ab5b5f8bed28f92b73b6d6051fc3b113251d9081b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.zip",
+            "hash": "7d221f9f194154410ab8be064e2bbc02d84c3067bb511cba78b4a2b57b378a10860fb0a2d0fa75e4ff992d9f76fe132df7afde056ab8e78b2038aba1fd3cfdd6"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.zip",
+            "hash": "dbed1bde38f5ff5b97d75c7bb45a84dfc6270093f8e8bce124f2318e28b9dbd60c21b373e7862007bff28fe7b21a45a3cd754f4fede4ad70cce070dc7a2fd14d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x86.exe",
+            "hash": "1826f5ab39efad23e1c7aef844d6e5d2d0aef5bc2bb0c708b4e3dfe577fe4b8d715cce2d754cb5774c15eea888ad260f83e4f6018092f4ceb327eb68910bb63e"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/2/A/2/2A21B61D-4D08-4E25-AB4A-7B9859300B0C/dotnet-sdk-2.1.100-win-x64.exe",
+            "hash": "7fff3190e67f70792009ff9f15999757f769182ef7256bbb5133382f139ef5cdea86c724dbdcfd7763dd48f9619e39778238502b59d5cc4f05af4e055a1b789e"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-01-09",
+      "release-version": "2.0.5",
+      "security": true,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.5",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-linux-x64.tar.gz",
+            "hash": "21d54e559c5130bb3f8c38eadacb7833ec90943f71c4e9c8fa2d53192313505311230b96f1afeb52d74d181d49ce736b83521754e55f15d96a8756921783cd33"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-osx-x64.tar.gz",
+            "hash": "993dab75a25b961b474f147bf42273b86b561c1823cb53458aa864599003f131880b54c5f31241bcbcee7b89b9a21bdd90d0f43fb440e2b9b5a1266f624e2e45"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-osx-x64.pkg",
+            "hash": "94de569a3124ab1de8b52d82dfa48bf58bfb85cac532a20b1111704d31bb0c8e361f4074d7ca3cca7d0e21a7e90cbcbd2a95361cf62b2cd4cb74424c83f16bee"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.zip",
+            "hash": "671fde7ff5a64738de7863feb8501692f4b62c2496acea9e3c47c381f14e51805f9e7237002ae63bc71189431411de0e051ab1e23200bfbe830a254ec5f7fa8e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.zip",
+            "hash": "5a4381d01d7b7769254aff980bb4a333aec41fdfe92e74bca95147931f1500a1d391ae8da873bc802524a83899e270e24e30faf3759a121505aef110fe9902dd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x86.exe",
+            "hash": "84dc1b30e36dc0aef5cc7294aeb43963570bf4bd6fd824ff9c9ae9fe5c7bb574b9b2a48d299d526097732879317ce92e76f9ac1b034b8c14eaebb27297b4401b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-runtime-2.0.5-win-x64.exe",
+            "hash": "dc6c0f438258e8a5ea825809cc5d7e3f0e69d6aa233894086ffafafe8e539d707aac1abcf4f56ea324fc54f578b52d7796c2b828c26bb838b9b94299bf754c20"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.4",
+        "version-display": null,
+        "runtime-version": "2.0.5",
+        "vs-version": "15.5.5",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-linux-x64.tar.gz",
+            "hash": "05fe90457a8b77ad5a5eb2f22348f53e962012a55077ac4ad144b279f6cad69740e57f165820bfd6104e88b30e93684bde3e858f781541d4f110f28cd52ce2b7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.tar.gz",
+            "hash": "1b08705b8679bf1800d40908408e0d8c1fac7963f6ce508710cf6425cdc1663fd46526e8b6ba8a67d6d327e6bbc143797aa7be4acfdb5205d4d3143de3951849"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-x64.pkg",
+            "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-gs-x64.pkg",
+            "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
+          },
+          {
+            "name": "dotnet-sdk-osx-nj-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-osx-nj-x64.pkg",
+            "hash": "3cabb2efefbc4356393491d878fe04892ab272411545f4f3cbe23c7206e0c39fafb50039c27eee294508fbeb43a4e39cc2d144ea3ad4a95b0e6691ce4f3a7dfc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.zip",
+            "hash": "e4d4872733710ddb93bb00fe724a63be4c7fb352d120841c255a89fc42c3e81da8749c201f63ecfc0e86cb473c9854da719e92a3e665f0c380c3e7cf862b1db3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.zip",
+            "hash": "955e20434007592f77fb866aa8543ef13efdc0b1cb91f0c946824f60d8726db5227d1245fbeb7409f93293cf918d50b99f96b0d4512b62a70577e69874f8c777"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x86.exe",
+            "hash": "57703986a5c7eea8ceee265ce206a047e85dec5c698ad570df74b68cbfed36026bf70aa454924ec94be4d37ff492c76716beb23e12ed98816e5cb8e25eeeff0b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.exe",
+            "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-gs-x64.exe",
+            "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"
+          },
+          {
+            "name": "dotnet-sdk-win-nj-x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-nj-x64.exe",
+            "hash": "10309b343be6dc51b04d09ed97035ddaabe250685e1799fec8a0d3f7f34ea77dddc1d742544320c21bacfa4a2c27678d262540ecf2cd69dad354a8ad207f388d"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.5",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/DotNetCore.2.0.5-WindowsHosting.exe",
+            "hash": "98a577cfee15a521484972fc7b6f212ccc37141502b417fcb003b29e67af732b6018b01dbe7b3eca22dcad7ec4e6fbb4f01898a15ffcf8342d7f4f5712eaee1c"
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/dotnet-hosting-2.0.5-linux-x64.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x64.exe",
+            "hash": "df4576532b715c9a8b7a6797458982d156a05acd3f676a9261886f892a98ba3fb71db17027c8ef065ae9792beedd4f4bd82f3791fce497ed9cff38f4139d978b"
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/AspNetCore.2.0.5.RuntimePackageStore_x86.exe",
+            "hash": "c5df5b0b2f1848c9a797d44cb464061c99c367ecdd6f05cc93aa82b49b2191f7122043bfa34349673d5b2af7018f7062c6be2e0f3fb1e63afad34d2ffa7030fa"
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x64.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-win7-x86.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-osx-x64.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/1/0/11046135-4207-40D3-A795-13ECEA741B32/aspnetcore-store-2.0.5-linux-x64.tar.gz",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-12-04",
+      "release-version": "2.0.3",
+      "security": true,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.3",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz",
+            "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz",
+            "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip",
+            "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip",
+            "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.2",
+        "version-display": null,
+        "runtime-version": "2.0.3",
+        "vs-version": "15.5.5",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-linux-x64.tar.gz",
+            "hash": "0f1006a5844f860242abb42c8d930f50dc5116ff5a3282b3cdae01ed9ac75dbfc6c74dc3d201358832082d7b6d0aa29b55043afa0493f61892e748c1cfbd0afa"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.tar.gz",
+            "hash": "078df91dff760652dddb8090967a59f552959f8b2cf217188793eb8dc21a47c797f22f334f8d958959a0184e0cf4ec2648549478188f8d32e4686cce7c87d699"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.pkg",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x86.zip",
+            "hash": "db638b7dff1f384f136da9358a57393b2a5f0365a663beda08130a3fd5694ac8660f8a02823f39490b435d9c96e45a475e848448fffef0b52824f7e54d08cf76"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-win-x64.zip",
+            "hash": "1b0988b048cc0d4aa7f6335a35e873d343546d1f11e2c19e323138205cdeefa8e0961390fb9477e750a46ec244ef9886ac83b6127ddcdfd77a75550d4aeeab27"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.3",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-11-14",
+      "release-version": "2.0.3",
+      "security": true,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.3",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-linux-x64.tar.gz",
+            "hash": "4fb483cae0c6147fbf13c278fe7fc23923b99cd84cf6e5f96f5c8e1971a733ab968b46b00d152f4c14521561387dd28e6e64d07cb7365d43a17430905da6c1c0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-osx-x64.tar.gz",
+            "hash": "20caae28a04dac96ac12de7e34c996ecc42d0b000c04900f1e7fc1c88a3369e2536165b6b16267a95428828d998bd0cf43f86065cc44fce6253491845fac55e5"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x86.zip",
+            "hash": "efa901c610507249ed9b715e3f261f655550e68c0684eb04d09a4f55d3c6fa45f7f28d0810830411dc87611c99ae8a90daefcf488fd704d63404fcddb8f5c4ba"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/dotnet-runtime-2.0.3-win-x64.zip",
+            "hash": "ac4eea527ee8e29286fe46a98be14bf7db3dab6c721eb0c319f80ad3bed57ddadaa719a4325ffd6343d12464d370be90971b1cb81db37d82e90ec7d40b5c3009"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.0.3",
+        "version-display": null,
+        "runtime-version": "2.0.3",
+        "vs-version": "15.5.4",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-linux-x64.tar.gz",
+            "hash": "74a0741d4261d6769f29a5f1ba3e8ff44c79f17bbfed5e240c59c0aa104f92e93f5e76b1a262bdfab3769f3366e33ea47603d9d725617a75cad839274ebc5f2b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.tar.gz",
+            "hash": "f3f78ed62c1c7b996a62e591843bc34be5d76d083d257c8a839049964c35d3054d56437ebf0f4890c96396d8f230a91ae8e9c64f030ccd3b62c8e18032081c1c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-osx-x64.pkg",
+            "hash": "052f42870a42f97a3f25863386d7337ff176258e775787ab0f567231337ebc62eec1f5ce7cf7adaf31b377aec7942be52a024bc9c2572dac69501c046b5a7ceb"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x86.zip",
+            "hash": "37deddbfc1a8ea72da4e864343bb4374bd50d744e1621910de30f8d83eaa3860b14f262750810a7ff66f8ab05a587cd71a935a130acf499257d8d4509e0b3cb2"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-2.0.3-win-x64.zip",
+            "hash": "8b4bd2174f413f9043374d0cfa7d4061f0aeedc28c16257e66b99f28454bc0a898c6f52d4cf8349413ae222b21e6f594a8f70c1892844a0416e2be2994af13f1"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.3",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/DotNetCore.2.0.3-WindowsHosting.exe",
+            "hash": ""
+          },
+          {
+            "name": "dotnet-hosting-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.3-125/dotnet-hosting-2.0.3-linux-x64.tar.gz",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x64.exe",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/AspNetCore.2.0.3.RuntimePackageStore_x86.exe",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x64.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x64.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-win7-x86.zip",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-win7-x86.zip",
+            "hash": ""
+          },
+          {
+            "name": "aspnetcore-store-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/C/1/5C190037-632B-443D-842D-39085F02E1E8/aspnetcore-store-2.0.3-osx-x64.tar.gz",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-08-14",
+      "release-version": "2.0.0",
+      "security": false,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.0",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-linux-x64.tar.gz",
+            "hash": "69ecad24bce4f2132e0db616b49e2c35487d13e3c379dabc3ec860662467b714"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-osx-x64.tar.gz",
+            "hash": "b92e6cff9e4f40d4d5126d0896d632951bc9a339dbc7b032098bf5ab76d571a0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-osx-x64.pkg",
+            "hash": "a70cffe0bb2b73a77c59c9de6c7080510a67cff56e519bed77055353e7f90104"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x64.exe",
+            "hash": "ea7f9fce864932b25b6c709d3fe9e4432cb6d119658d1dafcafaac59b75066a1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x86.exe",
+            "hash": "e2c57d314bbba4c2ebbfb18a75a41e7948ec913e0bd24a2cae21f361b2f96849"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-win-x86.zip",
+            "hash": "f6f595a8f842a73c7176a16ce9c4568af756894cd67a1870c245216e4990587e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/5/F/0/5F0362BD-7D0A-4A9D-9BF9-022C6B15B04D/dotnet-runtime-2.0.0-win-x64.zip",
+            "hash": "750cee101278cb3d521447a0a2ed11a779a42ee680baa32cd7a6cb5ceb8d08a6"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.0.0",
+        "version-display": null,
+        "runtime-version": "2.0.0",
+        "vs-version": "15.3.3",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-linux-x64.tar.gz",
+            "hash": "6059a6f72fb7aa6205ef4b52583e9c041fd128e768870a0fc4a33ed84c98ca6b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-osx-x64.tar.gz",
+            "hash": "6e87270e72b5a02ea4e3c4b2266d079366e0e55d6892f9dad5f64dee3f8a341b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x86.zip",
+            "hash": "5eaa475a12843cfff9a97f4b7d3b205eb169fd372ddfc9ddde92225e9e4c1c7c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip",
+            "hash": "541d4dd17023aff14a0aeb6505b200ccabffffc34ab2f629caeb994cedf8afd9"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-osx-x64.pkg",
+            "hash": "69300051d696f5ae8e42bd79e5aa13a08116723d79c324fd248df7ead2869291"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x64.exe",
+            "hash": "cc490d28f55b67185688ff51dc6274aea6a582e47a07e9d084437e940c69f7a0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x86.exe",
+            "hash": "af488629001e60d50bd0ca268de28b2ab97f6c20213be007dda763b93d51c3d4"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.0.0",
+        "version-display": null,
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "AspNetCore.RuntimePackageStore_x64.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x64.exe",
+            "hash": ""
+          },
+          {
+            "name": "AspNetCore.RuntimePackageStore_x86.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/AspNetCore.2.0.0.RuntimePackageStore_x86.exe",
+            "hash": ""
+          },
+          {
+            "name": "DotNetCore-WindowsHosting.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/B/1/D/B1D7D5BF-3920-47AA-94BD-7A6E48822F18/DotNetCore.2.0.0-WindowsHosting.exe",
+            "hash": ""
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2017-06-28",
+      "release-version": "2.0.0-preview2",
+      "security": false,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.0-preview2-25407-01",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-linux-x64.tar.gz",
+            "hash": "1fe615f179fef606b97d43ce07a491da9067716ff594f929b82d8772d461c027"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.tar.gz",
+            "hash": "3b09436c2e03e81da9d08ddd32334d1d50906e9e03cfa94831a8cc6f6fbfeb70"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x86.zip",
+            "hash": "e4f7630d7f4ac1a9510ce60bee712b94712b76f5581fa278b75bc7ba8ba3d810"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/5/8/85896F6E-C7F5-4ECA-ADF7-CCE8EFAD9AA6/dotnet-runtime-2.0.0-preview2-25407-01-win-x64.zip",
+            "hash": "807e1361c628f43e395f349b9e921f7340aba9a2f699142791ed5330c0918491"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.0.0-preview2-006497",
+        "version-display": null,
+        "runtime-version": "2.0.0-preview2-25407-01",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-linux-x64.tar.gz",
+            "hash": "f70b6dfc4e46230001ef863b54992b32bb04c998b098ad58dd47152f348a0997"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-osx-x64.tar.gz",
+            "hash": "97dfd57b1e3f3c6ae365654141d3670619699449cca76c3d7ef13a9f0b967ad5"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x86.zip",
+            "hash": "2a804fcb5d7502cc6d6fe0b2fc17676c96002d64075b32ea0e3eb6240812b863"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/F/A/A/FAAE9280-F410-458E-8819-279C5A68EDCF/dotnet-sdk-2.0.0-preview2-006497-win-x64.zip",
+            "hash": "c9b0205f24d310204dde39e80b996f98b6d546ad4507723cceb2578a208e507f"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2017-05-10",
+      "release-version": "2.0.0-preview1",
+      "security": false,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.0.0-preview1-002111-00",
+        "version-display": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-linux-x64.2.0.0-preview1-002111-00.tar.gz",
+            "hash": "421ab6b516f68e6302878750d565a48ed7a41d6f04eedca7b03e0a8ac55cc5ba"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-osx-x64.2.0.0-preview1-002111-00.tar.gz",
+            "hash": "10f37ee22e6c0495a91b0aaac7978305b223258e81bd4c5997046325db90a55a"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/4/8/048C286D-59CB-4B7C-95A1-D0F7FD4D37D2/dotnet-win-x86.2.0.0-preview1-002111-00.exe",
+            "hash": "da1cc72c84e79f1e2aef0c334535f5170339108fc07a3b026d835300370ca55a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/9/0/09060200-E749-4025-A51A-83391C611C86/dotnet-win-x64.2.0.0-preview1-002111-00.zip",
+            "hash": "df73f34c35a0ed5286e2dc0f5db545502d917221aacf04cdeab266eb013936e1"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.0.0-preview1-005977",
+        "version-display": null,
+        "runtime-version": "2.0.0-preview1-002111-00",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-linux-x64.2.0.0-preview1-005977.tar.gz",
+            "hash": "1774a15ae12dd1786d14397c691411e936cb0937d59add08cc16c89e80aa65c1"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-osx-x64.2.0.0-preview1-005977.tar.gz",
+            "hash": "b3394f082f4aa00a25e2ef5a18b067fdd84faccb40f0863509f29dce496643e9"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x86.2.0.0-preview1-005977.exe",
+            "hash": "44e03bb1b703745b07316980bcc7ce86792cd33865fca6e932f96a3da001fdf9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x64.2.0.0-preview1-005977.exe",
+            "hash": "ba2a47e5e63f2e695317dfcee928f5655ce87b2956a4de9e31d9a7a57e0618fd"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    }
+  ]
 }

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -1,2042 +1,2347 @@
 {
-    "channel-version": "2.1",
-    "latest-release": "2.1.502",
-    "latest-release-date":"2018-12-11",
-    "latest-runtime": "2.1.6",
-    "latest-sdk": "2.1.502",
-    "support-phase": "lts",
-    "eol-date": "",
-    "lifecycle-policy": "https://www.microsoft.com/net/support/policy",    
-    "releases": 
-    [
-        {
-            "release-date": "2018-12-11",
-            "release-version": "2.1.502",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.6/2.1.502.md",
-            "sdk": {
-              "version": "2.1.502",
-              "version-display": "2.1.502",
-              "runtime-version": "2.1.6",
-              "vs-version": "15.9",
-              "csharp-version": "7.3",
-              "fsharp-version": "4.5",
-              "vb-version": "15.0",
-              "files": [
-                {
-                  "name": "dotnet-sdk-linux-arm.tar.gz",
-                  "rid": "linux-arm",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/3690b37f-002a-4e8b-9563-cf30fbba8c57/36498efa5d47af3b9e9addb50d839db6/dotnet-sdk-2.1.502-linux-arm.tar.gz",
-                  "hash": "F5A9BF61C81E0BC5A33367F63320C792680E80DEDE884C604531715BFB741F4B0F53779BA57ED8E0A2AD3546358A42F531FB28952725E17F8CB5CA3A4B66AC60"
-                },
-                {
-                  "name": "dotnet-sdk-linux-arm64.tar.gz",
-                  "rid": "linux-arm64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/aa69f29a-6cde-4ca4-8c34-d60df776a648/63065948aa517fb0af456eca88eae5a5/dotnet-sdk-2.1.502-linux-arm64.tar.gz",
-                  "hash": "F3D8907623B1BD7D15E2D9B9F51B8BDA6DF00969F720E7D224E9B3B5DFFE9FA1B2A9269CFE3AD6AA8FAC81129DDD94D88F8674839B9D41A41BAC4E3630306D63"
-                },
-                {
-                  "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-                  "rid": "linux-musl-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/91c9af05-2149-4ba5-88f7-a8b77298197e/be1802e1a05a7b34dd1a5cdfbb6443f9/dotnet-sdk-2.1.502-linux-musl-x64.tar.gz",
-                  "hash": "5C06A416ECFD04AC58AB104BB2D173246D41AA2AC1F6DCF1B141C0D825638E9BDE9B378AAA73F08BEEA6EFA68C8B8E206B5B33F43AC40B119C7E6AF7CFBA9AB8"
-                },
-                {
-                  "name": "dotnet-sdk-linux-x64.tar.gz",
-                  "rid": "linux-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/4c8893df-3b05-48a5-b760-20f2db692c45/ff0545dbbb3c52f6fa38657ad97d65d8/dotnet-sdk-2.1.502-linux-x64.tar.gz",
-                  "hash": "366609243FCAE4693218154A3F374822B5CEB77B7E1A3561DD0CC89755131FCAEC04777E99AC041554D452B4862D2856926A1C213029FC80C7292959CAF3AAF6"
-                },
-                {
-                  "name": "dotnet-sdk-osx-gs-x64.pkg",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/06addaf0-590c-4418-9cf4-83f63376ed16/d6e57f0ef630fb767a8ac8cde58e4a6e/dotnet-sdk-2.1.502-osx-gs-x64.pkg",
-                  "hash": "4A006A5D02C0BE76DDFC4FC89E93C620AE396B407BDA0C2BB034711AA6E473CB60AE2CA943EDE656F3DC3D7262D2AFA222FF94F9A28F5DE69FB14C24A469881F"
-                },
-                {
-                  "name": "dotnet-sdk-osx-x64.pkg",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/7e834c38-a210-44e0-be84-0380298901e7/cc0a2df529f71622ef3dc6781cab0d6b/dotnet-sdk-2.1.502-osx-x64.pkg",
-                  "hash": "4A006A5D02C0BE76DDFC4FC89E93C620AE396B407BDA0C2BB034711AA6E473CB60AE2CA943EDE656F3DC3D7262D2AFA222FF94F9A28F5DE69FB14C24A469881F"
-                },
-                {
-                  "name": "dotnet-sdk-osx-x64.tar.gz",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/50729ca4-03ce-4e19-af87-bfae014b0431/1c830d9dcffa7663702e32fab6953425/dotnet-sdk-2.1.502-osx-x64.tar.gz",
-                  "hash": "79302509DDFDBCD6B1C870FE79884EAE919072AE94C20F89ABB2E056770A77F76544E1160E633F6EB81FC346564D85993329A5A4EDE3C12D28A11D2D031A1130"
-                },
-                {
-                  "name": "dotnet-sdk-rhel.6-x64.tar.gz",
-                  "rid": "rhel.6-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/c1120295-348f-4135-9f0c-ac157a72bd4a/733da9695dc48fa554db4e173b8ab168/dotnet-sdk-2.1.502-rhel.6-x64.tar.gz",
-                  "hash": "C5A9D86306EB7A19A58D60D60E14A77058D57F9EA6A1D2DB52B9107834E62B04B721ED34E16194F5F7C99CD81724241280C87B7855D68ABD7AA9997B6C153089"
-                },
-                {
-                  "name": "dotnet-sdk-win-gs-x64.exe",
-                  "rid": "",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/f86f7cf7-9c38-4b97-aeea-713ead74902d/d381b15374c3dc9e1759e2f7c19231c3/dotnet-sdk-2.1.502-win-gs-x64.exe",
-                  "hash": "20E5D2E54CCAD8CE2C5EED0EFFCBA5D610C8BF1D15F8D2EE2E792547B35697EA408A415D2F580E0E2F693339E5E10F0A46B82B88171016378AFBBA4BF4A55227"
-                },
-                {
-                  "name": "dotnet-sdk-win-gs-x86.exe",
-                  "rid": "",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/bef7de68-66c5-4102-9c7a-2087ae2d9e06/a1f1c1afd190d8aae7a2fc0803b470ee/dotnet-sdk-2.1.502-win-gs-x86.exe",
-                  "hash": "F4969D01F05ECA28B545B335E221DA6DA07A3B087A4B91BE0153494ECD483DB943178BBFB8EA1C8D032C07F0C1F50F801CCEF1542F3B09016E760E0D1CE8B277"
-                },
-                {
-                  "name": "dotnet-sdk-win-x64.exe",
-                  "rid": "win-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/70b3a142-06fa-4d86-b1cc-67a48c1eaacb/55e147bd47db930a642a8f8176949a76/dotnet-sdk-2.1.502-win-x64.exe",
-                  "hash": "20E5D2E54CCAD8CE2C5EED0EFFCBA5D610C8BF1D15F8D2EE2E792547B35697EA408A415D2F580E0E2F693339E5E10F0A46B82B88171016378AFBBA4BF4A55227"
-                },
-                {
-                  "name": "dotnet-sdk-win-x64.zip",
-                  "rid": "win-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/c88b53e5-121c-4bc9-af5d-47a9d154ea64/e62eff84357c48dc8052a9c6ce5dfb8a/dotnet-sdk-2.1.502-win-x64.zip",
-                  "hash": "E6408DCE29660B36EBF5318F9B9108FCD2672FD0B14B999847C6173E0FDA7F553DB40718DBE1FE2900147E2090930DDD35E3B6CEF3EF47B3749ADC62CD274A9D"
-                },
-                {
-                  "name": "dotnet-sdk-win-x86.exe",
-                  "rid": "win-x86",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/caa1967f-4459-40a0-9703-cd7c4330be6a/722e7928c1bbebf2b174f5293c97328f/dotnet-sdk-2.1.502-win-x86.exe",
-                  "hash": "F4969D01F05ECA28B545B335E221DA6DA07A3B087A4B91BE0153494ECD483DB943178BBFB8EA1C8D032C07F0C1F50F801CCEF1542F3B09016E760E0D1CE8B277"
-                },
-                {
-                  "name": "dotnet-sdk-win-x86.zip",
-                  "rid": "win-x86",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/e2d8f451-0133-418e-a1c6-caeda12360ef/d1ea1b0296c02a2dd4b23d33f89db12c/dotnet-sdk-2.1.502-win-x86.zip",
-                  "hash": "CDE212A2292093103F79ED104283E2EC0159CA38C9A9EE9048A61A6CE3951C421D4D8BD62C16A5B7B637DDCD8F5B40BB87AE6195CAE9589BA8A768AC17F4A6C3"
-                }
-              ]
-            },
-            "symbols": {
-              "version": "2.1.6",
-              "files": [
-                {
-                  "name": "sdk-symbols-symbols.zip",
-                  "rid": null,
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/319e69e5-3a4a-47a9-a454-b4e17380e5da/6af8d9c315d8f24e95e6d4c9a28cfd3d/sdk-symbols-2.1.502-symbols.zip",
-                  "hash": "3AEE6A4B827400C0B4264591BEAFAECA0936D0E7229D50CD436C78B63CC408555AACC59A0060063730D59E6514309B12769C1DDFFE0FDC36768B5BDABB16858C"
-                }
-              ]
-            }
-        },
-        {
-            "release-date": "2018-12-06",
-            "release-version": "2.1.600-preview",
-            "security": false,
-            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.600-preview.md",
-            "sdk": {
-              "version": "2.1.600-preview-009426",
-              "version-display": "2.1.600-preview-009426",
-              "runtime-version": "2.1.6",
-              "vs-version": "16.0-preview-1",
-              "csharp-version": "7.3",
-              "fsharp-version": "4.5",
-              "vb-version": "15.0",
-              "files": [
-                {
-                  "name": "dotnet-sdk-linux-arm.tar.gz",
-                  "rid": "linux-arm",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/1fade46c-c475-4187-927b-7d7157369c3b/2fb766d7c38c239012f731023556db56/dotnet-sdk-2.1.600-preview-009426-linux-arm.tar.gz",
-                  "hash": "865FCF406BAE3E39A7EB2277FAF3C96F1AF7800F1AF3096F768558F52F901CCD23203641807942951B84BF324F2F7F05D9074D0D7702B61EE1BC1BF590499BD7"
-                },
-                {
-                  "name": "dotnet-sdk-linux-arm64.tar.gz",
-                  "rid": "linux-arm64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/ecafb359-728b-4427-bf63-934c716bc7e0/834ce1100ba2c0b2e49774df486dcdb3/dotnet-sdk-2.1.600-preview-009426-linux-arm64.tar.gz",
-                  "hash": "9641CE375F63B42F49E472456146B0155FE3A714375DEE36939EA94A12E51E7C6A27A26469ED90581AE6C46E2AEB6C5526C11D23647FB9F3908127BBAD11B958"
-                },
-                {
-                  "name": "dotnet-sdk-linux-x64.tar.gz",
-                  "rid": "linux-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/6816ef17-18ae-49c3-9ad4-46fbe6267f1d/da7b8326a6d798864a9afd0a7c880b70/dotnet-sdk-2.1.600-preview-009426-linux-x64.tar.gz",
-                  "hash": "2DDDDC2652032DE14DEBDBF55D6940AA227F8FD37199D098F0AE23645732A77B850A02444084D4FBCF4BDFDCEF89A2964E47FF210179D89816970F9B7BC391CD"
-                },
-                {
-                    "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-                    "rid": "linux-musl-x64",
-                    "url": "https://download.visualstudio.microsoft.com/download/pr/8a16c4c8-b187-4a05-93de-fa1e4c11ea0a/d2d4c18b99c2d1ec0fcbd2f8de4ff08d/dotnet-sdk-2.1.600-preview-009426-linux-musl-x64.tar.gz",
-                    "hash": "F43E826845065FC877659614FCDE3C0F9E588C636E5284EBE72FA48A8F52EAAE56FCD99AD18A2C77145CEB761F88A6EEF9AF1C48C3AC3ECDB539BF189938279D"
-                },
-                {
-                  "name": "dotnet-sdk-osx-gs-x64.pkg",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/1690aa3e-6039-493c-a57e-9d24f2616e96/d56658e8c3886d6d69d58e6c83ab5c22/dotnet-sdk-2.1.600-preview-009426-osx-gs-x64.pkg",
-                  "hash": "FF77BF94390B4CE0A0B3237F3B5A854FD2527C694F519E5D74DEA9217A888644A3F202E63A9F5E4AAF497A2617EC59B1B840655B5592EC7617BC3DF9439D7176"
-                },
-                {
-                  "name": "dotnet-sdk-osx-x64.pkg",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/a7fb7ea6-9007-4f82-9dd2-775bb447cf53/dbf5150a44ed20a661733817210baf1a/dotnet-sdk-2.1.600-preview-009426-osx-x64.pkg",
-                  "hash": "FF77BF94390B4CE0A0B3237F3B5A854FD2527C694F519E5D74DEA9217A888644A3F202E63A9F5E4AAF497A2617EC59B1B840655B5592EC7617BC3DF9439D7176"
-                },
-                {
-                  "name": "dotnet-sdk-osx-x64.tar.gz",
-                  "rid": "osx-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/2f213fe3-7064-40ba-a0c3-743c73f45f65/4912a6736c4213f1af8441228d0e01e7/dotnet-sdk-2.1.600-preview-009426-osx-x64.tar.gz",
-                  "hash": "3ADE09CAEA4FB32CC4CD380A3043F59602B6D9D3721144ED1A975082767FE5C354FE480CDF2CDB8CFF968101F3876F37B55651B09DAC36BDB47741A83664D5B3"
-                },
-                {
-                  "name": "dotnet-sdk-rhel.6-x64.tar.gz",
-                  "rid": "rhel.6-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/58cc9506-7391-4963-b34e-627c49af5d28/067849b44703738968ff5935ce45cc70/dotnet-sdk-2.1.600-preview-009426-rhel.6-x64.tar.gz",
-                  "hash": "24C526293BA5A8A1F0B200AF8E6412BF49E96C3C6008E9C472C3AA6A581D6B785CE78551B9CC2C8343B3BAC358CD2680905330ABCD92A5715D476F8CDC4ABD02"
-                },
-                {
-                  "name": "dotnet-sdk-win-gs-x64.exe",
-                  "rid": "",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/31a8cd43-a31d-4d33-b6f4-0f430543c9b5/e88b8ff32ae2f40c88c7828cb8ab589e/dotnet-sdk-2.1.600-preview-009426-win-gs-x64.exe",
-                  "hash": "FDADAF2CB923431993C02ED3F6A8C6336357F444B4123FA8C92B9C706C84A977E32EFEB0FCBF333854A07A3FAC2C088CDB569EC763D6DBDBCEE44E41E6C662F3"
-                },
-                {
-                  "name": "dotnet-sdk-win-gs-x86.exe",
-                  "rid": "",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/e8fa06be-54bd-4a15-bda6-6876b688abcd/be8609cfb001a1c94bfffd7af310ba14/dotnet-sdk-2.1.600-preview-009426-win-gs-x86.exe",
-                  "hash": "B77812812B33F53606A947184438D6D0A41D4EBFF38E2E9E68DB3FD0460EFD3A066B6A0F37E9E0F8BE31FE39C8AB5DC3A2CB6255A0DFEA648679B93FDA2DDA1C"
-                },
-                {
-                  "name": "dotnet-sdk-win-x64.exe",
-                  "rid": "win-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/154685e2-3cbd-4505-b559-a57da259faaf/5e1d31266aa5bc670c2201acd357a220/dotnet-sdk-2.1.600-preview-009426-win-x64.exe",
-                  "hash": "FDADAF2CB923431993C02ED3F6A8C6336357F444B4123FA8C92B9C706C84A977E32EFEB0FCBF333854A07A3FAC2C088CDB569EC763D6DBDBCEE44E41E6C662F3"
-                },
-                {
-                  "name": "dotnet-sdk-win-x64.zip",
-                  "rid": "win-x64",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/5e82e02c-e7f8-4b4b-8e51-b874162e6c9d/dfb0d37d216779d788fa7990bb441342/dotnet-sdk-2.1.600-preview-009426-win-x64.zip",
-                  "hash": "46B0609F69ADFB6FB1B714C402C312E9E10D372BC50F3B7DC4670C25509DB2FF1EB47235006AA21D9B2BC49B92B9959E45BA1C70F5071A7C1EF9717C1FA5C922"
-                },
-                {
-                  "name": "dotnet-sdk-win-x86.exe",
-                  "rid": "win-x86",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/b7a5055e-b595-4e18-895e-0a6ad1718c60/3f180c6bbfb5b2e451fe1871d9f58fe8/dotnet-sdk-2.1.600-preview-009426-win-x86.exe",
-                  "hash": "B77812812B33F53606A947184438D6D0A41D4EBFF38E2E9E68DB3FD0460EFD3A066B6A0F37E9E0F8BE31FE39C8AB5DC3A2CB6255A0DFEA648679B93FDA2DDA1C"
-                },
-                {
-                  "name": "dotnet-sdk-win-x86.zip",
-                  "rid": "win-x86",
-                  "url": "https://download.visualstudio.microsoft.com/download/pr/f8ee2e6e-d56d-464d-a4ef-55e7243ed58a/9a6637ccd2fe5bb14ab65b711798cb22/dotnet-sdk-2.1.600-preview-009426-win-x86.zip",
-                  "hash": "B736C393A6A2AB062FB5C41E8FA633628051A4D221E7AEA64E5F0008C12B040E911BFD112DBF085D0A2817F1137D20FC1FABEB6F0A91FCEABBA1A5E6D9DF0172"
-                }
-              ]
-            }
-        },
-        {
-            "release-date":  "2018-11-13",
-            "release-version":  "2.1.6",
-            "security":  false,
-            "release-notes":  "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.6/2.1.6.md",
-            "runtime":  
-            {
-                "version":  "2.1.6",
-                "version-display":  "2.1.6",
-                "vs-version":  "15.9",
-                "files":  
-                [
-                    {
-                        "name":  "dotnet-runtime-linux-arm.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/7d461733-a0cd-48ee-9963-791337dcaafa/3b75ee4c7fb9d6bc7d0ddd9761676096/dotnet-runtime-2.1.6-linux-arm.tar.gz",
-                        "hash":  "4F44CD5F6B61D0A4B7E73B138FDF5EDCAA9E148BF0473514551F4D03D97C29F297662C726D145ECDF80CB58A086F925F97B7896C796CB3D82FE927F5CAF7BBCC"
-                    },
-                    {
-                        "name":  "dotnet-runtime-linux-arm64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/9cb31ef2-d5ec-490d-8a3f-f45f52d28fec/4c906b6132f2c0fe55e9e0209f08b352/dotnet-runtime-2.1.6-linux-arm64.tar.gz",
-                        "hash":  "C3CAF2E270C2EFF9B84A16335C0A81681D43A95BCB08C444F4AD04B4AC78FE19D49BFE4BB57E4DED9B965F300534130CB91377E9A7B6252E312924D6378DB807"
-                    },
-                    {
-                        "name":  "dotnet-runtime-linux-musl-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/b934284c-96e3-49ab-9c86-6332092bafa7/480c4ba3ddd68c4a303c8de3616ac4ee/dotnet-runtime-2.1.6-linux-musl-x64.tar.gz",
-                        "hash":  "8A0900B7DC010AA2293C5926D13A05F0A2DE1F13EAC6A1EAA3C9997A8EC6363D83C852763B118B3DDB6586F95F34263CF27E769B4637BB4BD196BF73AA62269E"
-                    },
-                    {
-                        "name":  "dotnet-runtime-linux-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/5c1334bc-bd26-4232-a745-2728b36a2628/8e163216cdcec15332ebf2e5575962de/dotnet-runtime-2.1.6-linux-x64.tar.gz",
-                        "hash":  "74D99AEFCBE953B30743330689E750156E68C3410BC26C40A11B60BBBF1D01887262BD6D7C0EEACCA4D6B696C1A04980D9BE2DC2A222226FA910B885D2FB5956"
-                    },
-                    {
-                        "name":  "dotnet-runtime-osx-x64.pkg",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/26452190-8866-4e1c-8bd2-e4699d775555/befaa5544a34e875621b239281d662a5/dotnet-runtime-2.1.6-osx-x64.pkg",
-                        "hash":  "605B81BBE71423FCD3C2A3F1548CCCA04DDCDE08566B0301AC43130C239406EF621D174064272F04C5584900CE1F3F2B4D93E1D3B8277F07150404EB3A492992"
-                    },
-                    {
-                        "name":  "dotnet-runtime-osx-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/0f36c0b9-397b-4303-9a83-2f09e08affb0/dc43655b905e0c3d5d5fd89cafc1fb81/dotnet-runtime-2.1.6-osx-x64.tar.gz",
-                        "hash":  "595578F419094175E9A0ECEA4D0C8FD86682C5962DDA98B68403C4EC0760FB5EE7C922BB9E15100894A2E05AC16D458D22E814CA32B5BB0790F0E51A2F563643"
-                    },
-                    {
-                        "name":  "dotnet-runtime-rhel.6-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/95777fc5-eb49-4fe3-b136-db2c1e8c4cab/17cafbf4d0d6e234e4ea6cc143739e1d/dotnet-runtime-2.1.6-rhel.6-x64.tar.gz",
-                        "hash":  "1367020B7808793C466692025466FBF08CCBC5C18D0A2DE4944FC3C53482FC30C699753581B12B387113AF1CACA505CAA1D1FDC1DB6985666CF0C718A081D8D6"
-                    },
-                    {
-                        "name":  "dotnet-runtime-win-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/8dcd5adb-21a8-43db-ab6a-d6c8e37b20fe/d52d48805fc35dbfa7ce411fbf5fda59/dotnet-runtime-2.1.6-win-x64.exe",
-                        "hash":  "603F397C1F5C37571F24A56AD4B22DF442AC98B86085CCF96E38077F7940700CC43678458030E626F49C7B6A027A5BA90FA5BAC03013C2223EC9E91FBDA4ED34"
-                    },
-                    {
-                        "name":  "dotnet-runtime-win-x64.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/3f6b6def-4e9a-4405-b21f-89f77d1605c4/52be50baa0e9bfa118fe6de80be89ab6/dotnet-runtime-2.1.6-win-x64.zip",
-                        "hash":  "F716C90B0A4512F3611A9D6D922FF1F7B5BF306440283798E17B893920D390DF15C503F5808EE34BEB3CE6355308C6BB3435F06CDAFDE60BE31397C2633CC270"
-                    },
-                    {
-                        "name":  "dotnet-runtime-win-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/af783fb4-da01-44f9-a8b8-9e52dda7970e/3d9920fc37175a41140f9c8af542a42c/dotnet-runtime-2.1.6-win-x86.exe",
-                        "hash":  "7BB07641D47BFC293F61BFD18F6F960C21F5590D7E52DBCB6BD95AEFF8D037DC1EC222A9067D2B7BFA3DBDB01EEBF843DF815400654D1E724D3BD71190FD9996"
-                    },
-                    {
-                        "name":  "dotnet-runtime-win-x86.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/3ef3e42c-281d-43e2-969b-3f6aafef56f1/a13f4c966b0f499b8883f6e6f8b1765c/dotnet-runtime-2.1.6-win-x86.zip",
-                        "hash":  "193C7F357F953D0B19012EF63ECCAD42CF69F5BA6DF12B132C0618C152EDE5F385CD7312CDB3D95841F9BB1705D1E4E50B0214776A111F38D50666DE52F545A2"
-                    }
-                ]
-            },
-            "sdk":  
-            {
-                "version":  "2.1.500",
-                "version-display":  "2.1.500",
-                "runtime-version": "2.1.6",
-                "vs-version":  "15.9",
-                "csharp-language":  "7.3",
-                "fsharp-language":  "4.5",
-                "files":  
-                [
-                    {
-                        "name":  "dotnet-sdk-linux-arm.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/201cbc49-c122-4653-a6c6-0680643d9a26/1951cfc077d868a31563a5a172d18d78/dotnet-sdk-2.1.500-linux-arm.tar.gz",
-                        "hash":  "106D3E5B7B96CA3522E78B77F094CECAAC38C348D7138C2FCAE0464FF9D57EC137802603C4A5C6F81B9EAE9DE39B86BFF8D9FC573817E033982EB576532E334C"
-                    },
-                    {
-                        "name":  "dotnet-sdk-linux-arm64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/fc8a549e-fe2e-4b88-961c-8f7b5d054faa/1676cb29cab62a698e75748a745950c7/dotnet-sdk-2.1.500-linux-arm64.tar.gz",
-                        "hash":  "E5C3BBD610A38BE1F74E4851EE5B701052103EDDF9A804AEAB276048A06E812278E726E7718C5955A1159C41CFE98B8E2700F8BEF1577C30B242D7AE1A8212E1"
-                    },
-                    {
-                        "name":  "dotnet-sdk-linux-musl-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/a0a6ac11-dcce-48b7-8369-423b8652545a/c337fcbef824fd32139ee087914726ad/dotnet-sdk-2.1.500-linux-musl-x64.tar.gz",
-                        "hash":  "AF061F17D88E4371FE523B895B60A0259296E2CC2BD9854A04541B87038638E0A7B7053288B45BC00A89FBB04DBDB7218A76EA9DFED8919457E758C532C15E9F"
-                    },
-                    {
-                        "name":  "dotnet-sdk-linux-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/e5eef3df-d2e3-429b-8204-f58372eb6263/20c825ddcc6062e93ff0c60e8354d3af/dotnet-sdk-2.1.500-linux-x64.tar.gz",
-                        "hash":  "85055728E2433DFDE41D15C85475F2DC6CFDD30242B4B23065B63CB12CC846ACB93C09C000B02B722890CEAC8AC382B40871C78660716CA2339C71052FE52F4E"
-                    },
-                    {
-                        "name":  "dotnet-sdk-osx-gs-x64.pkg",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/576dbb8d-03f2-4d45-857a-b226d39b3dbe/0d4fbf91aa1137352680ec98ef9edb5d/dotnet-sdk-2.1.500-osx-gs-x64.pkg",
-                        "hash":  "07DC690149914252EA88D16D0862685F213405E375E5C49162420B3BE4B8FF0AB562B7DF12C800A77DABF0574CB57D4D6DE0EB961696F7410A4563B88CB49E7C"
-                    },
-                    {
-                        "name":  "dotnet-sdk-osx-x64.pkg",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/59a7b78f-4e86-473b-b230-c84d15505cec/766e3e5f35e7bb9677dd785071c5fbf7/dotnet-sdk-2.1.500-osx-x64.pkg",
-                        "hash":  "07DC690149914252EA88D16D0862685F213405E375E5C49162420B3BE4B8FF0AB562B7DF12C800A77DABF0574CB57D4D6DE0EB961696F7410A4563B88CB49E7C"
-                    },
-                    {
-                        "name":  "dotnet-sdk-osx-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/901c2283-505d-408b-a7b0-01b5ee477783/ae5185f3fde13c7a62651608387a2a71/dotnet-sdk-2.1.500-osx-x64.tar.gz",
-                        "hash":  "E87FD0EA816C1875A896CB284F762F22D2AC7A23C84F4D10F5299EA54E8ADD9D4E782656F53726627D615F98D2E6C288AD634B75F80D6F815EDF8B35F484C817"
-                    },
-                    {
-                        "name":  "dotnet-sdk-rhel.6-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/6b4325af-ce22-4440-ba5e-b4b1444cf712/3691bc5eabd7390b47657e9d1d232355/dotnet-sdk-2.1.500-rhel.6-x64.tar.gz",
-                        "hash":  "323A727C1112A167E87C3C3510496C07DB10B36757736F8510150EA200B45FEC02913CA81518115205C526B075BE25A2DCF45C63C23B5B1C3BB759D36D18D17B"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-gs-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/9b60a25e-5b31-4550-aae1-72516c1067f6/52e8387487fecef06266a7a19c97ddee/dotnet-sdk-2.1.500-win-gs-x64.exe",
-                        "hash":  "A6EB777DF0F8581872EF34D9363EA0148A95314546507B879B648CA8AA051791DA59377CA3F1786F18D2831823F2A2A9B6D275C96572F0917C88FBEB18272C32"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-gs-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/246c196e-2934-4571-bf21-b988a0f57e90/11329123100c557261e585a9871c2398/dotnet-sdk-2.1.500-win-gs-x86.exe",
-                        "hash":  "E34065EA573598F4098A9D57A05243FB9EE58C7A8AA08A81E7F6248372BF850F4A69CD2558FE1BE98B267491FBAC5022657E67625595795F9FB9AB5BBF6F8B14"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/cd42f66a-2b6a-4a7a-9e69-0bb4eb5a83a1/0ce246546a0886349d9acf872f4e15a4/dotnet-sdk-2.1.500-win-x64.exe",
-                        "hash":  "A6EB777DF0F8581872EF34D9363EA0148A95314546507B879B648CA8AA051791DA59377CA3F1786F18D2831823F2A2A9B6D275C96572F0917C88FBEB18272C32"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-x64.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/2a508a9d-91e8-4126-904c-f7a515f8a33b/24ff5fe2610ce1ce76370ed053b14094/dotnet-sdk-2.1.500-win-x64.zip",
-                        "hash":  "C8A398773A517B7D36BC29895FC1C4B6B0D47CFDBED04D115FC75E8D0A4B7542B67C9125F701EC1C53038E846848F3C77CACAE2B61986E66164CFCA05005CA08"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/59613bc7-269f-4c39-a58a-46b35fe314c0/ddae846724f96c9886b319b8f825e475/dotnet-sdk-2.1.500-win-x86.exe",
-                        "hash":  "E34065EA573598F4098A9D57A05243FB9EE58C7A8AA08A81E7F6248372BF850F4A69CD2558FE1BE98B267491FBAC5022657E67625595795F9FB9AB5BBF6F8B14"
-                    },
-                    {
-                        "name":  "dotnet-sdk-win-x86.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/f1e5fc51-e5f1-44d8-bd59-88b0aa849b3a/fbe1740c06c7fc87b8345c193a12bd59/dotnet-sdk-2.1.500-win-x86.zip",
-                        "hash":  "5143FA77EC0BA779CFDED5E1FE27C9E4A4081F0F67FB69F7E73746A907EC1554D91347BC4D747A4B79B45A5B18E7D3438CF8A7EDDEB3C094C15E70A197FEA8EE"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":  
-            {
-                "version":  "2.1.6",
-                "version-display":  "2.1.6",
-                "version-aspnetcoremodule":  
-                [
-                    "12.2.18248.0",
-                    "8.2.1991.0"
-                ],
-                "files":  
-                [
-                    {
-                        "name":  "aspnetcore-runtime-linux-arm.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/9c5d6af2-868c-4021-8b25-4913daca41c3/46cfc8ddb9b8f10ebd56de1b1a534e32/aspnetcore-runtime-2.1.6-linux-arm.tar.gz",
-                        "hash":  "2312BA29EBCB3CA2E473C90727563E04C89CD771BCB68BE76ED8BCB1D196E7D5B9A886177481837AE397142497CC2947A19372FE0DA23F0ADA0B3C1AD4FD0218"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-linux-musl-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/e4770dec-8d9d-4591-ba45-a8ad1d71841e/fa87d518261a484787824fc0e1d9365f/aspnetcore-runtime-2.1.6-linux-musl-x64.tar.gz",
-                        "hash":  "F909A6B70D105588C0D4C684E88C1EB2B83001BA55B9BFB0932807953EA9756C5539D3B9BD11666CB07CC68ED362F3786C8F6A0FF91DA072E4B67CD8B5ABC16A"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-linux-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/5ecfed21-c776-4924-b734-126400fd324a/4e1bfb9c870ffcf99b1bf953b91ef072/aspnetcore-runtime-2.1.6-linux-x64.tar.gz",
-                        "hash":  "4D6416C7C078047ABE3493FDD7BEBE0A796BDB2AAEFAD302FB6A64DD225C871A1183F016F0974C6DCD82F80AE893660B2AEAC2ABB70509435845A430E0117E29"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-osx-x64.tar.gz",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/1f6f813c-f02a-47ca-a300-0b89bacac920/19e4e3315b9ec9934f06915b8d367706/aspnetcore-runtime-2.1.6-osx-x64.tar.gz",
-                        "hash":  "4DC06D8A145BBC78641FABEB699691F05E01A3DBB199F0AC1BD297C5CA57E91A65CB4F77971DA0528563D649988C5DD97A913B11760C0904403E317EF0442564"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-win-x64.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/400d3dfc-03ab-4d2b-9d2a-5c1e9d7ef2e1/a1c8fba4dd848186623470da09ec8f88/aspnetcore-runtime-2.1.6-win-x64.exe",
-                        "hash":  "D52A47BBDF9FDEB2172A04ABFB3E09E318950F512136E020F40845A3604A93DA1B344603204EE9092936CBB76B32150F8A25A9B5DD4786520A3C7460207BCD97"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-win-x64.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/aeab1a67-fec1-4525-af50-332817900212/016c23f84f53d0976da7070c88c7873f/aspnetcore-runtime-2.1.6-win-x64.zip",
-                        "hash":  "333C7EADBD5E5202DB706696ED682298C4FC66551AD87A9C374A28CD459AA8C6A47952434BC642E1191B0F10E09520B9A34E6BE19C5387AEEC1FF19C2001EC32"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-win-x86.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/207ccb26-48a9-4588-a9f3-e009be0a37cc/afdf4db8ad55a07357f0663fbde4140b/aspnetcore-runtime-2.1.6-win-x86.exe",
-                        "hash":  "3C23C66D9F9FD65EF8CD4E5779B8E9E1301519578084CF14E35CC366AA1B66C039459E2480AFC855428B1CE23DDC38A5DED8699A37B1237C18B700D0B6657792"
-                    },
-                    {
-                        "name":  "aspnetcore-runtime-win-x86.zip",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/5fbad133-3085-4748-90a7-cd863e910001/c7379a8658d8ff6547b7c74fd59615c3/aspnetcore-runtime-2.1.6-win-x86.zip",
-                        "hash":  "5D84CF72F6A500E276D3D8C10E138BC180EDA50F29603C3CA0DAF8B4F686B6EE0EAAA8B1A928790DFEBDDAF0EA2E863DD95F86A566A5C98346953C848641CE23"
-                    },
-                    {
-                        "name":  "dotnet-hosting-win.exe",
-                        "url":  "https://download.visualstudio.microsoft.com/download/pr/3f674c39-ab51-45c3-a7b8-094d86594fbc/9f7efb24d3486086b2d1f1a8d205a776/dotnet-hosting-2.1.6-win.exe",
-                        "hash":  "E4F36F3DF427CBB59749B7BD993934229D6D6E985786DFE3F92E77F6F5F10209F57E450AE74B5ACD70C5CE2067C881C1DDAEBEF5164D009E15C648CDC1A7B51E"
-                    }
-                ]
-            },
-            "symbols":  
-            {
-                "version":  "2.1.6",
-                "files": 
-                [
-                    {
-                      "name": "aspnet-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/d77ca6f6-fa77-4eb8-82f9-9e8be43e4acd/830ad12af9a632ff05a70e2530a3c564/aspnet-2.1.6-symbols.zip",
-                      "hash": "605c894697d96b1e72edf056c874a9eb6a471eb96865275d34404b55484e264467b34d9dac4b748e3e8f3caeac528c207759ee9ef265fcd350af079a91465451"
-                    },
-                    {
-                      "name": "cli-2.1.500.symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/bbff4d72-ae50-42c7-9a5e-e3f24448be01/604a59b419eddbbd6a4148b5bf90a89e/cli-2.1.500.symbols.zip",
-                      "hash": "0d325c0473f5ce4e6f6b60b2f771b66139e2302aeef22f40f2503d18cc3cd309bdafe1fa319798ec149e50947b5585d22c4454332d2c20208d45d262aaaa0861"
-                    },
-                    {
-                      "name": "cli-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/31972dfb-b0fd-4e01-9d2b-5008321dbf68/f198c9f2aa57f8c7e141d95a6c6b098d/cli-2.1.6-symbols.zip",
-                      "hash": "2e552add81cfc61709e043f22158b1714ecb4a28506d61851b868c30b9c24e4acf0b173c2b6fb935cca49302a5aa7cde37bf9ae10f097869e46e970a1c98792f"
-                    },
-                    {
-                      "name": "core-setup-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/04ddc39e-1db1-472f-a7a6-4a51d73cc75c/3d0f620127304ddfa981bdc9dbc6aee9/core-setup-2.1.6-symbols.zip",
-                      "hash": "4b3dfd92de61ad1a909380128f88c1e12c40cfda9121b57259b04f62f7ef6410c0fe99194b7e8c6b5f88bd9c1100e76728f1032826546675f8183b86d6a03a6c"
-                    },
-                    {
-                      "name": "coreclr-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/459e604d-efc0-4e1a-838b-e311c890bdaa/bc02969da98047faf9b4d1dc1c70b349/coreclr-2.1.6-symbols.zip",
-                      "hash": "77d494554e80e893c78c17385a45debd18b9cb6a8291e4744efabf1f9ac032842e71e90241d569884122b3633b4994273f6b68484fc47b25348a9e30f03a9ec0"
-                    },
-                    {
-                      "name": "corefx-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/dc20e757-f7ca-4683-900b-3d0a94134c0d/1743c2e0e4952e9a5ddf2d1c8934af95/corefx-2.1.6-symbols.zip",
-                      "hash": "ac621eb41eb81ab6cc9327ea78ef296c71760739ef1f36c25d2a1b8cb92e3e55966de31ed4cdf77817bc23f35242d436dc9c61b49edf710b035e7143fd4319f5"
-                    },
-                    {
-                      "name": "dotnet-sdk-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/05930291-d788-4c74-8727-67a8dc91bd10/abef49e4ac04610e9c3ff1317a5b4140/dotnet-sdk-2.1.6-symbols.zip",
-                      "hash": "1c98fc7290bdc5cc31cd02f3a6150ca92df3ab18cb15f1a3238124401307076096aa8b45a738a5374d473a31a23185e6be31c3399f36f7cfeedafa730b44617b"
-                    },
-                    {
-                      "name": "sdk-symbols-2.1.6-symbols.zip",
-                      "url": "https://download.visualstudio.microsoft.com/download/pr/b8907954-0bb6-484b-a1ee-1beba64843e0/490b81242561a2b9b3f14bb3be467611/sdk-symbols-2.1.6-symbols.zip",
-                      "hash": "89dce1499fc54c35160a357b6d3d5c116c19bdbc2a4510fc7b05cc2cba046695de983ac29bd2fc66da3c5464d6eb369acb2a1fb1bbc4662c1286d9a0e5c410ef"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date":  "2018-10-02",
-            "release-version":  "2.1.5",
-            "security":  false,
-            "release-notes":  "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.5/2.1.5.md",
-            "runtime":  
-            {
-                "version":  "2.1.5",
-                "version-display":  "2.1.5",
-                "vs-version":  "15.8.6",
-                "files":  
-                [
-                    {
-                        "name": "dotnet-runtime-linux-arm.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/4d555219-1f04-47c6-90e5-8b3ff8989b9c/0798763e6e4b98a62846116f997d046e/dotnet-runtime-2.1.5-linux-arm.tar.gz",
-                        "hash": "89a77a07065ea24e7198c77a233b9ce5c6cf51b1deb2ef55c88f0adbb2ecd9db1ba4e7d55eec2ef7139c47f91346fed360161a5bb6e3a7ccfc4559bcde286364"
-                    },
-                    {
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/42912b6c-fab3-4666-a467-65e1ecbfc4b3/44f1a69971dd0c81de9ede19393de24c/dotnet-runtime-2.1.5-linux-musl-x64.tar.gz",
-                        "hash": "6823778d6ae0a57a9782d1fa460fcea2c7df99c719d14d4aef96e4cbc48406936090e2f727cbcb961f6e645ea960374575e37db8f59907cfc5a588bb1044d840"
-                    },
-                    {
-                        "name": "dotnet-runtime-linux-arm64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/8b757bfd-de6c-4c72-8d73-abfa6d7bae35/54a47a57feccb5277e0973e17142caa6/dotnet-runtime-2.1.5-linux-arm64.tar.gz",
-                        "hash": "4c4d45f4bf0c86b83dd9dd1a844754c3cdc15e0c4b417a069132607e6e95b0e9d8ef410ebdd8b9f5479d91bd704dd098cc674a5f42fd6e67c62df75e1b3e96d7"
-                    },
-                    {
-                        "name": "dotnet-runtime-linux-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/05a71d80-3e59-4f1f-8298-2697013e261c/be191f2f4f4db74c29030008ed3632f0/dotnet-runtime-2.1.5-linux-x64.tar.gz",
-                        "hash": "d815c79fd868d2642898ddc09c890a90c4ab26ef8999046581d7e3912bb06ec97ce6637ce8bf0ceb9deb773daab1c0cd93e336992c885a4fd7550d6686d4dbf4"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.pkg",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/b83df670-529a-4d28-b4f5-81c46d339ef9/6d23d425c2b0ffd9828c521dbf19ef63/dotnet-runtime-2.1.5-osx-x64.pkg",
-                        "hash": "a1835776f4873327229d68f641cf320e45f4857007875cc1ec25463a266ef7be3f520e68acfa1d2e27d1f69a6030667e36f9d9f2099d6e12a84784a5462af12e"
-                    },
-                    {
-                        "name": "dotnet-runtime-osx-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/eafd1d99-8824-4af0-8924-df9050d2265f/76094b7c8d80390504eba6ec08e4044a/dotnet-runtime-2.1.5-osx-x64.tar.gz",
-                        "hash": "8d95f08a55e913aa5c885e42f126eacf479e6de3a59dcab6594d4e90d7dbdf36f03c4eb084a9bf4405a1e52db5b84be583f44ec4f02dbe4e58c3582329b0b50c"
-                    },
-                    {
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/5b4b7ccd-7167-42f8-9111-bd7f09cc7b1c/fc68d0ca7566224ec99b56df25b7f9ee/dotnet-runtime-2.1.5-rhel.6-x64.tar.gz",
-                        "hash": "83ab74399d25a85fcb091bd63a3d620f5c5bf62700ec8f8fe5a63de8764f725ce25156a07e5da1e8f326360fefa625402de295e03e2d9e67cca5a2fb95b60c06"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/2781df30-e8c8-4c96-a317-a369a1d27b88/d70f97bfd35b88fe6e2b5410b3655247/dotnet-runtime-2.1.5-win-x64.exe",
-                        "hash": "1fcd054b48b93a40e1b23903d00f0163382e19827c9dec297acd9fdb61f117c0c79fa86c1fe16989038db300274e4813a4a65ea0100a571e1085ce8a8ec6887a"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x64.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/ce443d89-75f1-4122-aaa8-c094a9017b4a/255b06ace4207a8ee923758160ed01c3/dotnet-runtime-2.1.5-win-x64.zip",
-                        "hash": "aa7145201f1ed0689ff6abeb53b9c64c1efa1420dee7e5cc916168fd2479e252ed56b2492221f4038edbc73056accd9d4a46ec469155f2bdf0fc71bd909bd220"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/4d7f6916-827d-4047-8abd-30dd6db910e9/694eaa49bbf7bb574b75429ed101035c/dotnet-runtime-2.1.5-win-x86.exe",
-                        "hash": "88c7cdcced8dc22aec86cc7edf105ad96887f98e6d5d013459e5b8957a7c146489371480dea0fecc5cd89da5ff94cadee9b5cbadb748c54399a6035c456d4e3b"
-                    },
-                    {
-                        "name": "dotnet-runtime-win-x86.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/256f1cce-ad71-4ebe-ae45-5be6b7d4edb8/68f8caf678adde0af55266e955556c74/dotnet-runtime-2.1.5-win-x86.zip",
-                        "hash": "0765035c328e479681bbc8967ae1b8031bc16e6fe399fb74b93d517677cc8ecc852984f556f0bb41960bdb7620c67bd7ac95c66304699966aa6cd1cea80b3b9e"
-                    }
-                ]
-            },
-            "sdk":  
-            {
-                "version":  "2.1.403",
-                "version-display":  "2.1.403",
-                "runtime-version": "2.1.5",
-                "vs-version":  "15.8.6",
-                "csharp-language":  "7.3",
-                "fsharp-language":  "4.5",
-                "files":  
-                [
-                    {
-                        "name": "dotnet-sdk-linux-arm64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/00038a67-bb86-4c39-88df-7c0998002a9e/97de51fd691c68e18ddd3dcaf3d60181/dotnet-sdk-2.1.403-linux-arm64.tar.gz",
-                        "hash": "a9eeffeca6b80b2873c21c7b8bb06df096290cd5b23a6e1e0fb158b60f2c2af6ee4b2bfcfd96a303ebf33ea2cc782f3dee629d06d48b634dda05ae9e11051335"
-                    },
-                    {
-                        "name": "dotnet-sdk-linux-arm.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/10b96626-02d8-415a-be85-051a2a48d0c2/5ec51d3d9f092ba558fb5f1f03d26699/dotnet-sdk-2.1.403-linux-arm.tar.gz",
-                        "hash": "144f1a8822f57d3e9286ed80b7ee0c7796cb2765632dd99d0f89a276248c3be77d8d90c8bf987af0237e67f2af26be834c138441980d2c7d35156ee1bb7e3d94"
-                    },
-                    {
-                        "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/527fff7b-1862-4d2e-ab78-94c6cca188bc/8c62477e25ac1448c93ed4a8da11cc37/dotnet-sdk-2.1.403-linux-musl-x64.tar.gz",
-                        "hash": "620f091eba8d111b13d440c20926f60919e64dd421c6cbf2696b6f3f643a3d654b7dc394e6e84b1c4bef6ff872c754a7317e9b94977cbcb93b5d0fdfe08d8b55"
-                    },
-                    {
-                        "name": "dotnet-sdk-linux-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/e85de743-f80b-481b-b10e-d2e37f05a7ce/0bf3ff93417e19ad8d6b2d3ded84d664/dotnet-sdk-2.1.403-linux-x64.tar.gz",
-                        "hash": "903a8a633aea9211ba36232a2decb3b34a59bb62bc145a0e7a90ca46dd37bb6c2da02bcbe2c50c17e08cdff8e48605c0f990786faf1f06be1ea4a4d373beb8a9"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.pkg",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/38102737-cb48-46c2-8f52-fb7102b50ae7/d81958d71c3c2679796e1ecfbd9cc903/dotnet-sdk-2.1.403-osx-x64.pkg",
-                        "hash": "ac87bddcbf5ceca22d95966f1da9f6ad55876f9cec9e221a25d84dc03aa7144b9e0fbcf2b492b520b85ac57f4eb16edf8239eb42d2f3b049b2dd483a2d27f323"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-gs-x64.pkg",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/8a8072ea-07b3-4e31-8c2b-db56c9dc0b3c/5ef3a090b5e1b7f7c80338249d29f2b3/dotnet-sdk-2.1.403-osx-gs-x64.pkg",
-                        "hash": "043f0e79f875eb5a47289e2d6f087927ba713c98b6bbdbc3828c49025d03ce1a210917f9519ff2671fa15a82ee2b544ddf272e4de7c28b46da436488c08c1cd1"
-                    },
-                    {
-                        "name": "dotnet-sdk-osx-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/fcdaa140-a2a3-46cf-bab1-e211e7d070c8/9498335457a65063ec789e5532020cf7/dotnet-sdk-2.1.403-osx-x64.tar.gz",
-                        "hash": "b20dadf3654522710a2ee2768566fe48aee6c234d678c87fece3395523e09e5243389214cd4433f850615585e46f5e9d53a0c46b6a5192fe399054126537d818"
-                    },
-                    {
-                        "name": "dotnet-sdk-rhel.6-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/db34d22e-e7ca-4883-a35e-b3d864a5b330/c5f9d14eb4630686574eba29b0049470/dotnet-sdk-2.1.403-rhel.6-x64.tar.gz",
-                        "hash": "30faa188766bf2b628064fc0b90fe76ce9a2bc63c07acee1dd8f082af895cec536aa52af7f48892aad6579ec98354e432d7c6860713a9b976d84482c624f8b3f"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/45f93081-cdb4-41c1-8d8d-e6c3bbf2872b/62d6a598956fdfe585acb1f15268d930/dotnet-sdk-2.1.403-win-x64.exe",
-                        "hash": "3630dc9c52ec6b08c0804da3fc9177d3d61f12f5629c65249f7bc75b34a24c4059812fc8e6cdef64dcc7c4030ad5952e998674ac1ef497f20e43b2ab4b53be90"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x64.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/7010cdb4-ae43-408b-8c9f-5f94101a1c70/3e1ae56a072c7c397f10278d7643b3e9/dotnet-sdk-2.1.403-win-gs-x64.exe",
-                        "hash": "3630dc9c52ec6b08c0804da3fc9177d3d61f12f5629c65249f7bc75b34a24c4059812fc8e6cdef64dcc7c4030ad5952e998674ac1ef497f20e43b2ab4b53be90"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x64.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/28820b2a-0aec-4c24-a271-a14bcb3e2686/5e0ad8ae32f1497e8d0cace2447b9e01/dotnet-sdk-2.1.403-win-x64.zip",
-                        "hash": "52bb1117f170587eaceec1f78cdc41a41d4272154b5535bf61c86bfb75287323cac248434b05eabe4bc7716facabdb0f6475015cbb63f38d91af662618a06720"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-gs-x86.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/a3660177-253e-48a3-9c79-cc16ced15c3a/ab0b9bfdac68c55de0e0f27ee6c57dc7/dotnet-sdk-2.1.403-win-gs-x86.exe",
-                        "hash": "c35be7071348b2812ee3694276b0bf7b9289f9176896b6d27ef0ab8d6c3f499e2678856d50b782a171c819e1837de070a4d9cb6897e05be86ed57cb97feda686"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/c0aa84bb-3da1-4bce-9434-7036e94ae4b2/6d4fb01377f1f1eebb0997289dc8ecfb/dotnet-sdk-2.1.403-win-x86.exe",
-                        "hash": "c35be7071348b2812ee3694276b0bf7b9289f9176896b6d27ef0ab8d6c3f499e2678856d50b782a171c819e1837de070a4d9cb6897e05be86ed57cb97feda686"
-                    },
-                    {
-                        "name": "dotnet-sdk-win-x86.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/849dd909-5412-4b79-a66b-b173d462d0f2/a75544b6df62239374e77e78d9a5899f/dotnet-sdk-2.1.403-win-x86.zip",
-                        "hash": "f3292cddad3cc2921ac532367568086a778340dd76a00825119f9e634958173d6688d3d3e93a9f4a0b091cae989f5d0213ed0ea4ba818f90efc901a86093c2fc"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":  
-            {
-                "version":  "2.1.5",
-                "version-display":  "2.1.5",
-                "version-aspnetcoremodule":  
-                [
-                    "12.2.18248.0",
-                    "8.2.1991.0"
-                ],
-                "files":  
-                [
-                    {
-                        "name": "aspnetcore-runtime-linux-arm.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/6253ecc6-4af6-42ac-a965-33a864a79a3b/b4ba7e62c5318106fd55aaa17b4335de/aspnetcore-runtime-2.1.5-linux-arm.tar.gz",
-                        "hash": "5d503f7181c59d95ddc7d537dbc4b26fb6d5b6bea25b0a29154906fa422e7014e80e0a8ee92c6f81484d169a17b3e8284d455e3e05d85cefe736190e769b7355"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/c283d1d5-b4c7-4d9b-bab5-b78c6d03887f/e6ba9246446aa885f935e2245acbbedd/aspnetcore-runtime-2.1.5-linux-musl-x64.tar.gz",
-                        "hash": "5d87fb86e4e70bf0769d081a0b0c4388348bcefe61559242af17a9604bbdb3269e4ab47c420105ab6a2236431978adede9406d3ff0845602a398bb81f4ecf6f7"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/97fce50e-e736-41c3-a700-d83d43178197/4c00b063affdbc940dd16f62c68d1505/aspnetcore-runtime-2.1.5-linux-x64.tar.gz",
-                        "hash": "3326963ba0a431ca430d8f1a7940487e516952ec560da563f03662b71b2ac8b5d9904b0e1422212e452b49f563349d10fea34241f4d5e4811d0aedc02c557029"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/48c6f111-9195-46bd-8115-dcbf8a954bba/4c011f106cfc78e8344ca50b0a08d056/aspnetcore-runtime-2.1.5-osx-x64.tar.gz",
-                        "hash": "a5f9ee4a89a50dd0dddb4b0bc089e0385cd8d11d667253f8bf3fb1722308a3189512022472394251c5f640332b843798a8f5a0c129b9d78094349130ffb93aac"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-win-x64.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/74b2ff3f-b288-4b4c-9b11-3ef77100ef5a/b0b90830e6b1050afec21c556d1b3733/aspnetcore-runtime-2.1.5-win-x64.exe",
-                        "hash": "ebb8f2b239155c9314c39b77ed6a89fb1954109d31d030783ee59427f7c6d6bf7af04037b9e57f82e60799292f507e003c8a76278036ddbae096a7f9baf03fd6"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-win-x64.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/6abfd5c4-f9e2-41fb-9363-fd60e3f9132f/1a5d3c82408f5e27b0e83be8c7f1ae42/aspnetcore-runtime-2.1.5-win-x64.zip",
-                        "hash": "98224c8646b7eab234b97f52735905bb0219ea2290490e408ff469459ea82116068854e7b9c5869bccef780b4ceac17477f34f23e06a0a6bedca445a3866d73e"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-win-x86.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/e3470fc1-4b89-4ef1-af3b-bf4fe57195f8/ae80490e90972949886a36816490f3ff/aspnetcore-runtime-2.1.5-win-x86.exe",
-                        "hash": "e7e62e13aa917a53015d987ef48fb255f887ce850b9aa1e869e46a13ab6f1697566f4e3d808ed71f6288e2b930f61bbcc26758f328382aadc6b53442f0c13e0f"
-                    },
-                    {
-                        "name": "aspnetcore-runtime-win-x86.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/de489207-08c5-4bb1-9b66-641528ea6ca2/03bd984cb700799179dca77dadf3a003/aspnetcore-runtime-2.1.5-win-x86.zip",
-                        "hash": "9c46619708fca22db2bd7206cfed0aae56d99f52f4f00aa12a43ae2e744da4c75bb749ea343311a051b900e6299352ef7a0e9c5378611971f4d9fdc585c95f20"
-                    },
-                    {
-                        "name": "dotnet-hosting-win.exe",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/86df96bb-384c-4d7a-82ce-2e4c2c871189/045870c1ab4004219cb312039c5a64d5/dotnet-hosting-2.1.5-win.exe",
-                        "hash": "51da1bc97185209f19ff753fe0ca8a4ae5afec9a96b15fc088c357ad1ecf327e03d68347f54cda85d190131d6289a6de595c840f1decf7895009aa0ca5563448"
-                    }
-                ]
-            },
-            "symbols":  
-            {
-                "version":  "2.1.5",
-                "files":  
-                [
-                    {
-                        "name": "aspnet-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/cd19548d-5b4b-49dc-b33b-be0fff2c814d/f92efb317bd7864097ef824174e6ded7/aspnet-2.1.5-symbols.zip",
-                        "hash": "b0f2ce9c018605395d5c7a47a233fac83097df41ab7cb351827d727387646f831b0a1c251cd488dfeb9c473a18510f53b50ba7b1fc4322808f95ab921fb8e84b"
-                    },
-                    {
-                        "name": "cli-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/d3d1518b-c3ad-445c-a6a4-bc31691517f1/cb22f3c8e70ccacfc9dbb74748d11ee8/cli-2.1.5-symbols.zip",
-                        "hash": "173168730d6fe23a7c5457ed5533e4dc103a2f95ae5c0118a3ac4fd06ad23a1bd5a605bd43b10148cf8bcfc3a5b4c32d78b8d745dd5ba57921449a236f2c8ad8"
-                    },
-                    {
-                        "name": "core-setup-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/b7ea7023-1d3e-4b6c-956f-fd95acddaf34/93db59925f87bf2088f262ea29536ced/core-setup-2.1.5-symbols.zip",
-                        "hash": "5581be34b1e54650e1495aef9e4c02d676532dd11316174344711cde7d55cd434382ff389cfa741d364bded66d6fa560399077080376e351cbd7678009441d8d"
-                    },
-                    {
-                        "name": "coreclr-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/26b24856-99c8-4caf-a5b4-81502b2df64f/ff4916b6eb2370d79241510511f845a6/coreclr-2.1.5-symbols.zip",
-                        "hash": "d7cf81866131e90b95067c60c2123f68411f940256673766061df6c8778d33b861b49d2e14996bf08cd6b900fd19b6f6ecf483da3b0931e469b27f159384ff43"
-                    },
-                    {
-                        "name": "corefx-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/d9ee037a-60e6-4efc-aa09-27c8b2f6c5df/73556861aecee927a870c2afb10576aa/corefx-2.1.5-symbols.zip",
-                        "hash": "e6c24e68333797b652f9408ba95ff2fd01d8ced3edc475d8f3446984a40a5856624b1da51850e819cc44f1e29d94cc0cc9c295e6508199d553d8982f064c023c"
-                    },
-                    {
-                        "name": "dotnet-sdk-symbols.zip",
-                        "url": "https://download.visualstudio.microsoft.com/download/pr/f5348f78-7a05-40c3-9b5d-240f9f96162e/90b6da7e4ed745894884ea596b22335a/dotnet-sdk-2.1.5-symbols.zip",
-                        "hash": "53d8a381108562253bd0c5336b2f8c3a665c54d95c09671e8867d3efd35b47967bda4a208735194a14e8d401bb7f9e995cddb20d430d1e90956222c266308d37"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-09-11",
-            "release-version": "2.1.4",
-            "security": false,
-            "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.4/2.1.4.md",
-            "runtime":
-            {
-                "version": "2.1.4",
-                "version-display": "2.1.4",
-                "vs-version": "",
-                "files":
-                [
-                    {   
-                        "name": "dotnet-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-arm.tar.gz", 
-                        "hash": "6ae83b0b51c180c44e0792a6c0b9dbeb40d9e28e695d7b565914232955cd0c6009186ca954d87255688163f79eb4b59d1fdd8abae7438de17f4cd919eb671028"
-                    },
-                    {   
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-musl-x64.tar.gz", 
-                        "hash": "854867452df8973ae5b2c266c07aa6bb69afabcce4bf9a693d5c71d437cd66a2d2d16d7fd9cb6ac5aa82884af816c470a74fff1e9e450bd8eb5d59cb36724551"
-                    },
-                    {   
-                        "name": "dotnet-runtime-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-arm64.tar.gz", 
-                        "hash": "4d604229653522456ebdeee7b1a6cfb8032a14f6ef1c757544e0e27ea64bc455fe448c6f7c0647700f9e2790c48ef015c24003705b58e209dcc9489b77b18c85"
-                    },
-                    {   
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-x64.tar.gz", 
-                        "hash": "94bd277112ccecf65d425e0ce98e7e30ac702e2ee91ebb976119a2a96f500745217dc77b4a3f0f5a7d6a4ee9779429c0bea419561cae09b446fba5cefb81e9fd"
-                    },
-                    {   
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-osx-x64.pkg", 
-                        "hash": "ae318363382be3fc6dd2487e03b125b1a0fe68cc9f00cb376dc956ec90d5ddaa0ee4b1f8f1114635620871d1271d1e15fc3fce7a869a6ed51b345106492828ac"
-                    },
-                    {   
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-osx-x64.tar.gz", 
-                        "hash": "da9cfcb9ae636e0d0739f75cd1d6ea6b4a48858f1dca11134fec57e4e66b28f0f1b0ac55a02a741edc506fb011b023976d1395eff3ec5a51bb5d15298a6a56ad"
-                    },
-                    {   
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-rhel.6-x64.tar.gz", 
-                        "hash": "e6837ecb264413b9663d2bb89c16246c9aca64dd424571ed3f7569fa1ae97d312dd32ded62eff418be598ecc4312bbecbf5244d14ee4cc673dfe0161ad236f4b"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x64.exe", 
-                        "hash": "2812c23e0fc89dd7cfdc972fc99b867ba1883d9a1a921659371f346d1efc7638205cd22e372d78cc3250c3878d6a764002177f14a6200adc70c4b61e322bd47f"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x64.zip", 
-                        "hash": "d89a09736c35388a82f9791bce478866b672dc68fd1e7254ee9c4e06a2083a4205b7a87cc0129210989a1a53f544660cc0338ffdfe4cf6a2407ad76180534b68"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x86.exe", 
-                        "hash": "76bc8246a9dcef7fb7486842b405c387abc4558e1fb82d408415904242ce50e387c73be792d4b4e367708f14251e3cf8976c3a9be20d89b09d1944fcddb07859"
-                    },
-                    {   
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x86.zip", 
-                        "hash": "4e8235d1271e79a2e6ec5f1ceb05a1daa85245529a56764bc4abd84e8483e2d4e739cf2e3efc6a6fa6a6dd94be2d491108ce71b15e1a555df43e3d9349d12c0c"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.402",
-                "version-display": "2.1.402",
-                "runtime-version": "2.1.4",
-                "vs-version": "",
-                "csharp-language": "7.3",
-                "fsharp-language":"4.5",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-arm64.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-arm64.tar.gz", 
-                        "hash": "7a71f34867da96c84380e17d5c5e6263ed4de455865df6ec0353f941529ac6f7964de72f72fb8ef4848a2ba8c5676f8c28de8480f411d591b7da38bdc015812a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-2.1.403-linux-arm.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-arm.tar.gz", 
-                        "hash": "021315da0bb32b70d9c39f793f5783010ebb7ba8dd1d4a4c38988004aeb56e8f14926a9b049ad707bd1dc93c3bf6653b5bbec20077be0cafae5669120d1b7726"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-musl-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-musl-x64.tar.gz", 
-                        "hash": "88309e5ddc1527f8ad19418bc1a628ed36fa5b21318a51252590ffa861e97bd4f628731bdde6cd481a1519d508c94960310e403b6cdc0e94c1781b405952ea3a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-x64.tar.gz", 
-                        "hash": "dd7f15a8202ffa2a435b7289865af4483bb0f642ffcf98a1eb10464cb9c51dd1d771efbb6120f129fe9666f62707ba0b7c476cf1fd3536d3a29329f07456de48"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-gs-x64.pkg", 
-                        "hash": "5ddb5374a9eaa71b6281c0e4d79cead5d22fb349270df32246486ebb055780b75659368fca50bbbdf97378206732f178b622a6b462a048662df1d962284d15af"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-x64.pkg", 
-                        "hash": "5ddb5374a9eaa71b6281c0e4d79cead5d22fb349270df32246486ebb055780b75659368fca50bbbdf97378206732f178b622a6b462a048662df1d962284d15af"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-x64.tar.gz", 
-                        "hash": "6abd86e3a340a6d529f6406be7a6db466bfe1daa2368631bd4e4c01216512c54ac4f2f710d1229e4f1550fd4332eb33ac1dd8a9dadd1947fa8b2981c2557cd2a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-rhel.6-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-rhel.6-x64.tar.gz", 
-                        "hash": "d224d51cf6d05211026fe8afd729f39eaf306d5f5f2df82ff000dbb4f9914b2ab9a9d4d27aefb892ff2a80532bf5377aef4e979ac9fc343cd8918bc860463b0a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x64.exe", 
-                        "hash": "1020bd17cb6587f73125f36428bd945b720ba612037f58d7bb33751b90783f6e26090e125cd1421439c167a309fb62d2c480b8ee8e9e40dee1bf33dbe0fd5d0d"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.exe", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x86.exe", 
-                        "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x64.exe", 
-                        "hash": "1020bd17cb6587f73125f36428bd945b720ba612037f58d7bb33751b90783f6e26090e125cd1421439c167a309fb62d2c480b8ee8e9e40dee1bf33dbe0fd5d0d"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x64.zip", 
-                        "hash": "405cbd7c65d63b36e3bd6bcdfc897ac6474c4eaf93db9db478a80ab511bfa7a1c4a84024cc6e4af0df0af86bcc0a1a96a8ba0864c77bf579f32bce437c28d5a8"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.exe", 
-                        "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-						"url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.zip", 
-                        "hash": "817d16ab72713b85af14becfdb828dc8e2dcfd2654d12b3ee8caae5bc960401df5e2923272f42ff9a39687d32a607d14a1642a9f45e6da0d3733708c5fe0c3dc"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.4",
-                "version-display": "2.1.4",
-                "version-aspnetcoremodule": 
-                [ 
-                    "12.2.18248.0", "8.2.1991.0" 
-                ],
-                "files":
-                [
-                    {	
-                        "name": "aspnetcore-runtime-linux-arm.tar.gz", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-arm.tar.gz", 
-                        "hash": "b0f2ce9c018605395d5c7a47a233fac83097df41ab7cb351827d727387646f831b0a1c251cd488dfeb9c473a18510f53b50ba7b1fc4322808f95ab921fb8e84b"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-musl-x64.tar.gz", 
-                        "hash": "173168730d6fe23a7c5457ed5533e4dc103a2f95ae5c0118a3ac4fd06ad23a1bd5a605bd43b10148cf8bcfc3a5b4c32d78b8d745dd5ba57921449a236f2c8ad8"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-x64.tar.gz", 
-                        "hash": "5581be34b1e54650e1495aef9e4c02d676532dd11316174344711cde7d55cd434382ff389cfa741d364bded66d6fa560399077080376e351cbd7678009441d8d"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-osx-x64.tar.gz", 
-                        "hash": "d7cf81866131e90b95067c60c2123f68411f940256673766061df6c8778d33b861b49d2e14996bf08cd6b900fd19b6f6ecf483da3b0931e469b27f159384ff43"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x64.exe", 
-                        "hash": "e6c24e68333797b652f9408ba95ff2fd01d8ced3edc475d8f3446984a40a5856624b1da51850e819cc44f1e29d94cc0cc9c295e6508199d553d8982f064c023c"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x64.zip", 
-                        "hash": "53d8a381108562253bd0c5336b2f8c3a665c54d95c09671e8867d3efd35b47967bda4a208735194a14e8d401bb7f9e995cddb20d430d1e90956222c266308d37"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x86.exe", 
-                        "hash": "1c76147f6cfdd463d79d9096930247dc86ea5e9e4d3256452a08ccb6bc09d8047e3f828c37a7aa15e03b8e6f2173d0e300ec8250b7277f33941d5c6ed5f2c9fc"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x86.zip", 
-                        "hash": "db8794adc8363fd061e592a264f0b8333e9db3a030ee8a2d3f811ab8d82dc7c9c084d4ccbf29082bb4400231365de0c70350a8dad48ec620fdfd89eaf0043dcf"
-                    },
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-						"url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-hosting-2.1.4-win.exe", 
-                        "hash": "3f80f0e9144b0dcb61d14c4e9f8d2b84ec0d111cfc56eab143570f0841794f596bb0092d68c09088a8d889f5ed49fb13d63e65b3497c7e3ec3b59e08b6b641e7"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-08-21",
-            "release-version": "2.1.3",
-            "security": false,
-            "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.3/2.1.3.md",
-            "runtime":
-            {
-                "version": "2.1.3",
-                "version-display": "2.1.3",
-                "vs-version": "",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-arm.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-arm.tar.gz", 
-                        "hash": "3d42d5127d1729028467cf692c11ee04ed9a9f8445e0968dc5fed5894946bc901bf8de6fc57fec8373aa24d88b2f27fbea98704615f52506901747bed407732c"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-arm64.tar.gz", 
-                        "hash": "a271e741ac4b9afacc466aa081add4b54e83b646b9d1e8b8e7001aaac2f24a51973a0c0e9f191f7a4b83a123557cccd057cc0a381075a70b1f52926009018fb1"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-musl-x64.tar.gz", 
-                        "hash": "fb9a080141038545af3fced55acbd7ef0d4948d527115f67937bfb6eee012eff0c1e18858ccab43f2752711f2eda29445d2c42edf5557348686844b2046a3b54"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-x64.tar.gz", 
-                        "hash": "e2a9a25436744498ee827125083e41151e90e914091863d396ff8d3916467e8ebef4cdfe5c97a13381e6d257d1e01b7a02f846b9c8406643848e3d433d6bd60a"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-osx-x64.pkg", 
-                        "hash": "397b32f3637d32e5e77265a73fc6af74f57c00e34f77566d3c50ae762dc0124b79ec5b34365eddeb856fb6cbf626c77d0eb16ed7d48f1f0eeff9e0b07a3c6015"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-osx-x64.tar.gz", 
-                        "hash": "504efdbe6a83ef5a0c8a21be486295e703dd0f6b0a11c633e297d9f99523a5ff570c57cb197f3772a80239e4df00c6c6d47d2021dc63496ef1026b3950772af9"
-                    },
-                    {	
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-rhel.6-x64.tar.gz", 
-                        "hash": "71663d1b5a15e89fe3022556c10ef12f689bcc7376fae7833c7a80535ec44b057346cb71aef90ad5679e41c0522850a950bbafe78a791a9dd50ff1c1e79dc58b"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x64.exe", 
-                        "hash": "17346ecd526edb965a91b217ee488ae649bf77e28cb33cbaebd505a6c4dc9e599dcbfce54782f8dd82eb4d1423621a7726c9f9fa1583495f24f81f3c1fb35386"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x64.zip", 
-                        "hash": "eec3465a1dfecc3890e8c07d45198352a9ef4026bebc867ca8723ddf4bf30e83b79dfae4c5b8800a4b1b83d38c63be06b8ebf7c5dce87cf7108cbb83b169b47f"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x86.exe", 
-                        "hash": "e7b04de3475b6352e19e3d6c2bdae8c962b555b2c77962685da86d47bfe166bd0a096c20367b0cfc94feb01baa1edeca77aee793756c3be4775de6b497f1d967"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x86.zip", 
-                        "hash": "c9dd70d7b98297d32de05108efc2f3859f31fcc4c92a20e8797c51df7d14608280185dbdce25d172a56bfc935562fa66677497c48b8115d92245be3e4bc6fa5b"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.401",
-                "version-display": "2.1.401",
-                "runtime-version": "2.1.3",
-                "vs-version": "",
-                "csharp-language": "7.3",
-                "fsharp-language":"4.5",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-arm64.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-arm64.tar.gz", 
-                        "hash": "b8e1a4ba94fe54d7f897da2118e88dfb3ec97ab8595b40f72b972e65d5e95a673b0907a58790b710c37ef2681f6f7a0988f2da67da5f8517a60208c887186550"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-arm.tar.gz", 
-                        "hash": "0b428331aae4adbc28fa0e8bd4696aeaffc86d1643cb366e9b7e8f7f27ada57d91c640490340acbe017fb7bbbe375cbc47c9e49d5905da230eac0eb8168ca6ff"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-musl-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-musl-x64.tar.gz", 
-                        "hash": "cc2a75abca3314118b97629dad9c21039d80c9dba86b0b89752b2259fa66b7c1734f7e6632e38e785b8db1b12f4a1be67d36330bda5128bec83306088a2547c5"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-x64.tar.gz", 
-                        "hash": "639f9f68f225246d9cce798d72d011f65c7eda0d775914d1394df050bddf93e2886555f5eed85a75d6c72e9063a54d8aa053c64c326c683b94e9e0a0570e5654"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-gs-x64.pkg", 
-                        "hash": "7b644c808a3987d26306431fbdca73fa0120680faefddbdc063c92335f23e2f892e0d3db4e4c410d2b292f732d9445d796150b2dd89af2668f15853050d4080c"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-x64.pkg", 
-                        "hash": "7b644c808a3987d26306431fbdca73fa0120680faefddbdc063c92335f23e2f892e0d3db4e4c410d2b292f732d9445d796150b2dd89af2668f15853050d4080c"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-x64.tar.gz", 
-                        "hash": "53ea33279f0f217a3b13b144e231b2931b001e43f9eb988722b698f8331c56e279ebfde5962fb6de98cbfeb552c8f538d127e08da639cca4b73d6407d102b523"
-                    },
-                    {	
-                        "name": "dotnet-sdk-rhel.6-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-rhel.6-x64.tar.gz", 
-                        "hash": "26ee3faa349f9351a4c6d789484c8ab62da43181fe63c468ba9983d68c65433fa66c2f5f52ce4dc7e8ef6a1f9345b5f4fe5612716e74dfdc47f9f4a44261f579"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-gs-x64.exe", 
-                        "hash": "cedf1e992a025c9e8887aa36e6c0b920ec9d2482fba3068505a110e7e7bfda603ca0e2675089b46c25c04e9d85c0a74dd35e5f42adbfb4f4848318c48f93031b"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.exe", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-gs-x86.exe", 
-                        "hash": "2e41720a7a055a12e23bd638f550b791f9919ad1eb0ca966060a8bb16b0ef018a8f1d052da10cf276c24998cce476be49be9f17f475325e7d09433a837db0f82"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x64.exe", 
-                        "hash": "cedf1e992a025c9e8887aa36e6c0b920ec9d2482fba3068505a110e7e7bfda603ca0e2675089b46c25c04e9d85c0a74dd35e5f42adbfb4f4848318c48f93031b"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x64.zip", 
-                        "hash": "7d017487c1a11ae4db862b1efa7ba9beb0eabcf5d2467bc4055aa2227a548663a596682ff4adba4688930b22472587f29b83bce9f689efc5e9f4e37f7edda000"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x86.exe", 
-                        "hash": "2e41720a7a055a12e23bd638f550b791f9919ad1eb0ca966060a8bb16b0ef018a8f1d052da10cf276c24998cce476be49be9f17f475325e7d09433a837db0f82"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-						"url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x86.zip", 
-                        "hash": "d3b5c9d071ba5e083feaa4507c60d99d3d10f8a01b69263ef1f05ae0ebe973a576a94a20fafd8455f7aba2f9feedaba671775586e9c553e1811e2cf32d477321"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.3",
-                "version-display": "2.1.3",
-                "files":
-                [
-                    {	
-                        "name": "aspnetcore-runtime-linux-arm.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-arm.tar.gz", 
-                        "hash": "89783eb504e52d393c85133861f0230c322aee452efb27b9e30dbe874e7255462eba7eecc152d5c8cedaa6101b05a4d73cd9f9db2240d0727a9fe3173fab7348"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-musl-x64.tar.gz", 
-                        "hash": "5699445c571a64c68000cf97555debee4439d892a43d3409c14dc730eca38b16dc8a4842807c3ed9b086d3e2e41fca28e15af430cbadf3c9959b055b17893795"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-x64.tar.gz", 
-                        "hash": "522eccf29a1d08f11d803934c8e436321485a12a96c51bab19a8bba58e363b7277fccdbf95909bdf4c20c9166e335b834f250ec8a782c6e91d44bb86c44782b9"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-osx-x64.tar.gz", 
-                        "hash": "4f48bbd22861826e6b63959ac4f28f66fcde56525d7e8b5a0eccfda565df860cc77b573d75a91615874addbab515997f10aab330082c14802426ef74ef875faf"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x64.exe", 
-                        "hash": "098bb4a0ebc04add24da0ee153eec4bc2f6b4bda8f04d6d05cf2956ac11a261d46611250cc4644a40293bf8c0dcdd15c03f664f71635d2f5b13295b3ad0ddaa4"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x64.zip", 
-                        "hash": "a9ab3f01fc07527016513f47fc46427f6da8ee45ab847eebe228ca940f00d7b791431295b5aeaf8c8fb07f4ff1d4e8894fb4cfe5c36e74684f08f7d9d15a0e6b"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x86.exe", 
-                        "hash": "cef632b7f47ee421764bea6e526fb2813dd5b2c3611a8c603bd1e72ff450f63a57fa6902d583625fceadb11c702b47d35e62766cedccecad8c91d7a8b69a1dbf"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x86.zip", 
-                        "hash": "7e9dfd7f1cae2739d1d79a07a35ea4d84cf4c28df6140ee65289a7694ef20f6b1ffd519990e900d38389357f9dae4bc63a47f26af1df70a1ec6f88448384f6b5"
-                    },
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-						"url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-hosting-2.1.3-win.exe", 
-                        "hash": "7868ba46822b6e53c2a8056ec28f59434c7ecadb8e0adf8285396e12deb31cdec26158c54e4d0cad0566f8f7cb2f0612f685bd1ef20feb9e2864e36702e47116"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-07-10",
-            "release-version": "2.1.2",
-            "security": true,
-            "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.2.md",
-            "runtime":
-            {
-                "version": "2.1.2",
-                "version-display": "2.1.2",
-                "vs-version": "",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-x64.tar.gz", 
-                        "hash": "229db61d9c1f9f587ce20f06ac3517e459a3c16b465dbbcf4fd0457ba216e0aea2d0a73df94b651992e744a8456de8bacf0211bff3a281198cf9fad845e9d8cf"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm.tar.gz", 
-                        "hash": "c720033a558284b139e891b588642e7975afdb0137da9aee096cd8c4bd73453d1641a75d18a13bb4aebb282d31730cf2a6fe963e84bec315f3296efd72924973"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-musl-x64.tar.gz", 
-                        "hash": "092c966af4e3b697aaff06315c3eb3e342651643d3a1929bd33bb5f638e73989944ecdfb02ac18b251b797ff4cadcb312f4be9fe8627b4dd4b8dd8b51ea59ba1"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm64.tar.gz", 
-                        "hash": "0567b927c23bfcb67b45d15d1c052036676c5196b7432ee918eba6f99e5538d9052d049de93234e469e3fafbebebcd2bdeacd6cf8ea9a787b632e0aff6dd06c8"
-                    },
-                    {	
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-rhel.6-x64.tar.gz", 
-                        "hash": "81eb0031553ccabf92fc63fb0c1bc7eaa5a746c95363ae55525ca48a9c638ef457ca51c785e0f13b03cdab49c16b04fe3d1c8c23e22148f504dbac8171c6fcb0"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.tar.gz", 
-                        "hash": "a39d10c1680e2adf98200285ee4b704b3861e371113e0359388fc0fa479222dd69e513b473e547b8382303918d708ce78a42edc06bcf4f6885775788dc0632d7"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.pkg", 
-                        "hash": "8cd973a1efe329c16b3099acd33ee191359314d4a6c9755ba0ea717ecb4ca773bb44bcfcc64181e68cfbd4ff6f214ab67ba1611b89b0c399423ffeb88b8f1d92"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.zip", 
-                        "hash": "e0e941c2b89b8638447e42f93a0a028cd81464ac4cea6123acb4130b72dda03744b3bcbb42683f1e9554b1cadd1c28f35d97523278f40de5e8c57606460556b8"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.zip", 
-                        "hash": "9e67c62feb34aeb52a45d0e623d1ad098637a322545956eb5e6de2287ddad2412b766c492ae5a7dddc123a4cb47cfc51d9bb10d0e30c007ec3fc90666f9733c8"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.exe", 
-                        "hash": "3539dbc699a1bd29f79c4fe95d28246cc53c4916acd30927868e9e6fe1da3a40693bbe9bc8e69b814a25d7f044c289231a200a74204a2f374d38545083440fbd"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.exe", 
-                        "hash": "b15d988c51bc2da9edeb9ad3b1b643ef1f71d16eda0e35dec6224a67a78e9e1d58a3f8d0fdd727cd9643b5d9816664b02aba158d7884f0bd2098561e237a3ffb"
-                        }
-                ]
-            },
-            "sdk":
-            {
-                    "version": "2.1.302",
-                    "version-display": "2.1.302",
-                    "runtime-version": "2.1.2",
-                    "vs-version": "",
-                    "csharp-language": "7.3",
-                    "files":
-                    [
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-x64.tar.gz", 
-                        "hash": "2166986e360f1c3456a33723edb80349e6ede115be04a6331bfbfd0f412494684d174a0cfb21d2feb00d509ce342030160a4b5b445e393ad83bedb613a64bc66"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.tar.gz", 
-                        "hash": "67a83f30f5c4d504eeafe5200711bff6e7c4c365067f4e6140e31f3e149974aa34e993d5ce9b39377b6e3e031c85e4348a46723519e87f200618dfebafd0b1f5"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.pkg", 
-                        "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-gs-x64.pkg", 
-                        "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.zip", 
-                        "hash": "bb540fa18f32bc9d911ccf29df682c216d08cd5881e6b6a988e182ee2350a60eed24e56392370f2bc5bdef046496ac7c63da7e7ffbaca79fbb54c299f109a0b7"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.zip", 
-                        "hash": "a8a74d3329191df6357a00e26591cdc64153970e0cf42f820ade0fb520c9cb0e6ab16ab357dc9538a8c488245c505930b4b0a6b63721e4eebf8682613a63441e"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.exe", 
-                        "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x86.exe", 
-                        "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.exe", 
-                        "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x64.exe", 
-                        "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm.tar.gz", 
-                        "hash": "af18d6dc918bd638342a5910415e4f53b55aa802adfed551f164ccd6d1441aff70947b7985d7ad1ce7c7eb7d8f05995b45c0405a520d9577ff9c019b0ef5cd6a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm64.tar.gz", 
-                        "hash": "93f481278d9da6ed7ba16d66c9742cdc9f66b31e6d09cd14b4b27621f44116f9a26386076de11e5ad3e967d51d95c17816287e164c80eebfd55852227a038457"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-musl-x64.tar.gz", 
-                        "hash": "0f9a6fcbad609ef1ff5b398de9a1f1bf59eebc59b28a4c8cfead28f0209bf77601d05d49f5ea1223c860a803fb82cd7e2401b6df290da34e54b36bdd8788ed48"
-                    },
-                    {	
-                        "name": "dotnet-sdk-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-rhel.6-x64.tar.gz", 
-                        "hash": "9991d57f1e5f4f2cd227bca9ef980457d3422ae28a36f6c5ed2a7d0665f9d378aad2c57d4b375a7d410eb229b13a18e818f3f980dc222e9c5347ef62dbde8633"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.2",
-                "version-display": "2.1.2",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-hosting-2.1.2-win.exe", 
-                        "hash": "1b20f9eee7b83d5068e8e4ac5230b7e584be944c4da1264fe117fa3a93aa520250e38e8bce7b54f87db73a40188e49c6caa9baa0f3ab45e38d4eba8a54e98e53"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.exe", 
-                        "hash": "63c8dfc01ff5a3a852a4d2930e185748f534ddc6c8aae96fac1cd6f7780a97aeb7d38a2b7be1f90c61df8bb3ca406cab37c5673676434d3597925ecbd2643276"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.exe", 
-                        "hash": "cf0f185c906dae5e359f230f2c5bcc65e6f04a3cf6fbac89b79f02ffe2e13f2c4085fb817a7f65038df5884be39057a992b43631d74f52c6d5951861c03f6031"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.zip", 
-                        "hash": "a9ab3f01fc07527016513f47fc46427f6da8ee45ab847eebe228ca940f00d7b791431295b5aeaf8c8fb07f4ff1d4e8894fb4cfe5c36e74684f08f7d9d15a0e6b"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.zip", 
-                        "hash": "86414db4ce9ca76b3c40649da098fdc8d8e6dd79e4f94ec3a1402eb5506070ca8d9ae571a6845262720d42e5ef35e4ef396a0c01ecaa58fc55bc503c1ab8dd65"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-osx-x64.tar.gz", 
-                        "hash": "5b9ad8e0fbe473cfc4f39516e3f793940287cefbb5fc2eac4dfcc346693d9b50242073aec605972fac0ac6f3d77f3d3715af32362061339565fb50db17f994d7"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-x64.tar.gz", 
-                        "hash": "294a6c256ce7954c05c3dee85d4114e320c7b94b2ae2e854a268b2bb4383a967e1063ee0df0da0f09511b3dc9c215aa735899f5c6db4f11bd58da3cb9cc8b6da"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-arm.tar.gz", 
-                        "hash": "49565a49e8357894b34a8cd12e1cccf9702c2c9c3dd06e1fc7c184ebee5b2fec43290e18998b60a77dbd5dfc5d59b838f3f4210675db1d64313cf206a22fc6b2"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-musl-x64.tar.gz", 
-                        "hash": "7e4ccfd0610949c4e228da38d40223ea8086bc98ec92d83fb0823909f40e897c3ad59706ff84e4dfec7873a587e83d9d98826dd13dc2bbea239a927f6906a9cb"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-06-19",
-            "release-version": "2.1.1",
-            "security": false,
-            "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.1.md",    
-            "runtime": 
-            {
-                "version": "2.1.1",
-                "version-display": "2.1.1",
-                "vs-version": "",
-                "files": 
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-x64.tar.gz", 
-                        "hash": "39737997bc10de06b8fcae448f1c740dd422d9f6e4f71a61f364b5643adfade3f3902ea07eebf38c6505e5262312d05cbc9f295d3ec5f8d5830f4ab73236a5a5"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm.tar.gz", 
-                        "hash": "470b0cc3a614b716ad288ad527e1f00e5e7321636ba6bdecfab770a3d84da20417fe4ac362a22f4c6eab4b34614b7b3490b4b00a2f9824ec957199e14696f7b9"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-musl-x64.tar.gz", 
-                        "hash": "5bb938b012d86bcecac42e3c4e915cded051ffeffcdb4122ce41cfd53896395b952d61ef10e22e37d330a78eeb861550e0c73d0595ae001228a03bb0d94bd286"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm64.tar.gz", 
-                        "hash": "28c170e1d7e01e0de67f77b0e65f26816cb20e3ea4cccb148506bef830d6dfc9ac0825408bd36432aee15027f6c0a41ca52c69f01060db134f21be724b6115e2"
-                    },
-                    {	
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-rhel.6-x64.tar.gz", 
-                        "hash": "d6e512a3f854ace827b0528299f4d2286e43f5dc526440d0c014bafebe98932ecef5079879e4eb53f965a4304e724a2238913e4233c9633d06e058a296bd32db"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.tar.gz", 
-                        "hash": "4e1ccaa728a12f508fcc69dd75270b9bac5cd6e4458eeb3ecad8d7ab718f5c1750d7d191420af9669a1d87c503b645f3b1dde98a92d818e9ab7e79a504136a1f"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.pkg", 
-                        "hash": "7b5c750aacb9c62e3fea36889661b63e7ad1fd2ed331a8d413f36c54e136d3d219e27fec8874202e9dd66f7458d6c60dd949c56f1dbdce927cdcdcb8ddd017f5"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.zip", 
-                        "hash": "864df7bc475e7a05dd20b8b5c927f8a7c2370446046070b5b1262a07c34253259769d1442a1f5c144cd4b91285a5f275a3919f8de2ae49d0e35a122e57af051c"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.zip", 
-                        "hash": "4414fe957d2630404ef23d2ceb9d8d2d37fa4d1249ef4755d05302b179a64821fca6d21d4de011f4b466c090ffd7c5422f2b94e88168bd868ddc3b22557bfacd"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.exe", 
-                        "hash": "5d2968020c2d255429860606b509f25ae3a5a4fa79569cdb4c5ae1fca6decd0c6c43feff171000111378d99c413e349504b7b413051e73b1dd9c2ce73f4d23dc"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.exe", 
-                        "hash": "e1ecf007a7ceb18e92acde8ea3d3f5c15c2adbadcb6366c8d743eb6752761efdac02185551a009420a9c878cba76a5abe6bd8d73626edaff104a2592a241d3ad"
-                    }
-                ]
-            },    
-            "sdk": 
-            {
-                "version": "2.1.301",
-                "version-display": "2.1.301",
-                "runtime-version": "2.1.1",
-                "vs-version": "",
-                "csharp-language": "7.3",
-                "files": 
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-x64.tar.gz", 
-                        "hash": "2101df5b1ca8a4a67f239c65080112a69fb2b48c1a121f293bfb18be9928f7cfbf2d38ed720cbf39c9c04734f505c360bb2835fa5f6200e4d763bd77b47027da"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.tar.gz", 
-                        "hash": "120444d800d7761b4c535d601b6e79a32c9d7443f8029a47600b6d30c59e0e0f0573ce7ff435b6a563028c2cd19abcb5406fff48afa3f969ee8464db7e216bde"
-                    },
-                    {	
-                        "name": "sdk-mac-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.pkg", 
-                        "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"
-                    },
-                    {	
-                        "name": "sdk-mac-x64.pkg-gs", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-gs-x64.pkg", 
-                        "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.zip", 
-                        "hash": "237a0a980d8bcdb4d8c9adf7824f9bb9e50da47af224fd291d7667f88efbe7432a66a606ea4fedae018f1a252db938c19bded3d451f7a2fe47b0ba47d0861e9f"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.zip", 
-                        "hash": "f2f6cc020f89dc4d4f8064cc914cffabde0ce422715138778a6bcbbb6803ca66d6fd967097a0209c47c89b85dd9e93db48486ac86999bd3a533e45b789fcea89"
-                    },
-                    {	
-                        "name": "sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.exe", 
-                        "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x86.exe", 
-                        "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.exe", 
-                        "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"
-                    },
-                    {	
-                        "name": "sdk-win-x64.exe-gs", 
-                        "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x64.exe", 
-                        "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"
-                    },
-                    {	
-                        "name": "sdk-linux-arm-x32", 
-                        "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm.tar.gz", 
-                        "hash": "f241a9e6b910f0000691973784a28b652ab7feaf329fd732a7a808a2c5926e7116c8c78e6c42806663135b6d3fecd7f9e1c28e24ec3db742a585a93befb17500"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm64.tar.gz", 
-                        "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm64.tar.gz", 
-                        "hash": "852d29e572398347afe166bbde5b17c5e09130d7af72ba5b483766b80b6fb657695102a92f5bd247f0d011f807cc05a4e7c61f8aeae577b95fa9fae9819bb3fc"
-                    },
-                    {	
-                        "name": "sdk-linux-musl-x64", 
-                        "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-musl-x64.tar.gz", 
-                        "hash": "86e288cce53999b719ced7959f5ba652f667b8c1e0aec266c3012c9870380e5142e3f5ac103f03691d4426158d9da4d7c89f0739dee5815419a6150c8ee84a12"
-                    },
-                    {	
-                        "name": "sdk-rhel.6-x64", 
-                        "url":"https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-rhel.6-x64.tar.gz", 
-                        "hash": "e638c0fdbf41668477e92afefe9a2ee29229aa2880dfaa83fc01b6c4298ab8d2699581fdbf543533d70873c8a4d430bf8da32c64a90b6b2c19a7766f34632739"
-                    }
-                    ]
-                },
-            "aspnetcore-runtime": 
-            {
-                "version": "2.1.1",
-                "version-display": "2.1.1",
-                "vs-version": "",
-                "files": 
-                [
-                    {	
-                        "name": "asp-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.exe", 
-                        "hash": "bc4c6ba1a5955e8486d3960d354182fa885afe1e56989e49b12420b6fa8dbbc28a42e653bbbde85e5ad638ad2fbf96bf99a52f5d5b1ade03b399e8585b28f897"
-                    },
-                    {	
-                        "name": "asp-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.exe" , 
-                        "hash": "83041e846f74ed2594d2ad0f6f28efb007ac5b7b8a7489326d9d6f2dedbe7132c3f5e769daaacbfcf56d183f66b339bc278c773496573adfedd52cdd30ed8f48"
-                    },
-                    {	
-                        "name": "asp-runtime-win-x64", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.zip", 
-                        "hash": "312b4610e3fffd2bcd92c6a215c245bb112f40276837bfa2edea9cb9376554f6c237fc773f2c83c146cca6e7bfcfc53d708627d9a76a896996174ff300666528"
-                    },
-                    {	
-                        "name": "asp-runtime-win-x86", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.zip", 
-                        "hash": "18c6fcb50376a57657ed0a4c254cea5fde0a5b7e7f7086dec7fb1153711f5545bb1f70beddf688c2ee7cc473fb607ec9a6a4663f05a25d473f2dad3a41de7034"
-                    },
-                    {	
-                        "name": "asp-runtime-mac-x64", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-osx-x64.tar.gz", 
-                        "hash": "2ef0ac04986c587914a9bcb9062d5abfbf4ec66efc68be8f3e8a6d46df20a839e0a04d0cfb7d6265a275bbc4e26245cf3d496a769e90bb88e1c5b8a7f944123b"
-                    },
-                    {	
-                        "name": "asp-runtime-linux-x64", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-x64.tar.gz", 
-                        "hash": "ab7de9d3e01d940ec985b1787532d856abb24d64b59066f0cee343f79edd2cd67be4b0de2788b9bfc97968311308384f912888e9ea8fd8d6def7e143c4e825c0"
-                    },
-                    {	
-                        "name": "asp-runtime-linux-arm", 
-                        "url":"https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-arm.tar.gz", 
-                        "hash": "5160edb49a16e24ff4cb018bf7ff2eb6638b514abaa9e0d5006e83399bd5830116c35e317b4d9418d2ecc7b757b21d7cf1353d445a7162fa81e990e9f9034a42"
-                    },
-                    {	
-                        "name": "asp-runtime-linux-musl-x64", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-musl-x64.tar.gz", 
-                        "hash": "b8d3ac5c1970b2a6d6fe812c66b55ff74b1a130010889d6b828a031296355c7b507b7289a90c149d5f710f93847609c6264fec0da5d196df6c2aab3100a8797f"
-                    },
-                    {	
-                        "name": "hosting-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-hosting-2.1.1-win.exe", 
-                        "hash": "6c24ec02e6c8996a419ad0f7092ada5e58754a5e1db7f1828670ce8f4503c22e14bd74ae8b86a99833147605157763a8d95bc5dbebbc5643c92fc28c4b58391f"
-                    }
-                    ]
-                }
-        },
-        {
-            "release-date": "2018-05-07",
-            "release-version": "2.1.0-rc1",
-            "security": false,
-            "release-notes":"https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.0-rc1.md",
-            "runtime":
-            {
-                "version": "2.1.0-rc1",
-                "version-display": "2.1.0-rc1",
-                "files": 
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-x64.tar.gz", 
-                        "hash": "29f27f7b208ed20be71941f8c57aa5dc3c4a0e0fceffa4cf80553fca81dcfbe3b7f26a93662aae86c10ebf5f43a150bcac9290033dff6876d28683141e5d98e4"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm.tar.gz", 
-                        "hash": "d2a49b3b08ab282bbecfc578a3e24f76dc25dc15be5cf2021a33942b6629e47f81ac6c4766f97d4529fd92c4dd8c781a28c13eff3bff2e7b484a5b2c994ae37e"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-musl-x64.tar.gz", 
-                        "hash": "4f4b6bb043bc927643448de7744139cd5006f6c6108d39aeb24af1c79f76d4bcac05013e0700972f230d35315fa73241113fee2374d82e3318bc9f170a533652"
-                    },
-                    {	
-                        "name": "dotnet-runtime-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm64.tar.gz", 
-                        "hash": "a5ddf10cf8477d811b1ad5958e4347cdb40a3fcdc9cd0e471d38245fca4e59e42e27d0c756a4e354988c979276ad41e33d42d151aae60f32601ddad21df56d85"
-                    },
-                    {	
-                        "name": "dotnet-runtime-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-rhel.6-x64.tar.gz", 
-                        "hash": "13e4cdc01d4dc0985a1d6edb9aa228b809532e4e07d29ba7e6f001663c2e2e8478fb4b3459622699133debd122214279a5597762f659000e3efe18d9544ccbe0"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.tar.gz", 
-                        "hash": "db2c6d403f5cd37c1fe0988d0f207d8dccc9940046553e280b16690f71225a638f3f90b86e43e2c26b02adedb86978c86ad6831c583f603dd43dcb7fb93fdcb2"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.pkg", 
-                        "hash": "5895c7dc2e721b921da579ec37b8defb47e53a5ccbca39a0dc989b04be24c9736c0b9c4fe2eeb0bb078f3a5cf472aae2d42c3f8f08b9fd2305f5e4e101503075"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.zip", 
-                        "hash": "1a161832ac0ded127b0f4ab36569b5d06cc1681818f72341cc530c4a645d7cc5b21b568c5e07749aa27968982487d9b18aae5e246cbf5ee385a10fc9783520f0"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.zip", 
-                        "hash": "781a67337f7717f38f061f623c8491dcb91be58750dcb47c15ef5519ab4be928ce8645500fad67a30026476e64e507d18210aab8f18213ffb48d83e0fa935cf7"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.exe", 
-                        "hash": "e5ea1830f5cc94a5aa5dee744797b19a6af5c59c4e222b1e694e05acd9deb5474ffd24b6aea49ff72d8d8743eba20f3adc19158c7b5fa7ea3168a20333562980"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.exe", 
-                        "hash": "279a5378ecff673dc15acb56c94fbd04e2261d77eea78f0679fa0a975a81b6f5bec37d3fe99f6a9bd2d228047afe024627071ebdbdd28ac6a57d76ed3e4eb1c0"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.300-rc1-008673",
-                "version-display": "2.1.300-rc1",
-                "runtime-version": "2.1.0-rc1",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-x64.tar.gz", 
-                        "hash": "f3964951e577b7b829a8f6cdc8b9477fd8ea39ad6baaed30f369280d06523ca3574cd8679d74bca027acdad0cb02fce76e46d742d705741a7074d99fdf95cc06"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.tar.gz", 
-                        "hash": "0e3e86ad493d7844d226d3e423b4d912124ea62ef8cb440de8fd318a579e105aacecde774e24c7c1c082d395e6b732970ae7c08c6e47e4e7477066174c251206"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg", 
-                        "hash": "3a0c2356712007232f83b38b89427d4cc6d576778e3db331455eedab393e1bc86ce771226eb7e2e6edd8230170fefb54e82d2a3b13ebf09d4478600c5b518ec8"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.zip", 
-                        "hash": "9e4e904f7743b6e0635f3474361eebb00f1164aa96e12fabcf6ecf2c56fa84abf974a1af5c7df8dc0139c8f11e43faaf5b85bd4401896320ea52f87f87aa37b3"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.zip", 
-                        "hash": "a9e8b89dcac02ebaec82bcd8bbb55b42480e1ce040b8204e5fb8c2241978af7a090952de09982c02b6f9a1bdb85555f7bf356c6c8aea2d0207003e1d5f521ab4"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.exe", 
-                        "hash": "803c748bb67c77939232b36ddcc90b3663fd3679cf82aab0baba5979caf28252a2b171e2e3c69bd313a87e2ca78869bd484597170a2118c359fffa3dfb2a4470"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.exe", 
-                        "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-gs-x64.exe", 
-                        "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm.tar.gz", 
-                        "hash": "2600659fe88f2ae0fa3e491e5495123d441d87aa392a2ea40d0eaedb0aee471c2c824de4b425742d1e4cc5c4abaf272ec56b079458b9f062eab31c6343a14862"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-arm64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm64.tar.gz", 
-                        "hash": "75ad50527eb4468b313bcd79d8e506c9da1670a92d4f06dfdfc6f524153edfd46447799ec50d90bb5b1dc6fbd04fbbd3fb7e4cf11b387db8005bdca2a947a67e"
-                    },
-                    {	
-                        "name": "dotnet-sdk-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-musl-x64.tar.gz", 
-                        "hash": "852b51b0802297c13d6b86f6fae38c515eaaf51893dedfce129966134a8100f5da2ab789295528ae868cf54cb9f7004fd37bf97927f716bb193a6232f181a38a"
-                    },
-                    {	
-                        "name": "dotnet-sdk-rhel.6-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-rhel.6-x64.tar.gz", 
-                        "hash": "687f0bd409c6370d7cdb6429eb59f345b31c6ae14ba1e76dafd518cecffee33ea23fd4705e3e89409dfa1ec6eeb31137656a00e791f59e5157a430a12cd42947"
-                    }
-                ]
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.0-rc1",
-                "version-display": "2.1.0-rc1",
-                "files": 
-                [
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-hosting-2.1.0-rc1-final-win.exe", 
-                        "hash": "45ae5913e8fca08513fef71bd9a849dabd829bbaf5fbd6e9489ffeb38177e65b1042e267243d40bd70df404ccd292c15746ecd2c820ad35527308b83da4bddc0"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.exe", 
-                        "hash": "1138f7e2a23cf0309cb53986e219d52a27cba30d8d5caa3697317b4cab951bf2976211f0894eaf60900da778b4aa790490c417041abe9bc741695a259ff94789"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.exe", 
-                        "hash": "b5e9a89ecfbd638c0f92bbb1626183def620c22e50169fa58a7a21faa83a2d48ef8f3cdc9b2815527e8885617db3624e25a5c63cdb23cf73ecd07056afe997f9"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.zip", 
-                        "hash": "18ce3332214fdf8e68afba978c2cc35213595e2b0d70c77d5e108f939990bc6234b6fda9159e9a020db3a7fe8ed5bee2d85df5bf569314056cd495a0a06fd1c3"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.zip", 
-                        "hash": "c11d4d533828267d661cd7c01afa8a6e14a979a7595bc446284635e2e24ba10c299aad451c960f0c39afe7597e00aa311c77c9eef85cbc6768c8a136f05b2b2a"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-osx-x64.tar.gz", 
-                        "hash": "d929b601885bbd965ae47d2942d0e9d875a9750d63ebfe4015879b9f54c928bf833b966f3a58430d0e650d4de5afca524dffa7a71d5a4a5af901b51be2012f3d"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-x64.tar.gz", 
-                        "hash": "156ab969bc533c3a64b770f2b88214f0b07d1d867922257182d496828ac3cad6d6c01ea44f2a2a1d568278bfdf916db9825452de26a1262bdc591ff19f6e4b99"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-arm.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-arm.tar.gz", 
-                        "hash": "c76690fb147b39ab8113efefd3442e40d26c3767bcd9e1c3b0692d6cb022ceb0aeb5eecd1ef38af89e3cba59adf8579347e005608b09622e10186732ecc41f47"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-musl-x64.tar.gz", 
-                        "hash": "701a96fc3b27d6ebc46f2c9192bc1a048d1c3915888cdc2223183e7a8c7be7e591e9ea317c2e6a363c841013ae2209564da470e48f268c374084ab57c28a66a2"
-                    }
-                ]
-            }
-        },
-        {
-            "release-date": "2018-04-10",
-	        "release-version": "2.1.0-preview2",
-            "security": false,
-            "runtime":
-            {
-                "version": "2.1.0-preview2-26406-04",
-                "version-display": "2.1.0-preview2",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-linux-x64.tar.gz", 
-                        "hash": "9f8dce51f0438e0cff5fbdf38a60c620d879825902aae4d59ec026c6cfd0f6d2237f220a5346836e6e3c50a5be7b357443ab4ae01f85c596abceec12a8dc29d7"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.tar.gz", 
-                        "hash": "5c8602cebe11b08a34e60b7bf2a826ee1e907e0e6aa4106b27f4af9063ffb2dc3cd03123c8bb1677445cdaab1fc0af758d11f752d5228187ac1f256eb9f82d75"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.pkg", 
-                        "hash": "a09fe3640b4dbfbf1ad005a44f488da264aceae83f8f9afac9d60df1ac51e0e8c96c2a5a88e880d545ea72162c286c206b833c2133260d10096bb8c50f50b065"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.zip", 
-                        "hash": "46816c29827516328f39147b5bf52f8f1786e8f58e3628ee02bdf5b080f7420e62b57751a9fb16caec8f4de41766be28693f29e42d5de1eae722938def6780ec"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.zip", 
-                        "hash": "eabf2cb0fbaa096739b5e25fb43ebe7b3a8a62756e25cdccf740658a0b7d1166259645c61f8c6e5c1c3577d440ee6285c9ce504ad6b9f66ba9d7fd71c211bd1a"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.exe", 
-                        "hash": "80a5894d44d153de640a9c9216c1ddd7c3a98033e06661658dc71be6d8c8f750e13f03f217ba01a4917fb2a20a78d8eadec742836357dc8d4f5e6bfaea60b732"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.exe", 
-                        "hash": "53c42d54ba7ce83d234efa63a6dae7c38593091ac28839d2f8706ea866f2fe2bebe88c8d03a09eaf8673ea257a3da099b4b7b8647cb100cdb17f3aa5257b2716"
-                    }
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.300-preview2-008533",
-                "version-display": "2.1.300-preview2",
-                "runtime-version": "2.1.0-preview2-26406-04",
-                "csharp-language": "7.3",
-                "checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.300-preview2-008533-sdk-sha.txt",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-linux-x64.tar.gz", 
-                        "hash": "a50ce826458092cc0547c36ff0d281e00b71b5689109414ab41b8bd9b57fc1f20c04fd55c6c298503bd552b1eb1ddf9eb634f947ea3ded2ceb3fb61436df0457"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.tar.gz", 
-                        "hash": "088ee5309bc07a32d8b142c6f8c4bc981d37f6d14a1138dec452baa67dac4840f82b091fb3a5dc0b8902dba540ccaf96bef10d9fb0b040ab07e2af170ceabe25"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.pkg", 
-                        "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-gs-x64.pkg", 
-                        "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.zip", 
-                        "hash": "fb906747d1bd7258eb803fae29256de02c1ca92d48041142cfc3a64feb5a36e7a91a04ffe12b407a2a67e003ae621a6181313a1f8833ce48417c7d2aa76c2566"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.zip", 
-                        "hash": "e2858d0809cd727ef361ecd192cc79208bfb04b258b1c7375c4a8fc34b897a4d0f244c67744f2c4154c1b8cf47cff4f656b70357f8c2d06c30058e82d115ef46"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.exe", 
-                        "hash": "3fe6174590802bea4e37f8c415d8ce5afc72113b8189511f15110057ba04cbf24d8495d57e8b67584a13706c033278a0daec33530ba43dea0403bf106524ea19"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.exe", 
-                        "hash": "584ff392f4a49700afe2e18819b888be8320cfcb3133618866934690d23f127a1b663eb35ea91072c19c8d2d498b4847f0f4ab4dfc15b4bf4f4ee4b96419308b"
-                    }
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.0-preview2-26406-04",
-                "version-display": "2.1.0-preview2",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-hosting-2.1.0-preview2-final-win.exe", 
-                        "hash": "5cca21d9f1cadebc130607f1ff14ab17db05f971ee218a7d855f452bd1f36ac8c7773af4662887c711c93ec6bd2c85a5e648aad845c2c9543ddf25e186cabd44"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz", 
-                        "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.exe", 
-                        "hash": "79567d9c4ee73195ea49d735b9a4a70f1f2485c3f38c53e83f624488b112a6304118f7ce8a48b7f5a169365165a8b11f5743c69141b260237846e24a560fb684"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.exe", 
-                        "hash": "a574395e4a478bd7f6a3f932e0ceccfc527661218ed24c7e33ea761a909d3598be522e7002b67f67a6569e9be5f79d4021cb1207d7877e17b48d0a82be6b0587"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.zip", 
-                        "hash": "5e247e07e29dc6932bdd810911461e78c16d30c5724403953d20971383be06dbed7b579a21a10b0da7d90ada884ef9f2d8a9ea7dfc442bcb4cefbc1a397c00bb"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.zip", 
-                        "hash": "857560b9e780b686e5503d84574da811a302c3f1435d8dc09398b5e28a1cb2b5f82da87fc04ea170e92f37e5bb68f2669d5ff68b8cf64ea10d8f1735bde34cfa"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-osx-x64.tar.gz", 
-                        "hash": "7f8463f06af03cd951d1a2497c7d76def63239269ef510443bd6843f6fc9e3b68f4b0d812f8d22236a9d45c0c0cfd8166793461250c76037f08c0122b151c3ae"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz", 
-                        "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"
-                    }                
-                ]            
-            }
-        },   
-        {
-            "release-date": "2018-02-27",
-            "release-version": "2.1.0-preview1",
-            "security": false,
-            "release-notes": "",
-            "runtime":
-            {
-                "version": "2.1.0-preview1-26216-03",
-                "version-display": "2.1.0-preview1",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-linux-x64.tar.gz", 
-                        "hash": "0249b32f68d1266e6f481e16266b4b2d027b1644d182da31e34ef3c60b37fc755c5f85a482de6c85cdf095c8185221f666c7d6bc62364a786f0f2f8b72919c88"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.tar.gz", 
-                        "hash": "47431a5e6126ebb883d8e8a18ea7327dce285da41fd809860597c9574ab1e35fb323933f743a49e7a5078fb6e41740ec4611f5e1ffddd3114379f0b4db30a8a7"
-                    },
-                    {	
-                        "name": "dotnet-runtime-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.pkg", 
-                        "hash": "8cbf0f7cacbb537619c580ff8ec7ac012aa40196ac00b2fbc2514a5097c878f766158d79a72e0582418ec20c6d98be7bfa81867c55e989b7da055f0942307ad7"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.zip", 
-                        "hash": "1c6c6a6821eb5e3435fa57c2661584c4118a5a951f5f7df8087922f692859ee230566dc806b9a48e8dceed703f157cac3ae3619c645e18db487a8f740db4ed95"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.zip", 
-                        "hash": "511447ea54aab82b9b890936440fe08a0c25e7b579050ec7706bf9212a58a31cfc56420a9de8775a7bf3bc1e39143045c542617c065e59b471323eb00567f9d4"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.exe", 
-                        "hash": "8ec6e0efe7134b79debea41fa7bb45736f7a317260b15955c33d018ccf21fc13c46f1b30f4d0abed385ba76437d3be861e97fdc12022b99bc69c31cf22497214"
-                    },
-                    {	
-                        "name": "dotnet-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.exe", 
-                        "hash": "b7830445ac00a37718ed1b3b563fa323ca5889484141d9dd30e9b46b004c62ac2c003cc8f8bba1d4266ead62966817c93dc21c36f0660de3867125dfaffe04d3"
-                    }                
-                ]
-            },
-            "sdk":
-            {
-                "version": "2.1.300-preview1-008174",
-                "version-display": "2.1.300-preview1",
-                "runtime-version": "2.1.0-preview1-26216-03",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-sdk-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-linux-x64.tar.gz", 
-                        "hash": "3030d6876eef6770c54e6d1e23f1be544b72dfe171915d2e55e00e40faacec0035fe4f9d72a6dc5fc5fb29b768ff64c57dcce0b9fddd8f1b7f7ce8389f535da9"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.tar.gz", 
-                        "hash": "65de990bdfd131f9246e5b47480211a2b829c73b1dd0248c6c32417c0489539c15d98d12ffd70034a69b952b49a89eb79360eb9e0f34802706ade2563c78e1c4"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg", 
-                        "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"
-                    },
-                    {	
-                        "name": "dotnet-sdk-osx-gs-x64.pkg", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-gs-x64.pkg", 
-                        "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.zip", 
-                        "hash": "e1466e7652e7787206c06f2e642f10bf8815a8d02a06b8fb4db7c7941bdb64463c10a4dc1fe59b8c768353404016fa384a00c5b14f228272845f6a75f14f1896"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.zip", 
-                        "hash": "d1195ec86e745854735c2d8431858987b937963d5b96dd2f1fbecfe8f3b9c4259fbd9454fc7e81542aef117903a0674c7aba242bef3a761a9c8237f71286793f"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x86.exe", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.exe", 
-                        "hash": "bd8a9145f651026cfa1ca7c264c2e05b3740afc0b5f8ac5572409a95836d8f87e1a8c460eb985182501f679b721a97fd174b7690ab8cdc5e43c8155ee8af94b5"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.exe", 
-                        "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"
-                    },
-                    {	
-                        "name": "dotnet-sdk-win-gs-x64.exe", 
-                        "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-gs-x64.exe", 
-                        "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"
-                    }                
-                ]            
-            },
-            "aspnetcore-runtime":
-            {
-                "version": "2.1.0-preview1-final",
-                "version-display": "2.1.0-preview1",
-                "files":
-                [
-                    {	
-                        "name": "dotnet-hosting-win.exe", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-hosting-2.1.0-preview1-final-win.exe", 
-                        "hash": "4f2b8bf998bbda10f32cad96b5fa15bc944f321afe97e9a21da3e1984d25aa4cc39fac5c138e88ae126b7e3db78f07149517a38acf1066f8e5d2321044f76aa0"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz", 
-                        "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.exe", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.exe", 
-                        "hash": "c14bfbfc0ceed63e08340384ee849ab9700f708486a3d09c4cb4651c7989a920563e008faaa3809e13e610231576cd55e3e676bdfb8e31c24f012484c4cbf433"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.exe", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.exe", 
-                        "hash": "8f114a4842d6f30c16b929f163e2c88428de25f2477baa0d4a0beb5965e7dd05c7c6e52d305ff1da9d3377bd3f7f6bb766a78920383a732542b1af30cad7d162"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x64.zip", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.zip", 
-                        "hash": "3a56bdf4ff099bd8f51e9b6b06a3bf3c34ff9769bbc655d81df2660be3af0de4508d97295e820fb3b04f7c79c3034b313509ad7cfa897636db8afab2115b8b63"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-win-x86.zip", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.zip", 
-                        "hash": "4792e530651ef0a276218e3ffb7c7d4e0bbd44d68eebb384f2f4f627024b4ba69d74ddce8fb9a6b2e0d9b11910bd7dea542c3b19eabc2e9396d2475ef681523c"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-osx-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-osx-x64.tar.gz", 
-                        "hash": "f8c78d7ea16f54d4ed87aec532b57bed8271265eefc3134647b50d760e6bd7fe001eaa6fdcba5d15d2db5330f3bc82ce2ff0b88b5bfedeaff53cf42143e2cc47"
-                    },
-                    {	
-                        "name": "aspnetcore-runtime-linux-x64.tar.gz", 
-                        "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz", 
-                        "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"
-                    }                
-                ]            
-            }
-        } 
-    ]
+  "channel-version": "2.1",
+  "latest-release": "2.1.502",
+  "latest-release-date": "2018-12-11",
+  "latest-runtime": "2.1.6",
+  "latest-sdk": "2.1.502",
+  "support-phase": "lts",
+  "eol-date": "",
+  "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+  "releases": [
+    {
+      "release-date": "2018-12-11",
+      "release-version": "2.1.502",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.6/2.1.502.md",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.502",
+        "version-display": "2.1.502",
+        "runtime-version": "2.1.6",
+        "vs-version": "15.9",
+        "csharp-version": "7.3",
+        "fsharp-version": "4.5",
+        "vb-version": "15.0",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3690b37f-002a-4e8b-9563-cf30fbba8c57/36498efa5d47af3b9e9addb50d839db6/dotnet-sdk-2.1.502-linux-arm.tar.gz",
+            "hash": "F5A9BF61C81E0BC5A33367F63320C792680E80DEDE884C604531715BFB741F4B0F53779BA57ED8E0A2AD3546358A42F531FB28952725E17F8CB5CA3A4B66AC60"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa69f29a-6cde-4ca4-8c34-d60df776a648/63065948aa517fb0af456eca88eae5a5/dotnet-sdk-2.1.502-linux-arm64.tar.gz",
+            "hash": "F3D8907623B1BD7D15E2D9B9F51B8BDA6DF00969F720E7D224E9B3B5DFFE9FA1B2A9269CFE3AD6AA8FAC81129DDD94D88F8674839B9D41A41BAC4E3630306D63"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/91c9af05-2149-4ba5-88f7-a8b77298197e/be1802e1a05a7b34dd1a5cdfbb6443f9/dotnet-sdk-2.1.502-linux-musl-x64.tar.gz",
+            "hash": "5C06A416ECFD04AC58AB104BB2D173246D41AA2AC1F6DCF1B141C0D825638E9BDE9B378AAA73F08BEEA6EFA68C8B8E206B5B33F43AC40B119C7E6AF7CFBA9AB8"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c8893df-3b05-48a5-b760-20f2db692c45/ff0545dbbb3c52f6fa38657ad97d65d8/dotnet-sdk-2.1.502-linux-x64.tar.gz",
+            "hash": "366609243FCAE4693218154A3F374822B5CEB77B7E1A3561DD0CC89755131FCAEC04777E99AC041554D452B4862D2856926A1C213029FC80C7292959CAF3AAF6"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/06addaf0-590c-4418-9cf4-83f63376ed16/d6e57f0ef630fb767a8ac8cde58e4a6e/dotnet-sdk-2.1.502-osx-gs-x64.pkg",
+            "hash": "4A006A5D02C0BE76DDFC4FC89E93C620AE396B407BDA0C2BB034711AA6E473CB60AE2CA943EDE656F3DC3D7262D2AFA222FF94F9A28F5DE69FB14C24A469881F"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7e834c38-a210-44e0-be84-0380298901e7/cc0a2df529f71622ef3dc6781cab0d6b/dotnet-sdk-2.1.502-osx-x64.pkg",
+            "hash": "4A006A5D02C0BE76DDFC4FC89E93C620AE396B407BDA0C2BB034711AA6E473CB60AE2CA943EDE656F3DC3D7262D2AFA222FF94F9A28F5DE69FB14C24A469881F"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50729ca4-03ce-4e19-af87-bfae014b0431/1c830d9dcffa7663702e32fab6953425/dotnet-sdk-2.1.502-osx-x64.tar.gz",
+            "hash": "79302509DDFDBCD6B1C870FE79884EAE919072AE94C20F89ABB2E056770A77F76544E1160E633F6EB81FC346564D85993329A5A4EDE3C12D28A11D2D031A1130"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c1120295-348f-4135-9f0c-ac157a72bd4a/733da9695dc48fa554db4e173b8ab168/dotnet-sdk-2.1.502-rhel.6-x64.tar.gz",
+            "hash": "C5A9D86306EB7A19A58D60D60E14A77058D57F9EA6A1D2DB52B9107834E62B04B721ED34E16194F5F7C99CD81724241280C87B7855D68ABD7AA9997B6C153089"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f86f7cf7-9c38-4b97-aeea-713ead74902d/d381b15374c3dc9e1759e2f7c19231c3/dotnet-sdk-2.1.502-win-gs-x64.exe",
+            "hash": "20E5D2E54CCAD8CE2C5EED0EFFCBA5D610C8BF1D15F8D2EE2E792547B35697EA408A415D2F580E0E2F693339E5E10F0A46B82B88171016378AFBBA4BF4A55227"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bef7de68-66c5-4102-9c7a-2087ae2d9e06/a1f1c1afd190d8aae7a2fc0803b470ee/dotnet-sdk-2.1.502-win-gs-x86.exe",
+            "hash": "F4969D01F05ECA28B545B335E221DA6DA07A3B087A4B91BE0153494ECD483DB943178BBFB8EA1C8D032C07F0C1F50F801CCEF1542F3B09016E760E0D1CE8B277"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/70b3a142-06fa-4d86-b1cc-67a48c1eaacb/55e147bd47db930a642a8f8176949a76/dotnet-sdk-2.1.502-win-x64.exe",
+            "hash": "20E5D2E54CCAD8CE2C5EED0EFFCBA5D610C8BF1D15F8D2EE2E792547B35697EA408A415D2F580E0E2F693339E5E10F0A46B82B88171016378AFBBA4BF4A55227"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c88b53e5-121c-4bc9-af5d-47a9d154ea64/e62eff84357c48dc8052a9c6ce5dfb8a/dotnet-sdk-2.1.502-win-x64.zip",
+            "hash": "E6408DCE29660B36EBF5318F9B9108FCD2672FD0B14B999847C6173E0FDA7F553DB40718DBE1FE2900147E2090930DDD35E3B6CEF3EF47B3749ADC62CD274A9D"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/caa1967f-4459-40a0-9703-cd7c4330be6a/722e7928c1bbebf2b174f5293c97328f/dotnet-sdk-2.1.502-win-x86.exe",
+            "hash": "F4969D01F05ECA28B545B335E221DA6DA07A3B087A4B91BE0153494ECD483DB943178BBFB8EA1C8D032C07F0C1F50F801CCEF1542F3B09016E760E0D1CE8B277"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e2d8f451-0133-418e-a1c6-caeda12360ef/d1ea1b0296c02a2dd4b23d33f89db12c/dotnet-sdk-2.1.502-win-x86.zip",
+            "hash": "CDE212A2292093103F79ED104283E2EC0159CA38C9A9EE9048A61A6CE3951C421D4D8BD62C16A5B7B637DDCD8F5B40BB87AE6195CAE9589BA8A768AC17F4A6C3"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": {
+        "version": "2.1.6",
+        "files": [
+          {
+            "name": "sdk-symbols-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/319e69e5-3a4a-47a9-a454-b4e17380e5da/6af8d9c315d8f24e95e6d4c9a28cfd3d/sdk-symbols-2.1.502-symbols.zip",
+            "hash": "3AEE6A4B827400C0B4264591BEAFAECA0936D0E7229D50CD436C78B63CC408555AACC59A0060063730D59E6514309B12769C1DDFFE0FDC36768B5BDABB16858C"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2018-12-06",
+      "release-version": "2.1.600-preview",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.600-preview.md",
+      "runtime": {
+        "version": null,
+        "version-display": null,
+        "vsversion": null,
+        "files": null
+      },
+      "sdk": {
+        "version": "2.1.600-preview-009426",
+        "version-display": "2.1.600-preview-009426",
+        "runtime-version": "2.1.6",
+        "vs-version": "16.0-preview-1",
+        "csharp-version": "7.3",
+        "fsharp-version": "4.5",
+        "vb-version": "15.0",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1fade46c-c475-4187-927b-7d7157369c3b/2fb766d7c38c239012f731023556db56/dotnet-sdk-2.1.600-preview-009426-linux-arm.tar.gz",
+            "hash": "865FCF406BAE3E39A7EB2277FAF3C96F1AF7800F1AF3096F768558F52F901CCD23203641807942951B84BF324F2F7F05D9074D0D7702B61EE1BC1BF590499BD7"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ecafb359-728b-4427-bf63-934c716bc7e0/834ce1100ba2c0b2e49774df486dcdb3/dotnet-sdk-2.1.600-preview-009426-linux-arm64.tar.gz",
+            "hash": "9641CE375F63B42F49E472456146B0155FE3A714375DEE36939EA94A12E51E7C6A27A26469ED90581AE6C46E2AEB6C5526C11D23647FB9F3908127BBAD11B958"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6816ef17-18ae-49c3-9ad4-46fbe6267f1d/da7b8326a6d798864a9afd0a7c880b70/dotnet-sdk-2.1.600-preview-009426-linux-x64.tar.gz",
+            "hash": "2DDDDC2652032DE14DEBDBF55D6940AA227F8FD37199D098F0AE23645732A77B850A02444084D4FBCF4BDFDCEF89A2964E47FF210179D89816970F9B7BC391CD"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8a16c4c8-b187-4a05-93de-fa1e4c11ea0a/d2d4c18b99c2d1ec0fcbd2f8de4ff08d/dotnet-sdk-2.1.600-preview-009426-linux-musl-x64.tar.gz",
+            "hash": "F43E826845065FC877659614FCDE3C0F9E588C636E5284EBE72FA48A8F52EAAE56FCD99AD18A2C77145CEB761F88A6EEF9AF1C48C3AC3ECDB539BF189938279D"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1690aa3e-6039-493c-a57e-9d24f2616e96/d56658e8c3886d6d69d58e6c83ab5c22/dotnet-sdk-2.1.600-preview-009426-osx-gs-x64.pkg",
+            "hash": "FF77BF94390B4CE0A0B3237F3B5A854FD2527C694F519E5D74DEA9217A888644A3F202E63A9F5E4AAF497A2617EC59B1B840655B5592EC7617BC3DF9439D7176"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7fb7ea6-9007-4f82-9dd2-775bb447cf53/dbf5150a44ed20a661733817210baf1a/dotnet-sdk-2.1.600-preview-009426-osx-x64.pkg",
+            "hash": "FF77BF94390B4CE0A0B3237F3B5A854FD2527C694F519E5D74DEA9217A888644A3F202E63A9F5E4AAF497A2617EC59B1B840655B5592EC7617BC3DF9439D7176"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f213fe3-7064-40ba-a0c3-743c73f45f65/4912a6736c4213f1af8441228d0e01e7/dotnet-sdk-2.1.600-preview-009426-osx-x64.tar.gz",
+            "hash": "3ADE09CAEA4FB32CC4CD380A3043F59602B6D9D3721144ED1A975082767FE5C354FE480CDF2CDB8CFF968101F3876F37B55651B09DAC36BDB47741A83664D5B3"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/58cc9506-7391-4963-b34e-627c49af5d28/067849b44703738968ff5935ce45cc70/dotnet-sdk-2.1.600-preview-009426-rhel.6-x64.tar.gz",
+            "hash": "24C526293BA5A8A1F0B200AF8E6412BF49E96C3C6008E9C472C3AA6A581D6B785CE78551B9CC2C8343B3BAC358CD2680905330ABCD92A5715D476F8CDC4ABD02"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/31a8cd43-a31d-4d33-b6f4-0f430543c9b5/e88b8ff32ae2f40c88c7828cb8ab589e/dotnet-sdk-2.1.600-preview-009426-win-gs-x64.exe",
+            "hash": "FDADAF2CB923431993C02ED3F6A8C6336357F444B4123FA8C92B9C706C84A977E32EFEB0FCBF333854A07A3FAC2C088CDB569EC763D6DBDBCEE44E41E6C662F3"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e8fa06be-54bd-4a15-bda6-6876b688abcd/be8609cfb001a1c94bfffd7af310ba14/dotnet-sdk-2.1.600-preview-009426-win-gs-x86.exe",
+            "hash": "B77812812B33F53606A947184438D6D0A41D4EBFF38E2E9E68DB3FD0460EFD3A066B6A0F37E9E0F8BE31FE39C8AB5DC3A2CB6255A0DFEA648679B93FDA2DDA1C"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/154685e2-3cbd-4505-b559-a57da259faaf/5e1d31266aa5bc670c2201acd357a220/dotnet-sdk-2.1.600-preview-009426-win-x64.exe",
+            "hash": "FDADAF2CB923431993C02ED3F6A8C6336357F444B4123FA8C92B9C706C84A977E32EFEB0FCBF333854A07A3FAC2C088CDB569EC763D6DBDBCEE44E41E6C662F3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5e82e02c-e7f8-4b4b-8e51-b874162e6c9d/dfb0d37d216779d788fa7990bb441342/dotnet-sdk-2.1.600-preview-009426-win-x64.zip",
+            "hash": "46B0609F69ADFB6FB1B714C402C312E9E10D372BC50F3B7DC4670C25509DB2FF1EB47235006AA21D9B2BC49B92B9959E45BA1C70F5071A7C1EF9717C1FA5C922"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b7a5055e-b595-4e18-895e-0a6ad1718c60/3f180c6bbfb5b2e451fe1871d9f58fe8/dotnet-sdk-2.1.600-preview-009426-win-x86.exe",
+            "hash": "B77812812B33F53606A947184438D6D0A41D4EBFF38E2E9E68DB3FD0460EFD3A066B6A0F37E9E0F8BE31FE39C8AB5DC3A2CB6255A0DFEA648679B93FDA2DDA1C"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f8ee2e6e-d56d-464d-a4ef-55e7243ed58a/9a6637ccd2fe5bb14ab65b711798cb22/dotnet-sdk-2.1.600-preview-009426-win-x86.zip",
+            "hash": "B736C393A6A2AB062FB5C41E8FA633628051A4D221E7AEA64E5F0008C12B040E911BFD112DBF085D0A2817F1137D20FC1FABEB6F0A91FCEABBA1A5E6D9DF0172"
+          }
+        ]
+      },
+      "aspnetcore-runtime": null,
+      "symbols": null
+    },
+    {
+      "release-date": "2018-11-13",
+      "release-version": "2.1.6",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.6/2.1.6.md",
+      "runtime": {
+        "version": "2.1.6",
+        "version-display": "2.1.6",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7d461733-a0cd-48ee-9963-791337dcaafa/3b75ee4c7fb9d6bc7d0ddd9761676096/dotnet-runtime-2.1.6-linux-arm.tar.gz",
+            "hash": "4F44CD5F6B61D0A4B7E73B138FDF5EDCAA9E148BF0473514551F4D03D97C29F297662C726D145ECDF80CB58A086F925F97B7896C796CB3D82FE927F5CAF7BBCC"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9cb31ef2-d5ec-490d-8a3f-f45f52d28fec/4c906b6132f2c0fe55e9e0209f08b352/dotnet-runtime-2.1.6-linux-arm64.tar.gz",
+            "hash": "C3CAF2E270C2EFF9B84A16335C0A81681D43A95BCB08C444F4AD04B4AC78FE19D49BFE4BB57E4DED9B965F300534130CB91377E9A7B6252E312924D6378DB807"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b934284c-96e3-49ab-9c86-6332092bafa7/480c4ba3ddd68c4a303c8de3616ac4ee/dotnet-runtime-2.1.6-linux-musl-x64.tar.gz",
+            "hash": "8A0900B7DC010AA2293C5926D13A05F0A2DE1F13EAC6A1EAA3C9997A8EC6363D83C852763B118B3DDB6586F95F34263CF27E769B4637BB4BD196BF73AA62269E"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5c1334bc-bd26-4232-a745-2728b36a2628/8e163216cdcec15332ebf2e5575962de/dotnet-runtime-2.1.6-linux-x64.tar.gz",
+            "hash": "74D99AEFCBE953B30743330689E750156E68C3410BC26C40A11B60BBBF1D01887262BD6D7C0EEACCA4D6B696C1A04980D9BE2DC2A222226FA910B885D2FB5956"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/26452190-8866-4e1c-8bd2-e4699d775555/befaa5544a34e875621b239281d662a5/dotnet-runtime-2.1.6-osx-x64.pkg",
+            "hash": "605B81BBE71423FCD3C2A3F1548CCCA04DDCDE08566B0301AC43130C239406EF621D174064272F04C5584900CE1F3F2B4D93E1D3B8277F07150404EB3A492992"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0f36c0b9-397b-4303-9a83-2f09e08affb0/dc43655b905e0c3d5d5fd89cafc1fb81/dotnet-runtime-2.1.6-osx-x64.tar.gz",
+            "hash": "595578F419094175E9A0ECEA4D0C8FD86682C5962DDA98B68403C4EC0760FB5EE7C922BB9E15100894A2E05AC16D458D22E814CA32B5BB0790F0E51A2F563643"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95777fc5-eb49-4fe3-b136-db2c1e8c4cab/17cafbf4d0d6e234e4ea6cc143739e1d/dotnet-runtime-2.1.6-rhel.6-x64.tar.gz",
+            "hash": "1367020B7808793C466692025466FBF08CCBC5C18D0A2DE4944FC3C53482FC30C699753581B12B387113AF1CACA505CAA1D1FDC1DB6985666CF0C718A081D8D6"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8dcd5adb-21a8-43db-ab6a-d6c8e37b20fe/d52d48805fc35dbfa7ce411fbf5fda59/dotnet-runtime-2.1.6-win-x64.exe",
+            "hash": "603F397C1F5C37571F24A56AD4B22DF442AC98B86085CCF96E38077F7940700CC43678458030E626F49C7B6A027A5BA90FA5BAC03013C2223EC9E91FBDA4ED34"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f6b6def-4e9a-4405-b21f-89f77d1605c4/52be50baa0e9bfa118fe6de80be89ab6/dotnet-runtime-2.1.6-win-x64.zip",
+            "hash": "F716C90B0A4512F3611A9D6D922FF1F7B5BF306440283798E17B893920D390DF15C503F5808EE34BEB3CE6355308C6BB3435F06CDAFDE60BE31397C2633CC270"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af783fb4-da01-44f9-a8b8-9e52dda7970e/3d9920fc37175a41140f9c8af542a42c/dotnet-runtime-2.1.6-win-x86.exe",
+            "hash": "7BB07641D47BFC293F61BFD18F6F960C21F5590D7E52DBCB6BD95AEFF8D037DC1EC222A9067D2B7BFA3DBDB01EEBF843DF815400654D1E724D3BD71190FD9996"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3ef3e42c-281d-43e2-969b-3f6aafef56f1/a13f4c966b0f499b8883f6e6f8b1765c/dotnet-runtime-2.1.6-win-x86.zip",
+            "hash": "193C7F357F953D0B19012EF63ECCAD42CF69F5BA6DF12B132C0618C152EDE5F385CD7312CDB3D95841F9BB1705D1E4E50B0214776A111F38D50666DE52F545A2"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.500",
+        "version-display": "2.1.500",
+        "runtime-version": "2.1.6",
+        "vs-version": "15.9",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/201cbc49-c122-4653-a6c6-0680643d9a26/1951cfc077d868a31563a5a172d18d78/dotnet-sdk-2.1.500-linux-arm.tar.gz",
+            "hash": "106D3E5B7B96CA3522E78B77F094CECAAC38C348D7138C2FCAE0464FF9D57EC137802603C4A5C6F81B9EAE9DE39B86BFF8D9FC573817E033982EB576532E334C"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fc8a549e-fe2e-4b88-961c-8f7b5d054faa/1676cb29cab62a698e75748a745950c7/dotnet-sdk-2.1.500-linux-arm64.tar.gz",
+            "hash": "E5C3BBD610A38BE1F74E4851EE5B701052103EDDF9A804AEAB276048A06E812278E726E7718C5955A1159C41CFE98B8E2700F8BEF1577C30B242D7AE1A8212E1"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0a6ac11-dcce-48b7-8369-423b8652545a/c337fcbef824fd32139ee087914726ad/dotnet-sdk-2.1.500-linux-musl-x64.tar.gz",
+            "hash": "AF061F17D88E4371FE523B895B60A0259296E2CC2BD9854A04541B87038638E0A7B7053288B45BC00A89FBB04DBDB7218A76EA9DFED8919457E758C532C15E9F"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e5eef3df-d2e3-429b-8204-f58372eb6263/20c825ddcc6062e93ff0c60e8354d3af/dotnet-sdk-2.1.500-linux-x64.tar.gz",
+            "hash": "85055728E2433DFDE41D15C85475F2DC6CFDD30242B4B23065B63CB12CC846ACB93C09C000B02B722890CEAC8AC382B40871C78660716CA2339C71052FE52F4E"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/576dbb8d-03f2-4d45-857a-b226d39b3dbe/0d4fbf91aa1137352680ec98ef9edb5d/dotnet-sdk-2.1.500-osx-gs-x64.pkg",
+            "hash": "07DC690149914252EA88D16D0862685F213405E375E5C49162420B3BE4B8FF0AB562B7DF12C800A77DABF0574CB57D4D6DE0EB961696F7410A4563B88CB49E7C"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/59a7b78f-4e86-473b-b230-c84d15505cec/766e3e5f35e7bb9677dd785071c5fbf7/dotnet-sdk-2.1.500-osx-x64.pkg",
+            "hash": "07DC690149914252EA88D16D0862685F213405E375E5C49162420B3BE4B8FF0AB562B7DF12C800A77DABF0574CB57D4D6DE0EB961696F7410A4563B88CB49E7C"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/901c2283-505d-408b-a7b0-01b5ee477783/ae5185f3fde13c7a62651608387a2a71/dotnet-sdk-2.1.500-osx-x64.tar.gz",
+            "hash": "E87FD0EA816C1875A896CB284F762F22D2AC7A23C84F4D10F5299EA54E8ADD9D4E782656F53726627D615F98D2E6C288AD634B75F80D6F815EDF8B35F484C817"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6b4325af-ce22-4440-ba5e-b4b1444cf712/3691bc5eabd7390b47657e9d1d232355/dotnet-sdk-2.1.500-rhel.6-x64.tar.gz",
+            "hash": "323A727C1112A167E87C3C3510496C07DB10B36757736F8510150EA200B45FEC02913CA81518115205C526B075BE25A2DCF45C63C23B5B1C3BB759D36D18D17B"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9b60a25e-5b31-4550-aae1-72516c1067f6/52e8387487fecef06266a7a19c97ddee/dotnet-sdk-2.1.500-win-gs-x64.exe",
+            "hash": "A6EB777DF0F8581872EF34D9363EA0148A95314546507B879B648CA8AA051791DA59377CA3F1786F18D2831823F2A2A9B6D275C96572F0917C88FBEB18272C32"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/246c196e-2934-4571-bf21-b988a0f57e90/11329123100c557261e585a9871c2398/dotnet-sdk-2.1.500-win-gs-x86.exe",
+            "hash": "E34065EA573598F4098A9D57A05243FB9EE58C7A8AA08A81E7F6248372BF850F4A69CD2558FE1BE98B267491FBAC5022657E67625595795F9FB9AB5BBF6F8B14"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cd42f66a-2b6a-4a7a-9e69-0bb4eb5a83a1/0ce246546a0886349d9acf872f4e15a4/dotnet-sdk-2.1.500-win-x64.exe",
+            "hash": "A6EB777DF0F8581872EF34D9363EA0148A95314546507B879B648CA8AA051791DA59377CA3F1786F18D2831823F2A2A9B6D275C96572F0917C88FBEB18272C32"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a508a9d-91e8-4126-904c-f7a515f8a33b/24ff5fe2610ce1ce76370ed053b14094/dotnet-sdk-2.1.500-win-x64.zip",
+            "hash": "C8A398773A517B7D36BC29895FC1C4B6B0D47CFDBED04D115FC75E8D0A4B7542B67C9125F701EC1C53038E846848F3C77CACAE2B61986E66164CFCA05005CA08"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/59613bc7-269f-4c39-a58a-46b35fe314c0/ddae846724f96c9886b319b8f825e475/dotnet-sdk-2.1.500-win-x86.exe",
+            "hash": "E34065EA573598F4098A9D57A05243FB9EE58C7A8AA08A81E7F6248372BF850F4A69CD2558FE1BE98B267491FBAC5022657E67625595795F9FB9AB5BBF6F8B14"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f1e5fc51-e5f1-44d8-bd59-88b0aa849b3a/fbe1740c06c7fc87b8345c193a12bd59/dotnet-sdk-2.1.500-win-x86.zip",
+            "hash": "5143FA77EC0BA779CFDED5E1FE27C9E4A4081F0F67FB69F7E73746A907EC1554D91347BC4D747A4B79B45A5B18E7D3438CF8A7EDDEB3C094C15E70A197FEA8EE"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.6",
+        "version-display": "2.1.6",
+        "version-aspnetcoremodule": [
+          "12.2.18248.0",
+          "8.2.1991.0"
+        ],
+        "vsversion": null,
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9c5d6af2-868c-4021-8b25-4913daca41c3/46cfc8ddb9b8f10ebd56de1b1a534e32/aspnetcore-runtime-2.1.6-linux-arm.tar.gz",
+            "hash": "2312BA29EBCB3CA2E473C90727563E04C89CD771BCB68BE76ED8BCB1D196E7D5B9A886177481837AE397142497CC2947A19372FE0DA23F0ADA0B3C1AD4FD0218"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e4770dec-8d9d-4591-ba45-a8ad1d71841e/fa87d518261a484787824fc0e1d9365f/aspnetcore-runtime-2.1.6-linux-musl-x64.tar.gz",
+            "hash": "F909A6B70D105588C0D4C684E88C1EB2B83001BA55B9BFB0932807953EA9756C5539D3B9BD11666CB07CC68ED362F3786C8F6A0FF91DA072E4B67CD8B5ABC16A"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5ecfed21-c776-4924-b734-126400fd324a/4e1bfb9c870ffcf99b1bf953b91ef072/aspnetcore-runtime-2.1.6-linux-x64.tar.gz",
+            "hash": "4D6416C7C078047ABE3493FDD7BEBE0A796BDB2AAEFAD302FB6A64DD225C871A1183F016F0974C6DCD82F80AE893660B2AEAC2ABB70509435845A430E0117E29"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f6f813c-f02a-47ca-a300-0b89bacac920/19e4e3315b9ec9934f06915b8d367706/aspnetcore-runtime-2.1.6-osx-x64.tar.gz",
+            "hash": "4DC06D8A145BBC78641FABEB699691F05E01A3DBB199F0AC1BD297C5CA57E91A65CB4F77971DA0528563D649988C5DD97A913B11760C0904403E317EF0442564"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/400d3dfc-03ab-4d2b-9d2a-5c1e9d7ef2e1/a1c8fba4dd848186623470da09ec8f88/aspnetcore-runtime-2.1.6-win-x64.exe",
+            "hash": "D52A47BBDF9FDEB2172A04ABFB3E09E318950F512136E020F40845A3604A93DA1B344603204EE9092936CBB76B32150F8A25A9B5DD4786520A3C7460207BCD97"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aeab1a67-fec1-4525-af50-332817900212/016c23f84f53d0976da7070c88c7873f/aspnetcore-runtime-2.1.6-win-x64.zip",
+            "hash": "333C7EADBD5E5202DB706696ED682298C4FC66551AD87A9C374A28CD459AA8C6A47952434BC642E1191B0F10E09520B9A34E6BE19C5387AEEC1FF19C2001EC32"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/207ccb26-48a9-4588-a9f3-e009be0a37cc/afdf4db8ad55a07357f0663fbde4140b/aspnetcore-runtime-2.1.6-win-x86.exe",
+            "hash": "3C23C66D9F9FD65EF8CD4E5779B8E9E1301519578084CF14E35CC366AA1B66C039459E2480AFC855428B1CE23DDC38A5DED8699A37B1237C18B700D0B6657792"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5fbad133-3085-4748-90a7-cd863e910001/c7379a8658d8ff6547b7c74fd59615c3/aspnetcore-runtime-2.1.6-win-x86.zip",
+            "hash": "5D84CF72F6A500E276D3D8C10E138BC180EDA50F29603C3CA0DAF8B4F686B6EE0EAAA8B1A928790DFEBDDAF0EA2E863DD95F86A566A5C98346953C848641CE23"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f674c39-ab51-45c3-a7b8-094d86594fbc/9f7efb24d3486086b2d1f1a8d205a776/dotnet-hosting-2.1.6-win.exe",
+            "hash": "E4F36F3DF427CBB59749B7BD993934229D6D6E985786DFE3F92E77F6F5F10209F57E450AE74B5ACD70C5CE2067C881C1DDAEBEF5164D009E15C648CDC1A7B51E"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "2.1.6",
+        "files": [
+          {
+            "name": "aspnet-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d77ca6f6-fa77-4eb8-82f9-9e8be43e4acd/830ad12af9a632ff05a70e2530a3c564/aspnet-2.1.6-symbols.zip",
+            "hash": "605c894697d96b1e72edf056c874a9eb6a471eb96865275d34404b55484e264467b34d9dac4b748e3e8f3caeac528c207759ee9ef265fcd350af079a91465451"
+          },
+          {
+            "name": "cli-2.1.500.symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bbff4d72-ae50-42c7-9a5e-e3f24448be01/604a59b419eddbbd6a4148b5bf90a89e/cli-2.1.500.symbols.zip",
+            "hash": "0d325c0473f5ce4e6f6b60b2f771b66139e2302aeef22f40f2503d18cc3cd309bdafe1fa319798ec149e50947b5585d22c4454332d2c20208d45d262aaaa0861"
+          },
+          {
+            "name": "cli-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/31972dfb-b0fd-4e01-9d2b-5008321dbf68/f198c9f2aa57f8c7e141d95a6c6b098d/cli-2.1.6-symbols.zip",
+            "hash": "2e552add81cfc61709e043f22158b1714ecb4a28506d61851b868c30b9c24e4acf0b173c2b6fb935cca49302a5aa7cde37bf9ae10f097869e46e970a1c98792f"
+          },
+          {
+            "name": "core-setup-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/04ddc39e-1db1-472f-a7a6-4a51d73cc75c/3d0f620127304ddfa981bdc9dbc6aee9/core-setup-2.1.6-symbols.zip",
+            "hash": "4b3dfd92de61ad1a909380128f88c1e12c40cfda9121b57259b04f62f7ef6410c0fe99194b7e8c6b5f88bd9c1100e76728f1032826546675f8183b86d6a03a6c"
+          },
+          {
+            "name": "coreclr-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/459e604d-efc0-4e1a-838b-e311c890bdaa/bc02969da98047faf9b4d1dc1c70b349/coreclr-2.1.6-symbols.zip",
+            "hash": "77d494554e80e893c78c17385a45debd18b9cb6a8291e4744efabf1f9ac032842e71e90241d569884122b3633b4994273f6b68484fc47b25348a9e30f03a9ec0"
+          },
+          {
+            "name": "corefx-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dc20e757-f7ca-4683-900b-3d0a94134c0d/1743c2e0e4952e9a5ddf2d1c8934af95/corefx-2.1.6-symbols.zip",
+            "hash": "ac621eb41eb81ab6cc9327ea78ef296c71760739ef1f36c25d2a1b8cb92e3e55966de31ed4cdf77817bc23f35242d436dc9c61b49edf710b035e7143fd4319f5"
+          },
+          {
+            "name": "dotnet-sdk-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05930291-d788-4c74-8727-67a8dc91bd10/abef49e4ac04610e9c3ff1317a5b4140/dotnet-sdk-2.1.6-symbols.zip",
+            "hash": "1c98fc7290bdc5cc31cd02f3a6150ca92df3ab18cb15f1a3238124401307076096aa8b45a738a5374d473a31a23185e6be31c3399f36f7cfeedafa730b44617b"
+          },
+          {
+            "name": "sdk-symbols-2.1.6-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b8907954-0bb6-484b-a1ee-1beba64843e0/490b81242561a2b9b3f14bb3be467611/sdk-symbols-2.1.6-symbols.zip",
+            "hash": "89dce1499fc54c35160a357b6d3d5c116c19bdbc2a4510fc7b05cc2cba046695de983ac29bd2fc66da3c5464d6eb369acb2a1fb1bbc4662c1286d9a0e5c410ef"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2018-10-02",
+      "release-version": "2.1.5",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.5/2.1.5.md",
+      "runtime": {
+        "version": "2.1.5",
+        "version-display": "2.1.5",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4d555219-1f04-47c6-90e5-8b3ff8989b9c/0798763e6e4b98a62846116f997d046e/dotnet-runtime-2.1.5-linux-arm.tar.gz",
+            "hash": "89a77a07065ea24e7198c77a233b9ce5c6cf51b1deb2ef55c88f0adbb2ecd9db1ba4e7d55eec2ef7139c47f91346fed360161a5bb6e3a7ccfc4559bcde286364"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/42912b6c-fab3-4666-a467-65e1ecbfc4b3/44f1a69971dd0c81de9ede19393de24c/dotnet-runtime-2.1.5-linux-musl-x64.tar.gz",
+            "hash": "6823778d6ae0a57a9782d1fa460fcea2c7df99c719d14d4aef96e4cbc48406936090e2f727cbcb961f6e645ea960374575e37db8f59907cfc5a588bb1044d840"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8b757bfd-de6c-4c72-8d73-abfa6d7bae35/54a47a57feccb5277e0973e17142caa6/dotnet-runtime-2.1.5-linux-arm64.tar.gz",
+            "hash": "4c4d45f4bf0c86b83dd9dd1a844754c3cdc15e0c4b417a069132607e6e95b0e9d8ef410ebdd8b9f5479d91bd704dd098cc674a5f42fd6e67c62df75e1b3e96d7"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05a71d80-3e59-4f1f-8298-2697013e261c/be191f2f4f4db74c29030008ed3632f0/dotnet-runtime-2.1.5-linux-x64.tar.gz",
+            "hash": "d815c79fd868d2642898ddc09c890a90c4ab26ef8999046581d7e3912bb06ec97ce6637ce8bf0ceb9deb773daab1c0cd93e336992c885a4fd7550d6686d4dbf4"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b83df670-529a-4d28-b4f5-81c46d339ef9/6d23d425c2b0ffd9828c521dbf19ef63/dotnet-runtime-2.1.5-osx-x64.pkg",
+            "hash": "a1835776f4873327229d68f641cf320e45f4857007875cc1ec25463a266ef7be3f520e68acfa1d2e27d1f69a6030667e36f9d9f2099d6e12a84784a5462af12e"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eafd1d99-8824-4af0-8924-df9050d2265f/76094b7c8d80390504eba6ec08e4044a/dotnet-runtime-2.1.5-osx-x64.tar.gz",
+            "hash": "8d95f08a55e913aa5c885e42f126eacf479e6de3a59dcab6594d4e90d7dbdf36f03c4eb084a9bf4405a1e52db5b84be583f44ec4f02dbe4e58c3582329b0b50c"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5b4b7ccd-7167-42f8-9111-bd7f09cc7b1c/fc68d0ca7566224ec99b56df25b7f9ee/dotnet-runtime-2.1.5-rhel.6-x64.tar.gz",
+            "hash": "83ab74399d25a85fcb091bd63a3d620f5c5bf62700ec8f8fe5a63de8764f725ce25156a07e5da1e8f326360fefa625402de295e03e2d9e67cca5a2fb95b60c06"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2781df30-e8c8-4c96-a317-a369a1d27b88/d70f97bfd35b88fe6e2b5410b3655247/dotnet-runtime-2.1.5-win-x64.exe",
+            "hash": "1fcd054b48b93a40e1b23903d00f0163382e19827c9dec297acd9fdb61f117c0c79fa86c1fe16989038db300274e4813a4a65ea0100a571e1085ce8a8ec6887a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ce443d89-75f1-4122-aaa8-c094a9017b4a/255b06ace4207a8ee923758160ed01c3/dotnet-runtime-2.1.5-win-x64.zip",
+            "hash": "aa7145201f1ed0689ff6abeb53b9c64c1efa1420dee7e5cc916168fd2479e252ed56b2492221f4038edbc73056accd9d4a46ec469155f2bdf0fc71bd909bd220"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4d7f6916-827d-4047-8abd-30dd6db910e9/694eaa49bbf7bb574b75429ed101035c/dotnet-runtime-2.1.5-win-x86.exe",
+            "hash": "88c7cdcced8dc22aec86cc7edf105ad96887f98e6d5d013459e5b8957a7c146489371480dea0fecc5cd89da5ff94cadee9b5cbadb748c54399a6035c456d4e3b"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/256f1cce-ad71-4ebe-ae45-5be6b7d4edb8/68f8caf678adde0af55266e955556c74/dotnet-runtime-2.1.5-win-x86.zip",
+            "hash": "0765035c328e479681bbc8967ae1b8031bc16e6fe399fb74b93d517677cc8ecc852984f556f0bb41960bdb7620c67bd7ac95c66304699966aa6cd1cea80b3b9e"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.403",
+        "version-display": "2.1.403",
+        "runtime-version": "2.1.5",
+        "vs-version": "15.8.6",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/00038a67-bb86-4c39-88df-7c0998002a9e/97de51fd691c68e18ddd3dcaf3d60181/dotnet-sdk-2.1.403-linux-arm64.tar.gz",
+            "hash": "a9eeffeca6b80b2873c21c7b8bb06df096290cd5b23a6e1e0fb158b60f2c2af6ee4b2bfcfd96a303ebf33ea2cc782f3dee629d06d48b634dda05ae9e11051335"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/10b96626-02d8-415a-be85-051a2a48d0c2/5ec51d3d9f092ba558fb5f1f03d26699/dotnet-sdk-2.1.403-linux-arm.tar.gz",
+            "hash": "144f1a8822f57d3e9286ed80b7ee0c7796cb2765632dd99d0f89a276248c3be77d8d90c8bf987af0237e67f2af26be834c138441980d2c7d35156ee1bb7e3d94"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/527fff7b-1862-4d2e-ab78-94c6cca188bc/8c62477e25ac1448c93ed4a8da11cc37/dotnet-sdk-2.1.403-linux-musl-x64.tar.gz",
+            "hash": "620f091eba8d111b13d440c20926f60919e64dd421c6cbf2696b6f3f643a3d654b7dc394e6e84b1c4bef6ff872c754a7317e9b94977cbcb93b5d0fdfe08d8b55"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e85de743-f80b-481b-b10e-d2e37f05a7ce/0bf3ff93417e19ad8d6b2d3ded84d664/dotnet-sdk-2.1.403-linux-x64.tar.gz",
+            "hash": "903a8a633aea9211ba36232a2decb3b34a59bb62bc145a0e7a90ca46dd37bb6c2da02bcbe2c50c17e08cdff8e48605c0f990786faf1f06be1ea4a4d373beb8a9"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38102737-cb48-46c2-8f52-fb7102b50ae7/d81958d71c3c2679796e1ecfbd9cc903/dotnet-sdk-2.1.403-osx-x64.pkg",
+            "hash": "ac87bddcbf5ceca22d95966f1da9f6ad55876f9cec9e221a25d84dc03aa7144b9e0fbcf2b492b520b85ac57f4eb16edf8239eb42d2f3b049b2dd483a2d27f323"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8a8072ea-07b3-4e31-8c2b-db56c9dc0b3c/5ef3a090b5e1b7f7c80338249d29f2b3/dotnet-sdk-2.1.403-osx-gs-x64.pkg",
+            "hash": "043f0e79f875eb5a47289e2d6f087927ba713c98b6bbdbc3828c49025d03ce1a210917f9519ff2671fa15a82ee2b544ddf272e4de7c28b46da436488c08c1cd1"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fcdaa140-a2a3-46cf-bab1-e211e7d070c8/9498335457a65063ec789e5532020cf7/dotnet-sdk-2.1.403-osx-x64.tar.gz",
+            "hash": "b20dadf3654522710a2ee2768566fe48aee6c234d678c87fece3395523e09e5243389214cd4433f850615585e46f5e9d53a0c46b6a5192fe399054126537d818"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db34d22e-e7ca-4883-a35e-b3d864a5b330/c5f9d14eb4630686574eba29b0049470/dotnet-sdk-2.1.403-rhel.6-x64.tar.gz",
+            "hash": "30faa188766bf2b628064fc0b90fe76ce9a2bc63c07acee1dd8f082af895cec536aa52af7f48892aad6579ec98354e432d7c6860713a9b976d84482c624f8b3f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/45f93081-cdb4-41c1-8d8d-e6c3bbf2872b/62d6a598956fdfe585acb1f15268d930/dotnet-sdk-2.1.403-win-x64.exe",
+            "hash": "3630dc9c52ec6b08c0804da3fc9177d3d61f12f5629c65249f7bc75b34a24c4059812fc8e6cdef64dcc7c4030ad5952e998674ac1ef497f20e43b2ab4b53be90"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7010cdb4-ae43-408b-8c9f-5f94101a1c70/3e1ae56a072c7c397f10278d7643b3e9/dotnet-sdk-2.1.403-win-gs-x64.exe",
+            "hash": "3630dc9c52ec6b08c0804da3fc9177d3d61f12f5629c65249f7bc75b34a24c4059812fc8e6cdef64dcc7c4030ad5952e998674ac1ef497f20e43b2ab4b53be90"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/28820b2a-0aec-4c24-a271-a14bcb3e2686/5e0ad8ae32f1497e8d0cace2447b9e01/dotnet-sdk-2.1.403-win-x64.zip",
+            "hash": "52bb1117f170587eaceec1f78cdc41a41d4272154b5535bf61c86bfb75287323cac248434b05eabe4bc7716facabdb0f6475015cbb63f38d91af662618a06720"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3660177-253e-48a3-9c79-cc16ced15c3a/ab0b9bfdac68c55de0e0f27ee6c57dc7/dotnet-sdk-2.1.403-win-gs-x86.exe",
+            "hash": "c35be7071348b2812ee3694276b0bf7b9289f9176896b6d27ef0ab8d6c3f499e2678856d50b782a171c819e1837de070a4d9cb6897e05be86ed57cb97feda686"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0aa84bb-3da1-4bce-9434-7036e94ae4b2/6d4fb01377f1f1eebb0997289dc8ecfb/dotnet-sdk-2.1.403-win-x86.exe",
+            "hash": "c35be7071348b2812ee3694276b0bf7b9289f9176896b6d27ef0ab8d6c3f499e2678856d50b782a171c819e1837de070a4d9cb6897e05be86ed57cb97feda686"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/849dd909-5412-4b79-a66b-b173d462d0f2/a75544b6df62239374e77e78d9a5899f/dotnet-sdk-2.1.403-win-x86.zip",
+            "hash": "f3292cddad3cc2921ac532367568086a778340dd76a00825119f9e634958173d6688d3d3e93a9f4a0b091cae989f5d0213ed0ea4ba818f90efc901a86093c2fc"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.5",
+        "version-display": "2.1.5",
+        "version-aspnetcoremodule": [
+          "12.2.18248.0",
+          "8.2.1991.0"
+        ],
+        "vsversion": null,
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6253ecc6-4af6-42ac-a965-33a864a79a3b/b4ba7e62c5318106fd55aaa17b4335de/aspnetcore-runtime-2.1.5-linux-arm.tar.gz",
+            "hash": "5d503f7181c59d95ddc7d537dbc4b26fb6d5b6bea25b0a29154906fa422e7014e80e0a8ee92c6f81484d169a17b3e8284d455e3e05d85cefe736190e769b7355"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c283d1d5-b4c7-4d9b-bab5-b78c6d03887f/e6ba9246446aa885f935e2245acbbedd/aspnetcore-runtime-2.1.5-linux-musl-x64.tar.gz",
+            "hash": "5d87fb86e4e70bf0769d081a0b0c4388348bcefe61559242af17a9604bbdb3269e4ab47c420105ab6a2236431978adede9406d3ff0845602a398bb81f4ecf6f7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/97fce50e-e736-41c3-a700-d83d43178197/4c00b063affdbc940dd16f62c68d1505/aspnetcore-runtime-2.1.5-linux-x64.tar.gz",
+            "hash": "3326963ba0a431ca430d8f1a7940487e516952ec560da563f03662b71b2ac8b5d9904b0e1422212e452b49f563349d10fea34241f4d5e4811d0aedc02c557029"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/48c6f111-9195-46bd-8115-dcbf8a954bba/4c011f106cfc78e8344ca50b0a08d056/aspnetcore-runtime-2.1.5-osx-x64.tar.gz",
+            "hash": "a5f9ee4a89a50dd0dddb4b0bc089e0385cd8d11d667253f8bf3fb1722308a3189512022472394251c5f640332b843798a8f5a0c129b9d78094349130ffb93aac"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/74b2ff3f-b288-4b4c-9b11-3ef77100ef5a/b0b90830e6b1050afec21c556d1b3733/aspnetcore-runtime-2.1.5-win-x64.exe",
+            "hash": "ebb8f2b239155c9314c39b77ed6a89fb1954109d31d030783ee59427f7c6d6bf7af04037b9e57f82e60799292f507e003c8a76278036ddbae096a7f9baf03fd6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6abfd5c4-f9e2-41fb-9363-fd60e3f9132f/1a5d3c82408f5e27b0e83be8c7f1ae42/aspnetcore-runtime-2.1.5-win-x64.zip",
+            "hash": "98224c8646b7eab234b97f52735905bb0219ea2290490e408ff469459ea82116068854e7b9c5869bccef780b4ceac17477f34f23e06a0a6bedca445a3866d73e"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e3470fc1-4b89-4ef1-af3b-bf4fe57195f8/ae80490e90972949886a36816490f3ff/aspnetcore-runtime-2.1.5-win-x86.exe",
+            "hash": "e7e62e13aa917a53015d987ef48fb255f887ce850b9aa1e869e46a13ab6f1697566f4e3d808ed71f6288e2b930f61bbcc26758f328382aadc6b53442f0c13e0f"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/de489207-08c5-4bb1-9b66-641528ea6ca2/03bd984cb700799179dca77dadf3a003/aspnetcore-runtime-2.1.5-win-x86.zip",
+            "hash": "9c46619708fca22db2bd7206cfed0aae56d99f52f4f00aa12a43ae2e744da4c75bb749ea343311a051b900e6299352ef7a0e9c5378611971f4d9fdc585c95f20"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/86df96bb-384c-4d7a-82ce-2e4c2c871189/045870c1ab4004219cb312039c5a64d5/dotnet-hosting-2.1.5-win.exe",
+            "hash": "51da1bc97185209f19ff753fe0ca8a4ae5afec9a96b15fc088c357ad1ecf327e03d68347f54cda85d190131d6289a6de595c840f1decf7895009aa0ca5563448"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "2.1.5",
+        "files": [
+          {
+            "name": "aspnet-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cd19548d-5b4b-49dc-b33b-be0fff2c814d/f92efb317bd7864097ef824174e6ded7/aspnet-2.1.5-symbols.zip",
+            "hash": "b0f2ce9c018605395d5c7a47a233fac83097df41ab7cb351827d727387646f831b0a1c251cd488dfeb9c473a18510f53b50ba7b1fc4322808f95ab921fb8e84b"
+          },
+          {
+            "name": "cli-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d3d1518b-c3ad-445c-a6a4-bc31691517f1/cb22f3c8e70ccacfc9dbb74748d11ee8/cli-2.1.5-symbols.zip",
+            "hash": "173168730d6fe23a7c5457ed5533e4dc103a2f95ae5c0118a3ac4fd06ad23a1bd5a605bd43b10148cf8bcfc3a5b4c32d78b8d745dd5ba57921449a236f2c8ad8"
+          },
+          {
+            "name": "core-setup-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b7ea7023-1d3e-4b6c-956f-fd95acddaf34/93db59925f87bf2088f262ea29536ced/core-setup-2.1.5-symbols.zip",
+            "hash": "5581be34b1e54650e1495aef9e4c02d676532dd11316174344711cde7d55cd434382ff389cfa741d364bded66d6fa560399077080376e351cbd7678009441d8d"
+          },
+          {
+            "name": "coreclr-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/26b24856-99c8-4caf-a5b4-81502b2df64f/ff4916b6eb2370d79241510511f845a6/coreclr-2.1.5-symbols.zip",
+            "hash": "d7cf81866131e90b95067c60c2123f68411f940256673766061df6c8778d33b861b49d2e14996bf08cd6b900fd19b6f6ecf483da3b0931e469b27f159384ff43"
+          },
+          {
+            "name": "corefx-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d9ee037a-60e6-4efc-aa09-27c8b2f6c5df/73556861aecee927a870c2afb10576aa/corefx-2.1.5-symbols.zip",
+            "hash": "e6c24e68333797b652f9408ba95ff2fd01d8ced3edc475d8f3446984a40a5856624b1da51850e819cc44f1e29d94cc0cc9c295e6508199d553d8982f064c023c"
+          },
+          {
+            "name": "dotnet-sdk-symbols.zip",
+            "rid": null,
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f5348f78-7a05-40c3-9b5d-240f9f96162e/90b6da7e4ed745894884ea596b22335a/dotnet-sdk-2.1.5-symbols.zip",
+            "hash": "53d8a381108562253bd0c5336b2f8c3a665c54d95c09671e8867d3efd35b47967bda4a208735194a14e8d401bb7f9e995cddb20d430d1e90956222c266308d37"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2018-09-11",
+      "release-version": "2.1.4",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.4/2.1.4.md",
+      "runtime": {
+        "version": "2.1.4",
+        "version-display": "2.1.4",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-arm.tar.gz",
+            "hash": "6ae83b0b51c180c44e0792a6c0b9dbeb40d9e28e695d7b565914232955cd0c6009186ca954d87255688163f79eb4b59d1fdd8abae7438de17f4cd919eb671028"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-musl-x64.tar.gz",
+            "hash": "854867452df8973ae5b2c266c07aa6bb69afabcce4bf9a693d5c71d437cd66a2d2d16d7fd9cb6ac5aa82884af816c470a74fff1e9e450bd8eb5d59cb36724551"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-arm64.tar.gz",
+            "hash": "4d604229653522456ebdeee7b1a6cfb8032a14f6ef1c757544e0e27ea64bc455fe448c6f7c0647700f9e2790c48ef015c24003705b58e209dcc9489b77b18c85"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-x64.tar.gz",
+            "hash": "94bd277112ccecf65d425e0ce98e7e30ac702e2ee91ebb976119a2a96f500745217dc77b4a3f0f5a7d6a4ee9779429c0bea419561cae09b446fba5cefb81e9fd"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-osx-x64.pkg",
+            "hash": "ae318363382be3fc6dd2487e03b125b1a0fe68cc9f00cb376dc956ec90d5ddaa0ee4b1f8f1114635620871d1271d1e15fc3fce7a869a6ed51b345106492828ac"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-osx-x64.tar.gz",
+            "hash": "da9cfcb9ae636e0d0739f75cd1d6ea6b4a48858f1dca11134fec57e4e66b28f0f1b0ac55a02a741edc506fb011b023976d1395eff3ec5a51bb5d15298a6a56ad"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-rhel.6-x64.tar.gz",
+            "hash": "e6837ecb264413b9663d2bb89c16246c9aca64dd424571ed3f7569fa1ae97d312dd32ded62eff418be598ecc4312bbecbf5244d14ee4cc673dfe0161ad236f4b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x64.exe",
+            "hash": "2812c23e0fc89dd7cfdc972fc99b867ba1883d9a1a921659371f346d1efc7638205cd22e372d78cc3250c3878d6a764002177f14a6200adc70c4b61e322bd47f"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x64.zip",
+            "hash": "d89a09736c35388a82f9791bce478866b672dc68fd1e7254ee9c4e06a2083a4205b7a87cc0129210989a1a53f544660cc0338ffdfe4cf6a2407ad76180534b68"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x86.exe",
+            "hash": "76bc8246a9dcef7fb7486842b405c387abc4558e1fb82d408415904242ce50e387c73be792d4b4e367708f14251e3cf8976c3a9be20d89b09d1944fcddb07859"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-win-x86.zip",
+            "hash": "4e8235d1271e79a2e6ec5f1ceb05a1daa85245529a56764bc4abd84e8483e2d4e739cf2e3efc6a6fa6a6dd94be2d491108ce71b15e1a555df43e3d9349d12c0c"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.402",
+        "version-display": "2.1.402",
+        "runtime-version": "2.1.4",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-arm64.tar.gz",
+            "hash": "7a71f34867da96c84380e17d5c5e6263ed4de455865df6ec0353f941529ac6f7964de72f72fb8ef4848a2ba8c5676f8c28de8480f411d591b7da38bdc015812a"
+          },
+          {
+            "name": "dotnet-sdk-2.1.403-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-arm.tar.gz",
+            "hash": "021315da0bb32b70d9c39f793f5783010ebb7ba8dd1d4a4c38988004aeb56e8f14926a9b049ad707bd1dc93c3bf6653b5bbec20077be0cafae5669120d1b7726"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-musl-x64.tar.gz",
+            "hash": "88309e5ddc1527f8ad19418bc1a628ed36fa5b21318a51252590ffa861e97bd4f628731bdde6cd481a1519d508c94960310e403b6cdc0e94c1781b405952ea3a"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-linux-x64.tar.gz",
+            "hash": "dd7f15a8202ffa2a435b7289865af4483bb0f642ffcf98a1eb10464cb9c51dd1d771efbb6120f129fe9666f62707ba0b7c476cf1fd3536d3a29329f07456de48"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-gs-x64.pkg",
+            "hash": "5ddb5374a9eaa71b6281c0e4d79cead5d22fb349270df32246486ebb055780b75659368fca50bbbdf97378206732f178b622a6b462a048662df1d962284d15af"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-x64.pkg",
+            "hash": "5ddb5374a9eaa71b6281c0e4d79cead5d22fb349270df32246486ebb055780b75659368fca50bbbdf97378206732f178b622a6b462a048662df1d962284d15af"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-osx-x64.tar.gz",
+            "hash": "6abd86e3a340a6d529f6406be7a6db466bfe1daa2368631bd4e4c01216512c54ac4f2f710d1229e4f1550fd4332eb33ac1dd8a9dadd1947fa8b2981c2557cd2a"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-rhel.6-x64.tar.gz",
+            "hash": "d224d51cf6d05211026fe8afd729f39eaf306d5f5f2df82ff000dbb4f9914b2ab9a9d4d27aefb892ff2a80532bf5377aef4e979ac9fc343cd8918bc860463b0a"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x64.exe",
+            "hash": "1020bd17cb6587f73125f36428bd945b720ba612037f58d7bb33751b90783f6e26090e125cd1421439c167a309fb62d2c480b8ee8e9e40dee1bf33dbe0fd5d0d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x86.exe",
+            "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x64.exe",
+            "hash": "1020bd17cb6587f73125f36428bd945b720ba612037f58d7bb33751b90783f6e26090e125cd1421439c167a309fb62d2c480b8ee8e9e40dee1bf33dbe0fd5d0d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x64.zip",
+            "hash": "405cbd7c65d63b36e3bd6bcdfc897ac6474c4eaf93db9db478a80ab511bfa7a1c4a84024cc6e4af0df0af86bcc0a1a96a8ba0864c77bf579f32bce437c28d5a8"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.exe",
+            "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.zip",
+            "hash": "817d16ab72713b85af14becfdb828dc8e2dcfd2654d12b3ee8caae5bc960401df5e2923272f42ff9a39687d32a607d14a1642a9f45e6da0d3733708c5fe0c3dc"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.4",
+        "version-display": "2.1.4",
+        "version-aspnetcoremodule": [
+          "12.2.18248.0",
+          "8.2.1991.0"
+        ],
+        "vsversion": null,
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-arm.tar.gz",
+            "hash": "b0f2ce9c018605395d5c7a47a233fac83097df41ab7cb351827d727387646f831b0a1c251cd488dfeb9c473a18510f53b50ba7b1fc4322808f95ab921fb8e84b"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-musl-x64.tar.gz",
+            "hash": "173168730d6fe23a7c5457ed5533e4dc103a2f95ae5c0118a3ac4fd06ad23a1bd5a605bd43b10148cf8bcfc3a5b4c32d78b8d745dd5ba57921449a236f2c8ad8"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-linux-x64.tar.gz",
+            "hash": "5581be34b1e54650e1495aef9e4c02d676532dd11316174344711cde7d55cd434382ff389cfa741d364bded66d6fa560399077080376e351cbd7678009441d8d"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-osx-x64.tar.gz",
+            "hash": "d7cf81866131e90b95067c60c2123f68411f940256673766061df6c8778d33b861b49d2e14996bf08cd6b900fd19b6f6ecf483da3b0931e469b27f159384ff43"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x64.exe",
+            "hash": "e6c24e68333797b652f9408ba95ff2fd01d8ced3edc475d8f3446984a40a5856624b1da51850e819cc44f1e29d94cc0cc9c295e6508199d553d8982f064c023c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x64.zip",
+            "hash": "53d8a381108562253bd0c5336b2f8c3a665c54d95c09671e8867d3efd35b47967bda4a208735194a14e8d401bb7f9e995cddb20d430d1e90956222c266308d37"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x86.exe",
+            "hash": "1c76147f6cfdd463d79d9096930247dc86ea5e9e4d3256452a08ccb6bc09d8047e3f828c37a7aa15e03b8e6f2173d0e300ec8250b7277f33941d5c6ed5f2c9fc"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/aspnetcore-runtime-2.1.4-win-x86.zip",
+            "hash": "db8794adc8363fd061e592a264f0b8333e9db3a030ee8a2d3f811ab8d82dc7c9c084d4ccbf29082bb4400231365de0c70350a8dad48ec620fdfd89eaf0043dcf"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-hosting-2.1.4-win.exe",
+            "hash": "3f80f0e9144b0dcb61d14c4e9f8d2b84ec0d111cfc56eab143570f0841794f596bb0092d68c09088a8d889f5ed49fb13d63e65b3497c7e3ec3b59e08b6b641e7"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-08-21",
+      "release-version": "2.1.3",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.3/2.1.3.md",
+      "runtime": {
+        "version": "2.1.3",
+        "version-display": "2.1.3",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-arm.tar.gz",
+            "hash": "3d42d5127d1729028467cf692c11ee04ed9a9f8445e0968dc5fed5894946bc901bf8de6fc57fec8373aa24d88b2f27fbea98704615f52506901747bed407732c"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-arm64.tar.gz",
+            "hash": "a271e741ac4b9afacc466aa081add4b54e83b646b9d1e8b8e7001aaac2f24a51973a0c0e9f191f7a4b83a123557cccd057cc0a381075a70b1f52926009018fb1"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-musl-x64.tar.gz",
+            "hash": "fb9a080141038545af3fced55acbd7ef0d4948d527115f67937bfb6eee012eff0c1e18858ccab43f2752711f2eda29445d2c42edf5557348686844b2046a3b54"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-linux-x64.tar.gz",
+            "hash": "e2a9a25436744498ee827125083e41151e90e914091863d396ff8d3916467e8ebef4cdfe5c97a13381e6d257d1e01b7a02f846b9c8406643848e3d433d6bd60a"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-osx-x64.pkg",
+            "hash": "397b32f3637d32e5e77265a73fc6af74f57c00e34f77566d3c50ae762dc0124b79ec5b34365eddeb856fb6cbf626c77d0eb16ed7d48f1f0eeff9e0b07a3c6015"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-osx-x64.tar.gz",
+            "hash": "504efdbe6a83ef5a0c8a21be486295e703dd0f6b0a11c633e297d9f99523a5ff570c57cb197f3772a80239e4df00c6c6d47d2021dc63496ef1026b3950772af9"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-rhel.6-x64.tar.gz",
+            "hash": "71663d1b5a15e89fe3022556c10ef12f689bcc7376fae7833c7a80535ec44b057346cb71aef90ad5679e41c0522850a950bbafe78a791a9dd50ff1c1e79dc58b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x64.exe",
+            "hash": "17346ecd526edb965a91b217ee488ae649bf77e28cb33cbaebd505a6c4dc9e599dcbfce54782f8dd82eb4d1423621a7726c9f9fa1583495f24f81f3c1fb35386"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x64.zip",
+            "hash": "eec3465a1dfecc3890e8c07d45198352a9ef4026bebc867ca8723ddf4bf30e83b79dfae4c5b8800a4b1b83d38c63be06b8ebf7c5dce87cf7108cbb83b169b47f"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x86.exe",
+            "hash": "e7b04de3475b6352e19e3d6c2bdae8c962b555b2c77962685da86d47bfe166bd0a096c20367b0cfc94feb01baa1edeca77aee793756c3be4775de6b497f1d967"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-runtime-2.1.3-win-x86.zip",
+            "hash": "c9dd70d7b98297d32de05108efc2f3859f31fcc4c92a20e8797c51df7d14608280185dbdce25d172a56bfc935562fa66677497c48b8115d92245be3e4bc6fa5b"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.401",
+        "version-display": "2.1.401",
+        "runtime-version": "2.1.3",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-arm64.tar.gz",
+            "hash": "b8e1a4ba94fe54d7f897da2118e88dfb3ec97ab8595b40f72b972e65d5e95a673b0907a58790b710c37ef2681f6f7a0988f2da67da5f8517a60208c887186550"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-arm.tar.gz",
+            "hash": "0b428331aae4adbc28fa0e8bd4696aeaffc86d1643cb366e9b7e8f7f27ada57d91c640490340acbe017fb7bbbe375cbc47c9e49d5905da230eac0eb8168ca6ff"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-musl-x64.tar.gz",
+            "hash": "cc2a75abca3314118b97629dad9c21039d80c9dba86b0b89752b2259fa66b7c1734f7e6632e38e785b8db1b12f4a1be67d36330bda5128bec83306088a2547c5"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-linux-x64.tar.gz",
+            "hash": "639f9f68f225246d9cce798d72d011f65c7eda0d775914d1394df050bddf93e2886555f5eed85a75d6c72e9063a54d8aa053c64c326c683b94e9e0a0570e5654"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-gs-x64.pkg",
+            "hash": "7b644c808a3987d26306431fbdca73fa0120680faefddbdc063c92335f23e2f892e0d3db4e4c410d2b292f732d9445d796150b2dd89af2668f15853050d4080c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-x64.pkg",
+            "hash": "7b644c808a3987d26306431fbdca73fa0120680faefddbdc063c92335f23e2f892e0d3db4e4c410d2b292f732d9445d796150b2dd89af2668f15853050d4080c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-osx-x64.tar.gz",
+            "hash": "53ea33279f0f217a3b13b144e231b2931b001e43f9eb988722b698f8331c56e279ebfde5962fb6de98cbfeb552c8f538d127e08da639cca4b73d6407d102b523"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-rhel.6-x64.tar.gz",
+            "hash": "26ee3faa349f9351a4c6d789484c8ab62da43181fe63c468ba9983d68c65433fa66c2f5f52ce4dc7e8ef6a1f9345b5f4fe5612716e74dfdc47f9f4a44261f579"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-gs-x64.exe",
+            "hash": "cedf1e992a025c9e8887aa36e6c0b920ec9d2482fba3068505a110e7e7bfda603ca0e2675089b46c25c04e9d85c0a74dd35e5f42adbfb4f4848318c48f93031b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-gs-x86.exe",
+            "hash": "2e41720a7a055a12e23bd638f550b791f9919ad1eb0ca966060a8bb16b0ef018a8f1d052da10cf276c24998cce476be49be9f17f475325e7d09433a837db0f82"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x64.exe",
+            "hash": "cedf1e992a025c9e8887aa36e6c0b920ec9d2482fba3068505a110e7e7bfda603ca0e2675089b46c25c04e9d85c0a74dd35e5f42adbfb4f4848318c48f93031b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x64.zip",
+            "hash": "7d017487c1a11ae4db862b1efa7ba9beb0eabcf5d2467bc4055aa2227a548663a596682ff4adba4688930b22472587f29b83bce9f689efc5e9f4e37f7edda000"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x86.exe",
+            "hash": "2e41720a7a055a12e23bd638f550b791f9919ad1eb0ca966060a8bb16b0ef018a8f1d052da10cf276c24998cce476be49be9f17f475325e7d09433a837db0f82"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/E/8/A/E8AF2EE0-5DDA-4420-A395-D1A50EEFD83E/dotnet-sdk-2.1.401-win-x86.zip",
+            "hash": "d3b5c9d071ba5e083feaa4507c60d99d3d10f8a01b69263ef1f05ae0ebe973a576a94a20fafd8455f7aba2f9feedaba671775586e9c553e1811e2cf32d477321"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.3",
+        "version-display": "2.1.3",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-arm.tar.gz",
+            "hash": "89783eb504e52d393c85133861f0230c322aee452efb27b9e30dbe874e7255462eba7eecc152d5c8cedaa6101b05a4d73cd9f9db2240d0727a9fe3173fab7348"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-musl-x64.tar.gz",
+            "hash": "5699445c571a64c68000cf97555debee4439d892a43d3409c14dc730eca38b16dc8a4842807c3ed9b086d3e2e41fca28e15af430cbadf3c9959b055b17893795"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-linux-x64.tar.gz",
+            "hash": "522eccf29a1d08f11d803934c8e436321485a12a96c51bab19a8bba58e363b7277fccdbf95909bdf4c20c9166e335b834f250ec8a782c6e91d44bb86c44782b9"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-osx-x64.tar.gz",
+            "hash": "4f48bbd22861826e6b63959ac4f28f66fcde56525d7e8b5a0eccfda565df860cc77b573d75a91615874addbab515997f10aab330082c14802426ef74ef875faf"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x64.exe",
+            "hash": "098bb4a0ebc04add24da0ee153eec4bc2f6b4bda8f04d6d05cf2956ac11a261d46611250cc4644a40293bf8c0dcdd15c03f664f71635d2f5b13295b3ad0ddaa4"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x64.zip",
+            "hash": "a9ab3f01fc07527016513f47fc46427f6da8ee45ab847eebe228ca940f00d7b791431295b5aeaf8c8fb07f4ff1d4e8894fb4cfe5c36e74684f08f7d9d15a0e6b"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x86.exe",
+            "hash": "cef632b7f47ee421764bea6e526fb2813dd5b2c3611a8c603bd1e72ff450f63a57fa6902d583625fceadb11c702b47d35e62766cedccecad8c91d7a8b69a1dbf"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/aspnetcore-runtime-2.1.3-win-x86.zip",
+            "hash": "7e9dfd7f1cae2739d1d79a07a35ea4d84cf4c28df6140ee65289a7694ef20f6b1ffd519990e900d38389357f9dae4bc63a47f26af1df70a1ec6f88448384f6b5"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/6/E/B/6EBD972D-2E2F-41EB-9668-F73F5FDDC09C/dotnet-hosting-2.1.3-win.exe",
+            "hash": "7868ba46822b6e53c2a8056ec28f59434c7ecadb8e0adf8285396e12deb31cdec26158c54e4d0cad0566f8f7cb2f0612f685bd1ef20feb9e2864e36702e47116"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-07-10",
+      "release-version": "2.1.2",
+      "security": true,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.2.md",
+      "runtime": {
+        "version": "2.1.2",
+        "version-display": "2.1.2",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-x64.tar.gz",
+            "hash": "229db61d9c1f9f587ce20f06ac3517e459a3c16b465dbbcf4fd0457ba216e0aea2d0a73df94b651992e744a8456de8bacf0211bff3a281198cf9fad845e9d8cf"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm.tar.gz",
+            "hash": "c720033a558284b139e891b588642e7975afdb0137da9aee096cd8c4bd73453d1641a75d18a13bb4aebb282d31730cf2a6fe963e84bec315f3296efd72924973"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-musl-x64.tar.gz",
+            "hash": "092c966af4e3b697aaff06315c3eb3e342651643d3a1929bd33bb5f638e73989944ecdfb02ac18b251b797ff4cadcb312f4be9fe8627b4dd4b8dd8b51ea59ba1"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-linux-arm64.tar.gz",
+            "hash": "0567b927c23bfcb67b45d15d1c052036676c5196b7432ee918eba6f99e5538d9052d049de93234e469e3fafbebebcd2bdeacd6cf8ea9a787b632e0aff6dd06c8"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-rhel.6-x64.tar.gz",
+            "hash": "81eb0031553ccabf92fc63fb0c1bc7eaa5a746c95363ae55525ca48a9c638ef457ca51c785e0f13b03cdab49c16b04fe3d1c8c23e22148f504dbac8171c6fcb0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.tar.gz",
+            "hash": "a39d10c1680e2adf98200285ee4b704b3861e371113e0359388fc0fa479222dd69e513b473e547b8382303918d708ce78a42edc06bcf4f6885775788dc0632d7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-osx-x64.pkg",
+            "hash": "8cd973a1efe329c16b3099acd33ee191359314d4a6c9755ba0ea717ecb4ca773bb44bcfcc64181e68cfbd4ff6f214ab67ba1611b89b0c399423ffeb88b8f1d92"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.zip",
+            "hash": "e0e941c2b89b8638447e42f93a0a028cd81464ac4cea6123acb4130b72dda03744b3bcbb42683f1e9554b1cadd1c28f35d97523278f40de5e8c57606460556b8"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.zip",
+            "hash": "9e67c62feb34aeb52a45d0e623d1ad098637a322545956eb5e6de2287ddad2412b766c492ae5a7dddc123a4cb47cfc51d9bb10d0e30c007ec3fc90666f9733c8"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x86.exe",
+            "hash": "3539dbc699a1bd29f79c4fe95d28246cc53c4916acd30927868e9e6fe1da3a40693bbe9bc8e69b814a25d7f044c289231a200a74204a2f374d38545083440fbd"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-runtime-2.1.2-win-x64.exe",
+            "hash": "b15d988c51bc2da9edeb9ad3b1b643ef1f71d16eda0e35dec6224a67a78e9e1d58a3f8d0fdd727cd9643b5d9816664b02aba158d7884f0bd2098561e237a3ffb"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.302",
+        "version-display": "2.1.302",
+        "runtime-version": "2.1.2",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-x64.tar.gz",
+            "hash": "2166986e360f1c3456a33723edb80349e6ede115be04a6331bfbfd0f412494684d174a0cfb21d2feb00d509ce342030160a4b5b445e393ad83bedb613a64bc66"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.tar.gz",
+            "hash": "67a83f30f5c4d504eeafe5200711bff6e7c4c365067f4e6140e31f3e149974aa34e993d5ce9b39377b6e3e031c85e4348a46723519e87f200618dfebafd0b1f5"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-x64.pkg",
+            "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-osx-gs-x64.pkg",
+            "hash": "6aa99c6810f6fe4aaffcbe1a9d69bff32acb0de8be665e00250f927fac00e8f4309da1c91bce28a60bb62938a65963ea08d4a79114ec07470ff5bf2253a1eddb"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.zip",
+            "hash": "bb540fa18f32bc9d911ccf29df682c216d08cd5881e6b6a988e182ee2350a60eed24e56392370f2bc5bdef046496ac7c63da7e7ffbaca79fbb54c299f109a0b7"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.zip",
+            "hash": "a8a74d3329191df6357a00e26591cdc64153970e0cf42f820ade0fb520c9cb0e6ab16ab357dc9538a8c488245c505930b4b0a6b63721e4eebf8682613a63441e"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x86.exe",
+            "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x86.exe",
+            "hash": "19239e9a54117baf7a3a1ffd56b4ec5b3e5b9e40f2ead3a70c549cf742f415cf3b65176d3e2c3b2d2668f6851c3dfa50bb178ba9af7bb36404a0620da2518519"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.exe",
+            "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-gs-x64.exe",
+            "hash": "30cd9f690f20c435f30430dff5901c778fd708e9ceab85d7a7bacd469524a7c027e9e5dbb951ec0bc8f7cf9bbd88df225159c87b581ff2cbb0fbc241917fc7aa"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm.tar.gz",
+            "hash": "af18d6dc918bd638342a5910415e4f53b55aa802adfed551f164ccd6d1441aff70947b7985d7ad1ce7c7eb7d8f05995b45c0405a520d9577ff9c019b0ef5cd6a"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-arm64.tar.gz",
+            "hash": "93f481278d9da6ed7ba16d66c9742cdc9f66b31e6d09cd14b4b27621f44116f9a26386076de11e5ad3e967d51d95c17816287e164c80eebfd55852227a038457"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-linux-musl-x64.tar.gz",
+            "hash": "0f9a6fcbad609ef1ff5b398de9a1f1bf59eebc59b28a4c8cfead28f0209bf77601d05d49f5ea1223c860a803fb82cd7e2401b6df290da34e54b36bdd8788ed48"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-rhel.6-x64.tar.gz",
+            "hash": "9991d57f1e5f4f2cd227bca9ef980457d3422ae28a36f6c5ed2a7d0665f9d378aad2c57d4b375a7d410eb229b13a18e818f3f980dc222e9c5347ef62dbde8633"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.2",
+        "version-display": "2.1.2",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/dotnet-hosting-2.1.2-win.exe",
+            "hash": "1b20f9eee7b83d5068e8e4ac5230b7e584be944c4da1264fe117fa3a93aa520250e38e8bce7b54f87db73a40188e49c6caa9baa0f3ab45e38d4eba8a54e98e53"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.exe",
+            "hash": "63c8dfc01ff5a3a852a4d2930e185748f534ddc6c8aae96fac1cd6f7780a97aeb7d38a2b7be1f90c61df8bb3ca406cab37c5673676434d3597925ecbd2643276"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.exe",
+            "hash": "cf0f185c906dae5e359f230f2c5bcc65e6f04a3cf6fbac89b79f02ffe2e13f2c4085fb817a7f65038df5884be39057a992b43631d74f52c6d5951861c03f6031"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x64.zip",
+            "hash": "a9ab3f01fc07527016513f47fc46427f6da8ee45ab847eebe228ca940f00d7b791431295b5aeaf8c8fb07f4ff1d4e8894fb4cfe5c36e74684f08f7d9d15a0e6b"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-win-x86.zip",
+            "hash": "86414db4ce9ca76b3c40649da098fdc8d8e6dd79e4f94ec3a1402eb5506070ca8d9ae571a6845262720d42e5ef35e4ef396a0c01ecaa58fc55bc503c1ab8dd65"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-osx-x64.tar.gz",
+            "hash": "5b9ad8e0fbe473cfc4f39516e3f793940287cefbb5fc2eac4dfcc346693d9b50242073aec605972fac0ac6f3d77f3d3715af32362061339565fb50db17f994d7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-x64.tar.gz",
+            "hash": "294a6c256ce7954c05c3dee85d4114e320c7b94b2ae2e854a268b2bb4383a967e1063ee0df0da0f09511b3dc9c215aa735899f5c6db4f11bd58da3cb9cc8b6da"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-arm.tar.gz",
+            "hash": "49565a49e8357894b34a8cd12e1cccf9702c2c9c3dd06e1fc7c184ebee5b2fec43290e18998b60a77dbd5dfc5d59b838f3f4210675db1d64313cf206a22fc6b2"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/1/f/7/1f7755c5-934d-4638-b89f-1f4ffa5afe89/aspnetcore-runtime-2.1.2-linux-musl-x64.tar.gz",
+            "hash": "7e4ccfd0610949c4e228da38d40223ea8086bc98ec92d83fb0823909f40e897c3ad59706ff84e4dfec7873a587e83d9d98826dd13dc2bbea239a927f6906a9cb"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-06-19",
+      "release-version": "2.1.1",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.1.md",
+      "runtime": {
+        "version": "2.1.1",
+        "version-display": "2.1.1",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-x64.tar.gz",
+            "hash": "39737997bc10de06b8fcae448f1c740dd422d9f6e4f71a61f364b5643adfade3f3902ea07eebf38c6505e5262312d05cbc9f295d3ec5f8d5830f4ab73236a5a5"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm.tar.gz",
+            "hash": "470b0cc3a614b716ad288ad527e1f00e5e7321636ba6bdecfab770a3d84da20417fe4ac362a22f4c6eab4b34614b7b3490b4b00a2f9824ec957199e14696f7b9"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-musl-x64.tar.gz",
+            "hash": "5bb938b012d86bcecac42e3c4e915cded051ffeffcdb4122ce41cfd53896395b952d61ef10e22e37d330a78eeb861550e0c73d0595ae001228a03bb0d94bd286"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-linux-arm64.tar.gz",
+            "hash": "28c170e1d7e01e0de67f77b0e65f26816cb20e3ea4cccb148506bef830d6dfc9ac0825408bd36432aee15027f6c0a41ca52c69f01060db134f21be724b6115e2"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-rhel.6-x64.tar.gz",
+            "hash": "d6e512a3f854ace827b0528299f4d2286e43f5dc526440d0c014bafebe98932ecef5079879e4eb53f965a4304e724a2238913e4233c9633d06e058a296bd32db"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.tar.gz",
+            "hash": "4e1ccaa728a12f508fcc69dd75270b9bac5cd6e4458eeb3ecad8d7ab718f5c1750d7d191420af9669a1d87c503b645f3b1dde98a92d818e9ab7e79a504136a1f"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-osx-x64.pkg",
+            "hash": "7b5c750aacb9c62e3fea36889661b63e7ad1fd2ed331a8d413f36c54e136d3d219e27fec8874202e9dd66f7458d6c60dd949c56f1dbdce927cdcdcb8ddd017f5"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.zip",
+            "hash": "864df7bc475e7a05dd20b8b5c927f8a7c2370446046070b5b1262a07c34253259769d1442a1f5c144cd4b91285a5f275a3919f8de2ae49d0e35a122e57af051c"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.zip",
+            "hash": "4414fe957d2630404ef23d2ceb9d8d2d37fa4d1249ef4755d05302b179a64821fca6d21d4de011f4b466c090ffd7c5422f2b94e88168bd868ddc3b22557bfacd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x86.exe",
+            "hash": "5d2968020c2d255429860606b509f25ae3a5a4fa79569cdb4c5ae1fca6decd0c6c43feff171000111378d99c413e349504b7b413051e73b1dd9c2ce73f4d23dc"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-runtime-2.1.1-win-x64.exe",
+            "hash": "e1ecf007a7ceb18e92acde8ea3d3f5c15c2adbadcb6366c8d743eb6752761efdac02185551a009420a9c878cba76a5abe6bd8d73626edaff104a2592a241d3ad"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.301",
+        "version-display": "2.1.301",
+        "runtime-version": "2.1.1",
+        "vs-version": "",
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-x64.tar.gz",
+            "hash": "2101df5b1ca8a4a67f239c65080112a69fb2b48c1a121f293bfb18be9928f7cfbf2d38ed720cbf39c9c04734f505c360bb2835fa5f6200e4d763bd77b47027da"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.tar.gz",
+            "hash": "120444d800d7761b4c535d601b6e79a32c9d7443f8029a47600b6d30c59e0e0f0573ce7ff435b6a563028c2cd19abcb5406fff48afa3f969ee8464db7e216bde"
+          },
+          {
+            "name": "dotnet-sdk-mac-x64.pkg",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-x64.pkg",
+            "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"
+          },
+          {
+            "name": "dotnet-sdk-mac-x64.pkg-gs",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-osx-gs-x64.pkg",
+            "hash": "37466af3f27ce6351487e2daad584f2d4d1780379866256953526781eb15aecdcd61a5a105b37a8f09bef020dd85a2b598b8bd9ef9148e053ac6dea771288799"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.zip",
+            "hash": "237a0a980d8bcdb4d8c9adf7824f9bb9e50da47af224fd291d7667f88efbe7432a66a606ea4fedae018f1a252db938c19bded3d451f7a2fe47b0ba47d0861e9f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.zip",
+            "hash": "f2f6cc020f89dc4d4f8064cc914cffabde0ce422715138778a6bcbbb6803ca66d6fd967097a0209c47c89b85dd9e93db48486ac86999bd3a533e45b789fcea89"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x86.exe",
+            "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x86.exe",
+            "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.exe",
+            "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe-gs",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x64.exe",
+            "hash": "894d620a9f700b2fe3f788f0ef12c26ac654f15b34d76bfde22570301054208aff4461567d3f18a7f76031132ea5f63b2ca9a42a122a3d246815aa4c4455cc96"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm-x32",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm.tar.gz",
+            "hash": "f241a9e6b910f0000691973784a28b652ab7feaf329fd732a7a808a2c5926e7116c8c78e6c42806663135b6d3fecd7f9e1c28e24ec3db742a585a93befb17500"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-arm64.tar.gz",
+            "hash": "852d29e572398347afe166bbde5b17c5e09130d7af72ba5b483766b80b6fb657695102a92f5bd247f0d011f807cc05a4e7c61f8aeae577b95fa9fae9819bb3fc"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-linux-musl-x64.tar.gz",
+            "hash": "86e288cce53999b719ced7959f5ba652f667b8c1e0aec266c3012c9870380e5142e3f5ac103f03691d4426158d9da4d7c89f0739dee5815419a6150c8ee84a12"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-rhel.6-x64.tar.gz",
+            "hash": "e638c0fdbf41668477e92afefe9a2ee29229aa2880dfaa83fc01b6c4298ab8d2699581fdbf543533d70873c8a4d430bf8da32c64a90b6b2c19a7766f34632739"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.1",
+        "version-display": "2.1.1",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "asp-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.exe",
+            "hash": "bc4c6ba1a5955e8486d3960d354182fa885afe1e56989e49b12420b6fa8dbbc28a42e653bbbde85e5ad638ad2fbf96bf99a52f5d5b1ade03b399e8585b28f897"
+          },
+          {
+            "name": "asp-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.exe",
+            "hash": "83041e846f74ed2594d2ad0f6f28efb007ac5b7b8a7489326d9d6f2dedbe7132c3f5e769daaacbfcf56d183f66b339bc278c773496573adfedd52cdd30ed8f48"
+          },
+          {
+            "name": "asp-runtime-win-x64",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x64.zip",
+            "hash": "312b4610e3fffd2bcd92c6a215c245bb112f40276837bfa2edea9cb9376554f6c237fc773f2c83c146cca6e7bfcfc53d708627d9a76a896996174ff300666528"
+          },
+          {
+            "name": "asp-runtime-win-x86",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-win-x86.zip",
+            "hash": "18c6fcb50376a57657ed0a4c254cea5fde0a5b7e7f7086dec7fb1153711f5545bb1f70beddf688c2ee7cc473fb607ec9a6a4663f05a25d473f2dad3a41de7034"
+          },
+          {
+            "name": "asp-runtime-mac-x64",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-osx-x64.tar.gz",
+            "hash": "2ef0ac04986c587914a9bcb9062d5abfbf4ec66efc68be8f3e8a6d46df20a839e0a04d0cfb7d6265a275bbc4e26245cf3d496a769e90bb88e1c5b8a7f944123b"
+          },
+          {
+            "name": "asp-runtime-linux-x64",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-x64.tar.gz",
+            "hash": "ab7de9d3e01d940ec985b1787532d856abb24d64b59066f0cee343f79edd2cd67be4b0de2788b9bfc97968311308384f912888e9ea8fd8d6def7e143c4e825c0"
+          },
+          {
+            "name": "asp-runtime-linux-arm",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-arm.tar.gz",
+            "hash": "5160edb49a16e24ff4cb018bf7ff2eb6638b514abaa9e0d5006e83399bd5830116c35e317b4d9418d2ecc7b757b21d7cf1353d445a7162fa81e990e9f9034a42"
+          },
+          {
+            "name": "asp-runtime-linux-musl-x64",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/aspnetcore-runtime-2.1.1-linux-musl-x64.tar.gz",
+            "hash": "b8d3ac5c1970b2a6d6fe812c66b55ff74b1a130010889d6b828a031296355c7b507b7289a90c149d5f710f93847609c6264fec0da5d196df6c2aab3100a8797f"
+          },
+          {
+            "name": "hosting-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-hosting-2.1.1-win.exe",
+            "hash": "6c24ec02e6c8996a419ad0f7092ada5e58754a5e1db7f1828670ce8f4503c22e14bd74ae8b86a99833147605157763a8d95bc5dbebbc5643c92fc28c4b58391f"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-05-07",
+      "release-version": "2.1.0-rc1",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.0-rc1.md",
+      "runtime": {
+        "version": "2.1.0-rc1",
+        "version-display": "2.1.0-rc1",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-x64.tar.gz",
+            "hash": "29f27f7b208ed20be71941f8c57aa5dc3c4a0e0fceffa4cf80553fca81dcfbe3b7f26a93662aae86c10ebf5f43a150bcac9290033dff6876d28683141e5d98e4"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm.tar.gz",
+            "hash": "d2a49b3b08ab282bbecfc578a3e24f76dc25dc15be5cf2021a33942b6629e47f81ac6c4766f97d4529fd92c4dd8c781a28c13eff3bff2e7b484a5b2c994ae37e"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-musl-x64.tar.gz",
+            "hash": "4f4b6bb043bc927643448de7744139cd5006f6c6108d39aeb24af1c79f76d4bcac05013e0700972f230d35315fa73241113fee2374d82e3318bc9f170a533652"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-linux-arm64.tar.gz",
+            "hash": "a5ddf10cf8477d811b1ad5958e4347cdb40a3fcdc9cd0e471d38245fca4e59e42e27d0c756a4e354988c979276ad41e33d42d151aae60f32601ddad21df56d85"
+          },
+          {
+            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-rhel.6-x64.tar.gz",
+            "hash": "13e4cdc01d4dc0985a1d6edb9aa228b809532e4e07d29ba7e6f001663c2e2e8478fb4b3459622699133debd122214279a5597762f659000e3efe18d9544ccbe0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.tar.gz",
+            "hash": "db2c6d403f5cd37c1fe0988d0f207d8dccc9940046553e280b16690f71225a638f3f90b86e43e2c26b02adedb86978c86ad6831c583f603dd43dcb7fb93fdcb2"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-osx-x64.pkg",
+            "hash": "5895c7dc2e721b921da579ec37b8defb47e53a5ccbca39a0dc989b04be24c9736c0b9c4fe2eeb0bb078f3a5cf472aae2d42c3f8f08b9fd2305f5e4e101503075"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.zip",
+            "hash": "1a161832ac0ded127b0f4ab36569b5d06cc1681818f72341cc530c4a645d7cc5b21b568c5e07749aa27968982487d9b18aae5e246cbf5ee385a10fc9783520f0"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.zip",
+            "hash": "781a67337f7717f38f061f623c8491dcb91be58750dcb47c15ef5519ab4be928ce8645500fad67a30026476e64e507d18210aab8f18213ffb48d83e0fa935cf7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x86.exe",
+            "hash": "e5ea1830f5cc94a5aa5dee744797b19a6af5c59c4e222b1e694e05acd9deb5474ffd24b6aea49ff72d8d8743eba20f3adc19158c7b5fa7ea3168a20333562980"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-runtime-2.1.0-rc1-win-x64.exe",
+            "hash": "279a5378ecff673dc15acb56c94fbd04e2261d77eea78f0679fa0a975a81b6f5bec37d3fe99f6a9bd2d228047afe024627071ebdbdd28ac6a57d76ed3e4eb1c0"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.300-rc1-008673",
+        "version-display": "2.1.300-rc1",
+        "runtime-version": "2.1.0-rc1",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-x64.tar.gz",
+            "hash": "f3964951e577b7b829a8f6cdc8b9477fd8ea39ad6baaed30f369280d06523ca3574cd8679d74bca027acdad0cb02fce76e46d742d705741a7074d99fdf95cc06"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.tar.gz",
+            "hash": "0e3e86ad493d7844d226d3e423b4d912124ea62ef8cb440de8fd318a579e105aacecde774e24c7c1c082d395e6b732970ae7c08c6e47e4e7477066174c251206"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg",
+            "hash": "3a0c2356712007232f83b38b89427d4cc6d576778e3db331455eedab393e1bc86ce771226eb7e2e6edd8230170fefb54e82d2a3b13ebf09d4478600c5b518ec8"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.zip",
+            "hash": "9e4e904f7743b6e0635f3474361eebb00f1164aa96e12fabcf6ecf2c56fa84abf974a1af5c7df8dc0139c8f11e43faaf5b85bd4401896320ea52f87f87aa37b3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.zip",
+            "hash": "a9e8b89dcac02ebaec82bcd8bbb55b42480e1ce040b8204e5fb8c2241978af7a090952de09982c02b6f9a1bdb85555f7bf356c6c8aea2d0207003e1d5f521ab4"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x86.exe",
+            "hash": "803c748bb67c77939232b36ddcc90b3663fd3679cf82aab0baba5979caf28252a2b171e2e3c69bd313a87e2ca78869bd484597170a2118c359fffa3dfb2a4470"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-x64.exe",
+            "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-win-gs-x64.exe",
+            "hash": "7256aca2c02827028213ce06ceb5414231b01bbc509d0d57d5258106760c0fa5621a9d5f629fca3f34d6c45523a133206561d7188a0cb4817d4d5cc6c172d6f0"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm.tar.gz",
+            "hash": "2600659fe88f2ae0fa3e491e5495123d441d87aa392a2ea40d0eaedb0aee471c2c824de4b425742d1e4cc5c4abaf272ec56b079458b9f062eab31c6343a14862"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-arm64.tar.gz",
+            "hash": "75ad50527eb4468b313bcd79d8e506c9da1670a92d4f06dfdfc6f524153edfd46447799ec50d90bb5b1dc6fbd04fbbd3fb7e4cf11b387db8005bdca2a947a67e"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-linux-musl-x64.tar.gz",
+            "hash": "852b51b0802297c13d6b86f6fae38c515eaaf51893dedfce129966134a8100f5da2ab789295528ae868cf54cb9f7004fd37bf97927f716bb193a6232f181a38a"
+          },
+          {
+            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
+            "rid": "rhel.6-x64",
+            "url": "https://download.microsoft.com/download/B/1/9/B19A2F87-F00F-420C-B4B9-A0BA4403F754/dotnet-sdk-2.1.300-rc1-008673-rhel.6-x64.tar.gz",
+            "hash": "687f0bd409c6370d7cdb6429eb59f345b31c6ae14ba1e76dafd518cecffee33ea23fd4705e3e89409dfa1ec6eeb31137656a00e791f59e5157a430a12cd42947"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.0-rc1",
+        "version-display": "2.1.0-rc1",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/dotnet-hosting-2.1.0-rc1-final-win.exe",
+            "hash": "45ae5913e8fca08513fef71bd9a849dabd829bbaf5fbd6e9489ffeb38177e65b1042e267243d40bd70df404ccd292c15746ecd2c820ad35527308b83da4bddc0"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.exe",
+            "hash": "1138f7e2a23cf0309cb53986e219d52a27cba30d8d5caa3697317b4cab951bf2976211f0894eaf60900da778b4aa790490c417041abe9bc741695a259ff94789"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.exe",
+            "hash": "b5e9a89ecfbd638c0f92bbb1626183def620c22e50169fa58a7a21faa83a2d48ef8f3cdc9b2815527e8885617db3624e25a5c63cdb23cf73ecd07056afe997f9"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x64.zip",
+            "hash": "18ce3332214fdf8e68afba978c2cc35213595e2b0d70c77d5e108f939990bc6234b6fda9159e9a020db3a7fe8ed5bee2d85df5bf569314056cd495a0a06fd1c3"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-win-x86.zip",
+            "hash": "c11d4d533828267d661cd7c01afa8a6e14a979a7595bc446284635e2e24ba10c299aad451c960f0c39afe7597e00aa311c77c9eef85cbc6768c8a136f05b2b2a"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-osx-x64.tar.gz",
+            "hash": "d929b601885bbd965ae47d2942d0e9d875a9750d63ebfe4015879b9f54c928bf833b966f3a58430d0e650d4de5afca524dffa7a71d5a4a5af901b51be2012f3d"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-x64.tar.gz",
+            "hash": "156ab969bc533c3a64b770f2b88214f0b07d1d867922257182d496828ac3cad6d6c01ea44f2a2a1d568278bfdf916db9825452de26a1262bdc591ff19f6e4b99"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-arm.tar.gz",
+            "hash": "c76690fb147b39ab8113efefd3442e40d26c3767bcd9e1c3b0692d6cb022ceb0aeb5eecd1ef38af89e3cba59adf8579347e005608b09622e10186732ecc41f47"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.microsoft.com/download/D/0/B/D0B7F62D-9C5D-4CF3-AB6C-88F56B4FC1A9/aspnetcore-runtime-2.1.0-rc1-final-linux-musl-x64.tar.gz",
+            "hash": "701a96fc3b27d6ebc46f2c9192bc1a048d1c3915888cdc2223183e7a8c7be7e591e9ea317c2e6a363c841013ae2209564da470e48f268c374084ab57c28a66a2"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-04-10",
+      "release-version": "2.1.0-preview2",
+      "security": false,
+      "cve-list": null,
+      "release-notes": null,
+      "runtime": {
+        "version": "2.1.0-preview2-26406-04",
+        "version-display": "2.1.0-preview2",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-linux-x64.tar.gz",
+            "hash": "9f8dce51f0438e0cff5fbdf38a60c620d879825902aae4d59ec026c6cfd0f6d2237f220a5346836e6e3c50a5be7b357443ab4ae01f85c596abceec12a8dc29d7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.tar.gz",
+            "hash": "5c8602cebe11b08a34e60b7bf2a826ee1e907e0e6aa4106b27f4af9063ffb2dc3cd03123c8bb1677445cdaab1fc0af758d11f752d5228187ac1f256eb9f82d75"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-osx-x64.pkg",
+            "hash": "a09fe3640b4dbfbf1ad005a44f488da264aceae83f8f9afac9d60df1ac51e0e8c96c2a5a88e880d545ea72162c286c206b833c2133260d10096bb8c50f50b065"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.zip",
+            "hash": "46816c29827516328f39147b5bf52f8f1786e8f58e3628ee02bdf5b080f7420e62b57751a9fb16caec8f4de41766be28693f29e42d5de1eae722938def6780ec"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.zip",
+            "hash": "eabf2cb0fbaa096739b5e25fb43ebe7b3a8a62756e25cdccf740658a0b7d1166259645c61f8c6e5c1c3577d440ee6285c9ce504ad6b9f66ba9d7fd71c211bd1a"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x86.exe",
+            "hash": "80a5894d44d153de640a9c9216c1ddd7c3a98033e06661658dc71be6d8c8f750e13f03f217ba01a4917fb2a20a78d8eadec742836357dc8d4f5e6bfaea60b732"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-runtime-2.1.0-preview2-26406-04-win-x64.exe",
+            "hash": "53c42d54ba7ce83d234efa63a6dae7c38593091ac28839d2f8706ea866f2fe2bebe88c8d03a09eaf8673ea257a3da099b4b7b8647cb100cdb17f3aa5257b2716"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.300-preview2-008533",
+        "version-display": "2.1.300-preview2",
+        "runtime-version": "2.1.0-preview2-26406-04",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-linux-x64.tar.gz",
+            "hash": "a50ce826458092cc0547c36ff0d281e00b71b5689109414ab41b8bd9b57fc1f20c04fd55c6c298503bd552b1eb1ddf9eb634f947ea3ded2ceb3fb61436df0457"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.tar.gz",
+            "hash": "088ee5309bc07a32d8b142c6f8c4bc981d37f6d14a1138dec452baa67dac4840f82b091fb3a5dc0b8902dba540ccaf96bef10d9fb0b040ab07e2af170ceabe25"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-x64.pkg",
+            "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-osx-gs-x64.pkg",
+            "hash": "e22f5947e492be96aabfd12372c656bf12dba76e70751bf2d76e1bb78f2660fbeb4020ad23e17882c7ae6762af14e32d417a46dd8a428fbba6c3aac7a49c684f"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.zip",
+            "hash": "fb906747d1bd7258eb803fae29256de02c1ca92d48041142cfc3a64feb5a36e7a91a04ffe12b407a2a67e003ae621a6181313a1f8833ce48417c7d2aa76c2566"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.zip",
+            "hash": "e2858d0809cd727ef361ecd192cc79208bfb04b258b1c7375c4a8fc34b897a4d0f244c67744f2c4154c1b8cf47cff4f656b70357f8c2d06c30058e82d115ef46"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x86.exe",
+            "hash": "3fe6174590802bea4e37f8c415d8ce5afc72113b8189511f15110057ba04cbf24d8495d57e8b67584a13706c033278a0daec33530ba43dea0403bf106524ea19"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/3/7/C/37C0D2E3-2056-4F9A-A67C-14DEFBD70F06/dotnet-sdk-2.1.300-preview2-008533-win-x64.exe",
+            "hash": "584ff392f4a49700afe2e18819b888be8320cfcb3133618866934690d23f127a1b663eb35ea91072c19c8d2d498b4847f0f4ab4dfc15b4bf4f4ee4b96419308b"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.0-preview2-26406-04",
+        "version-display": "2.1.0-preview2",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/dotnet-hosting-2.1.0-preview2-final-win.exe",
+            "hash": "5cca21d9f1cadebc130607f1ff14ab17db05f971ee218a7d855f452bd1f36ac8c7773af4662887c711c93ec6bd2c85a5e648aad845c2c9543ddf25e186cabd44"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz",
+            "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.exe",
+            "hash": "79567d9c4ee73195ea49d735b9a4a70f1f2485c3f38c53e83f624488b112a6304118f7ce8a48b7f5a169365165a8b11f5743c69141b260237846e24a560fb684"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.exe",
+            "hash": "a574395e4a478bd7f6a3f932e0ceccfc527661218ed24c7e33ea761a909d3598be522e7002b67f67a6569e9be5f79d4021cb1207d7877e17b48d0a82be6b0587"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x64.zip",
+            "hash": "5e247e07e29dc6932bdd810911461e78c16d30c5724403953d20971383be06dbed7b579a21a10b0da7d90ada884ef9f2d8a9ea7dfc442bcb4cefbc1a397c00bb"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-win-x86.zip",
+            "hash": "857560b9e780b686e5503d84574da811a302c3f1435d8dc09398b5e28a1cb2b5f82da87fc04ea170e92f37e5bb68f2669d5ff68b8cf64ea10d8f1735bde34cfa"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-osx-x64.tar.gz",
+            "hash": "7f8463f06af03cd951d1a2497c7d76def63239269ef510443bd6843f6fc9e3b68f4b0d812f8d22236a9d45c0c0cfd8166793461250c76037f08c0122b151c3ae"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz",
+            "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"
+          }
+        ]
+      },
+      "symbols": null
+    },
+    {
+      "release-date": "2018-02-27",
+      "release-version": "2.1.0-preview1",
+      "security": false,
+      "cve-list": null,
+      "release-notes": "",
+      "runtime": {
+        "version": "2.1.0-preview1-26216-03",
+        "version-display": "2.1.0-preview1",
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-linux-x64.tar.gz",
+            "hash": "0249b32f68d1266e6f481e16266b4b2d027b1644d182da31e34ef3c60b37fc755c5f85a482de6c85cdf095c8185221f666c7d6bc62364a786f0f2f8b72919c88"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.tar.gz",
+            "hash": "47431a5e6126ebb883d8e8a18ea7327dce285da41fd809860597c9574ab1e35fb323933f743a49e7a5078fb6e41740ec4611f5e1ffddd3114379f0b4db30a8a7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-osx-x64.pkg",
+            "hash": "8cbf0f7cacbb537619c580ff8ec7ac012aa40196ac00b2fbc2514a5097c878f766158d79a72e0582418ec20c6d98be7bfa81867c55e989b7da055f0942307ad7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.zip",
+            "hash": "1c6c6a6821eb5e3435fa57c2661584c4118a5a951f5f7df8087922f692859ee230566dc806b9a48e8dceed703f157cac3ae3619c645e18db487a8f740db4ed95"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.zip",
+            "hash": "511447ea54aab82b9b890936440fe08a0c25e7b579050ec7706bf9212a58a31cfc56420a9de8775a7bf3bc1e39143045c542617c065e59b471323eb00567f9d4"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x86.exe",
+            "hash": "8ec6e0efe7134b79debea41fa7bb45736f7a317260b15955c33d018ccf21fc13c46f1b30f4d0abed385ba76437d3be861e97fdc12022b99bc69c31cf22497214"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-runtime-2.1.0-preview1-26216-03-win-x64.exe",
+            "hash": "b7830445ac00a37718ed1b3b563fa323ca5889484141d9dd30e9b46b004c62ac2c003cc8f8bba1d4266ead62966817c93dc21c36f0660de3867125dfaffe04d3"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "2.1.300-preview1-008174",
+        "version-display": "2.1.300-preview1",
+        "runtime-version": "2.1.0-preview1-26216-03",
+        "vs-version": null,
+        "csharp-version": null,
+        "fsharp-version": null,
+        "vb-version": null,
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-linux-x64.tar.gz",
+            "hash": "3030d6876eef6770c54e6d1e23f1be544b72dfe171915d2e55e00e40faacec0035fe4f9d72a6dc5fc5fb29b768ff64c57dcce0b9fddd8f1b7f7ce8389f535da9"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.tar.gz",
+            "hash": "65de990bdfd131f9246e5b47480211a2b829c73b1dd0248c6c32417c0489539c15d98d12ffd70034a69b952b49a89eb79360eb9e0f34802706ade2563c78e1c4"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg",
+            "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"
+          },
+          {
+            "name": "dotnet-sdk-osx-gs-x64.pkg",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-gs-x64.pkg",
+            "hash": "7eda0b3191621de9e858eb27560bdce44b475584b3f789b2bc15e15c5b183c7cb419a7dfc99a1ec021afa87859d3c2f5417acfdb3ee317f6ace654901ef96925"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.zip",
+            "hash": "e1466e7652e7787206c06f2e642f10bf8815a8d02a06b8fb4db7c7941bdb64463c10a4dc1fe59b8c768353404016fa384a00c5b14f228272845f6a75f14f1896"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.zip",
+            "hash": "d1195ec86e745854735c2d8431858987b937963d5b96dd2f1fbecfe8f3b9c4259fbd9454fc7e81542aef117903a0674c7aba242bef3a761a9c8237f71286793f"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x86.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x86.exe",
+            "hash": "bd8a9145f651026cfa1ca7c264c2e05b3740afc0b5f8ac5572409a95836d8f87e1a8c460eb985182501f679b721a97fd174b7690ab8cdc5e43c8155ee8af94b5"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-x64.exe",
+            "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"
+          },
+          {
+            "name": "dotnet-sdk-win-gs-x64.exe",
+            "rid": null,
+            "url": "https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-win-gs-x64.exe",
+            "hash": "d6749ef041136865353289250a92fae582c118f77b2838ceb9484854b636249bc2950da942bd807bd3ec04f91bc2b9ccf0bc73a9771c04e8552db82d56eb73ee"
+          }
+        ]
+      },
+      "aspnetcore-runtime": {
+        "version": "2.1.0-preview1-final",
+        "version-display": "2.1.0-preview1",
+        "version-aspnetcoremodule": null,
+        "vsversion": null,
+        "files": [
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/dotnet-hosting-2.1.0-preview1-final-win.exe",
+            "hash": "4f2b8bf998bbda10f32cad96b5fa15bc944f321afe97e9a21da3e1984d25aa4cc39fac5c138e88ae126b7e3db78f07149517a38acf1066f8e5d2321044f76aa0"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz",
+            "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.exe",
+            "hash": "c14bfbfc0ceed63e08340384ee849ab9700f708486a3d09c4cb4651c7989a920563e008faaa3809e13e610231576cd55e3e676bdfb8e31c24f012484c4cbf433"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.exe",
+            "hash": "8f114a4842d6f30c16b929f163e2c88428de25f2477baa0d4a0beb5965e7dd05c7c6e52d305ff1da9d3377bd3f7f6bb766a78920383a732542b1af30cad7d162"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x64.zip",
+            "hash": "3a56bdf4ff099bd8f51e9b6b06a3bf3c34ff9769bbc655d81df2660be3af0de4508d97295e820fb3b04f7c79c3034b313509ad7cfa897636db8afab2115b8b63"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-win-x86.zip",
+            "hash": "4792e530651ef0a276218e3ffb7c7d4e0bbd44d68eebb384f2f4f627024b4ba69d74ddce8fb9a6b2e0d9b11910bd7dea542c3b19eabc2e9396d2475ef681523c"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-osx-x64.tar.gz",
+            "hash": "f8c78d7ea16f54d4ed87aec532b57bed8271265eefc3134647b50d760e6bd7fe001eaa6fdcba5d15d2db5330f3bc82ce2ff0b88b5bfedeaff53cf42143e2cc47"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.microsoft.com/download/A/B/1/AB1AA972-8F2F-43AD-9A81-72E9245CB0F5/aspnetcore-runtime-2.1.0-preview1-final-linux-x64.tar.gz",
+            "hash": "7a8a3f98f65f99e8a6439253e72abc78a2a7f741176f93dfbdd9b6589f98ef22881ba2afa7997ca047a2b2e3217d25988b4bc4ac6133ff61115f7a68b2bd3af6"
+          }
+        ]
+      },
+      "symbols": null
+    }
+  ]
 }

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -14,6 +14,7 @@
           "release-version": "2.2.101",
           "security": false,
           "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.0/2.2.101.md",
+          "runtime": {},
           "sdk": {
             "version": "2.2.101",
             "version-display": "2.2.101",
@@ -115,6 +116,7 @@
             "release-version": "2.2.200-preview",
             "security": false,
             "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/Preview/2.2.200-preview.md",
+            "runtime": {},
             "sdk": {
               "version": "2.2.200-preview-009648",
               "version-display": "2.2.200-preview-009648",


### PR DESCRIPTION
- add rid field and calculate rids (need another pass on 1.0/1.1 to file non-portable linux rids)
- add empty runtime element to sdk-only releases. this is needed for the update notification tool.