### PR TITLE
Fix .NET 6.0 install instructions supported OS links

### DIFF
--- a/release-notes/6.0/install-linux.md
+++ b/release-notes/6.0/install-linux.md
@@ -35,7 +35,7 @@ Preview release installers are not available from the Microsoft package reposito
 
 Here's what the script does.
 
-* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0-supported-os.md).
+* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 * Determines if additional system dependencies or utilities are needed to successfully complete and install them. For example, `tar` is used to unpack that installer packages.
 * Downloads the tar.gz containing the .NET preview installer packages for the detected distribution.
 * Downloads the system dependency installer, if needed.

--- a/release-notes/6.0/preview/6.0.0-preview.1-install-instructions.md
+++ b/release-notes/6.0/preview/6.0.0-preview.1-install-instructions.md
@@ -40,7 +40,7 @@ Preview release installers are not available from the Microsoft package reposito
 
 Here's what the script does.
 
-* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0-supported-os.md).
+* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 * Determines if additional system dependencies or utilities are needed to successfully complete and install them. For example `tar` is used to unpack that installer packages.
 * Downloads the tar.gz containing the .NET preview installer packages for the detected distribution.
 * Downloads the system dependency installer, if needed.

--- a/release-notes/6.0/preview/6.0.0-preview.2-install-instructions.md
+++ b/release-notes/6.0/preview/6.0.0-preview.2-install-instructions.md
@@ -41,7 +41,7 @@ Preview release installers are not available from the Microsoft package reposito
 
 Here's what the script does.
 
-* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0-supported-os.md).
+* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 * Determines if additional system dependencies or utilities are needed to successfully complete and install them. For example `tar` is used to unpack that installer packages.
 * Downloads the tar.gz containing the .NET preview installer packages for the detected distribution.
 * Downloads the system dependency installer, if needed.

--- a/release-notes/6.0/preview/6.0.0-preview.3-install-instructions.md
+++ b/release-notes/6.0/preview/6.0.0-preview.3-install-instructions.md
@@ -41,7 +41,7 @@ Preview release installers are not available from the Microsoft package reposito
 
 Here's what the script does.
 
-* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0-supported-os.md).
+* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 * Determines if additional system dependencies or utilities are needed to successfully complete and install them. For example `tar` is used to unpack that installer packages.
 * Downloads the tar.gz containing the .NET preview installer packages for the detected distribution.
 * Downloads the system dependency installer, if needed.

--- a/release-notes/6.0/preview/6.0.0-preview.4-install-instructions.md
+++ b/release-notes/6.0/preview/6.0.0-preview.4-install-instructions.md
@@ -41,7 +41,7 @@ Preview release installers are not available from the Microsoft package reposito
 
 Here's what the script does.
 
-* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0-supported-os.md).
+* Detects the distribution and version. The script supports platforms and versions listed in [.NET 6.0 - Supported OS versions](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 * Determines if additional system dependencies or utilities are needed to successfully complete and install them. For example `tar` is used to unpack that installer packages.
 * Downloads the tar.gz containing the .NET preview installer packages for the detected distribution.
 * Downloads the system dependency installer, if needed.


### PR DESCRIPTION
All the Linux install instructions for .NET 6.0 point to an incorrect link for supported os'.
This pr points them to the correct location.