### PR TITLE
Remove package manager section for Linux for 5.0 previews

### DIFF
--- a/release-notes/5.0/preview/5.0.0-preview.5-install-instructions.md
+++ b/release-notes/5.0/preview/5.0.0-preview.5-install-instructions.md
@@ -58,10 +58,6 @@ mkdir -p $HOME/dotnet && tar zxf dotnet.tar.gz -C $HOME/dotnet
 export PATH=$PATH:$HOME/dotnet
 ```
 
-## .NET Core Runtime-only installation
-
-If only the .NET Core Runtime is needed, install `dotnet-runtime-5.0` using your package manager. If you also need ASP.NET Core functionality, installing `aspnetcore-runtime-5.0` will install both the Aspnetcore Runtime and .NET Core Runtime.
-
 ## Windows Server Hosting
 
 If you are looking to host stand-alone apps on Servers, the following installer can be used on Windows systems.


### PR DESCRIPTION
I wanted to install 5.0 preview on Ubuntu, and followed from the landing page to this document. Then jumped to this section, and of course it doesn't work. We would like to avoid any paths from the landing page that will not lead to a successful install 😃 

Removing the section because 
1. This section does not indicate which distros it applies to. It seems Ubuntu packages do not exist for any .NET version as source-build isn't available for Debian type distros yet.
2. Regardless, I understand from @dseefeld that the packages are not available yet for 5.0 previews so this won't work for any distro today.

Is this the right edit? Is the rest correct? @rbhanda I assume you will make sure that the instructions are updated when we put out preview packages?