### PR TITLE
Update readme to have correct version number

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -8,7 +8,7 @@ You can download the latest updates for .NET Core.
 
 * [.NET Core 3.0.0](3.0/3.0.0/3.0.0-download.md)
 * [.NET Core 2.2.7](2.2/2.2.7/2.2.7-download.md)
-* [.NET Core 2.1.12](2.1/2.1.13/2.1.13-download.md)
+* [.NET Core 2.1.13](2.1/2.1.13/2.1.13-download.md)
 
 ## Release Information
 


### PR DESCRIPTION
The readme contain the text to 2.1.12 while it was pointing to 2.1.13. This PR fixes this.