### PR TITLE
Removing unsupported release 2.2 links

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -8,7 +8,6 @@ You can download the latest updates for .NET Core.
 
 * [.NET Core 3.1.0](3.1/3.1.0/3.1.0.md)
 * [.NET Core 3.0.1](3.0/3.0.1/3.0.1.md)
-* [.NET Core 2.2.8](2.2/2.2.8/2.2.8.md)
 * [.NET Core 2.1.14](2.1/2.1.14/2.1.14.md)
 
 ## Release Information
@@ -17,7 +16,6 @@ You can download the latest updates for .NET Core.
 * [Releases Index][releases-index.json] -- Index for all release channels in JSON format
 * [3.1 Release Details][3.1-releases.json] -- All releases details for the 3.1 channel in JSON format
 * [3.0 Release Details][3.0-releases.json] -- All releases details for the 3.0 channel in JSON format
-* [2.2 Release Details][2.2-releases.json] -- All releases details for the 2.2 channel in JSON format
 * [2.1 Release Details][2.1-releases.json] -- All releases details for the 2.1 channel in JSON format
 
 ## See also
@@ -27,5 +25,4 @@ You can download the latest updates for .NET Core.
 [releases-index.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json
 [3.1-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json
 [3.0-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json
-[2.2-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json
 [2.1-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json


### PR DESCRIPTION
2.2 is out of support, removing links to its downloads from "main" page.