### PR TITLE
fix 2.2 laster release in index json

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -14,7 +14,7 @@
         },
         {
             "channel-version": "2.2",
-            "latest-release": "2.2.401",
+            "latest-release": "2.2.6",
             "latest-release-date": "2019-07-24",
             "security": false,
             "latest-runtime": "2.2.6",


### PR DESCRIPTION
SDK version was incorrectly used as the latest release value in the 2.2 channel. This resolves https://github.com/dotnet/core/issues/3258