### PR TITLE
Add missing downloads for SDK 2.0.0-preview1

### DIFF
--- a/release-notes/2.0/releases.json
+++ b/release-notes/2.0/releases.json
@@ -1989,11 +1989,23 @@
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
+            "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-win-x86.2.0.0-preview1-005977.zip",
+            "hash": "0740404555687060f8d3bd32fb134d6dd92ac6fcdaaf439deb2aa3a9d55d211b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-win-x64.2.0.0-preview1-005977.zip",
+            "hash": "f85b46532faf6e6fb1adf9f6a6df3ffa039154b89aa3db63b633f227cd1a1e43"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
             "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x86.2.0.0-preview1-005977.exe",
             "hash": "44e03bb1b703745b07316980bcc7ce86792cd33865fca6e932f96a3da001fdf9"
           },
           {
-            "name": "dotnet-sdk-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://download.microsoft.com/download/3/7/F/37F1CA21-E5EE-4309-9714-E914703ED05A/dotnet-dev-win-x64.2.0.0-preview1-005977.exe",
             "hash": "ba2a47e5e63f2e695317dfcee928f5655ce87b2956a4de9e31d9a7a57e0618fd"


### PR DESCRIPTION
There were entries for win/x86 and win/x64 named "dotnet-sdk-win-x86/x64.zip", but they pointed to the executable installers.
This corrects their name, and adds the correct links to the zip packages.

(Created directly on GitHub, so I have no control over the apparent addition of a final newline)