### PR TITLE
Update 3.0.0-preview-known-issues.md

### DIFF
--- a/release-notes/3.0/preview/3.0.0-preview-known-issues.md
+++ b/release-notes/3.0/preview/3.0.0-preview-known-issues.md
@@ -18,14 +18,9 @@ To update the path for every new terminal session, the `export` entry will need 
 
 - **Builds fail with `MSB3041` when a `.resx` file is in a subfolder [microsoft/msbuild#4695](https://github.com/microsoft/msbuild/issues/4695)**
 
-    MSBuild incorrectly constructs paths to `DependentUpon` source files related to `.resx` files that aren't at the project root. There are two possible workarounds:
+    MSBuild incorrectly constructs paths to `DependentUpon` source files related to `.resx` files that aren't at the project root. There is a workaround:
     
-    1. Revert to preview8 behavior by setting this property in your project (or in a [`Directory.Build.props`](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets) for all of your projects).
-    ```xml
-    <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
-    ```
-    
-    2. Explicitly set `DependentUpon` metadata for resource files ([example for Entity Framework migrations](https://github.com/aspnet/EntityFramework6/issues/1225#issuecomment-528571274).
+    Explicitly set `DependentUpon` metadata for resource files ([example for Entity Framework migrations](https://github.com/aspnet/EntityFramework6/issues/1225#issuecomment-528571274)).
 
 ### Preview 5
 


### PR DESCRIPTION
As stated in https://github.com/aspnet/EntityFramework6/issues/1225#issuecomment-528887298, the workaround with EmbeddedResourceUseDependentUponConvention will cause issues at runtime. That's why I've excluded this workaround from the readme.