### PR TITLE
Fix formatting issue causing misunderstanding

### DIFF
--- a/release-notes/5.0/5.0.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0/5.0.0.md
@@ -12,6 +12,7 @@ The .NET 5.0.0 and .NET SDK 5.0.100 releases are available for download. The lat
 |  | [Checksums][checksums-sdk]                             | [Checksums][checksums-sdk]                                      | [Checksums][checksums-runtime]                             | [Checksums][checksums-runtime]  | [Checksums][checksums-runtime]  | [Checksums][checksums-runtime]
 
 </br>
+
 1. Includes the .NET Runtime and ASP.NET Core Runtime
 2. For hosting stand-alone apps on Windows Servers. Includes the ASP.NET Core Module for IIS and can be installed separately on servers without installing .NET Runtime.
 

--- a/release-notes/5.0/5.0.1/5.0.1.md
+++ b/release-notes/5.0/5.0.1/5.0.1.md
@@ -12,6 +12,7 @@ The .NET 5.0.1 and .NET SDK 5.0.101 releases are available for download. The lat
 |  | [Checksums][checksums-sdk]                             | [Checksums][checksums-sdk]                                      | [Checksums][checksums-runtime]                             | [Checksums][checksums-runtime]  | [Checksums][checksums-runtime]  | [Checksums][checksums-runtime]
 
 </br>
+
 1. Includes the .NET Runtime and ASP.NET Core Runtime
 2. For hosting stand-alone apps on Windows Servers. Includes the ASP.NET Core Module for IIS and can be installed separately on servers without installing .NET Runtime.
 


### PR DESCRIPTION
The markdown list needs at least one empty line above it for a markdown renderer to display it as a list. Without the empty line, it is interpreted as a paragraph. This caused the "2" to look like a version number after "ASP.NET Core Runtime". See the issue for a screenshot. 

Fixes #5721 