### PR TITLE
Add runtime platform deps for .NET 6

### DIFF
--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -530,7 +530,7 @@
               "usage": "printing"
             },
             {
-              "name": "libgdiplus:6.0.1",
+              "name": "libgdiplus0:6.0.1",
               "dependencyType": "LinuxPackage",
               "usage": "default"
             },

--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -409,11 +409,6 @@
           "type": "Framework",
           "platformDependencies": [
             {
-              "name": "Core Foundation",
-              "dependencyType": "MacOSFramework",
-              "usage": "default"
-            },
-            {
               "name": "libobjc.dylib",
               "dependencyType": "Library",
               "usage": "default"
@@ -421,11 +416,6 @@
             {
               "name": "libproc.dylib",
               "dependencyType": "Library",
-              "usage": "default"
-            },
-            {
-              "name": "System Configuration",
-              "dependencyType": "MacOSFramework",
               "usage": "default"
             }
           ]
@@ -456,11 +446,6 @@
           "name": "System.Drawing.Common",
           "type": "NuGetPackage",
           "platformDependencies": [
-            {
-              "name": "Carbon Framework",
-              "dependencyType": "MacOSFramework",
-              "usage": "default"
-            },
             {
               "name": "libgdiplus.dylib:6.0.1",
               "dependencyType": "Library",

--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -305,7 +305,7 @@
               "usage": "default"
             },
             {
-              "name": "libx11-dev",
+              "name": "libX11-devel",
               "dependencyType": "LinuxPackage",
               "usage": "xwindows"
             }
@@ -393,7 +393,7 @@
               "usage": "default"
             },
             {
-              "name": "libx11-dev",
+              "name": "libX11-devel",
               "dependencyType": "LinuxPackage",
               "usage": "xwindows"
             }
@@ -535,7 +535,7 @@
               "usage": "default"
             },
             {
-              "name": "libx11-dev",
+              "name": "libX11-devel",
               "dependencyType": "LinuxPackage",
               "usage": "xwindows"
             }
@@ -623,7 +623,7 @@
               "usage": "default"
             },
             {
-              "name": "libx11-dev",
+              "name": "libX11-devel",
               "dependencyType": "LinuxPackage",
               "usage": "xwindows"
             }

--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -980,6 +980,11 @@
               "usage": "default"
             },
             {
+              "name": "gdiplus.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
               "name": "winspool.drv",
               "dependencyType": "DeviceDriver",
               "usage": "printing"

--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -3,7 +3,6 @@
   "dependencyUsages": {
     "default": "Used by default or for canonical scenarios",
     "diagnostics": "Used for diagnostic scenarios such as tracing or debugging",
-    "graphics": "Used for scenarios involving graphics/drawing/fonts",
     "http.sys": "Used to access the HTTP.sys listener in Windows",
     "localization": "Used for locale and culture scenarios",
     "media": "Used for multimedia scenarios",

--- a/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
+++ b/release-notes/6.0/preview/6.0.0-preview.4-runtime-deps.json
@@ -1,0 +1,1035 @@
+{
+  "dotnetReleaseVersion": "6.0.0-preview.4",
+  "dependencyUsages": {
+    "default": "Used by default or for canonical scenarios",
+    "diagnostics": "Used for diagnostic scenarios such as tracing or debugging",
+    "graphics": "Used for scenarios involving graphics/drawing/fonts",
+    "http.sys": "Used to access the HTTP.sys listener in Windows",
+    "localization": "Used for locale and culture scenarios",
+    "media": "Used for multimedia scenarios",
+    "printing": "Used for printing to printers",
+    "security": "Used for security scenarios",
+    "xwindows": "Used to access the X Window System of a Linux or Unix-based system"
+  },
+  "platforms": [
+    {
+      "rid": "alpine",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "icu-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "krb5-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libintl",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libssl1.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "lttng-ust",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "tzdata",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib1g",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "cups",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "debian",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "libc6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgssapi-krb5-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libicu57",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "liblttng-ust0",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "libssl1.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "tzdata",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib1g",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap-2.4-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libcups2",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ],
+      "platforms": [
+        {
+          "rid": "debian.10",
+          "components": [
+            {
+              "name": "Microsoft.NETCore.App",
+              "type": "Framework",
+              "platformDependencies": [
+                {
+                  "name": "libicu63",
+                  "overrides": {
+                    "name": "libicu57",
+                    "dependencyType": "LinuxPackage"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "rid": "debian.11",
+          "components": [
+            {
+              "name": "Microsoft.NETCore.App",
+              "type": "Framework",
+              "platformDependencies": [
+                {
+                  "name": "libicu67",
+                  "overrides": {
+                    "name": "libicu57",
+                    "dependencyType": "LinuxPackage"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "fedora",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "glibc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "krb5-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libicu",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "lttng-ust",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "openssl-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "tzdata",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "openldap",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "cups-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "opensuse",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "glibc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "icu",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "krb5",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc_s1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "liblttng-ust0",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "libopenssl1_0_0 || libopenssl1_1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "timezone",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap-2_4-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libcups2",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus0:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "osx",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "Core Foundation",
+              "dependencyType": "MacOSFramework",
+              "usage": "default"
+            },
+            {
+              "name": "libobjc.dylib",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "libproc.dylib",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "System Configuration",
+              "dependencyType": "MacOSFramework",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Data.Odbc",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libodbc.2.dylib",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap.dylib",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "Carbon Framework",
+              "dependencyType": "MacOSFramework",
+              "usage": "default"
+            },
+            {
+              "name": "libgdiplus.dylib:6.0.1",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "rhel",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "glibc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "krb5-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libicu",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "lttng-ust",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "openssl-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "tzdata",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "openldap",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "cups-libs",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "sles",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "glibc",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc_s1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "krb5",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "icu",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "liblttng-ust0",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "libopenssl1_0_0 || libopenssl1_1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "timeszone",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap-2_4-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libcups2",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus0:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "ubuntu",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "libc6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgcc1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libgssapi-krb5-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libicu60",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "liblttng-ust0",
+              "dependencyType": "LinuxPackage",
+              "usage": "diagnostics"
+            },
+            {
+              "name": "libssl1.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libstdc++6",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "tzdata",
+              "dependencyType": "LinuxPackage",
+              "usage": "localization"
+            },
+            {
+              "name": "zlib1g",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libldap-2.4-2",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "libcups2",
+              "dependencyType": "LinuxPackage",
+              "usage": "printing"
+            },
+            {
+              "name": "libgdiplus:6.0.1",
+              "dependencyType": "LinuxPackage",
+              "usage": "default"
+            },
+            {
+              "name": "libx11-dev",
+              "dependencyType": "LinuxPackage",
+              "usage": "xwindows"
+            }
+          ]
+        }
+      ],
+      "platforms": [
+        {
+          "rid": "ubuntu.20.04",
+          "components": [
+            {
+              "name": "Microsoft.NETCore.App",
+              "type": "Framework",
+              "platformDependencies": [
+                {
+                  "name": "libicu66",
+                  "overrides": {
+                    "name": "libicu60",
+                    "dependencyType": "LinuxPackage"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rid": "win",
+      "components": [
+        {
+          "name": "Microsoft.NETCore.App",
+          "type": "Framework",
+          "platformDependencies": [
+            {
+              "name": "advapi32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "bcrypt.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "crypt32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "httpapi.dll",
+              "dependencyType": "Library",
+              "usage": "http.sys"
+            },
+            {
+              "name": "iphlpapi.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "kernel32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "mswsock.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "ncrypt.dll",
+              "dependencyType": "Library",
+              "usage": "security"
+            },
+            {
+              "name": "normaliz.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "ntdll.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "ole32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "oleaut32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "secur32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "shell32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "sspicli.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "user32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "version.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "websocket.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "winhttp.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "ws2_32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "Microsoft.Win32.SystemEvents",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "wtsapi32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Data.Odbc",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "odbc32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Diagnostics.EventLog",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "wevtapi.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Diagnostics.PerformanceCounter",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "pdh.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "activeds.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "dnsapi.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "netapi32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.AccountManagement",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "activeds.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "authz.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "credui.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "dsrole.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "logoncli.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "netutils.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "wkscli.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.DirectoryServices.Protocols",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "wldap32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Drawing.Common",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "comdlg32.dll",
+              "dependencyType": "Library",
+              "usage": "printing"
+            },
+            {
+              "name": "gdi32.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "winspool.drv",
+              "dependencyType": "DeviceDriver",
+              "usage": "printing"
+            }
+          ]
+        },
+        {
+          "name": "System.Speech",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "winmm.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
+          "name": "System.Windows.Extensions",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "cryptui.dll",
+              "dependencyType": "Library",
+              "usage": "security"
+            },
+            {
+              "name": "winmm.dll",
+              "dependencyType": "Library",
+              "usage": "media"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/6.0/runtime-deps.json
+++ b/release-notes/6.0/runtime-deps.json
@@ -347,6 +347,7 @@
             },
             {
               "name": "libopenssl1_0_0 || libopenssl1_1",
+              "id": "libopenssl",
               "dependencyType": "LinuxPackage",
               "usage": "default"
             },
@@ -577,6 +578,7 @@
             },
             {
               "name": "libopenssl1_0_0 || libopenssl1_1",
+              "id": "libopenssl",
               "dependencyType": "LinuxPackage",
               "usage": "default"
             },

--- a/release-notes/6.0/runtime-deps.json
+++ b/release-notes/6.0/runtime-deps.json
@@ -197,7 +197,7 @@
                 {
                   "name": "libicu63",
                   "overrides": {
-                    "name": "libicu57",
+                    "id": "libicu57",
                     "dependencyType": "LinuxPackage"
                   }
                 }
@@ -215,7 +215,7 @@
                 {
                   "name": "libicu67",
                   "overrides": {
-                    "name": "libicu57",
+                    "id": "libicu57",
                     "dependencyType": "LinuxPackage"
                   }
                 }
@@ -729,7 +729,7 @@
                 {
                   "name": "libicu66",
                   "overrides": {
-                    "name": "libicu60",
+                    "id": "libicu60",
                     "dependencyType": "LinuxPackage"
                   }
                 }

--- a/release-notes/6.0/runtime-deps.json
+++ b/release-notes/6.0/runtime-deps.json
@@ -8,6 +8,7 @@
     "media": "Used for multimedia scenarios",
     "printing": "Used for printing to printers",
     "security": "Used for security scenarios",
+    "dtc-transactions": "Used for DTC transactions",
     "xwindows": "Used to access the X Window System of a Linux or Unix-based system"
   },
   "platforms": [
@@ -784,6 +785,11 @@
               "usage": "default"
             },
             {
+              "name": "msxactps.dll",
+              "dependencyType": "Library",
+              "usage": "dtc-transactions"
+            },
+            {
               "name": "ncrypt.dll",
               "dependencyType": "Library",
               "usage": "security"
@@ -994,13 +1000,39 @@
           ]
         },
         {
+          "name": "System.Management",
+          "type": "NuGetPackage",
+          "platformDependencies": [
+            {
+              "name": "fastprox.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "wbemsvc.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            },
+            {
+              "name": "wmiutils.dll",
+              "dependencyType": "Library",
+              "usage": "default"
+            }
+          ]
+        },
+        {
           "name": "System.Speech",
           "type": "NuGetPackage",
           "platformDependencies": [
             {
-              "name": "winmm.dll",
+              "name": "sapi.dll",
               "dependencyType": "Library",
               "usage": "default"
+            },
+            {
+              "name": "winmm.dll",
+              "dependencyType": "Library",
+              "usage": "media"
             }
           ]
         },

--- a/release-notes/6.0/runtime-deps.json
+++ b/release-notes/6.0/runtime-deps.json
@@ -1,5 +1,5 @@
 {
-  "dotnetReleaseVersion": "6.0.0-preview.4",
+  "productVersion": "6.0",
   "dependencyUsages": {
     "default": "Used by default or for canonical scenarios",
     "diagnostics": "Used for diagnostic scenarios such as tracing or debugging",

--- a/release-notes/6.0/runtime-deps.json
+++ b/release-notes/6.0/runtime-deps.json
@@ -16,7 +16,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "icu-libs",
@@ -104,7 +104,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "libc6",
@@ -192,7 +192,7 @@
           "components": [
             {
               "name": "Microsoft.NETCore.App",
-              "type": "Framework",
+              "type": "SharedFramework",
               "platformDependencies": [
                 {
                   "name": "libicu63",
@@ -210,7 +210,7 @@
           "components": [
             {
               "name": "Microsoft.NETCore.App",
-              "type": "Framework",
+              "type": "SharedFramework",
               "platformDependencies": [
                 {
                   "name": "libicu67",
@@ -230,7 +230,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "glibc",
@@ -318,7 +318,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "glibc",
@@ -406,7 +406,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "libobjc.dylib",
@@ -460,7 +460,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "glibc",
@@ -548,7 +548,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "glibc",
@@ -636,7 +636,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "libc6",
@@ -724,7 +724,7 @@
           "components": [
             {
               "name": "Microsoft.NETCore.App",
-              "type": "Framework",
+              "type": "SharedFramework",
               "platformDependencies": [
                 {
                   "name": "libicu66",
@@ -744,7 +744,7 @@
       "components": [
         {
           "name": "Microsoft.NETCore.App",
-          "type": "Framework",
+          "type": "SharedFramework",
           "platformDependencies": [
             {
               "name": "advapi32.dll",


### PR DESCRIPTION
Related to https://github.com/dotnet/core/issues/5646

Defines all of .NET's runtime platform dependencies for Linux, Windows, and macOS.  This uses the [platform dependency schema](https://github.com/dotnet/designs/blob/main/accepted/2021/platform-dependencies/platform-dependencies.md#schema).

This relies on the RID inheritance model.  For example, RHEL and CentOS have the same package dependencies and the `centos` RID inherits from `rhel`.  So in the dependency model, I defined dependencies just for the `rhel` RID which would be implicitly inherited by `centos`.

I decided not to include any Windows desktop UI packages such as WPF and WinForms because I didn't see much benefit to having them. One of the main reasons for tracking Windows dependencies is to differentiate what libraries exist between the different Windows variants (Windows Server, Windows desktop, Windows Server Core, and Nano Server).  Since Windows Server Core and Nano Server are headless, using the desktop UI packages isn't really an option.  And the remaining variants, Windows Server and Windows desktop, provide all the necessary dependencies.  Based on that, producing an itemized list of what those dependencies are seems like a lot of work without much benefit.  We can re-evaluate later if we determine there's a need.

I won't actually merge this until Preview 4 ships.