### PR TITLE
Remove VS preview version number for 5-preview.8

### DIFF
--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -195,7 +195,7 @@
           "version": "5.0.100-preview.8.20417.9",
           "version-display": "5.0.100-preview.8",
           "runtime-version": "5.0.0-preview.8.20407.11",
-          "vs-version": "16.8 Preview 2",
+          "vs-version": "",
           "vs-mac-version": "",
           "vs-support": "Visual Studio 2019 (v16.8, Preview 2)",
           "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
@@ -284,7 +284,7 @@
         "version-aspnetcoremodule": [
           "15.0.20228.0"
         ],
-        "vs-version": "16.8 Preview 2",
+        "vs-version": "",
         "files": [
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",


### PR DESCRIPTION
Looking at other releases, it looks to be very uncommon (this is the only one
I found) to mention VS preview versions in the vs-version field. It is usually
only mentioned in the vs-support field for the corresponding SDK, just as
was done here for the `sdk` (but not the `sdks.[0]`) field.

The reason to remove it is that 16.8 Preview 2 is not a valid version "number",
due to the spaces in the label.