### PR TITLE
Preview 5: Single file publishes host components out of bundle

### DIFF
--- a/release-notes/5.0/5.0-known-issues.md
+++ b/release-notes/5.0/5.0-known-issues.md
@@ -32,3 +32,8 @@ This will be fixed in the Preview 5 release. It is tracked by [dotnet/aspnetcore
 ### Preview 1
 
 1. Runtime-dependent deployments of apps targeting .NET Core 3.1 that are created with .NET Core SDK 5.0.100 Preview 1 will require version 3.1.2 of the .NET Core runtime. This issue is tracked by [dotnet/sdk #10812](https://github.com/dotnet/sdk/issues/10812)
+
+### Preview 5
+
+1. For self-contained single-file apps, hostfxr and hostpolicy are not bundled into the application bundle, but are published alongside it. Framework-dependent single-file apps are not affected (since hostfxr and hostpolicy reside within the framework). This issue will be resolved in Preview 6, tracked by [dotnet/runtime #32823](https://github.com/dotnet/runtime/issues/32823). 
+    


### PR DESCRIPTION
Add a known-issue with publishing self-contained single-file apps in Preview 5.