### PR TITLE
Add missing cve-list property for 5.0.11.

### DIFF
--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -11,6 +11,12 @@
       "release-date": "2021-10-12",
       "release-version": "5.0.11",
       "security": true,
+      "cve-list": [
+        {
+          "cve-id": "CVE-2021-41355",
+          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41355"
+        }
+      ],
       "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.11/5.0.11.md",
       "runtime": {
         "version": "5.0.11",


### PR DESCRIPTION
Add CVE for security vulnerability fixed in 5.0.11.

I found this because I have [some automation](https://github.com/martincostello/update-dotnet-sdk/blob/d2510572b5337b318655715c49ab601a0187510b/src/DotNetSdkUpdater.ts#L294-L303) that doesn't check for the list not being present, which broke it.

I'll make it more resilient to that in the future, but seems to make sense to add this anyway to match other releases.

/cc @rbhanda 