### PR TITLE
[release notes] List the correct workload names

### DIFF
--- a/release-notes/6.0/preview/6.0.0-rc.2.md
+++ b/release-notes/6.0/preview/6.0.0-rc.2.md
@@ -58,11 +58,11 @@ $ dotnet workload install maui
 The following workloads are also available to install individually:
 
 ```console
-$ dotnet workload install microsoft-android-sdk-full
-$ dotnet workload install microsoft-ios-sdk-full
-$ dotnet workload install microsoft-maccatalyst-sdk-full
-$ dotnet workload install microsoft-macos-sdk-full
-$ dotnet workload install microsoft-tvos-sdk-full
+$ dotnet workload install android
+$ dotnet workload install ios
+$ dotnet workload install maccatalyst
+$ dotnet workload install macos
+$ dotnet workload install tvos
 ```
 
 </br>


### PR DESCRIPTION
We renamed these workloads to be more user-friendly.

You can see the full list with:

    > dotnet workload search
    
    Workload ID           Description
    -------------------------------------------------------------------------------------------
    android               .NET SDK Workload for building Android applications.
    android-aot           .NET SDK Workload for building Android applications with AOT support.
    ios                   .NET SDK Workload for building iOS applications.
    maccatalyst           .NET SDK Workload for building macOS applications with MacCatalyst.
    macos                 .NET SDK Workload for building macOS applications.
    maui                  .NET MAUI SDK for all platforms
    maui-android          .NET MAUI SDK for Android
    maui-desktop          .NET MAUI SDK for Desktop
    maui-ios              .NET MAUI SDK for iOS
    maui-maccatalyst      .NET MAUI SDK for Mac Catalyst
    maui-mobile           .NET MAUI SDK for Mobile
    maui-windows          .NET MAUI SDK for Windows
    tvos                  .NET SDK Workload for building tvOS applications.
    wasm-tools            .NET WebAssembly build tools