### PR TITLE
json data corretions

### DIFF
--- a/release-notes/1.1/releases.json
+++ b/release-notes/1.1/releases.json
@@ -224,7 +224,7 @@
         "vs-version": "15.0",
         "files": [
           {
-            "name": "DotNetCore_1.1.12-WindowsHosting.exe",
+            "name": "DotNetCore-WindowsHosting.exe",
             "rid": "win-x86_x64",
             "url": "https://download.visualstudio.microsoft.com/download/pr/1110274e-cd5c-4b82-8a3f-c71937d603b9/f507bbb5a47ca15cadf0d55efcdb5176/dotnetcore.1.0.15_1.1.12-windowshosting.exe",
             "hash": "8E8353B4BA51F62AF7866D166E6A1BD1C3B99B0FE71EEC79B4F10CC3EFFC1B78EB0341F431CE4D5A9F0BD87DD9A94EAEFFC0BDD8D78C700473A7FC111C12013B"
@@ -1152,8 +1152,8 @@
       ],
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.7.md",
       "runtime": {
-        "version": null,
-        "version-display": null,
+        "version": "1.1.7",
+        "version-display": "1.1.7",
         "vs-version": null,
         "files": [
           {

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -3532,7 +3532,7 @@
             "hash": "b8d3ac5c1970b2a6d6fe812c66b55ff74b1a130010889d6b828a031296355c7b507b7289a90c149d5f710f93847609c6264fec0da5d196df6c2aab3100a8797f"
           },
           {
-            "name": "hosting-win-x64.exe",
+            "name": "dotnet-hosting-win.exe",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/9/3/E/93ED35C8-57B9-4D50-AE32-0330111B38E8/dotnet-hosting-2.1.1-win.exe",
             "hash": "6c24ec02e6c8996a419ad0f7092ada5e58754a5e1db7f1828670ce8f4503c22e14bd74ae8b86a99833147605157763a8d95bc5dbebbc5643c92fc28c4b58391f"


### PR DESCRIPTION
Resolves some of the issues identified in https://github.com/dotnet/core/issues/2563#issuecomment-482998172

- [x] runtime release 2.1.1 in https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json has an inconsistent files.name property for hosting package. For most, if not all records, it is named dotnet-hosting-win.exe but for this specific release, it is named hosting-win-x64.exe.
- [ ] 2.0 release manifest has inconsistent files.name for hosting package. **No changes** *This is an artifact of 2.0 era file naming. Since 2.0 is out of support, changing the field name (breaking change or anyone else already using these fields) for the sake of consistency doesn't seem worthwhile.*
- [ ] runtime release 2.0.8 has a url of https://download.microsoft.com/download/E/F/7/EF7302FE-4F84-4529-9E3A-893450F76501/dotnet-runtime-2.0.7-win-x64.exe while runtime release 2.0.7 has a url of https://download.microsoft.com/download/A/9/F/A9F8872C-48B2-41DB-8AAD-D5908D988592/dotnet-runtime-2.0.7-win-x64.exe. They are both valid too. **No changes** *This was a strange release where only the ASP.NET components were updated. Probably not the right choices with respect to release versioning and again, 2.0 is out of support.*
- [ ] sdk releases for 1.1 channel have file.name values of dotnet-dev-win-x64.exe compare to dotnet-sdk-win-x64.exe **No changes** *1.x era naming*
- [x] 1.1 release manifest has a null value for runtime release version 1.1.7
- [x] 1.1 release manifest has aspnetcore-runtime.files.name values with versions in them instead of something more generic like 2.0, 2.1, 2.2. example, DotNetCore_1.1.12-WindowsHosting.exe.
- [ ] 1.1 release manifest has runtime.files.name values of dotnet-win-x64.exe instead of dotnet-runtime-win-x64.exe unlike 2.0, 2.1, 2.2. **No changes** *Field name is based on the filename minus version string so making a change now will likely break some folks*