### PR TITLE
Fixes incorrect Blog Post link in 2.2.4.md

### DIFF
--- a/release-notes/2.2/2.2.4/2.2.4.md
+++ b/release-notes/2.2/2.2.4/2.2.4.md
@@ -211,4 +211,4 @@ runtime.win-x86.microsoft.netcore.dotnethostresolver | 2.2.4
 
 [linux-install]: https://www.microsoft.com/net/download/linux
 [linux-setup]: https://github.com/dotnet/core/blob/master/Documentation/linux-setup.md
-[dotnet-blog]: https://devblogs.microsoft.com/dotnet/net-core-march-2019/
+[dotnet-blog]: https://devblogs.microsoft.com/dotnet/net-core-april-2019-updates-2-1-10-and-2-2-4/


### PR DESCRIPTION
Fixes the "Blog Post" link to point to April 2019 Updates