### PR TITLE
Correct F# versions

### DIFF
--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -237,7 +237,7 @@
         "vs-version": "16.3.0-preview4",
         "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
         "csharp-version": "8.0-preview",
-        "fsharp-version": "4.6",
+        "fsharp-version": "4.7-preview",
         "files": [
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -351,7 +351,7 @@
           "vs-version": "16.3.0-preview4",
           "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
           "csharp-version": "8.0-preview",
-          "fsharp-version": "4.6",
+          "fsharp-version": "4.7-preview",
           "files": [
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -795,7 +795,7 @@
         "vs-version": "16.3.0-preview3",
         "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
         "csharp-version": "8.0-preview",
-        "fsharp-version": "4.6",
+        "fsharp-version": "4.7-preview",
         "files": [
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -909,7 +909,7 @@
           "vs-version": "16.3.0-preview3",
           "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
           "csharp-version": "8.0-preview",
-          "fsharp-version": "4.6",
+          "fsharp-version": "4.7-preview",
           "files": [
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -1335,7 +1335,7 @@
         "vs-version": "",
         "vs-support": "Visual Studio 2019 (v16.3, latest preview)",
         "csharp-version": "8.0-preview",
-        "fsharp-version": "4.6",
+        "fsharp-version": "4.7-preview",
         "files": [
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -1449,7 +1449,7 @@
           "vs-version": "",
           "vs-support": "Visual Studio 2019 (v16.3, latest preview)",
           "csharp-version": "8.0-preview",
-          "fsharp-version": "4.6",
+          "fsharp-version": "4.7-preview",
           "files": [
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -1753,7 +1753,7 @@
         "runtime-version": "3.0.0-preview7-27912-14",
         "vs-support": "Visual Studio 2019 (v16.2. latest preview)",
         "csharp-version": "8.0-preview",
-        "fsharp-version": "4.6",
+        "fsharp-version": "4.7-preview",
         "files": [
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
@@ -1854,7 +1854,7 @@
           "runtime-version": "3.0.0-preview7-27912-14",
           "vs-support": "Visual Studio 2019 (v16.2. latest preview)",
           "csharp-version": "8.0-preview",
-          "fsharp-version": "4.6",
+          "fsharp-version": "4.7-preview",
           "files": [
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",


### PR DESCRIPTION
F# 4.7 has been in .NET Core 3.0 since preview 7