### PR TITLE
.NET Core 1.x EOL

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -56,7 +56,7 @@
             "latest-runtime": "1.1.13",
             "latest-sdk": "1.1.14",
             "product": ".NET Core",
-            "support-phase": "maintenance",
+            "support-phase": "eol",
             "eol-date": "2019-06-27",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json"
         },
@@ -68,7 +68,7 @@
             "latest-runtime": "1.0.16",
             "latest-sdk": "1.1.14",
             "product": ".NET Core",
-            "support-phase": "maintenance",
+            "support-phase": "eol",
             "eol-date": "2019-06-27",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json"
         }


### PR DESCRIPTION
https://devblogs.microsoft.com/dotnet/net-core-1-0-and-1-1-will-reach-end-of-life-on-june-27-2019/