### PR TITLE
Use export PATH=$PATH:$HOME/dotnet consistently

### DIFF
--- a/release-notes/1.0/1.0.14/1.0.14-download.md
+++ b/release-notes/1.0/1.0.14/1.0.14-download.md
@@ -57,7 +57,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 [blob-runtime]: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/
 [blob-sdk]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/

--- a/release-notes/1.0/1.0.15/1.0.15-download.md
+++ b/release-notes/1.0/1.0.15/1.0.15-download.md
@@ -56,7 +56,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 [blob-runtime]: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/
 [blob-sdk]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/

--- a/release-notes/1.1/1.1.11/1.1.11-download.md
+++ b/release-notes/1.1/1.1.11/1.1.11-download.md
@@ -60,7 +60,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 [blob-runtime]: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/
 [blob-sdk]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/

--- a/release-notes/1.1/1.1.12/1.1.12-download.md
+++ b/release-notes/1.1/1.1.12/1.1.12-download.md
@@ -60,7 +60,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 [blob-runtime]: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/
 [blob-sdk]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/

--- a/release-notes/2.1/2.1.10/2.1.10-download.md
+++ b/release-notes/2.1/2.1.10/2.1.10-download.md
@@ -85,7 +85,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.502-SDK/2.1.502-download.md
+++ b/release-notes/2.1/2.1.502-SDK/2.1.502-download.md
@@ -57,7 +57,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.6/2.1.6-download.md
+++ b/release-notes/2.1/2.1.6/2.1.6-download.md
@@ -61,7 +61,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.602-SDK/2.1.602-SDK.md
+++ b/release-notes/2.1/2.1.602-SDK/2.1.602-SDK.md
@@ -60,7 +60,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.603-SDK/2.1.603-SDK-download.md
+++ b/release-notes/2.1/2.1.603-SDK/2.1.603-SDK-download.md
@@ -69,7 +69,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.7/2.1.7-download.md
+++ b/release-notes/2.1/2.1.7/2.1.7-download.md
@@ -60,7 +60,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.700-SDK/2.1.700-SDK-download.md
+++ b/release-notes/2.1/2.1.700-SDK/2.1.700-SDK-download.md
@@ -69,7 +69,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.8/2.1.8-download.md
+++ b/release-notes/2.1/2.1.8/2.1.8-download.md
@@ -76,7 +76,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/2.1.9/2.1.9-download.md
+++ b/release-notes/2.1/2.1.9/2.1.9-download.md
@@ -76,7 +76,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.1/Preview/2.1.600-preview-download.md
+++ b/release-notes/2.1/Preview/2.1.600-preview-download.md
@@ -52,7 +52,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.0/2.2.0-download.md
+++ b/release-notes/2.2/2.2.0/2.2.0-download.md
@@ -60,7 +60,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.1/2.2.1-download.md
+++ b/release-notes/2.2/2.2.1/2.2.1-download.md
@@ -59,7 +59,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.101-SDK/2.2.101-download.md
+++ b/release-notes/2.2/2.2.101-SDK/2.2.101-download.md
@@ -57,7 +57,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.2/2.2.2-download.md
+++ b/release-notes/2.2/2.2.2/2.2.2-download.md
@@ -76,7 +76,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.202-SDK/2.2.202-SDK.md
+++ b/release-notes/2.2/2.2.202-SDK/2.2.202-SDK.md
@@ -59,7 +59,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.203-SDK/2.2.203-SDK-download.md
+++ b/release-notes/2.2/2.2.203-SDK/2.2.203-SDK-download.md
@@ -68,7 +68,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.204-SDK/2.2.204-SDK-download.md
+++ b/release-notes/2.2/2.2.204-SDK/2.2.204-SDK-download.md
@@ -68,7 +68,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/2.2.4/2.2.4-download.md
+++ b/release-notes/2.2/2.2.4/2.2.4-download.md
@@ -85,7 +85,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/2.2/preview/2.2.0-preview3-download.md
+++ b/release-notes/2.2/preview/2.2.0-preview3-download.md
@@ -34,7 +34,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 [blob-runtime]: https://dotnetcli.blob.core.windows.net/dotnet/Runtime/

--- a/release-notes/2.2/preview/2.2.200-preview-download.md
+++ b/release-notes/2.2/preview/2.2.200-preview-download.md
@@ -52,7 +52,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/3.0/preview/3.0.0-preview4-download.md
+++ b/release-notes/3.0/preview/3.0.0-preview4-download.md
@@ -47,7 +47,7 @@ Installing from the Snap package detailed above is recommended or you can instal
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## Windows Server Hosting

--- a/release-notes/3.0/preview/3.0.0-preview5-download.md
+++ b/release-notes/3.0/preview/3.0.0-preview5-download.md
@@ -64,7 +64,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## .NET Core Runtime-only installation

--- a/release-notes/download-archives/1.0.13-download.md
+++ b/release-notes/download-archives/1.0.13-download.md
@@ -59,7 +59,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## Windows Server Hosting

--- a/release-notes/download-archives/1.1.10-download.md
+++ b/release-notes/download-archives/1.1.10-download.md
@@ -62,7 +62,7 @@ Installing from the packages detailed above is recommended or you can install fr
 
 ```bash
 mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
-export PATH=$HOME/dotnet
+export PATH=$PATH:$HOME/dotnet
 ```
 
 ## Windows Server Hosting


### PR DESCRIPTION
The old variant, export PATH=$HOME/dotnet would remove the existing
entries (like /bin) from PATH. Lets not do that. Lets always append to
PATH.

This change was done via: 

    grep -r 'export PATH=$HOME/dotnet' -l | xargs sed -i -e  's|PATH=$HOME/dotnet|PATH=$PATH:$HOME/dotnet|g'

See #2797 and #2498