### PR TITLE
Update releases.json

### DIFF
--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -9605,7 +9605,6 @@
           },
           {
             "name": "dotnet-sdk-win-gs-x86.exe",
-            "rid": "win-x86",
             "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x86.exe",
             "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
           },
@@ -9623,6 +9622,7 @@
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
             "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.exe",
             "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
           },

--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -9604,7 +9604,7 @@
             "hash": "1020bd17cb6587f73125f36428bd945b720ba612037f58d7bb33751b90783f6e26090e125cd1421439c167a309fb62d2c480b8ee8e9e40dee1bf33dbe0fd5d0d"
           },
           {
-            "name": "dotnet-sdk-win-x86.exe",
+            "name": "dotnet-sdk-win-gs-x86.exe",
             "rid": "win-x86",
             "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-gs-x86.exe",
             "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
@@ -9622,7 +9622,7 @@
             "hash": "405cbd7c65d63b36e3bd6bcdfc897ac6474c4eaf93db9db478a80ab511bfa7a1c4a84024cc6e4af0df0af86bcc0a1a96a8ba0864c77bf579f32bce437c28d5a8"
           },
           {
-            "name": "dotnet-sdk-win-gs-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "url": "https://download.microsoft.com/download/8/A/7/8A765126-50CA-4C6F-890B-19AE47961E4B/dotnet-sdk-2.1.402-win-x86.exe",
             "hash": "b80459549cff5e93e5c1701fa1c852124fb22fde4dc513fef46d19d9c503e17e2567c04593551cc0dc9a6f573add5b6e0e3a7eed10998dd82a95b3e10a903505"
           },


### PR DESCRIPTION
Correct 2.1.402 Win x86 entries which had mismatched names and download targets.