### PR TITLE
Update .NET 5 URLs

### DIFF
--- a/release-notes/5.0/README.md
+++ b/release-notes/5.0/README.md
@@ -4,6 +4,6 @@ The following .NET 5 releases have been shipped. You must be on the latest patch
 
 | Release Date | Description | Download |
 | :-- | :-- | :--: |
-| 2020/04/23 | [5.0.0 Preview 3](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md) | [download](https://dotnet.microsoft.com/download/dotnet-core/5.0) |
-| 2020/04/02 | [5.0.0 Preview 2](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.2.md) | [download](https://dotnet.microsoft.com/download/dotnet-core/5.0) |
-| 2020/03/16 | [5.0.0 Preview 1](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.1.md) | [download](https://dotnet.microsoft.com/download/dotnet-core/5.0) |
+| 2020/04/23 | [5.0.0 Preview 3](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md) | [download](https://dotnet.microsoft.com/download/dotnet/5.0) |
+| 2020/04/02 | [5.0.0 Preview 2](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.2.md) | [download](https://dotnet.microsoft.com/download/dotnet/5.0) |
+| 2020/03/16 | [5.0.0 Preview 1](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.1.md) | [download](https://dotnet.microsoft.com/download/dotnet/5.0) |

--- a/release-notes/5.0/preview/5.0.0-preview.1.md
+++ b/release-notes/5.0/preview/5.0.0-preview.1.md
@@ -2,7 +2,7 @@
 
 .NET 5.0.0 Preview 1 is available for download and usage in your environment. This release includes .NET 5.0.0 Preview 1 and .NET SDK 5.0.100 Preview 1.
 
-* [Downloads](https://dotnet.microsoft.com/download/dotnet-core/5.0)
+* [Downloads](https://dotnet.microsoft.com/download/dotnet/5.0)
 * [.NET 5.0 Preview 1 Blog][dotnet-blog]
 * [ASP.NET Core Blog][aspnet-blog]
 * [EF Core Blog][ef-blog]

--- a/release-notes/5.0/preview/5.0.0-preview.2.md
+++ b/release-notes/5.0/preview/5.0.0-preview.2.md
@@ -2,7 +2,7 @@
 
 .NET 5.0.0 Preview 2 is available for download and usage in your environment. This release includes .NET 5.0.0 Preview 2 and .NET SDK 5.0.100 Preview 2.
 
-* [Downloads](https://dotnet.microsoft.com/download/dotnet-core/5.0)
+* [Downloads](https://dotnet.microsoft.com/download/dotnet/5.0)
 * [.NET 5.0 Preview 2 Blog][dotnet-blog]
 * [ASP.NET Core Blog][aspnet-blog]
 * [EF Core Blog][ef-blog]

--- a/release-notes/5.0/preview/5.0.0-preview.3.md
+++ b/release-notes/5.0/preview/5.0.0-preview.3.md
@@ -2,7 +2,7 @@
 
 .NET 5.0.0 Preview 3 is available for download and usage in your environment. This release includes .NET 5.0.0 Preview 3 and .NET SDK 5.0.100 Preview 3.
 
-* [Downloads](https://dotnet.microsoft.com/download/dotnet-core/5.0)
+* [Downloads](https://dotnet.microsoft.com/download/dotnet/5.0)
 * [.NET 5.0 Preview 3 Blog][dotnet-blog]
 * [ASP.NET Core Blog][aspnet-blog]
 * [EF Core Blog][ef-blog]


### PR DESCRIPTION
We've updated the URL for .NET 5 to be dotnet.microsoft.com/download/dotnet instead of dotnet.microsoft.com/download/dotnet-core.

We have redirect in place, but it's better to send people to the right place.