### PR TITLE
Update 5.0-known-issues.md

### DIFF
--- a/release-notes/5.0/5.0-known-issues.md
+++ b/release-notes/5.0/5.0-known-issues.md
@@ -90,7 +90,7 @@ Edit Areas\Identity\Pages\Shared\_LoginPartial.cshtml in the project and change 
 1. For self-contained single-file apps, hostfxr and hostpolicy are not bundled into the application bundle, but are published alongside it. Framework-dependent single-file apps are not affected (since hostfxr and hostpolicy reside within the framework). This issue should be resolved in Preview 6, tracked by [dotnet/runtime #32823](https://github.com/dotnet/runtime/issues/32823). 
 
 ### Preview 8
-1. Running xUnit tests fails to discover tests in with message `No test is available in <assembly> Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.`. To solve this update your `xunit.runner.visualstudio` package to version 2.4.3. This version is used in `dotnet new` templates, but existing projects targetting, or updating to net5.0 need to be updated manually.
+1. (Fixed in RC1, affects only Preview 8 and RC1 before 5.0.100-rc.1.20451.10) Running xUnit tests fails to discover tests in with message `No test is available in <assembly> Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.`. To solve this update your `xunit.runner.visualstudio` package to version 2.4.3. This version is used in `dotnet new` templates, but existing projects targetting, or updating to net5.0 need to be updated manually.
 
 2. Projects targeting net5.0-windows will fail to build if the `TargetPlatformMinimumVersion` does not match the `TargetPlatformVersion`
 


### PR DESCRIPTION
The change that broke xunit and vstest was reverted, Preview8 and early builds of RC1 are affected, but the shipping RC1 won't be affected. I am not sure if these notes are meant to be cumulative or not.