### PR TITLE
Release metadata tidy up to support .NET website

### DIFF
--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -254,12 +254,6 @@
             "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
           },
           {
-            "name": "dotnet-sdk-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x86.exe",
-            "hash": "d43906850d834df01e4664941633cb75db765fbab6b73057a7eec98b1be43de8fed08ccf6d73c1453baa4666c8f7bf26e9cb70592078d8102a6ae17c4aa20fc0"
-          },
-          {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/C/7/D/C7DCA2DE-7163-45D1-A05A-5112DAF51445/dotnet-sdk-2.1.201-win-x64.exe",

--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -1861,7 +1861,7 @@
       "release-notes": null,
       "runtime": {
         "version": "2.0.0-preview2-25407-01",
-        "version-display": null,
+        "version-display": "2.0.0-preview2",
         "vs-version": null,
         "files": [
           {
@@ -1892,7 +1892,7 @@
       },
       "sdk": {
         "version": "2.0.0-preview2-006497",
-        "version-display": null,
+        "version-display": "2.0.0-preview2",
         "runtime-version": "2.0.0-preview2-25407-01",
         "vs-version": null,
         "csharp-version": null,
@@ -1936,7 +1936,7 @@
       "release-notes": null,
       "runtime": {
         "version": "2.0.0-preview1-002111-00",
-        "version-display": null,
+        "version-display": "2.0.0-preview1",
         "vs-version": null,
         "files": [
           {
@@ -1967,7 +1967,7 @@
       },
       "sdk": {
         "version": "2.0.0-preview1-005977",
-        "version-display": null,
+        "version-display": "2.0.0-preview1",
         "runtime-version": "2.0.0-preview1-002111-00",
         "vs-version": null,
         "csharp-version": null,

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -195,6 +195,7 @@
           "runtime-version": "2.1.13",
           "vs-version": "16.2.5",
           "vs-support": "Visual Studio 2019 (v16.2)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.1, v8.2, v8.3)",
           "csharp-version": "7.3",
           "fsharp-version": "4.5",
           "files": [
@@ -272,6 +273,7 @@
           "runtime-version": "2.1.13",
           "vs-version": "16.0.8",
           "vs-support": "Visual Studio 2019 (v16.0)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.1, v8.2, v8.3)",
           "csharp-version": "7.3",
           "fsharp-version": "4.5",
           "files": [

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -5608,12 +5608,6 @@
             "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
           },
           {
-            "name": "dotnet-sdk-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-gs-x86.exe",
-            "hash": "dfddde070115ddc8a637f24ed80f0f1439e9813e850c8cbffcdb245b7ee6d99a3d28278f031a58d4fdd7255009e30effab69cad38da768ee525f391872299dbe"
-          },
-          {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-2.1.301-win-x64.exe",
@@ -6296,12 +6290,6 @@
             "rid": "osx-x64",
             "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-osx-x64.tar.gz",
             "hash": "7f8463f06af03cd951d1a2497c7d76def63239269ef510443bd6843f6fc9e3b68f4b0d812f8d22236a9d45c0c0cfd8166793461250c76037f08c0122b151c3ae"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.microsoft.com/download/9/0/F/90F8F18D-CD21-4A79-ACDC-AF4CB95F490C/aspnetcore-runtime-2.1.0-preview2-final-linux-x64.tar.gz",
-            "hash": "4bbc0f25623947048430f5e44a0d3dc444f13fb8fd0058b148f86ef31a0167c35c72accf6c713c92762840bd0059890417e5ebed0c408e5f7d4f25ea2e3844c1"
           }
         ]
       }

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -4149,7 +4149,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.1/Preview/2.1.600-preview.md",
       "sdk": {
         "version": "2.1.600-preview-009426",
-        "version-display": "2.1.600-preview-009426",
+        "version-display": "2.1.600-preview",
         "runtime-version": "2.1.6",
         "vs-version": "16.0-preview-1",
         "csharp-version": "7.3",

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -4190,7 +4190,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/preview/2.2.200-preview.md",
       "sdk": {
         "version": "2.2.200-preview-009648",
-        "version-display": "2.2.200-preview-009648",
+        "version-display": "2.2.200-preview",
         "runtime-version": "2.2.0",
         "vs-version": "16.0-preview-1",
         "csharp-version": "7.3",
@@ -4602,7 +4602,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/2.2/preview/2.2.0-preview3.md",
       "runtime": {
         "version": "2.2.0-preview3-27014-02",
-        "version-display": "2.2.0-preview3-27014-02",
+        "version-display": "2.2.0-preview3",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -4674,7 +4674,7 @@
       },
       "sdk": {
         "version": "2.2.100-preview3-009430",
-        "version-display": "2.2.100-preview3-009430",
+        "version-display": "2.2.100-preview3",
         "runtime-version": "2.2.0-preview3-27014-02",
         "files": [
           {
@@ -4762,7 +4762,7 @@
       },
       "aspnetcore-runtime": {
         "version": "2.2.0-preview3-35497",
-        "version-display": "2.2.0-preview3-35497",
+        "version-display": "2.2.0-preview3",
         "version-aspnetcoremodule": [
           "12.2.18248.0",
           "8.2.1991.0"

--- a/release-notes/2.2/releases.json
+++ b/release-notes/2.2/releases.json
@@ -202,6 +202,7 @@
           "runtime-version": "2.2.7",
           "vs-version": "16.2.5",
           "vs-support": "Visual Studio 2019 (v16.2)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.1, v8.2, v8.3)",
           "csharp-version": "7.3",
           "fsharp-version": "4.5",
           "files": [
@@ -285,6 +286,7 @@
           "runtime-version": "2.2.7",
           "vs-version": "16.0.8",
           "vs-support": "Visual Studio 2019 (v16.0)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.1, v8.2, v8.3)",
           "csharp-version": "7.3",
           "fsharp-version": "4.5",
           "files": [

--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -433,7 +433,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-rc1.md",
       "runtime": {
         "version": "3.0.0-rc1-19456-20",
-        "version-display": "3.0.0-rc1-19456-20",
+        "version-display": "3.0.0-rc1",
         "vs-version": "16.3.0-preview4",
         "files": [
           {
@@ -650,7 +650,7 @@
       },
       "sdk": {
         "version": "3.0.100-rc1-014190",
-        "version-display": "3.0.100-rc1-014190",
+        "version-display": "3.0.100-rc1",
         "runtime-version": "3.0.0-rc1-19456-20",
         "vs-version": "16.3.0-preview4",
         "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
@@ -764,7 +764,7 @@
       "sdks": [
         {
           "version": "3.0.100-rc1-014190",
-          "version-display": "3.0.100-rc1-014190",
+          "version-display": "3.0.100-rc1",
           "runtime-version": "3.0.0-rc1-19456-20",
           "vs-version": "16.3.0-preview4",
           "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
@@ -878,7 +878,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.0.0-rc1.19457.4",
-        "version-display": "3.0.0-rc1.19457.4",
+        "version-display": "3.0.0-rc1",
         "version-aspnetcoremodule": [
           "13.0.19236"
         ],
@@ -991,7 +991,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview9.md",
       "runtime": {
         "version": "3.0.0-preview9-19423-09",
-        "version-display": "3.0.0-preview9-19423-09",
+        "version-display": "3.0.0-preview9",
         "vs-version": "16.3.0-preview3",
         "files": [
           {
@@ -1208,7 +1208,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview9-014004",
-        "version-display": "3.0.100-preview9-014004",
+        "version-display": "3.0.100-preview9",
         "runtime-version": "3.0.0-preview9-19423-09",
         "vs-version": "16.3.0-preview3",
         "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
@@ -1322,7 +1322,7 @@
       "sdks": [
         {
           "version": "3.0.100-preview9-014004",
-          "version-display": "3.0.100-preview9-014004",
+          "version-display": "3.0.100-preview9",
           "runtime-version": "3.0.0-preview9-19423-09",
           "vs-version": "16.3.0-preview3",
           "vs-support": "Visual Studio 2019 (v16.3 - latest preview)",
@@ -1436,7 +1436,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.0.0-preview9.19424.4",
-        "version-display": "3.0.0-preview9.19424.4",
+        "version-display": "3.0.0-preview9",
         "version-aspnetcoremodule": [
           "13.0.19236"
         ],
@@ -1549,7 +1549,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview8.md",
       "runtime": {
         "version": "3.0.0-preview8-28405-07",
-        "version-display": "3.0.0-preview8-28405-07",
+        "version-display": "3.0.0-preview8",
         "vs-version": "",
         "files": [
           {
@@ -1748,7 +1748,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview8-013656",
-        "version-display": "3.0.100-preview8-013656",
+        "version-display": "3.0.100-preview8",
         "runtime-version": "3.0.0-preview8-28405-07",
         "vs-version": "",
         "vs-support": "Visual Studio 2019 (v16.3, latest preview)",
@@ -1862,7 +1862,7 @@
       "sdks": [
         {
           "version": "3.0.100-preview8-013656",
-          "version-display": "3.0.100-preview8-013656",
+          "version-display": "3.0.100-preview8",
           "runtime-version": "3.0.0-preview8-28405-07",
           "vs-version": "",
           "vs-support": "Visual Studio 2019 (v16.3, latest preview)",
@@ -1976,7 +1976,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.0.0-preview8.19405.7",
-        "version-display": "3.0.0-preview8.19405.7",
+        "version-display": "3.0.0-preview8",
         "version-aspnetcoremodule": [
           "13.0.19218.0"
         ],
@@ -2089,7 +2089,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview7.md",
       "runtime": {
         "version": "3.0.0-preview7-27912-14",
-        "version-display": "3.0.0-preview7-27912-14",
+        "version-display": "3.0.0-preview7",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -2167,7 +2167,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview7-012821",
-        "version-display": "3.0.100-preview7-012821",
+        "version-display": "3.0.100-preview7",
         "runtime-version": "3.0.0-preview7-27912-14",
         "vs-support": "Visual Studio 2019 (v16.2. latest preview)",
         "csharp-version": "8.0-preview",
@@ -2268,7 +2268,7 @@
       "sdks": [
         {
           "version": "3.0.100-preview7-012821",
-          "version-display": "3.0.100-preview7-012821",
+          "version-display": "3.0.100-preview7",
           "runtime-version": "3.0.0-preview7-27912-14",
           "vs-support": "Visual Studio 2019 (v16.2. latest preview)",
           "csharp-version": "8.0-preview",
@@ -2369,7 +2369,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.0.0-preview7.19365.7",
-        "version-display": "3.0.0-preview7.19365.7",
+        "version-display": "3.0.0-preview7",
         "version-aspnetcoremodule": [
           "13.0.19197.0"
         ],
@@ -2451,7 +2451,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview6.md",
       "runtime": {
         "version": "3.0.0-preview6-27804-01",
-        "version-display": "3.0.0-preview6-27804-01",
+        "version-display": "3.0.0-preview6",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -2529,7 +2529,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview6-012264",
-        "version-display": "3.0.100-preview6-012264",
+        "version-display": "3.0.100-preview6",
         "runtime-version": "3.0.0-preview6-27804-01",
         "vs-support": "Visual Studio 2019 (v16.2, latest preview)",
         "csharp-version": "8.0-preview",
@@ -2629,7 +2629,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview6-27804-01",
-        "version-display": "3.0.0-preview6-27804-01",
+        "version-display": "3.0.0-preview6",
         "version-aspnetcoremodule": [
           "13.0.19150.0"
         ],
@@ -2806,7 +2806,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview5.md",
       "runtime": {
         "version": "3.0.0-preview5-27626-15",
-        "version-display": "3.0.0-preview5-27626-15",
+        "version-display": "3.0.0-preview5",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -2884,7 +2884,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview5-011568",
-        "version-display": "3.0.100-preview5-011568",
+        "version-display": "3.0.100-preview5",
         "runtime-version": "3.0.0-preview5-27626-15",
         "vs-support": "Visual Studio 2019 (v16.1, latest preview)",
         "csharp-version": "8.0-preview",
@@ -2984,7 +2984,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview5-27626-15",
-        "version-display": "3.0.0-preview5-27626-15",
+        "version-display": "3.0.0-preview5",
         "version-aspnetcoremodule": [
           "13.0.19118.0"
         ],
@@ -3161,7 +3161,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview4.md",
       "runtime": {
         "version": "3.0.0-preview4-27615-11",
-        "version-display": "3.0.0-preview4-27615-11",
+        "version-display": "3.0.0-preview4",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -3239,7 +3239,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview4-011223",
-        "version-display": "3.0.100-preview4-011223",
+        "version-display": "3.0.100-preview4",
         "runtime-version": "3.0.0-preview4-27615-11",
         "vs-support": "Visual Studio 2019 (v16.1, latest preview)",
         "csharp-version": "8.0-preview",
@@ -3339,7 +3339,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview4-27615-11",
-        "version-display": "3.0.0-preview4-27615-11",
+        "version-display": "3.0.0-preview4",
         "version-aspnetcoremodule": [
           "13.0.19106.0"
         ],
@@ -3451,7 +3451,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview3.md",
       "runtime": {
         "version": "3.0.0-preview3-27503-5",
-        "version-display": "3.0.0-preview3-27503-5",
+        "version-display": "3.0.0-preview3",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -3529,7 +3529,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview3-010431",
-        "version-display": "3.0.100-preview3-010431",
+        "version-display": "3.0.100-preview3",
         "runtime-version": "3.0.0-preview3-27503-5",
         "csharp-version": "8.0-preview",
         "fsharp-version": "4.6",
@@ -3628,7 +3628,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview3-27503-5",
-        "version-display": "3.0.0-preview3-27503-5",
+        "version-display": "3.0.0-preview3",
         "version-aspnetcoremodule": [
           "13.0.19063.0"
         ],
@@ -3734,7 +3734,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview2.md",
       "runtime": {
         "version": "3.0.0-preview-27324-5",
-        "version-display": "3.0.0-preview-27324-5",
+        "version-display": "3.0.0-preview2",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -3818,7 +3818,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview-010184",
-        "version-display": "3.0.100-preview-010184",
+        "version-display": "3.0.100-preview2",
         "runtime-version": "3.0.0-preview-27324-5",
         "csharp-version": "8.0-preview",
         "fsharp-version": "10.4.0-rtm-181207-02",
@@ -3918,7 +3918,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview-19075-0444",
-        "version-display": "3.0.0-preview-19075-0444",
+        "version-display": "3.0.0-preview2",
         "version-aspnetcoremodule": [
           "13.0.19026.0"
         ],
@@ -4024,7 +4024,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.0/preview/3.0.0-preview1.md",
       "runtime": {
         "version": "3.0.0-preview-27122-01",
-        "version-display": "3.0.0-preview-27122-01",
+        "version-display": "3.0.0-preview1",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -4108,7 +4108,7 @@
       },
       "sdk": {
         "version": "3.0.100-preview-009812",
-        "version-display": "3.0.100-preview-009812",
+        "version-display": "3.0.100-preview1",
         "runtime-version": "3.0.0-preview-27122-01",
         "csharp-version": "8.0-preview",
         "fsharp-version": "4.5",
@@ -4208,7 +4208,7 @@
       },
       "aspnetcore-runtime": {
         "version": "3.0.0-preview-18579-0056",
-        "version-display": "3.0.0-preview-18579-0056",
+        "version-display": "3.0.0-preview1",
         "version-aspnetcoremodule": [
           "13.0.18333.0"
         ],

--- a/release-notes/3.0/releases.json
+++ b/release-notes/3.0/releases.json
@@ -230,6 +230,7 @@
           "runtime-version": "3.0.0",
           "vs-version": "16.3",
           "vs-support": "Visual Studio 2019 (v16.3)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.3)",
           "csharp-version": "8.0",
           "fsharp-version": "4.7",
           "files": [

--- a/release-notes/3.1/releases.json
+++ b/release-notes/3.1/releases.json
@@ -16,7 +16,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/preview/3.1.0-preview2.md",
       "runtime": {
         "version": "3.1.0-preview2.19525.6",
-        "version-display": "3.1.0-preview2.19525.6",
+        "version-display": "3.1.0-preview2",
         "vs-version": "16.4.0",
         "files": [
           {
@@ -215,7 +215,7 @@
       },
       "sdk": {
         "version": "3.1.100-preview2-014569",
-        "version-display": "3.1.100-preview2-014569",
+        "version-display": "3.1.100-preview2",
         "runtime-version": "3.1.0-preview2.19525.6",
         "vs-version": "16.4.0",
         "vs-support": "Visual Studio 2019 (v16.4, latest preview)",
@@ -329,7 +329,7 @@
       "sdks": [
         {
           "version": "3.1.100-preview2-014569",
-          "version-display": "3.1.100-preview2-014569",
+          "version-display": "3.1.100-preview2",
           "runtime-version": "3.1.0-preview2.19525.6",
           "vs-version": "16.4.0",
           "vs-support": "Visual Studio 2019 (v16.4, latest preview)",
@@ -443,7 +443,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.1.0-preview2.19528.8",
-        "version-display": "3.1.0-preview2.19528.8",
+        "version-display": "3.1.0-preview2",
         "version-aspnetcoremodule": [
           "13.1.19302.0"
         ],
@@ -560,7 +560,7 @@
       "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/preview/3.1.0-preview1.md",
       "runtime": {
         "version": "3.1.0-preview1.19506.1",
-        "version-display": "3.1.0-preview1.19506.1",
+        "version-display": "3.1.0-preview1",
         "vs-version": "16.4.0",
         "files": [
           {
@@ -759,7 +759,7 @@
       },
       "sdk": {
         "version": "3.1.100-preview1-014459",
-        "version-display": "3.1.100-preview1-014459",
+        "version-display": "3.1.100-preview1",
         "runtime-version": "3.1.0-preview1.19506.1",
         "vs-version": "16.4.0",
         "vs-support": "Visual Studio 2019 (v16.4, latest preview)",
@@ -874,7 +874,7 @@
       "sdks": [
         {
           "version": "3.1.100-preview1-014459",
-          "version-display": "3.1.100-preview1-014459",
+          "version-display": "3.1.100-preview1",
           "runtime-version": "3.1.0-preview1.19506.1",
           "vs-version": "16.4.0",
           "vs-support": "Visual Studio 2019 (v16.4, latest preview)",
@@ -989,7 +989,7 @@
       ],
       "aspnetcore-runtime": {
         "version": "3.1.0-preview1.19508.20",
-        "version-display": "3.1.0-preview1.19508.20",
+        "version-display": "3.1.0-preview1",
         "version-aspnetcoremodule": [
           "13.1.19282.0"
         ],


### PR DESCRIPTION
There were three releases where we had exactly the same file entry listed twice. Also fixing up display versions for several releases.