### PR TITLE
Solve erorr

### DIFF
--- a/release-notes/3.1/3.1.2/3.1.2-install-instructions.md
+++ b/release-notes/3.1/3.1.2/3.1.2-install-instructions.md
@@ -20,7 +20,7 @@ Snap is a system which installs applications in an isolated environment and prov
 
 After configuring Snap on your system, run the following command to install the latest .NET Core SDK.
 
-`sudo snap install dotnet-sdk --channel 3.1/stable –classic`
+`sudo snap install dotnet-sdk --channel 3.1/stable --classic`
 
 When .NET Core in installed using the Snap package, the default .NET Core command is `dotnet-sdk.dotnet`, as opposed to just `dotnet`. The benefit of the namespaced command is that it will not conflict with a globally installed .NET Core version you may have. This command can be aliased to `dotnet` with:
 


### PR DESCRIPTION
error: This revision of snap "dotnet-sdk" was published using classic
       confinement and thus may perform arbitrary system changes outside of the
       security sandbox that snaps are usually confined to, which may put your
       system at risk.

       If you understand and want to proceed repeat the command including
       --classic.