### PR TITLE
Update dotnetsay tool to roll-forward

### DIFF
--- a/samples/dotnetsay/dotnetsay.csproj
+++ b/samples/dotnetsay/dotnetsay.csproj
@@ -16,7 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackAsTool>true</PackAsTool>
     <!-- 
-      Enables too to run on any runtime version.
+      Enables tool to run on any runtime version.
       Will run on .NET Core 2.1 if available. Otherwise, the latest. 
     -->
     <RollForward>LatestMajor</RollForward>

--- a/samples/dotnetsay/dotnetsay.csproj
+++ b/samples/dotnetsay/dotnetsay.csproj
@@ -4,8 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Description>A simple .NET Core global tool called "dotnetsay".</Description>
-    <LangVersion>Latest</LangVersion>
-    <VersionPrefix>2.1.4</VersionPrefix>
+    <VersionPrefix>2.1.5</VersionPrefix>
     <Authors>.NET Team</Authors>
     <Product>dotnetsay</Product>
     <Copyright>MIT</Copyright>
@@ -15,10 +14,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <!-- Optional performance setting - enables tiered JIT compilation-->
-    <TieredCompilation>true</TieredCompilation>
+    <!-- 
+      Enables too to run on any runtime version.
+      Will run on .NET Core 2.1 if available. Otherwise, the latest. 
+    -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)'=='true'">


### PR DESCRIPTION
I updated the tool to rollforward to the latest runtime (if the desired runtime is missing).

Intended to replace #3535