### PR TITLE
Remove netcorecli-fsc from the list.

### DIFF
--- a/Documentation/core-repos.md
+++ b/Documentation/core-repos.md
@@ -23,7 +23,6 @@ There are many repos that make up .NET Core. To file an issue, make a PR, or eng
 * [dotnet/roslyn](https://github.com/dotnet/roslyn) - Roslyn and C#
 * [dotnet/csharplang](https://github.com/dotnet/csharplang) - C# spec
 * [dotnet/vblang](https://github.com/dotnet/vblang) - VB spec
-* [dotnet/netcorecli-fsc](https://github.com/dotnet/netcorecli-fsc) - F# integration into .NET CLI
 
 ## NuGet
 


### PR DESCRIPTION
The netcorecli-fsc repo is now archived, see https://github.com/dotnet/netcorecli-fsc/commit/669730b920ae9d256f75705ccade40dc9b5f20d9.