### PR TITLE
Fixes 2.1.13 release notes

### DIFF
--- a/release-notes/2.1/2.1.13/2.1.13-download.md
+++ b/release-notes/2.1/2.1.13/2.1.13-download.md
@@ -8,13 +8,13 @@
 
 See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.13/2.1.13.md) for details about what is included in this update.
 
-The September Update for .NET Core 2.2 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-sdk-download.md).
+The September Update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-download.md).
 
 | OS | Development Environment | .NET Core SDK |
 | :-- | :-- | :--: |
-| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-sdk-download.md) |
+| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-download.md) |
 | Windows | Visual Studio 2017 | [2.1.509](#downloads) |
 | MacOS | Visual Studio for Mac | [Visual Studio for Mac .NET Core Support](https://docs.microsoft.com/en-us/visualstudio/mac/net-core-support) |
 

--- a/release-notes/2.1/2.1.13/2.1.13.md
+++ b/release-notes/2.1/2.1.13/2.1.13.md
@@ -2,13 +2,13 @@
 
 .NET Core 2.1.13 is available for [download](2.1.13-download.md) and usage in your environment. This release includes .NET Core 2.1.13, ASP.NET Core 2.1.13 and the .NET Core SDK.
 
-The September Update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [.NET Core SDK 2.1.802](2.1.802-sdk-download.md).
+The September Update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [.NET Core SDK 2.1.802](2.1.802-download.md).
 
 | OS | Development Environment | .NET Core SDK |
 | :-- | :-- | :--: |
-| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-sdk-download.md) |
+| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-download.md) |
 | Windows | Visual Studio 2017 | [2.1.509](#downloads) |
 | MacOS | Visual Studio for Mac | [Visual Studio for Mac .NET Core Support](https://docs.microsoft.com/en-us/visualstudio/mac/net-core-support) |
 

--- a/release-notes/2.1/2.1.13/2.1.606-download.md
+++ b/release-notes/2.1/2.1.13/2.1.606-download.md
@@ -8,14 +8,14 @@
 
 See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.13/2.1.13.md) for details about what is included in this update.
 
-The September Update for .NET Core 2.2 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-sdk-download.md).
+The September Update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-download.md).
 
 | OS | Development Environment | .NET Core SDK |
 | :-- | :-- | :--: |
-| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-sdk-download.md) |
-| Windows | Visual Studio 2017 | [2.1.509](#downloads) |
+| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-download.md) |
+| Windows | Visual Studio 2019 version 16.0 | [2.1.606](#downloads) |
+| Windows | Visual Studio 2017 | [2.1.509](2.1.13-download.md) |
 | MacOS | Visual Studio for Mac | [Visual Studio for Mac .NET Core Support](https://docs.microsoft.com/en-us/visualstudio/mac/net-core-support) |
 
 ## Downloads

--- a/release-notes/2.1/2.1.13/2.1.802-download.md
+++ b/release-notes/2.1/2.1.13/2.1.802-download.md
@@ -8,14 +8,14 @@
 
 See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.13/2.1.13.md) for details about what is included in this update.
 
-The September Update for .NET Core 2.2 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-sdk-download.md).
+The September Update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual Studio 2019, Visual Studio 2017 or Visual Studio for Mac user, there are MSBuild version requirements that are satisfied by specific, matching .NET Core SDK versions. See the table below to select the correct download. Otherwise, the best version to download is [2.1.802](2.1.802-download.md).
 
 | OS | Development Environment | .NET Core SDK |
 | :-- | :-- | :--: |
-| Any supported | Command line and/or Visual Studio Code | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.2 | [2.1.802](2.1.802-sdk-download.md) |
-| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-sdk-download.md) |
-| Windows | Visual Studio 2017 | [2.1.509](#downloads) |
+| Any supported | Command line and/or Visual Studio Code | [2.1.802](#downloads) |
+| Windows | Visual Studio 2019 version 16.2 | [2.1.802](#downloads) |
+| Windows | Visual Studio 2019 version 16.0 | [2.1.606](2.1.606-download.md) |
+| Windows | Visual Studio 2017 | [2.1.509](2.1.13-download.md) |
 | MacOS | Visual Studio for Mac | [Visual Studio for Mac .NET Core Support](https://docs.microsoft.com/en-us/visualstudio/mac/net-core-support) |
 
 ## Downloads


### PR DESCRIPTION
Fixes for 2.1.13 release notes:
- Broken/incorrect links
- Incorrect version numbers: 2.2 -> 2.1

/cc @leecow 