### PR TITLE
fixed markdown formatting

### DIFF
--- a/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
+++ b/release-notes/5.0/5.0.0/5.0.0-install-instructions.md
@@ -59,7 +59,7 @@ If you only need to run existing applications, run the following command. The .N
 ```bash
 sudo [package manager] update or refresh
 sudo [package manager] install aspnetcore-runtime-5.0
-
+```
 ### Installation from a binary archive
 
 Installing from the packages detailed above is recommended or you can install from binary archive, if that better suits your needs. When using binary archives to install, the contents must be extracted to a user location such as `$HOME/dotnet`, a symbolic link created for `dotnet` and a few dependencies installed. Dependency requirements can be seen in the [Linux System Prerequisites](https://github.com/dotnet/core/blob/master/Documentation/linux-prereqs.md) document.

--- a/release-notes/5.0/5.0.1/5.0.1-install-instructions.md
+++ b/release-notes/5.0/5.0.1/5.0.1-install-instructions.md
@@ -59,7 +59,7 @@ If you only need to run existing applications, run the following command. The .N
 ```bash
 sudo [package manager] update or refresh
 sudo [package manager] install aspnetcore-runtime-5.0
-
+```
 ### Installation from a binary archive
 
 Installing from the packages detailed above is recommended or you can install from binary archive, if that better suits your needs. When using binary archives to install, the contents must be extracted to a user location such as `$HOME/dotnet`, a symbolic link created for `dotnet` and a few dependencies installed. Dependency requirements can be seen in the [Linux System Prerequisites](https://github.com/dotnet/core/blob/master/Documentation/linux-prereqs.md) document.

--- a/release-notes/5.0/5.0.2/5.0.2-install-instructions.md
+++ b/release-notes/5.0/5.0.2/5.0.2-install-instructions.md
@@ -59,7 +59,7 @@ If you only need to run existing applications, run the following command. The .N
 ```bash
 sudo [package manager] update or refresh
 sudo [package manager] install aspnetcore-runtime-5.0
-
+```
 ### Installation from a binary archive
 
 Installing from the packages detailed above is recommended or you can install from binary archive, if that better suits your needs. When using binary archives to install, the contents must be extracted to a user location such as `$HOME/dotnet`, a symbolic link created for `dotnet` and a few dependencies installed. Dependency requirements can be seen in the [Linux System Prerequisites](https://github.com/dotnet/core/blob/master/Documentation/linux-prereqs.md) document.

--- a/release-notes/5.0/5.0.3/5.0.3-install-instructions.md
+++ b/release-notes/5.0/5.0.3/5.0.3-install-instructions.md
@@ -61,7 +61,7 @@ If you only need to run existing applications, run the following command. The .N
 ```bash
 sudo [package manager] update or refresh
 sudo [package manager] install aspnetcore-runtime-5.0
-
+```
 ### Installation from a binary archive
 
 Installing from the packages detailed above is recommended or you can install from binary archive, if that better suits your needs. When using binary archives to install, the contents must be extracted to a user location such as `$HOME/dotnet`, a symbolic link created for `dotnet` and a few dependencies installed. Dependency requirements can be seen in the [Linux System Prerequisites](https://github.com/dotnet/core/blob/master/Documentation/linux-prereqs.md) document.


### PR DESCRIPTION
in the release notes for v5.0.* it looks like someone missed 3 backticks which caused a section to become formatted as bash code.