### PR TITLE
Add error when using Test.SDK older than 16.3.0

### DIFF
--- a/release-notes/5.0/5.0-known-issues.md
+++ b/release-notes/5.0/5.0-known-issues.md
@@ -92,12 +92,14 @@ Edit Areas\Identity\Pages\Shared\_LoginPartial.cshtml in the project and change 
 ### Preview 8
 1. Running xUnit tests fails to discover tests in with message `No test is available in <assembly> Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.`. To solve this update your `xunit.runner.visualstudio` package to version 2.4.3. This version is used in `dotnet new` templates, but existing projects targetting, or updating to net5.0 need to be updated manually.
 
-2. Projects targeting net5.0-windows will fail to build if the `TargetPlatformMinimumVersion` does not match the `TargetPlatformVersion`
+1. (Fixed in RC1, affects only Preview 8 and RC1 before 5.0.100-rc.1.20451.10) Running tests from net5.0 project referencing `Microsoft.NET.Test.SDK` older than 16.3.0 or older will fail to run tests with: `Microsoft.VisualStudio.TestPlatform.ObjectModel.SettingsException: Invalid settings 'RunConfiguration'. Invalid value 'net5.0' specified for 'TargetFrameworkVersion'.` To solve this update your `Microsoft.NET.Test.SDK` reference to `16.3.0` or newer, or update your SDK version to the latest RC1.
+
+1. Projects targeting net5.0-windows will fail to build if the `TargetPlatformMinimumVersion` does not match the `TargetPlatformVersion`
 
     - An error similar to the following will be generated:
     
     > NETSDK1005: Assets file 'C:\Users\username\source\repos\project\NuGetPackageExplorer-main\NuGetPackageExplorer-main\Types\obj\project.assets.json' doesn't have a target for 'net5.0-windows10.0.18362'. Ensure that restore has run and that you have included 'net5.0-windows10.0.18362' in the TargetFrameworks for your project.
-3. C++/CLI 
+1. C++/CLI 
     - C++/CLI projects will not build if targeted to .NET 5.0
-4. Warning icons in Dependencies node in Solution Explorer
+1. Warning icons in Dependencies node in Solution Explorer
     - For projects targeting .NET 5, warning icons may be displayed on packages listed in the Solution Explorer Depdendencies node


### PR DESCRIPTION
Add error when using Test.SDK older than 16.3.0
Use automatic markdown numbering