### PR TITLE
Update 3.1 and 5.0 release notes to reference the new .NET Docker repos

### DIFF
--- a/release-notes/2.1/2.1.23/2.1.23-install-instructions.md
+++ b/release-notes/2.1/2.1.23/2.1.23-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/2.1/2.1.23/2.1.23-install-instructions.md
+++ b/release-notes/2.1/2.1.23/2.1.23-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/2.1/2.1.23/2.1.23.md
+++ b/release-notes/2.1/2.1.23/2.1.23.md
@@ -38,16 +38,14 @@ Note: This is not a security release hence this update won't be immediately avai
 
 ## Docker Images
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://blogs.msdn.microsoft.com/dotnet/2018/06/18/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://blogs.msdn.microsoft.com/dotnet/2018/06/18/staying-up-to-date-with-net-container-images/).
 
 The following repos have been updated
 
-* [dotnet/core/runtime](https://hub.docker.com/_/microsoft-dotnet-core-runtime/)
-* [dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/)
-* [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples)
-* [dotnet/aspnetcore](https://hub.docker.com/_/microsoft-dotnet-core-aspnet)
-
-The images are expected to be available later today.
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET Core SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Core Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Core Runtime Dependencies
 
 ## Azure AppServices
 

--- a/release-notes/2.1/2.1.23/2.1.23.md
+++ b/release-notes/2.1/2.1.23/2.1.23.md
@@ -38,9 +38,9 @@ Note: This is not a security release hence this update won't be immediately avai
 
 ## Docker Images
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://blogs.msdn.microsoft.com/dotnet/2018/06/18/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
-The following repos have been updated
+The following repos have been updated:
 
 * [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET Core SDK
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime

--- a/release-notes/2.1/2.1.23/2.1.616-download.md
+++ b/release-notes/2.1/2.1.23/2.1.616-download.md
@@ -34,7 +34,7 @@ This update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual 
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/2.1/2.1.23/2.1.616-download.md
+++ b/release-notes/2.1/2.1.23/2.1.616-download.md
@@ -34,7 +34,7 @@ This update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual 
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/2.1/2.1.23/2.1.811-download.md
+++ b/release-notes/2.1/2.1.23/2.1.811-download.md
@@ -35,7 +35,7 @@ This update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual 
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/2.1/2.1.23/2.1.811-download.md
+++ b/release-notes/2.1/2.1.23/2.1.811-download.md
@@ -35,7 +35,7 @@ This update for .NET Core 2.1 includes multiple SDK builds. If you are a Visual 
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/3.1/3.1.10/3.1.10-install-instructions.md
+++ b/release-notes/3.1/3.1.10/3.1.10-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/3.1/3.1.10/3.1.10-install-instructions.md
+++ b/release-notes/3.1/3.1.10/3.1.10-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/3.1/3.1.10/3.1.10.md
+++ b/release-notes/3.1/3.1.10/3.1.10.md
@@ -35,7 +35,7 @@ Visit [.NET Documentation](https://docs.microsoft.com/en-us/dotnet/core/) to lea
 
 ## Docker Images
 
-The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 The following repos have been updated.
 

--- a/release-notes/3.1/3.1.10/3.1.10.md
+++ b/release-notes/3.1/3.1.10/3.1.10.md
@@ -35,19 +35,14 @@ Visit [.NET Documentation](https://docs.microsoft.com/en-us/dotnet/core/) to lea
 
 ## Docker Images
 
-The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. .NET container samples are available at [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md). You can use the following command to try running the latest .NET 3.1 release in containers:
-
-```console
-docker run --rm -it mcr.microsoft.com/dotnet/samples
-```
+The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 The following repos have been updated.
 
-* [dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/): .NET Core SDK
-* [dotnet/core/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-aspnet/): ASP.NET Core Runtime
-* [dotnet/core/runtime](https://hub.docker.com/_/microsoft-dotnet-core-runtime/): .NET Core Runtime
-* [dotnet/core/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-runtime-deps/): .NET Core Runtime Dependencies
-* [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET Core SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Core Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Core Runtime Dependencies
 
 ### Azure App Services
 

--- a/release-notes/3.1/3.1.10/3.1.404-download.md
+++ b/release-notes/3.1/3.1.10/3.1.404-download.md
@@ -36,7 +36,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/3.1/3.1.10/3.1.404-download.md
+++ b/release-notes/3.1/3.1.10/3.1.404-download.md
@@ -36,7 +36,7 @@ See the [Release Notes](https://github.com/dotnet/core/blob/master/release-notes
 
 ## Docker
 
-The [.NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Core Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Installing .NET Core on Linux
 

--- a/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
+++ b/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes][release-notes] for details about what is included in thi
 
 ## Docker
 
-The [.NET Docker images](https://hub.docker.com/r/microsoft/dotnet/) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
 
 ## Install .NET on Linux
 

--- a/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
+++ b/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
@@ -10,7 +10,7 @@ See the [Release Notes][release-notes] for details about what is included in thi
 
 ## Docker
 
-The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. Details on our Docker versioning and how to work with the images can be seen in ["Staying up-to-date with .NET Container Images"](https://devblogs.microsoft.com/dotnet/staying-up-to-date-with-net-container-images/).
+The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together.
 
 ## Install .NET on Linux
 

--- a/release-notes/5.0/5.0.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0/5.0.0.md
@@ -29,7 +29,7 @@ Visit [.NET Documentation](https://docs.microsoft.com/en-us/dotnet/core/) to lea
 
 ## Docker Images
 
-The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. .NET container samples are available at [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md). You can use the following command to try running the latest .NET 5.0 release in containers:
+The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET and Docker together. You can use the following command to try running the latest .NET 5.0 release in containers:
 
 ```console
 docker run --rm mcr.microsoft.com/dotnet/samples

--- a/release-notes/5.0/5.0.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0/5.0.0.md
@@ -32,16 +32,16 @@ Visit [.NET Documentation](https://docs.microsoft.com/en-us/dotnet/core/) to lea
 The [.NET Docker images](https://hub.docker.com/_/microsoft-dotnet) have been updated for this release. .NET container samples are available at [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md). You can use the following command to try running the latest .NET 5.0 release in containers:
 
 ```console
-docker run --rm -it mcr.microsoft.com/dotnet/samples
+docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
 The following repos have been updated.
 
-* [dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/): .NET Core SDK
-* [dotnet/core/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-aspnet/): ASP.NET Core Runtime
-* [dotnet/core/runtime](https://hub.docker.com/_/microsoft-dotnet-core-runtime/): .NET Core Runtime
-* [dotnet/core/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-runtime-deps/): .NET Core Runtime Dependencies
-* [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
 ## Visual Studio Compatibility
 


### PR DESCRIPTION
With the 5.0 release, the .NET Docker repos were renamed to align with the new branding which drops "core" from the name.  See https://github.com/dotnet/dotnet-docker/issues/2375 for details.  With this PR, I have updated the most recent release notes for each of the supported channels to reference the new repos.  The old repos links will still work via redirect but it is better to use the new links going forward.