### PR TITLE
supported-os: Update Fedora EOL versions.

### DIFF
--- a/release-notes/2.1/2.1-supported-os.md
+++ b/release-notes/2.1/2.1-supported-os.md
@@ -30,7 +30,7 @@ OS                            | Version                       | Architectures  |
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://www.microsoft.com/net/support/policy)
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
-Fedora                        | 30+                     | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
+Fedora                        | 31+                     | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9+                             | x64, ARM32     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 20.10, 20.04, 18.04, 16.04           | x64, ARM32\*   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
 Linux Mint                    | 18, 17                        | x64            | [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
@@ -50,7 +50,8 @@ Support for the following versions was ended by the distribution owners and are 
 |OS         | Version  | End of Life |
 |-----------|----------|-------------|
 | Windows 10| 1703     | [10/08/2019](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet) |
-| Fedora    | 29       | [11/30/2019](https://fedoraproject.org/wiki/End_of_life)   |
+| Fedora    | 30       | [26/05/2020](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/7UTUFY7WEL6RTFRXJB75XAFH44Y6RPUC/)   |
+| Fedora    | 29       | [11/26/2019](https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/BB4ECDFSJ66AQU63ZKNYROEFMMLSLFUK/)   |
 | Fedora    | 28       | [05/28/2019](https://fedoramagazine.org/fedora-28-end-of-life/)   |
 | Fedora    | 27       | [11/30/2018](https://fedoramagazine.org/fedora-27-end-of-life/)   |
 | Fedora    | 26       | [5/29/2018](https://fedoramagazine.org/fedora-26-end-life/)   |

--- a/release-notes/3.1/3.1-supported-os.md
+++ b/release-notes/3.1/3.1-supported-os.md
@@ -31,7 +31,7 @@ OS                            | Version                       | Architectures  |
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6+                            | x64            | [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy/)
 Red Hat Enterprise Linux <br> CentOS <br> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
-Fedora                        | 30+                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
+Fedora                        | 31+                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9+                       | x64, ARM32, ARM64     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 20.10, 20.04, 18.04, 16.04                  | x64, ARM32, ARM64   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)
 Linux Mint                    | 18+                          | x64            | [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)
@@ -49,6 +49,7 @@ Support for the following versions was ended by the distribution owners and are 
 |OS         | Version  | End of Life | Supported Version|
 |-----------|----------|-------------|------------------|
 | Windows 10| 1703     | [10/08/2019](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet) |
-| Alpine    | 3.8    | [05/01/2020](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases)   |
+| Fedora    | 30       | [26/05/2020](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/7UTUFY7WEL6RTFRXJB75XAFH44Y6RPUC/)   |
+| Alpine    | 3.8      | [05/01/2020](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases)   |
 | Ubuntu    | 19.04    | [01/23/2020](https://wiki.ubuntu.com/Releases)   |
 | Ubuntu    | 19.10    | [07/17/2020](https://wiki.ubuntu.com/Releases)   |

--- a/release-notes/5.0/5.0-supported-os.md
+++ b/release-notes/5.0/5.0-supported-os.md
@@ -30,7 +30,7 @@ OS                                    | Version               | Architectures   
 [Alpine Linux][Alpine]                | 3.11+                 | x64, ARM64        | [Alpine][Alpine-lifecycle]
 [CentOS][CentOS]                      | 7+                    | x64               | [CentOS][CentOS-lifecycle]
 [Debian][Debian]                      | 9+                    | x64, ARM32, ARM64 | [Debian][Debian-lifecycle]
-[Fedora][Fedora]                      | 30+                   | x64               | [Fedora][Fedora-lifecycle]
+[Fedora][Fedora]                      | 32+                   | x64               | [Fedora][Fedora-lifecycle]
 [Linux Mint][Linux-Mint]              | 18+                   | x64               | [Linux Mint][Linux-Mint-lifecycle]
 [openSUSE][OpenSUSE]                  | 15+                   | x64               | [OpenSUSE][OpenSUSE-lifecycle]
 [Red Hat Enterprise Linux][RHEL]      | 7+                    | x64               | [Red Hat][RHEL-lifecycle]


### PR DESCRIPTION
Please notice that I went a month into the future so this update also marks F31 which **will be** EOL in a little over a month. I can split it into two PRs if that's preferred.