### PR TITLE
Update 5.0.10.md to fix link for blog roundup

### DIFF
--- a/release-notes/5.0/5.0.10/5.0.10.md
+++ b/release-notes/5.0/5.0.10/5.0.10.md
@@ -77,7 +77,7 @@ Your feedback is important and appreciated. We've created an issue at [dotnet/co
 [linux-install]: https://docs.microsoft.com/dotnet/core/install/linux
 [linux-setup]: https://github.com/dotnet/core/blob/main/Documentation/linux-setup.md
 
-[dotnet-blog]:  https://devblogs.microsoft.com/dotnet/net-september-2021/
+[dotnet-blog]:  https://devblogs.microsoft.com/dotnet/september-2021-updates/ 
 
 [sdk_bugs]: https://github.com/dotnet/sdk/issues?q=is%3Aissue+is%3Aclosed+milestone%3A5.0.10xx+is%3Aclosed
 


### PR DESCRIPTION
Correct bad link to Blog Roundup to https://devblogs.microsoft.com/dotnet/september-2021-updates/.  Bad link was https://devblogs.microsoft.com/dotnet/net-september-2021/