### PR TITLE
Remove ASP.NET Core Shared Framework links.

### DIFF
--- a/daily-builds.md
+++ b/daily-builds.md
@@ -9,7 +9,6 @@ Preview branches are for new major/minor versions of .NET Core that have not yet
 |Component|*.NET Core 3.0*|*.NET Core 2.2*|
 |:------:|:------:|:------:|
 |SDK|[.NET Core SDK 3.0.1xx  (Master)](https://github.com/dotnet/core-sdk/blob/master/README.md#installers-and-binaries)|[.NET Core SDK 2.2.1xx](https://github.com/dotnet/core-sdk/blob/master/README.md#installers-and-binaries)|
-|ASP.NET Core|[ASP.NET Core Shared Framework 3.0 (Master)](https://github.com/aspnet/universe#daily-builds)|[ASP.NET Core Shared Framework 2.2](https://github.com/aspnet/universe#daily-builds)|
 |Runtime|[.NET Core Runtime 3.0 (Master)](https://github.com/dotnet/core-setup/blob/master/README.md#daily-builds)|[.NET Core Runtime 2.2](https://github.com/dotnet/core-setup/blob/master/README.md#daily-builds)|
 
 ## Servicing Releases
@@ -19,5 +18,4 @@ Servicing branches are for new patch versions of .NET Core that have not yet bee
 |Component|*.NET Core 2.1*|*.NET Core 2.0*|*.NET Core 1.1*|*.NET Core 1.0*|
 |:------:|:------:|:------:|:------:|:------:|
 |SDK|[.NET Core SDK 2.1.401](https://github.com/dotnet/core-sdk/blob/master/README.md#installers-and-binaries)|[.NET Core SDK 2.0](https://github.com/dotnet/cli/blob/release/2.0.0/README.md#installers-and-binaries)|[.NET Core SDK 1.1](https://github.com/dotnet/cli/blob/rel/1.1.0/README.md#installers-and-binaries)|[.NET Core SDK 1.1](https://github.com/dotnet/cli/blob/rel/1.1.0/README.md#installers-and-binaries)|
-|ASP.NET Core|[ASP.NET Core Shared Framework 2.1](https://github.com/aspnet/universe#daily-builds)|**N/A**|**N/A**|**N/A**|
 |Runtime|[.NET Core Runtime 2.1](https://github.com/dotnet/core-setup/blob/master/README.md#daily-builds)|[.NET Core Runtime 2.0](https://github.com/dotnet/core-setup/blob/release/2.0.0/README.md#officially-released-builds)|[.NET Core Runtime 1.1](https://github.com/dotnet/core-setup/blob/release/1.1.0/README.md#latest-versions)|[.NET Core Runtime 1.0](https://github.com/dotnet/core-setup/blob/release/1.0.0/README.md#latest-versions)|


### PR DESCRIPTION
https://github.com/aspnet/AspNetCore/pull/6955 removed these links.