### PR TITLE
Fix System.Reflection.Metadata entry in 3.1.4

### DIFF
--- a/release-notes/3.1/3.1.4/3.1.4.md
+++ b/release-notes/3.1/3.1.4/3.1.4.md
@@ -354,7 +354,7 @@ System.Text.Encodings.Web | 4.7.1
 System.Text.Encoding.CodePages | 4.7.1
 System.Resources.Extensions | 4.7.1
 System.Reflection.MetadataLoadContext | 4.7.1
-System.Reflection.Metadata.1.8.1
+System.Reflection.Metadata | 1.8.1
 System.Reflection.DispatchProxy | 4.7.1
 System.Threading.Channels | 4.7.1
 System.Net.WebSockets.WebSocketProtocol | 4.7.1


### PR DESCRIPTION
@lg2de pointed this out at https://github.com/dotnet/runtime/issues/36033#issuecomment-647019497. (Thanks!)

I'm not sure when/where this list comes from, it might be worth digging in to see if it's a bug with the Arcade infra: https://github.com/dotnet/arcade/issues/4397.