### PR TITLE
Fix 3.0 release notes links in releases.json

### DIFF
--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -430,7 +430,7 @@
       "release-version": "3.0.0-rc1",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0.0-rc1/3.0.0-rc1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-rc1.md",
       "runtime": {
         "version": "3.0.0-rc1-19456-20",
         "version-display": "3.0.0-rc1-19456-20",
@@ -988,7 +988,7 @@
       "release-version": "3.0.0-preview9",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0.0-preview9-19423-09/3.0.0-preview9.md",
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview9.md",
       "runtime": {
         "version": "3.0.0-preview9-19423-09",
         "version-display": "3.0.0-preview9-19423-09",


### PR DESCRIPTION
@leecow Seems like your logic for preview release notes is a bit off.