### PR TITLE
Move 2.2.401 sdk into the the 2.2.6 release SDKS collection and update missing vs-versions

### DIFF
--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -205,7 +205,7 @@
           "version": "2.2.401",
           "version-display": "2.2.401",
           "runtime-version": "2.2.6",
-          "vs-version": "",
+          "vs-version": "16.2.0",
           "vs-support": "Visual Studio 2019 (v16.2)",
           "csharp-version": "7.3",
           "fsharp-version": "4.6",

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -102,7 +102,7 @@
         "version": "2.2.401",
         "version-display": "2.2.401",
         "runtime-version": "2.2.6",
-        "vs-version": "",
+        "vs-version": "16.2.0",
         "vs-support": "Visual Studio 2019 (v16.2)",
         "csharp-version": "7.3",
         "fsharp-version": "4.6",

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -98,8 +98,7 @@
           }
         ]
       },
-      "sdk": 
-      {
+      "sdk": {
         "version": "2.2.401",
         "version-display": "2.2.401",
         "runtime-version": "2.2.6",

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -1,7 +1,7 @@
 {
   "channel-version": "2.2",
-  "latest-release": "2.2.401",
-  "latest-release-date": "2019-07-24",
+  "latest-release": "2.2.6",
+  "latest-release-date": "2019-07-09",
   "latest-runtime": "2.2.6",
   "latest-sdk": "2.2.401",
   "support-phase": "current",
@@ -9,11 +9,16 @@
   "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
   "releases": [
     {
-      "release-date": "2019-07-24",
-      "release-version": "2.2.401",
-      "security": false,
-      "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.6/2.2.401.md",
+      "release-date": "2019-07-09",
+      "release-version": "2.2.6",
+      "security": true,
+      "cve-list": [
+        {
+          "cve-id": " CVE-2019-1075",
+          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1075"
+        }
+      ],
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.6/2.2.6.md",
       "runtime": {
         "version": "2.2.6",
         "version-display": "2.2.6",
@@ -93,7 +98,8 @@
           }
         ]
       },
-      "sdk": {
+      "sdk": 
+      {
         "version": "2.2.401",
         "version-display": "2.2.401",
         "runtime-version": "2.2.6",
@@ -297,272 +303,7 @@
               "hash": "DF31F54A77DFF9855E7E1EAE2E0BCFE81E6FD3DFC6BAEE28FA7AF26BEF9B647BD6BB20A9EB69C98DF65ADA04EE74C4DDC1BC35A0A120265F8E846A65A4CB0534"
             }
           ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "2.2.6",
-        "version-display": "2.2.6",
-        "version-aspnetcoremodule": [
-          "12.2.19169.6"
-        ],
-        "vs-version": "15.9.13, 16.1.3, 16.2.0",
-        "files": [
-          {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/13798f38-c14e-4944-83c9-4f5b7c535f4d/1e1c3414f3ad791098d1f654640f9bcf/aspnetcore-runtime-2.2.6-linux-arm.tar.gz",
-            "hash": "349FABB7BF1A2FC68A51D57CC0A12C84A333D98F53AC74338568512E1EC2F3D55FA7EE765CC690FBFA4D0D84A6E8BDC783FA42B60AAF7F65FCFAEB8E14656EF8"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c3257647-9887-4822-8a18-0debbeabd3b2/5cd0346e78464231883604e544cee8dd/aspnetcore-runtime-2.2.6-linux-musl-x64.tar.gz",
-            "hash": "590E73898A6F1B3EF7B86E019B681A3099B7046B02CDB7F99DEA61460AA6079211A42AF3587BF71C03C19655DC24455098B14B3E9A9A12AEB2E64B7ECC207F84"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5d59077f-07f3-4997-b514-d88bce8cdcbf/3729ac370c4b96720829e098bee7ee5e/aspnetcore-runtime-2.2.6-linux-x64.tar.gz",
-            "hash": "B5B86FFA40A4294E2532D22F6B3C173EBF17ED569CCB1E51FA9FE8804128B9541CE5FCCABE74E71BE9A7D42B80414F74B4F27A4733CA9C1DD50CB0B69C92829F"
-          },
-          {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/65bfd3c1-8321-4496-97d7-cad0743e2aea/7a23c05f5842df826017e4c8d3482d47/aspnetcore-runtime-2.2.6-osx-x64.tar.gz",
-            "hash": "7141594C490ADA6669535B5F6667075D7536C7F723D2D19C384838B4C0CE327A111E45C6C262A4CB0C826BBCF2E40384BC846D7DE7E8217830CB4C20A0B2D16B"
-          },
-          {
-            "name": "aspnetcore-runtime-win-arm.zip",
-            "rid": "win-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8ded9840-cde7-44ed-aa96-76135d7d7945/7bc757c65f531dc997379b7dd9066c8e/aspnetcore-runtime-2.2.6-win-arm.zip",
-            "hash": "3CC3DF0872EFB7C7849B373B8778B567CE25CF4D9A9C85B919CACAC0B4F06D1ED7030DCB5A5E9EAB5811284F3B31291B4D76F1BEBD47D1C31EF3A53C01E7BD9B"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a021d9b2-8585-473c-a8d1-011717383ad7/819dbf76040767ed1a49d6c7c5681b8a/aspnetcore-runtime-2.2.6-win-x64.exe",
-            "hash": "9F956A2BB808C4781A53B1803A6EA1048BBF0D6B4C5FDAB838314AA74E8C118965102EDEC989CE6274A0E1ABB1B3E03AAE8E633EF6EFAF29C10A461DECA2AEDC"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/add4620e-7d1f-4e04-bff2-361fa1e19347/20e8bceb10fe70eb8a5255b1bed9d80d/aspnetcore-runtime-2.2.6-win-x64.zip",
-            "hash": "2FE420125B762FE5CE49E869C0A6F6E6318DF024CBD6F37A743D2EAE29136C8F982BD7B05E480639513520959E559EF45D6B590F95D83F5136E8931FF42506E5"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f67e7c14-7be8-48be-a58f-6fcbb1e40e8f/5ef54f876d48a645b1015e76b97cf75b/aspnetcore-runtime-2.2.6-win-x86.exe",
-            "hash": "8DD6063DB64FF9220916B83AAE3B82E866582C5B15697F8F49E4620F7FBB5DF758517D8C93D2CF0B372C75CC40381841DC23FEE0391EBB4C9C4C93FE5E45626E"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/396c5a1d-352a-42b5-8819-8939565982a5/d71358582d46baafb6abc1b57e350632/aspnetcore-runtime-2.2.6-win-x86.zip",
-            "hash": "2F83E2D9BDC51550F89EDF7285E3B721BDC32352C0C1425BD051DE9C52551BD20300C0EE15D5A5417FC6C1B617AB5FFD1AEC7DDF21BB1DB97C2571CE1FCB796E"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "win-x86_x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a9bb6d52-5f3f-4f95-90c2-084c499e4e33/eba3019b555bb9327079a0b1142cc5b2/dotnet-hosting-2.2.6-win.exe",
-            "hash": "BEEA1B4A00F2411737E2D1E5D665CA60555934F694F3442414DCAE1396F861FB078C333721043D4A0C456DA7289F8BC9FE035885C4673CB2D63A48BE7C6DB55C"
-          }
-        ]
-      }
-    },
-    {
-      "release-date": "2019-07-09",
-      "release-version": "2.2.6",
-      "security": true,
-      "cve-list": [
-        {
-          "cve-id": " CVE-2019-1075",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1075"
-        }
-      ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.6/2.2.6.md",
-      "runtime": {
-        "version": "2.2.6",
-        "version-display": "2.2.6",
-        "vs-version": "15.9.13, 16.1.3, 16.2.0",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/428aaa32-f66c-4847-b845-aa21f90504e4/1cf033db866414997140c2672bd75069/dotnet-runtime-2.2.6-linux-arm.tar.gz",
-            "hash": "D61B66A6663676F04FB1AE19129D793109DB7BB1BF88DC9FBA32257B214B852B3579DA2114E41A7103392871CE62E1B93E9CA99F57B79804C72DE06D52168ACB"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f5e04830-50fc-435c-8bb5-fcd4629da944/8aa7cce5c3fcb6a7db180b923d3574ef/dotnet-runtime-2.2.6-linux-arm64.tar.gz",
-            "hash": "55A14B94AE5B981D8AC6218EDD2D8119776E778F094071FCF0F9E42AFFEB3992552D31840A7368FD9C01E8B23566651D02BA88CDC9E38B46B91ACC4E485D6663"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a6b8ba2c-30f2-4bb8-80ed-3f12ac623c41/2455fd6f2369d9a7396bb363482e9047/dotnet-runtime-2.2.6-linux-musl-x64.tar.gz",
-            "hash": "C4F45AB88FFDA26B30C53B1DB03E50FE0EAFF92D6DD5DAFF05F4E019FC111405D016A787CADCB3A61DF4E973D297A1F63BA2535F3802EFF83B2E81B3C31CF0F9"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f21e352-9d2c-4e3b-af45-915da89158db/0e8a7ea83cc08d4bcf417a927a36ed6f/dotnet-runtime-2.2.6-linux-x64.tar.gz",
-            "hash": "8AF7A39407B4A3503A7C6D83106336140EEEF2BC24DECF1B817C7D5A3E5596C8CEFED8F211019148CD89A31759D851836DD6147E544B8C1D183DCFBD5A8D4636"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7fd8704c-560f-47dc-8fe0-b777e5e743e7/d7a4476f50828bf4095455b49c02cc01/dotnet-runtime-2.2.6-osx-x64.pkg",
-            "hash": "EA47F0D890FB90715564D33E2E9FE7CF3B152D01E6F777B37973D93FFE4FEAA9F786517461D6D4CE5142C31C571B22DEEE3CD20A1172386C62DA8DCBEA3060CA"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9c986070-0a73-4414-9067-61181fc0895a/7320179081b9d38d9acaae68a22c51a2/dotnet-runtime-2.2.6-osx-x64.tar.gz",
-            "hash": "A703476B817D355A16748F94DBF9BD4C4FAF3F51A299BAD2E77D2435796921E72247041EFD7E8BB154874FC9A7DDEC83586C1275C6F7C61DA283613B1CD8A7D1"
-          },
-          {
-            "name": "dotnet-runtime-rhel.6-x64.tar.gz",
-            "rid": "rhel.6-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/26800e2a-e889-4cef-a48e-5e9cf98fcd6a/b3103fe551ed2d81a56e4fe057d1a230/dotnet-runtime-2.2.6-rhel.6-x64.tar.gz",
-            "hash": "59D095813535F943D5A74100377F0B07117A4BAC663DE108E0D8B80E2D7B1DE6E7E040EBA78BAF856443AD8E9517155C5C8AE1CC526B91E1CA9E60D56D803026"
-          },
-          {
-            "name": "dotnet-runtime-win-arm.zip",
-            "rid": "win-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fcb51bad-4ce4-4bec-bd82-845d404f2740/7ff61be20c8038a966a62b8ce76b06d4/dotnet-runtime-2.2.6-win-arm.zip",
-            "hash": "703F84F84A441A20F09A68F07F7DF15D99C6552840B3C3247B16EEBD668D40BF1E8E1C904341C1A371B3FF50AC6C2D4B016C3560225419AC2BDDCDCEABB62970"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e65be1d4-dbe3-460c-8517-3fafb26b3dc4/e7760a9dbb9135e3b0b0150f36ef0f05/dotnet-runtime-2.2.6-win-x64.exe",
-            "hash": "C6C399D009E2D742C55E467E351EDF23E64832D8559E6A07005215DB465A75DFE08A1B46828C58EB9929C6051161555F790EB6059FBD1F046CE67A7F3091E57D"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/215c9079-af62-4265-aea5-1ee400b475ae/0c718d5c8fff0926c9eeec76221de22c/dotnet-runtime-2.2.6-win-x64.zip",
-            "hash": "B4AD5FDC9729E4BE5BDA5CFA7D7EAF9967C7792E099FF139E08B4617118E0EC7C62F0252A235F9B3E861E3014795C4BBD75E1EDDA0D284567F456D935CD02D14"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f9b622df-fc7d-4ec6-8996-b03ad7553c93/910152992719bfee5011c722ae82c680/dotnet-runtime-2.2.6-win-x86.exe",
-            "hash": "886FB3A42954D8181A77429140B6DEA49B00783D48CDBB0AEE621F2436C4DD09D6E43EE08FE98CC5EDE9B17A630DFF0FB68761F3EAD74673200066FEB83F0E5C"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/69872dbc-3e5d-42e9-bb1a-ae72c98c8392/8c6fa5f8a539ff93009ea81533c1d69b/dotnet-runtime-2.2.6-win-x86.zip",
-            "hash": "D99714079D73A45C7E8413B7F4A7050B436BD6621006FD59919699BBFAEEACD21BF703000D4ACC7DBA04B67A96372A0272E3C38AA19F66E3A426B2B6A17FB6BA"
-          }
-        ]
-      },
-      "sdk": {
-        "version": "2.2.301",
-        "version-display": "2.2.301",
-        "runtime-version": "2.2.6",
-        "vs-version": "16.1.3",
-        "vs-support": "Visual Studio 2019 (v16.1)",
-        "csharp-version": "7.3",
-        "fsharp-version": "4.5",
-        "vb-version": null,
-        "files": [
-          {
-            "name": "dotnet-sdk-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4bc4d8e7-e736-4323-b82c-f75559502e9c/582e01f7b7a67cd23a22e5bfff317f10/dotnet-sdk-2.2.301-linux-arm.tar.gz",
-            "hash": "A7C30EA64C135C9D414B55611198A9432D790B8B811C8AF68241174BD614FBAFE6DD35B72890DF6B7A098D570878FF8854F8BF42215696F67F5E376E2FB1D6CF"
-          },
-          {
-            "name": "dotnet-sdk-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0af74ee1-47bb-43bd-b55f-1657f079c309/6649fd1bc91b14aee4a6b4ed44a2f45d/dotnet-sdk-2.2.301-linux-arm64.tar.gz",
-            "hash": "2C56C559E7FA73F3F875B32632FFA4E3259616694DA0438A292016E752053FAF4C41A5D88F998634F702113E0D7962FD3A0F70FC925895BC809B2F3FDB35AC68"
-          },
-          {
-            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9bf52b85-f9fa-417e-9f3c-a3a83fcc6d46/ebff0554910172dbde7484035f0fdc73/dotnet-sdk-2.2.301-linux-musl-x64.tar.gz",
-            "hash": "B0C7B73E39AC38920F332EAA91AC615226A38A2250F16071E55BF432C3E7B0BACA038B29976CC42928E7E3512300AB1F2D13B1ADBF39FE286E97738377A9E3C3"
-          },
-          {
-            "name": "dotnet-sdk-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3224f4c4-8333-4b78-b357-144f7d575ce5/ce8cb4b466bba08d7554fe0900ddc9dd/dotnet-sdk-2.2.301-linux-x64.tar.gz",
-            "hash": "63C54261B58B8D5E56326D0EFB2EF3B25F120AE16E49F7BD470537DA9CDDDF96B1E0B6288C159EC808BD0B7E2CC9C93D0DF2E4122948995E74A797C04098C599"
-          },
-          {
-            "name": "dotnet-sdk-osx-gs-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/19f39d7d-3296-4ed2-af75-f0190d074d43/84949e2b33ccdc6b7c51d5835df2844e/dotnet-sdk-2.2.301-osx-gs-x64.pkg",
-            "hash": "675D5539901D8247B251CAB3C054A5FDD95F1D95C3E3479CA9325325227D590AFC2CF5E3D86744D2E59AE567582A05F1A212D73A5BF4F161CD6A3D8653AC61AA"
-          },
-          {
-            "name": "dotnet-sdk-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1440e4a9-4e5f-4148-b8d2-8a2b3da4e622/d0c5cb2712e51c188200ea420d771c2f/dotnet-sdk-2.2.301-osx-x64.pkg",
-            "hash": "675D5539901D8247B251CAB3C054A5FDD95F1D95C3E3479CA9325325227D590AFC2CF5E3D86744D2E59AE567582A05F1A212D73A5BF4F161CD6A3D8653AC61AA"
-          },
-          {
-            "name": "dotnet-sdk-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/838546de-7f3d-4fc9-98ef-fff8c8e45e17/c09e44c880ec45c0a202f59a943a13eb/dotnet-sdk-2.2.301-osx-x64.tar.gz",
-            "hash": "01C228BC1743AA2533418FB114AA5F4D7AF3D4AB4BC0CD712B2E31472C9321A9C83D9C6A1F25A25B1345CB15FD1F370E94DD12AE2B0E715F63F4E33535B4CD19"
-          },
-          {
-            "name": "dotnet-sdk-rhel.6-x64.tar.gz",
-            "rid": "rhel.6-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a04bea27-1d6d-49fb-a76d-cfd3876001c3/a9b98db9d439d37378e999a9351621e3/dotnet-sdk-2.2.301-rhel.6-x64.tar.gz",
-            "hash": "A647C0CE1F79779FF04701780DCD9FD2D6206E3D9FFC5E590B53D7269591B4CB45189893E349F1AE3E93EF4E144CEFAB1DA9B8E80C0A67CBA9889E3AFF5EBDEB"
-          },
-          {
-            "name": "dotnet-sdk-win-arm.zip",
-            "rid": "win-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/221613f8-831f-4fe1-b296-f45cc3f99aa0/f41c279b9317b6e72bfb2dbbf4053b0f/dotnet-sdk-2.2.301-win-arm.zip",
-            "hash": "307A781041BAE1EFAA56B5CAE4EECF19E82268567204C5303C21E512A53FB06B0DB1891D09E79D2D61B320F34CA2402824BC533277D4FF82BC78A112BDD8F4FD"
-          },
-          {
-            "name": "dotnet-sdk-win-gs-x64.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f2372bd-6630-4da0-b5ff-7f3363a0111b/cd48423b1c7b4985ea213dcf551786d9/dotnet-sdk-2.2.301-win-gs-x64.exe",
-            "hash": "DF3B007439AE965941AFB54900B3AEBF740C88B4E9907D2A178D16A6DC776E0C95627A1F29476C324953A8DA7DF0BAAE5EADAE643446FB319DCF10544FD658A9"
-          },
-          {
-            "name": "dotnet-sdk-win-gs-x86.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cad41544-4702-4236-997a-b67f8fd71d3a/5ce6ba16d1fc142f2819f8bd65e1b628/dotnet-sdk-2.2.301-win-gs-x86.exe",
-            "hash": "66170E7C84C1082B957857B6841432AEF1CA0E2ACD2CD3A5ADBEFE2E0F9840C69A158AE66A54B2E1605C99B81C92064AD62290B1F97D2A361DB7BED705F2BF06"
-          },
-          {
-            "name": "dotnet-sdk-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/15e45d59-071a-448f-9ebe-361fa8d7b55c/e028b3bc38bb96e982cfab90003683dc/dotnet-sdk-2.2.301-win-x64.exe",
-            "hash": "DF3B007439AE965941AFB54900B3AEBF740C88B4E9907D2A178D16A6DC776E0C95627A1F29476C324953A8DA7DF0BAAE5EADAE643446FB319DCF10544FD658A9"
-          },
-          {
-            "name": "dotnet-sdk-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3c7fcb0b-52ee-40b2-853d-710c58883371/78bbdf5fcd85697e8e306c355d02d0b0/dotnet-sdk-2.2.301-win-x64.zip",
-            "hash": "2F7BAAA7CA994A0F6550879DA66DAB67B4799DC634354C2CE746F2E107F35FB931536E8B19C85620A1A400A33E71B6B1B03BF373632A1D338C6B737A2A9CC81B"
-          },
-          {
-            "name": "dotnet-sdk-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ffea64d6-9050-406a-a9a7-00abcbbac35d/d3f943d449982b552cc35ed279e24edb/dotnet-sdk-2.2.301-win-x86.exe",
-            "hash": "66170E7C84C1082B957857B6841432AEF1CA0E2ACD2CD3A5ADBEFE2E0F9840C69A158AE66A54B2E1605C99B81C92064AD62290B1F97D2A361DB7BED705F2BF06"
-          },
-          {
-            "name": "dotnet-sdk-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/20a278a3-0a11-4cea-bf4b-6444f39d2439/86cdf5de22d23321b76be7ee238fe154/dotnet-sdk-2.2.301-win-x86.zip",
-            "hash": "9F01B6EB1185D3136AB787AE9CBC79527B009BFF92F4C2EBB82804B10CD2156002365F06ADCF0EEE9101BDE1CA3F403FA3A4FF16E44EB0D3FD20C8C0FBD19A77"
-          }
-        ]
-      },
-      "sdks": [
+        },
         {
           "version": "2.2.301",
           "version-display": "2.2.301",


### PR DESCRIPTION
The intent of the SDKs collection is to enable us to group SDKs within the supported runtime. This means that 2.2.401 should have been added inside of the 2.2.6 release. I realize there’s a release-date missing to make this completely right but will need to determine if that’s necessary.

Also including missing vs-version fixups discovered by @arthurrump.