### PR TITLE
Update core-repos.md

### DIFF
--- a/Documentation/core-repos.md
+++ b/Documentation/core-repos.md
@@ -25,7 +25,7 @@
 
 |Repository                                                        |Description |
 |------------------------------------------------------------------|------------|
-|[microsoft/dotnet](https://github.com/microsoft/dotnet) |Catch-all repository for .NET (where most .NET Framework issues are filed)|
+|[Dev Community](https://developercommunity.visualstudio.com/spaces/61/index.html) |Catch-all repository for .NET (where most .NET Framework issues are filed)|
 |[microsoft/dotnet-framework-docker](https://github.com/microsoft/dotnet-framework-docker) |.NET Framework Docker images|
 
 ## .NET Standard


### PR DESCRIPTION
[microsoft/dotnet] (https://github.com/microsoft/dotnet/issues) is not being monitored and we are moving issues to the respective repos as mentioned [microsoft/dotnet#1275](https://github.com/microsoft/dotnet/issues/1275). Changing the Framework issue reporting location.