### PR TITLE
Remove 3.0 links

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -8,7 +8,6 @@ You can download the latest updates for .NET Core.
 
 * [.NET 5.0 Preview 3](5.0/preview/5.0.0-preview.3.md)
 * [.NET Core 3.1.3](3.1/3.1.3/3.1.3.md)
-* [.NET Core 3.0.3](3.0/3.0.3/3.0.3.md)
 * [.NET Core 2.1.17](2.1/2.1.17/2.1.17.md)
 
 ## Release Information
@@ -17,7 +16,6 @@ You can download the latest updates for .NET Core.
 * [Releases Index][releases-index.json] -- Index for all release channels in JSON format
 * [5.0 Release Details][5.0-releases.json] -- All releases details for the 5.0 channel in JSON format
 * [3.1 Release Details][3.1-releases.json] -- All releases details for the 3.1 channel in JSON format
-* [3.0 Release Details][3.0-releases.json] -- All releases details for the 3.0 channel in JSON format
 * [2.1 Release Details][2.1-releases.json] -- All releases details for the 2.1 channel in JSON format
 
 ## See also
@@ -27,5 +25,4 @@ You can download the latest updates for .NET Core.
 [releases-index.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json
 [5.0-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json
 [3.1-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json
-[3.0-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json
 [2.1-releases.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json


### PR DESCRIPTION
3.0 is out of support - removing links to the releases from main release page.