### PR TITLE
Indicate that macOS 10.13 support was dropped

### DIFF
--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -97,6 +97,6 @@ None yet.
 
 Support for the following versions was ended by the distribution owners and are [no longer supported by .NET 6.0][OS-lifecycle-policy].
 
-None yet.
+* macOS 10.13
 
 [OS-lifecycle-policy]: https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md


### PR DESCRIPTION
macOS 10.13 was supported in .NET 5, however .NET 6 drops support for macOS 10.13 and makes the minimum 10.14.

This changes the "Out of support OS versions" to indicate that 6.0 dropped support for macOS 10.13.