### PR TITLE
Remove duplicate dotnet-hosting

### DIFF
--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -3291,12 +3291,6 @@
         "vs-version": "16.2.5",
         "files": [
           {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "win-x86_x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/070b4126-8c0c-445f-8c0e-7a29963b0a1c/d50548fc04e2e0063dad4fda8232cd9d/dotnet-hosting-2.1.13-win.exe",
-            "hash": "674D14D1EA87D97D5362525AEE2119062F7E79E8D03BDAC5501D170E7B74DA2E853B84A81E307B1BBD355F75B5C237A987B52A5E5C5C206CABD8695C3B634628"
-          },
-          {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
             "url": "https://download.visualstudio.microsoft.com/download/pr/4f9988da-8a62-4e01-9978-d9f1dd4fc386/3acb243f96e8e20b6774c64694d478ce/dotnet-runtime-2.1.13-linux-arm.tar.gz",


### PR DESCRIPTION
2.1.13 release had a duplicate dotnet-hosting entries in the runtime and aspnetcore sections. Convention is list this file under aspnetcore so removing the duplicate entry from the runtime section.