### PR TITLE
Fix incorrect checksums

### DIFF
--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -85,55 +85,55 @@
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz",
-            "hash": "c1b07ce8849619ca505aafd2983bcdd7141536ccae243d4249b0c9665daf107e03a696ad5f1d95560142cd841a0888bbf5f1a8ff77d3bdc3696b5873481f0998"
+            "hash": "e785b9b488b5570708eb060f9a4cb5cf94597d99a8b0a3ee449d2e5df83771c1ba643a87db17ae6727d0e2acb401eca292fb8c68ad92eeb59d7f0d75eab1c20a"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.tar.gz",
-            "hash": "aa5c5eb13a663b33a82ab30222885ec95ac2079ed743375fb98be913373596e64426d55089c0dc9ec64710a19a1e3f746af4a20c46b98aa7fe0e1113ef603ff7"
+            "hash": "74dd07c73576f4c3e5fb68fb2bab738851ea4505f0ba50b493270ad6627ad7bd958b6d6dc937fe0a9b052a54bb8e5e3f77a521d1dab14fb6d090a677a2403e84"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-x64.pkg",
-            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+            "hash": "e4156b91c1da41bda1873febeb8a54f6b3b56d1f966fa3b0954bb553ba49f6aaec4e22ddc5dd44b55bec9d0ddd86c0b38a90063ffe6acd0db3c70a024f7d271e"
           },
           {
             "name": "dotnet-sdk-osx-gs-x64.pkg",
             "rid": "",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-osx-gs-x64.pkg",
-            "hash": "f0a7a36432948a570b1d8ecb48a5a5dba73d93ade43a6df989237c9d2d898ba5343704fc81cd150fc08abe0c66656cd7b10149aa442cdd333324bec0321c3aac"
+            "hash": "e4156b91c1da41bda1873febeb8a54f6b3b56d1f966fa3b0954bb553ba49f6aaec4e22ddc5dd44b55bec9d0ddd86c0b38a90063ffe6acd0db3c70a024f7d271e"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.zip",
-            "hash": "304887eaa7189d31024eca3ca02e6b43ce01e85193551365eec1c437f3f7e5c6b7bdf4563bd4f7964c6f4d97efa1f266e304817a5f7fa8dc366a6c90e0b325af"
+            "hash": "d56c80643b2c404920362a738949c38a00c7710c146ac53f798a610ec40c8075b347be8acddb51fc296b7912f63fa7e41867439e2239fbeb8f5e4ec6764b71ce"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.zip",
-            "hash": "5cae6f4c577182e7d84d991b9d20162c1a76ce17f65b7b52a7e6df8d98ec389e03626f61969eaed4f23a5f6c96a3ab188e71a0b94cc58f86e485ac9296c4af64"
+            "hash": "ae0c8044a021498089cfd5dbe8888acca8cdd3295b42ff7f447ac3b11f6e43dac3b6394c4055ae17dcf7c6800aa2d59b9c62859ff1dde4496dfbb59047597bf6"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x86.exe",
-            "hash": "04ea62e1391820ee3289a6c622221908ac7336465d8cf6615228d6bfcab7e46419c3e6a826b27f41dd8ec629dc24aebf9af8ef85d0e6bf1fb8664ffff238d96f"
+            "hash": "75271cc08343510c80d56d28eacfe47e58a788e08b72f9833e47ec92295b12f64eab1199f9f639946f85bfa069b16acce9023b0921d229a677acf24680c7f484"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-x64.exe",
-            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+            "hash": "6e65baed24518266cf1edaead53cdf9cde467e8be20806c00635a7e5fc1a1ef5d803926bb0e36badaa86c40c90f3f33eed8b33749467d62ca2f7317cd4e35d4b"
           },
           {
             "name": "dotnet-sdk-win-gs-x64.exe",
             "rid": "",
             "url": "https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-win-gs-x64.exe",
-            "hash": "0bde9fbd2d5f1e3376e96a499056dd29d788ad98674ea5e6c683a66709293374b418f094d0ac17388b6435fdade61f276752155fe158df798c1213083b5e0ea9"
+            "hash": "6e65baed24518266cf1edaead53cdf9cde467e8be20806c00635a7e5fc1a1ef5d803926bb0e36badaa86c40c90f3f33eed8b33749467d62ca2f7317cd4e35d4b"
           }
         ]
       },


### PR DESCRIPTION
- Align values with those previously published in https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.1.202-sdk-sha.txt
- dotnet-sdk-osx-x64.pkg is not listed in above file, so checksum was recalculated manually

Resolves #3250