### PR TITLE
Revert "Update ICU breaking change in known issues with more details"

### DIFF
--- a/release-notes/5.0/5.0-known-issues.md
+++ b/release-notes/5.0/5.0-known-issues.md
@@ -17,15 +17,7 @@ This document lists known issues for **.NET 5 Preview 1 and beyond releases** wh
 1. The Microsoft.Windows.Compatibility package references dependencies that are not available at the targeted versions. To workaround, individually reference the packages your project needs. It is tracked by [dotnet/runtime/issues #34351](https://github.com/dotnet/runtime/issues/34351)
 
 ### Preview 4
-1. .NET 5.0 on Windows 10 May 2019 Update and later versions depends on ICU library for the Globalization:
-  - The returned value of System.Globalization.TextInfo.ListSeparator can return different values than it used to return. Also, sometimes can return empty string. [https://github.com/dotnet/runtime/issues/43795](https://github.com/dotnet/runtime/issues/43795)
-  - `string.IndexOf(string)`, `string.EndsWith(string)`, `string.StartsWith(string)`, `string.LastIndexOf(string)`, and `string` culture-aware comparisons can return different results for some inputs. [dotnet/runtime#43736](https://github.com/dotnet/runtime/issues/43736). We're thinking and discussing how to mitigate this long term, [dotnet/runtime#43956](https://github.com/dotnet/runtime/issues/43956).
-
-  Please read the following docs to see the motivation behind the change, workarounds and more information about how you can encounter these breaks and mitigate them:
-    - [.NET globalization and ICU](https://docs.microsoft.com/dotnet/standard/globalization-localization/globalization-icu)
-    - [Behavior changes when comparing strings on .NET5+](https://docs.microsoft.com/dotnet/standard/base-types/string-comparison-net-5-plus)
-    - [Globalization breaking changes](https://docs.microsoft.com/dotnet/core/compatibility/globalization)
-
+1. As .NET 5.0 depends on ICU library for the Globalization, the returned value of System.Globalization.TextInfo.ListSeparator can return different values than it used to return. Also, sometimes can return empty string. [https://github.com/dotnet/runtime/issues/43795](https://github.com/dotnet/runtime/issues/43795)
 
 ### Preview 6
 


### PR DESCRIPTION
Reverts dotnet/core#5530 as it is part of: https://github.com/dotnet/core-private/pull/75