### PR TITLE
Dotnet core 3.0 support matrix WRT Fedora

### DIFF
--- a/release-notes/3.0/3.0-supported-os.md
+++ b/release-notes/3.0/3.0-supported-os.md
@@ -32,7 +32,7 @@ OS                            | Version                       | Architectures  |
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://www.microsoft.com/net/support/policy)
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
-Fedora                        | 28                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
+Fedora                        | 28+                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9                       | x64, ARM32, ARM64     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 16.04+                  | x64, ARM32, ARM64   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
 Linux Mint                    | 18                          | x64            | [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)


### PR DESCRIPTION
.NET Core 2.2 claims support for Fedora 29, which I'd expect to be the true for 3.0 as well.

If that's not true, we should include a disclaimer for such unusual change in the support matrix.