### PR TITLE
Fix 3.0-preview6 release notes link

### DIFF
--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -13,7 +13,7 @@
       "release-version": "3.0.0-preview6",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0.0-preview6-27804-01/3.0.0-preview6.md",
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview6.md",
       "runtime": {
         "version": "3.0.0-preview6-27804-01",
         "version-display": "3.0.0-preview6-27804-01",


### PR DESCRIPTION
Note that the release notes links for 2.1.700 and 2.2.300 [are also incorrect](https://github.com/arthurrump/dotnet-core/runs/147170851), but since there aren't any release notes available for these, I don't know what they should be linking to.