### PR TITLE
Add release notes link to latest 2.2 release

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -72,6 +72,7 @@
 		"csharp-language": "7.3",
 		"fsharp-language": "4.5",
 		"vb-language": "15.9",
+		"release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.1/2.2.1.md",
 		"checksums-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.2.103-sdk-sha.txt",
 		"blob-sdk": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.103",
 		"sdk-linux-arm-32": "https://download.visualstudio.microsoft.com/download/pr/1de01e2e-aa87-4535-af42-8a8a9b4df215/a2fc245f1c26130a2ec22bbf5d0cb3e6/dotnet-sdk-2.2.103-linux-arm.tar.gz",


### PR DESCRIPTION
This is used to drive the release notes link on the .NET website