### PR TITLE
Update 5.0.0-preview.1-install-instructions.md

### DIFF
--- a/release-notes/5.0/preview/5.0.0-preview.1-install-instructions.md
+++ b/release-notes/5.0/preview/5.0.0-preview.1-install-instructions.md
@@ -35,7 +35,7 @@ Preview release installers are not available from the Microsoft package reposito
 **Note:** `curl` must be available on the system before running the following steps. Once you have confirmed that `curl` is available, complete the steps to download and install the .NET 5 Preview 1 SDK and Runtime.
 
 1. Create a directory to use for the download location and change into that directory. For example `mkdir $HOME/dotnet_install && cd $HOME/dotnet_install`
-2. Run `curl -L https://aka.ms/install-dotnet-preview -o install-dotnet-preview.sh
+2. Run `curl -L https://aka.ms/install-dotnet-preview -o install-dotnet-preview.sh`
 3. Run the script with `sudo bash install-dotnet-preview.sh`
 
 Here's what the script does.


### PR DESCRIPTION
Fix ending tilde for install instructions in 'deb/rpm packages' section