### PR TITLE
Fix download link for SDK 2.1.3, win/x86

### DIFF
--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -1414,7 +1414,7 @@
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.3-win-x86.zip",
+            "url": "https://download.microsoft.com/download/2/9/3/293BC432-348C-4D1C-B628-5AC8AB7FA162/dotnet-sdk-2.1.3-win-x86.zip",
             "hash": "9adc65a0708d7ae8300ae13db509313083ecece3901576c98c69413608ccffe7e73f35547583760c4ee08f01a9e9b6e89098788344027827602053ee4106af38"
           },
           {


### PR DESCRIPTION
It used the URL prefix from SDK 2.1.2, but the filename for 2.1.3, resulting in a broken link.

(Created directly on GitHub, so I have no control over the apparent addition of a final newline)