### PR TITLE
Fix minimum Windows Server version

### DIFF
--- a/release-notes/3.0/3.0-supported-os.md
+++ b/release-notes/3.0/3.0-supported-os.md
@@ -15,7 +15,7 @@ OS                            | Version                       | Architectures  |
 Windows Client                | 7 SP1+, 8.1                   | x64, x86       |
 Windows 10 Client             | Version 1607+                 | x64, x86       |
 Nano Server                   | Version 1803+                 | x64, ARM32     |
-Windows Server                | 2012 R2 SP1+                  | x64, x86       |
+Windows Server                | 2012 R2+                      | x64, x86       |
 
 See the [Windows Lifecycle Fact Sheet](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet) for details regarding each Windows release lifecycle.
 


### PR DESCRIPTION
2012 R2 doesn't have an SP1 (leftover from when the minimum was 2008 R2 SP1).