### PR TITLE
Mark issues resolved by 3.1.1 (hosting bundle)

### DIFF
--- a/release-notes/3.1/3.1-known-issues.md
+++ b/release-notes/3.1/3.1-known-issues.md
@@ -35,19 +35,19 @@ We are working to update our installers for the new Catalina requirements. These
 
 ### 3.1.0
 
-* **The 3.1.0 Hosting Bundle for Windows installs a .NET Core Runtime incorrectly branded "3.1.0 Preview 3".**
+* **[RESOLVED] The 3.1.0 Hosting Bundle for Windows installs a .NET Core Runtime incorrectly branded "3.1.0 Preview 3".**
 
 This is a cosmetic bug: the hosting bundle is expected to function normally.
 
-This will be fixed with 3.1.1. More information at [dotnet/core#3962](https://github.com/dotnet/core/issues/3962).
+This is fixed with 3.1.1. More information at [dotnet/core#3962](https://github.com/dotnet/core/issues/3962).
 
 The Hosting Bundle briefly shows that it is installing "Microsoft .NET Core Runtime - 3.1.0 Preview 3". That string is also visible in Add/Remove Programs after the install completes. This is **not** the old November 2019 3.1.0 Preview 3 Runtime. The Hosting Bundle is installing a more recent build of 3.1.0 that has incorrect branding.
 
-* **If the 3.1.0 SDK and Hosting Bundle were previously installed on Windows, installing the 3.1.0 .NET Core Runtime directly may remove important files such as `hostpolicy.dll`.**
+* **[RESOLVED] If the 3.1.0 SDK and Hosting Bundle were previously installed on Windows, installing the 3.1.0 .NET Core Runtime directly may remove important files such as `hostpolicy.dll`.**
 
 To fix this, repair the .NET Core Runtime installation. (Execute the installer again and click Repair, or find the .NET Core Runtime 3.1.0 installation in Add/Remove Programs, select Modify, then click Repair.)
 
-This will be fixed with 3.1.1. More information at [dotnet/core#3962](https://github.com/dotnet/core/issues/3962) and [dotnet/runtime#703](https://github.com/dotnet/runtime/issues/703).
+This is fixed with 3.1.1. More information at [dotnet/core#3962](https://github.com/dotnet/core/issues/3962) and [dotnet/runtime#703](https://github.com/dotnet/runtime/issues/703).
 
 Missing this file can cause errors like the following, for example when running `dotnet --info`:
 


### PR DESCRIPTION
Mark 3.1.0 issues in https://github.com/dotnet/core/pull/3982 as resolved by 3.1.1.