### PR TITLE
Some releases.json fixes

### DIFF
--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -497,7 +497,7 @@
         "runtime": {
           "version": "2.1.19",
           "version-display": "2.1.19",
-          "vs-version": "15.9.24 16.0.15 16.4.10 16.6.2",
+          "vs-version": "15.9.24, 16.0.15, 16.4.10, 16.6.2",
           "files": [
             {
               "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -889,7 +889,7 @@
           "version-aspnetcoremodule": [
             "12.1.20149.19"
           ],
-          "vs-version": "15.9.24 16.0.15 16.4.10 16.6.2",
+          "vs-version": "15.9.24, 16.0.15, 16.4.10, 16.6.2",
           "files": [
             {
               "name": "aspnetcore-runtime-linux-arm.tar.gz",

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -22,7 +22,7 @@
       "runtime": {
         "version": "2.1.20",
         "version-display": "2.1.20",
-        "vs-version": "15.9.25, 16.0.16, 16.4.11, 16.6.4, 16.7 Preview 4",
+        "vs-version": "15.9.25, 16.0.16, 16.4.11, 16.6.4",
         "vs-mac-version": "8.6.6",
         "files": [
           {

--- a/release-notes/3.1/releases.json
+++ b/release-notes/3.1/releases.json
@@ -478,7 +478,7 @@
       "runtime": {
         "version": "3.1.5",
         "version-display": "3.1.5",
-        "vs-version": "16.4.10 16.6.2",
+        "vs-version": "16.4.10, 16.6.2",
         "files": [
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -817,7 +817,7 @@
         "version-aspnetcoremodule": [
           "13.1.20142.5"
         ],
-        "vs-version": "16.4.10 16.6.2",
+        "vs-version": "16.4.10, 16.6.2",
         "files": [
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",

--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -2564,7 +2564,7 @@
       "sdk": {
         "version": "5.0.100-preview.1.20155.7",
         "version-display": "5.0.100-preview.1",
-        "runtime-version": "5.0.100-preview.1.20155.7",
+        "runtime-version": "5.0.0-preview.1.20120.5",
         "vs-version": "",
         "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
         "csharp-version": "8.0",

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -20,6 +20,7 @@
             "latest-sdk": "3.1.302",
             "product": ".NET Core",
             "support-phase": "lts",
+            "eol-date": "2022-12-03",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
         },
         {
@@ -43,6 +44,7 @@
             "latest-sdk": "2.1.808",
             "product": ".NET Core",
             "support-phase": "lts",
+            "eol-date": "2021-08-21",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
         },
         {


### PR DESCRIPTION
There were a couple vs-version fields that listed multiple versions without a separating comma, as is done everywhere else. A preview version of Visual Studio was listed, even though that never happens and it wasn't a valid version number, so I removed that. Also fixed a slight mistake in v5.0.0-preview1, where it listed the SDK version and not the runtime version in the SDKs runtime-version field and added back some eol-dates in releases-index.json.