### PR TITLE
Fixed install guide that breaks shell

### DIFF
--- a/release-notes/2.2/2.2.3/2.2.3-download.md
+++ b/release-notes/2.2/2.2.3/2.2.3-download.md
@@ -76,7 +76,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/3.0/preview/3.0.0-preview2-download.md
+++ b/release-notes/3.0/preview/3.0.0-preview2-download.md
@@ -44,7 +44,7 @@ You can also install from binary archive, if that better suits your needs. When 
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/3.0/preview/3.0.0-preview3-download.md
+++ b/release-notes/3.0/preview/3.0.0-preview3-download.md
@@ -45,7 +45,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation


### PR DESCRIPTION
```export PATH=$HOME/dotnet```
Replaces path contents, essentially breaking the shell.
Fixed for latest releases.