### PR TITLE
remove windowsdesktop winarm64 from 5.0

### DIFF
--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -488,12 +488,6 @@
         "version-display": "5.0.4",
         "files": [
           {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9972cac4-3605-46f0-933f-7e62a19bf6c3/64c60574923619b1aa3a4eb711d8722c/windowsdesktop-runtime-5.0.4-win-arm64.exe",
-            "hash": "f764625ae45b42e5d05f5ba076bfda88c397c0b02472349eab311883b7baeb72c5afcf98add94cfba5e5cbf9975a156e74e555b232280af6daeb36bd8cfc8bab"
-          },
-          {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
             "url": "https://download.visualstudio.microsoft.com/download/pr/7a5d15ae-0487-428d-8262-2824279ccc00/6a10ce9e632bce818ce6698d9e9faf39/windowsdesktop-runtime-5.0.4-win-x64.exe",


### PR DESCRIPTION
win-arm64 windowsdesktop packages are not quite ready for publishing.