### PR TITLE
Update releases.json for 5.0 with EOL date

### DIFF
--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -5,6 +5,7 @@
   "latest-runtime": "5.0.11",
   "latest-sdk": "5.0.402",
   "support-phase": "current",
+  "eol-date": "2022-05",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [
     {


### PR DESCRIPTION
Site is now ready to support the EOL with month and year only