### PR TITLE
FIx broken link for net6 preview7

### DIFF
--- a/release-notes/6.0/preview/api-diff/preview7/README.md
+++ b/release-notes/6.0/preview/api-diff/preview7/README.md
@@ -2,6 +2,6 @@
 
 The following API changes were made in .NET 6.0 Preview 7:
 
-- [.NET](./.Net/6.0-preview7.md)
+- [.NET](./.Net/6.0.0-preview7.md)
 - [ASP.NET](./Asp.Net/6.0-preview7.md)
 - [WindowsDesktop](./WindowsDesktop/6.0-preview7.md)


### PR DESCRIPTION
First link here https://github.com/dotnet/core/tree/main/release-notes/6.0/preview/api-diff/preview7 (.NET) is missing `-0` and hence is broken. This PR fixes that.