### PR TITLE
Update 6.0.0-rc.2.md

### DIFF
--- a/release-notes/6.0/preview/6.0.0-rc.2.md
+++ b/release-notes/6.0/preview/6.0.0-rc.2.md
@@ -106,7 +106,7 @@ Your feedback is important and appreciated. We've created an issue at [dotnet/co
 [linux-install]: https://docs.microsoft.com/dotnet/core/install/linux
 [linux-setup]: https://github.com/dotnet/core/blob/main/Documentation/linux-setup.md
 
-[dotnet-blog]:  https://devblogs.microsoft.com/dotnet/announcing-net-6-rc2/
+[dotnet-blog]:  https://devblogs.microsoft.com/dotnet/announcing-net-6-release-candidate-2/
 [aspnet-blog]:  https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-rc-2
 [maui-blog]: https://devblogs.microsoft.com/dotnet/update-on-dotnet-maui/
 [ef_bugs]: https://github.com/dotnet/efcore/issues?q=is%3Aissue+milestone%3A6.0.0-rc2+is%3Aclosed+label%3Atype-bug


### PR DESCRIPTION
The link to the .NET blog is wrong

Should be 

https://devblogs.microsoft.com/dotnet/announcing-net-6-release-candidate-2/

not 

https://devblogs.microsoft.com/dotnet/announcing-net-6-rc2/