### PR TITLE
Simpler calls to ReadAllLines by using using static.

### DIFF
--- a/samples/dotnet-runtimeinfo/Program.cs
+++ b/samples/dotnet-runtimeinfo/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using static System.Console;
+using static System.IO.File;
 
 namespace RuntimeEnvironment
 {
@@ -27,9 +28,9 @@ namespace RuntimeEnvironment
             if(RuntimeInformation.OSDescription.StartsWith("Linux") && Directory.Exists("/sys/fs/cgroup"))
             {
                 WriteLine("**CGroup info**");
-                WriteLine($"cfs_quota_us: {System.IO.File.ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0]}");
-                WriteLine($"memory.limit_in_bytes: {System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0]}");
-                WriteLine($"memory.usage_in_bytes: {System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0]}");
+                WriteLine($"cfs_quota_us: {ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0]}");
+                WriteLine($"memory.limit_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0]}");
+                WriteLine($"memory.usage_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0]}");
             }
         }
     }


### PR DESCRIPTION
Not sure it's worth it, but given the `Console.WriteLine` is using it, I'll give it a shot.