### PR TITLE
Grammar fix

### DIFF
--- a/release-notes/3.0/preview/3.0.0-preview7.md
+++ b/release-notes/3.0/preview/3.0.0-preview7.md
@@ -65,7 +65,7 @@ Here is list of some of the additions and updates we're excited to bring in Prev
 * ASP.NET Core: [bugs][aspnet_bugs] | [features][aspnet_features]
 
 ## Lifecycle News
-[Debian 10](https://www.debian.org/releases/buster/) has released (GA) and will be supported by .NET Core 3.0 going forward. 
+[Debian 10](https://www.debian.org/releases/buster/) has been released (GA) and will be supported by .NET Core 3.0 going forward. 
 
 As described in [.NET Core OS Lifecycle Policy](../../../os-lifecycle-policy.md), we will no longer test .NET Core or produce updates for OS versions which are out of standard support or are end of life.
 


### PR DESCRIPTION
“release” is a transitive verb, so it needs an object. “Debian” itself is the object here, and given the sentence’s construction as passive voice, it needs an auxiliary.