### PR TITLE
Mark v2.1 as EOL in releases.json

### DIFF
--- a/release-notes/2.1/releases.json
+++ b/release-notes/2.1/releases.json
@@ -4,7 +4,7 @@
   "latest-release-date": "2021-08-19",
   "latest-runtime": "2.1.30",
   "latest-sdk": "2.1.818",
-  "support-phase": "lts",
+  "support-phase": "eol",
   "eol-date": "2021-08-21",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -55,7 +55,7 @@
             "latest-runtime": "2.1.30",
             "latest-sdk": "2.1.818",
             "product": ".NET Core",
-            "support-phase": "lts",
+            "support-phase": "eol",
             "eol-date": "2021-08-21",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
         },


### PR DESCRIPTION
Because it has been EOL for a while now 😉