### PR TITLE
Update Raspberry Pi instructions

### DIFF
--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -8,23 +8,45 @@ We recommend that you use .NET Core 3 for Raspberry Pi development. There are si
 
 Note: .NET Core supports Raspberry Pi 2 and Pi 3. We recommend the Pi 3.
 
-Note: You can run [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), [64-bit Linux](https://gist.github.com/richlander/467813274cea8abc624553ee72b28213#how-to-install-arm64-builds) and [32-bit Windows](https://docs.microsoft.com/en-us/windows/iot-core/downloads) on the Pi. Any of those options will work with .NET Core. On Linux, it may be helpful to [Starting ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
+## Run with Docker
 
-## Configuring Linux
+You can run [sample .NET Core Docker apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) if you have Docker installed. 
 
-For [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), you need to [install the following prerequisites](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit):
+You can also run the .NET Core SDK with a simple command:
+
+```console
+docker run --rm -it microsoft/dotnet:3.0-sdk
+```
+
+## Installing and Configuring Linux
+
+For [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), you need to [install the following prerequisites](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit) using the following commands, here for Debian:
 
 ```console
 sudo apt-get update
 sudo apt-get install curl libunwind8 gettext apt-transport-https
 ```
 
-For 64-bit Linux, there are several different distros in progress:
+For 64-bit Linux, there are several different distros in progress that you can try:
 
 * [Debian on Raspberry Pi 3](https://github.com/Debian/raspi3-image-spec)
 * [Fedora on Raspberry Pi 3](https://fedoraproject.org/wiki/Architectures/ARM/Raspberry_Pi#Raspberry_Pi_3_aarch64_support)
 * [Ubuntu on Raspberry Pi 3](https://wiki.ubuntu.com/ARM/RaspberryPi#arm64)
 * [Ubuntu on Pine64](http://wiki.pine64.org/index.php/Pine_A64_Software_Release#Xenial_Mate)
+
+Note: We've had the most success with Debian on ARM64 for the Pi.
+
+For 64-bit, You need to install the following components using the following commands, here for Debian:
+
+```console
+sudo apt-get update
+sudo apt-get install libc6 libgcc1 libgssapi-krb5-2 libicu60 liblttng-ust0 libssl1.0.0 libstdc++6 zlib1g
+``` 
+
+Note: There are various tricks that makes it easier to manage installing Linux images:
+
+* [Installing operating system images](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)
+* [Starting ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
 
 ## Installing the .NET Core SDK on Rasberry Pi for Linux ARM32/ARM64
 
@@ -105,7 +127,3 @@ Build self-contained Linux ARM32 app and copy to Pi:
 6. Navigate to webapp in desktop browser at: `192.168.1.75:5100`
 
 Note: For Linux ARM32, use `-r linux-arm`, for  Linux ARM64, use `-r linux-arm64` and for Windows ARM32, use `-r win-arm` .
-
-## Run with Docker
-
-You can run [sample .NET Core Docker apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) if you have Docker installed.

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -4,13 +4,13 @@
 
 You can build an application for ARM either on an ARM device or on your X64 machine. Both options are documented below.
 
-We recommend that you use .NET Core 3 for Raspberry Pi development. There are significant improvements in .NET Core 3 that make the experience much better.
+This document is written for .NET Core 3, but can be adapted to work for .NET Core 2.1 or 2.2.
 
-Note: .NET Core supports Raspberry Pi 2 and Pi 3. We recommend the Pi 3.
+Note: .NET Core supports Raspberry Pi 2 and Pi 3. We recommend using the Raspberry Pi 3.
 
 ## Run with Docker
 
-You can run [sample .NET Core Docker apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) if you have Docker installed. 
+You can run [.NET Core sample apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-arm32.md) and [ASP.NET Core sample apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnetcore-docker-arm32.md) with Docker.
 
 You can also run the .NET Core SDK with a simple command:
 
@@ -20,14 +20,25 @@ docker run --rm -it microsoft/dotnet:3.0-sdk
 
 ## Installing and Configuring Linux
 
-For [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), you need to [install the following prerequisites](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit) using the following commands, here for Debian:
+We recommend [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/) for Pi users.
+
+.NET Core has a set of [dependencies](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit) that must be installed.
+
+32-bit Debian/Raspian:
 
 ```console
 sudo apt-get update
 sudo apt-get install curl libunwind8 gettext apt-transport-https
 ```
 
-For 64-bit Linux, there are several different distros in progress that you can try:
+64-bit Debian:
+
+```console
+sudo apt-get update
+sudo apt-get install libc6 libgcc1 libgssapi-krb5-2 libicu60 liblttng-ust0 libssl1.0.0 libstdc++6 zlib1g
+```
+
+There are several ARM64 distros in progress that you can try:
 
 * [Debian on Raspberry Pi 3](https://github.com/Debian/raspi3-image-spec)
 * [Fedora on Raspberry Pi 3](https://fedoraproject.org/wiki/Architectures/ARM/Raspberry_Pi#Raspberry_Pi_3_aarch64_support)
@@ -36,14 +47,7 @@ For 64-bit Linux, there are several different distros in progress that you can t
 
 Note: We've had the most success with Debian on ARM64 for the Pi.
 
-For 64-bit, You need to install the following components using the following commands, here for Debian:
-
-```console
-sudo apt-get update
-sudo apt-get install libc6 libgcc1 libgssapi-krb5-2 libicu60 liblttng-ust0 libssl1.0.0 libstdc++6 zlib1g
-``` 
-
-Note: There are various tricks that makes it easier to manage installing Linux images:
+There are various techniques that we use to makes it easier to install Linux images:
 
 * [Install operating system images](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)
 * [Start ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
@@ -54,15 +58,16 @@ The best way to install .NET Core on ARM platforms is currently via curl. We are
 
 Note: The pattern documented below is the same one we use for [Docker](https://github.com/dotnet/dotnet-docker). You can look at .NET Core Dockerfiles to learn more about specific installation needs.
 
-1. Download .NET Core via curl (choose the version that works for you):
-  * 2.2 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.103/dotnet-sdk-2.2.103-linux-arm.tar.gz`
-  * 3.0 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm.tar.gz`
-  * 3.0 ARM64: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm64.tar.gz`
+1. Download .NET Core via curl (choose the version that works for you, or grab an [official build](https://dotnet.microsoft.com/download/archives)):
 
-  Note: The latest download links are available at the [.NET Core Download page](https://dotnet.microsoft.com/download/archives).
+  * 3.0 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm.tar.gz`
+  * 3.0 ARM64: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm64.tar.gz`
+
 2. Unpack .NET Core to a global location:
+
   * `sudo mkdir -p /usr/share/dotnet`
   * `sudo tar -zxf dotnet.tar.gz -C /usr/share/dotnet`
+
 3. Symbolically link dotnet into a path location:
   * `sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet`
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -45,8 +45,8 @@ sudo apt-get install libc6 libgcc1 libgssapi-krb5-2 libicu60 liblttng-ust0 libss
 
 Note: There are various tricks that makes it easier to manage installing Linux images:
 
-* [Installing operating system images](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)
-* [Starting ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
+* [Install operating system images](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)
+* [Start ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
 
 ## Installing the .NET Core SDK on Rasberry Pi for Linux ARM32/ARM64
 
@@ -87,7 +87,7 @@ Console App:
 1. `dotnet new console -o app` // Generate app from template
 2. `cd app`
 3. `dotnet run` // Build and run app
-4. `./bin/Debug/netcoreapp3.0/app` // Alternatively, run app directly
+4. `./bin/Debug/netcoreapp3.0/app` // Run app directly (once built)
 
 Web App:
 
@@ -105,7 +105,7 @@ You can build and publish app on another machine (likely x64) and publish to the
 1. `dotnet new webapp -o webapp` // Generate app from template
 2. `cd webapp`
 3. `dotnet run` // Build and run app -- will use `localhost:5000`
-4. `\bin\Debug\netcoreapp3.0\webapp.exe` // Alternatively, run app directly
+4. `\bin\Debug\netcoreapp3.0\webapp.exe` // Run app directly (once built)
 
 Now, we will copy the app to the Pi with scp (other tools work similarly, like Putty). There are a few different options.
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -12,12 +12,19 @@ Note: You can run [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/
 
 ## Configuring Linux
 
-For Raspbian [Debian 9 Jessie](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit) you need to do the following:
+For [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), you need to [install the following prerequisites](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit):
 
 ```console
 sudo apt-get update
 sudo apt-get install curl libunwind8 gettext apt-transport-https
 ```
+
+For 64-bit Linux, there are several different distros in progress:
+
+* [Debian on Raspberry Pi 3](https://github.com/Debian/raspi3-image-spec)
+* [Fedora on Raspberry Pi 3](https://fedoraproject.org/wiki/Architectures/ARM/Raspberry_Pi#Raspberry_Pi_3_aarch64_support)
+* [Ubuntu on Raspberry Pi 3](https://wiki.ubuntu.com/ARM/RaspberryPi#arm64)
+* [Ubuntu on Pine64](http://wiki.pine64.org/index.php/Pine_A64_Software_Release#Xenial_Mate)
 
 ## Installing the .NET Core SDK on Rasberry Pi for Linux ARM32/ARM64
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -1,13 +1,39 @@
 # .NET Core on Raspberry Pi
 
-Arm32 builds are available as community supported builds for .NET Core 2.0. 
-**There is no SDK that runs on ARM32** but you can publish an application that will run on a Raspberry Pi. 
+.NET Core builds are available that run on the Raspberry Pi and similar hardware. In particular, the Raspberry Pi uses an ARM chip, and requires .NET Core ARM builds. .NET Core supports ARM32 and ARM64.
 
-These steps have been tested on a RPi 2 and RPi 3 with Linux and Windows.
+You can build an application for ARM either on an ARM device or on your X64 machine. Both options are documented below.
 
-Note: All models of generation 1 and Pi Zero are not supported because the .NET Core JIT depends on armv7 instructions not available on those versions.
+We recommend that you use .NET Core 3 for Raspberry Pi development. There are significant improvements in .NET Core 3 that make the experience much better.
 
-## Creating an app:
+Note: .NET Core supports Raspberry Pi 2 and Pi 3. We recommend the Pi 3.
+
+## Installing the .NET Core SDK on Rasberry Pi
+
+The best way to install .NET Core on ARM platforms is via curl.
+
+Note: The pattern documented below is the same one we use for [Docker](https://github.com/dotnet/dotnet-docker). You can look at .NET Core Dockerfiles to learn more about specific installation needs.
+
+Download .NET Core via curl (choose the version that works for you):
+
+* 2.2 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.103/dotnet-sdk-2.2.103-linux-arm.tar.gz`
+* 3.0 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm.tar.gz`
+* 3.0 ARM64: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm64.tar.gz`
+
+Note: The latest download links are available at the [.NET Core Download page](https://dotnet.microsoft.com/download/archives).
+
+Unpack .NET Core to a global location:
+
+* `sudo mkdir -p /usr/share/dotnet`
+* `sudo tar -zxf dotnet.tar.gz -C /usr/share/dotnet`
+
+Symbolically link dotnet into a path location:
+
+* `sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet`
+
+## Installation .NET Core
+
+
 
 * [Install .NET Core SDK](https://www.microsoft.com/net/core) into a supported developer configuration.
 (Raspberry Pi itself is supported only as deployment target but there is an unsupported version of the SDK available as well.)

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -1,4 +1,4 @@
-# .NET Core on Raspberry Pi
+# Run .NET Core Apps on Raspberry Pi
 
 .NET Core builds are available that run on the Raspberry Pi and similar hardware. In particular, the Raspberry Pi uses an ARM chip, and requires .NET Core ARM builds. .NET Core supports ARM32 and ARM64.
 

--- a/samples/RaspberryPiInstructions.md
+++ b/samples/RaspberryPiInstructions.md
@@ -8,89 +8,97 @@ We recommend that you use .NET Core 3 for Raspberry Pi development. There are si
 
 Note: .NET Core supports Raspberry Pi 2 and Pi 3. We recommend the Pi 3.
 
-## Installing the .NET Core SDK on Rasberry Pi
+Note: You can run [32-bit Linux](https://www.raspberrypi.org/downloads/raspbian/), [64-bit Linux](https://gist.github.com/richlander/467813274cea8abc624553ee72b28213#how-to-install-arm64-builds) and [32-bit Windows](https://docs.microsoft.com/en-us/windows/iot-core/downloads) on the Pi. Any of those options will work with .NET Core. On Linux, it may be helpful to [Starting ssh automatically at boot time](https://raspberrypi.stackexchange.com/questions/1747/starting-ssh-automatically-at-boot-time).
 
-The best way to install .NET Core on ARM platforms is via curl.
-
-Note: The pattern documented below is the same one we use for [Docker](https://github.com/dotnet/dotnet-docker). You can look at .NET Core Dockerfiles to learn more about specific installation needs.
-
-Download .NET Core via curl (choose the version that works for you):
-
-* 2.2 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.103/dotnet-sdk-2.2.103-linux-arm.tar.gz`
-* 3.0 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm.tar.gz`
-* 3.0 ARM64: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm64.tar.gz`
-
-Note: The latest download links are available at the [.NET Core Download page](https://dotnet.microsoft.com/download/archives).
-
-Unpack .NET Core to a global location:
-
-* `sudo mkdir -p /usr/share/dotnet`
-* `sudo tar -zxf dotnet.tar.gz -C /usr/share/dotnet`
-
-Symbolically link dotnet into a path location:
-
-* `sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet`
-
-## Installation .NET Core
-
-
-
-* [Install .NET Core SDK](https://www.microsoft.com/net/core) into a supported developer configuration.
-(Raspberry Pi itself is supported only as deployment target but there is an unsupported version of the SDK available as well.)
-
-* From the terminal/commandline create a folder named `helloworld` and go into it.
-* Run `dotnet new console`
-* You can find a `helloworld.csproj` file is created under current directory.
-
-```
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-</Project>
-```
-
-* If you get restore errors, make sure you have a nuget.config file next to your csproj that includes the dotnet-core myget feed: `<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />`.
-
-```
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>
-```
-
-## Publishing an app to run on the Pi:
-
-* Run `dotnet publish -r <runtime identifier>` for example `dotnet publish -r win-arm` to publish the application for windows and `dotnet publish -r linux-arm` for Linux running on Raspberry Pi.
-
-* Under `./bin/Debug/netcoreapp2.1/<runtime identifier>/publish` or `.\bin\Debug\netcoreapp2.1\<runtime identifier>\publish` you will see the whole self contained app that you need to copy to your Raspberry Pi.
-
-
-## Getting the app to run on the Pi.
-
-### Linux
-
-* Install [Linux](https://www.raspberrypi.org/downloads/) on your Pi.
-
-* Install the [platform dependencies from your distro's package manager](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) for .NET Core. .NET Core depends on some packages from the Linux package manager as prerequisites to running your application.
+## Configuring Linux
 
 For Raspbian [Debian 9 Jessie](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-debian-8-or-debian-9-64-bit) you need to do the following:
-```
+
+```console
 sudo apt-get update
 sudo apt-get install curl libunwind8 gettext apt-transport-https
 ```
 
-* Copy your app, i.e. whole `publish` directory mentioned above, to the Raspberry Pi and execute run `./helloworld` to see `Hello World!` from .NET Core running on your Pi! (make sure you `chmod 755 ./helloworld`)
+## Installing the .NET Core SDK on Rasberry Pi for Linux ARM32/ARM64
 
-### Win10 IoT Core
+The best way to install .NET Core on ARM platforms is currently via curl. We are working on other options.
 
-* Install [Windows 10 IoT Core](https://docs.microsoft.com/en-us/windows/iot-core/getstarted) on your Pi.
+Note: The pattern documented below is the same one we use for [Docker](https://github.com/dotnet/dotnet-docker). You can look at .NET Core Dockerfiles to learn more about specific installation needs.
 
-* Copy your app, i.e. whole `publish` directory mentioned above, to the Raspberry Pi and execute run `helloworld.exe` to see `Hello World!` from .NET Core running on your Pi. 
+1. Download .NET Core via curl (choose the version that works for you):
+  * 2.2 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.103/dotnet-sdk-2.2.103-linux-arm.tar.gz`
+  * 3.0 ARM32: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm.tar.gz`
+  * 3.0 ARM64: `curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.0.100-preview-010184/dotnet-sdk-3.0.100-preview-010184-linux-arm64.tar.gz`
 
-**It is important that you copy the `publish` directory contents displayed at the end of the publish operation and not from another location in the `bin` folder.**
+  Note: The latest download links are available at the [.NET Core Download page](https://dotnet.microsoft.com/download/archives).
+2. Unpack .NET Core to a global location:
+  * `sudo mkdir -p /usr/share/dotnet`
+  * `sudo tar -zxf dotnet.tar.gz -C /usr/share/dotnet`
+3. Symbolically link dotnet into a path location:
+  * `sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet`
+
+You should be able to run .NET Core at this point:
+
+```console
+dotnet
+```
+
+## Installing the .NET Core SDK on Raspberry Pi on Win10 IoT Core
+
+Install [Windows 10 IoT Core](https://docs.microsoft.com/en-us/windows/iot-core/getstarted) on your Pi.
+
+Install the [.NET Core 3.0 SDK for Windows ARM32](https://dotnet.microsoft.com/download/dotnet-core/3.0).
+
+## Creating and Running an Application on the Pi
+
+It is easy to run an application on the Pi. The following commands are for Linux, but switching the casing will enable the same commands to work on Windows.
+
+Console App:
+
+1. `dotnet new console -o app` // Generate app from template
+2. `cd app`
+3. `dotnet run` // Build and run app
+4. `./bin/Debug/netcoreapp3.0/app` // Alternatively, run app directly
+
+Web App:
+
+1. `dotnet new webapp -o webapp` // Generate app from template
+2. `cd webapp`
+3. `dotnet run` // Build and run app -- will use `localhost`
+4. `./bin/Debug/netcoreapp3.0/webapp --urls "http://*:5100"` //Run app, exposed on port 5100
+
+Note: `dotnet run` will use the `localhost` loopback by default. To view the site on an external port, [configure ASP.NET Core](https://docs.microsoft.com/aspnet/core/fundamentals/host/web-host?view=aspnetcore-2.1#server-urls) to do so with `--urls "http://*:5100"` argument (with `dotnet run` or direct exectuable launch, as seen in step 4 above) and then view on the appropriate IP address and port, such as `http://192.168.1.75:5100`.
+
+## Build on X64 and Publish to Pi
+
+You can build and publish app on another machine (likely x64) and publish to the Pi. We will use a webapp for this example and first test on the local machine (desktop or laptop).
+
+1. `dotnet new webapp -o webapp` // Generate app from template
+2. `cd webapp`
+3. `dotnet run` // Build and run app -- will use `localhost:5000`
+4. `\bin\Debug\netcoreapp3.0\webapp.exe` // Alternatively, run app directly
+
+Now, we will copy the app to the Pi with scp (other tools work similarly, like Putty). There are a few different options.
+
+Assume matching .NET Core runtime is installed on Pi:
+
+1. `scp -r bin\Debug\netcoreapp3.0\ pi@192.168.1.75:~/webapp` // copy app to Pi
+2. `ssh pi@@192.168.1.75`
+3. `chmod 755 ./webapp/webapp`
+4. `./webapp/webapp --urls "http://*:5100"`
+5. Navigate to webapp in desktop browser at: `192.168.1.75:5100`
+
+Build self-contained Linux ARM32 app and copy to Pi:
+
+1. `dotnet publish -r linux-arm`
+2. `scp -r bin\Debug\netcoreapp3.0\linux-arm\publish pi@192.168.1.75:~/webapp` // copy app to Pi
+3. `ssh pi@@192.168.1.75`
+4. `chmod 755 ./webapp/webapp`
+5. `./webapp/webapp --urls "http://*:5100"`
+6. Navigate to webapp in desktop browser at: `192.168.1.75:5100`
+
+Note: For Linux ARM32, use `-r linux-arm`, for  Linux ARM64, use `-r linux-arm64` and for Windows ARM32, use `-r win-arm` .
+
+## Run with Docker
+
+You can run [sample .NET Core Docker apps](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) if you have Docker installed.


### PR DESCRIPTION
This doc is intended to explain how to use .NET Core on the Raspberry Pi for Linux and Windows, ARM32 and ARM64 (where applicable).

To make things simpler, I am going to make the doc .NET Core 3.0 only and direct people to where to get links for 2.x. The product is so much easier and more pleasant to use on the Pi with 3.0 so we should go with that.