### PR TITLE
Updating broken rpm links

### DIFF
--- a/release-notes/3.0/preview/3.0.0-preview8-download.md
+++ b/release-notes/3.0/preview/3.0.0-preview8-download.md
@@ -95,8 +95,8 @@ cd $HOME/Downloads
 mkdir preview8
 cd preview8
 
-wget -c https://download.visualstudio.microsoft.com/download/pr/21c1edcc-4296-45fe-9e09-b5f0b992ec04/4119552e4774c7d2289cdac1b41d005d/dotnet-host-TBD.rpm
-wget -c https://download.visualstudio.microsoft.com/download/pr/e1d79e2c-7d95-46be-a394-7ada4821fdb9/3a36e07e3d8db39db289123fa0c339eb/dotnet-hostfxr-TBD.rpm
+wget -c https://download.visualstudio.microsoft.com/download/pr/e6c88fa0-7af3-4a5e-924c-c2b7746a3c56/058c182d3153f92102c36ba18a540c73/dotnet-host-3.0.0-preview8-28405-07-x64.rpm
+wget -c https://download.visualstudio.microsoft.com/download/pr/be0dd399-26ff-4535-8817-cea74af8870f/caba64c029563357d10101531e7d1bba/dotnet-hostfxr-3.0.0-preview8-28405-07-x64.rpm
 wget -c https://download.visualstudio.microsoft.com/download/pr/c7b80a75-be96-41ed-a17d-fb5d2a7e4ca7/c6ba37aa37e57cc4f15d068921abe225/dotnet-runtime-3.0.0-preview8-28405-07-x64.rpm
 wget -c https://download.visualstudio.microsoft.com/download/pr/c76d6e7e-dcba-41bf-83ae-77ef4d4b83b9/80a4ac4e1f832552ebcc5f080bf80610/dotnet-runtime-deps-3.0.0-preview8-28405-07-fedora.27-x64.rpm
 wget -c https://download.visualstudio.microsoft.com/download/pr/fca66248-bd05-4948-8efd-390b5d056397/c3078f7d3368438863eb26d93308858f/aspnetcore-runtime-3.0.0-preview8.19405.7-x64.rpm
@@ -107,7 +107,7 @@ wget -c https://download.visualstudio.microsoft.com/download/pr/ba96af61-e1c3-46
 wget -c https://download.visualstudio.microsoft.com/download/pr/82467fdf-3521-4a44-85c6-ef23061a022d/9e07507d17cc70800891aa4441581c9c/netstandard-targeting-pack-2.1.0-preview8-28405-07-x64.rpm
 wget -c https://download.visualstudio.microsoft.com/download/pr/26473bdd-e207-4e89-9eb5-14729db564a9/673896c711e4b8d54543b1c790c31be8/aspnetcore-targeting-pack-3.0.0-preview8.19405.7.rpm
 
-sudo rpm -ivh dotnet-runtime-deps-3.0.0-preview7-27912-14-fedora.27-x64.rpm
+sudo rpm -ivh dotnet-runtime-deps-3.0.0-preview8-28405-07-fedora.27-x64.rpm
 sudo rpm -ivh dotnet-host-3.0.0-preview8-28405-07-x64.rpm
 sudo rpm -ivh dotnet-hostfxr-3.0.0-preview8-28405-07-x64.rpm
 sudo rpm -ivh dotnet-runtime-3.0.0-preview8-28405-07-x64.rpm


### PR DESCRIPTION
Fixing wget links for dotnet-runtime-deps and dotnet-host were broken, and updating the rpm command on dotnet-runtime-deps from version 7 to 8