### PR TITLE
Improve description for Roslyn

### DIFF
--- a/Documentation/core-repos.md
+++ b/Documentation/core-repos.md
@@ -21,7 +21,7 @@ There are many repos that make up .NET Core. To file an issue, make a PR, or eng
 
 ## Languages
 
-* [dotnet/roslyn](https://github.com/dotnet/roslyn) - Roslyn and C#
+* [dotnet/roslyn](https://github.com/dotnet/roslyn) - Roslyn (C#/VB compiler) and C#
 * [dotnet/csharplang](https://github.com/dotnet/csharplang) - C# spec
 * [dotnet/vblang](https://github.com/dotnet/vblang) - VB spec
 * [dotnet/fsharp](https://github.com/dotnet/fsharp) - The F# compiler, FSharp.Core library, and tools for F#


### PR DESCRIPTION
The entry for dotnet/roslyn is just "Roslyn and C#". That doesn't mean a whole lot unless you are already familiar with the fact that roslyn is the .NET compiler.  On the other hand, the repo description for roslyn is much more descriptive: "The Roslyn .NET compiler provides C# and Visual Basic languages with rich code analysis APIs."

Earlier I was trying to figure out where to create an issue about a C# compiler error, and just ended up putting it in dotnet/cli. This was incorrect, and there was already an issue about my problem in dotnet/roslyn. If the description for dotnet/roslyn had stated it was the primary repo for the .NET compiler (like its repo description clearly states).

I'm open to having the core-repos.md description phrased however the maintainers want, but IMO I should be able to Ctrl+F "compiler".