### PR TITLE
Correct filename/version in two links

### DIFF
--- a/release-notes/6.0/preview/api-diff/rc1/README.md
+++ b/release-notes/6.0/preview/api-diff/rc1/README.md
@@ -3,5 +3,5 @@
 The following API changes were made in .NET 6.0 RC1:
 
 - [.NET](./.Net/6.0.0-rc1.md)
-- [ASP.NET](./Asp.Net/6.0-rc1.md)
-- [WindowsDesktop](./WindowsDesktop/6.0-rc1.md)
+- [ASP.NET](./Asp.Net/6.0.0-rc1.md)
+- [WindowsDesktop](./WindowsDesktop/6.0.0-rc1.md)


### PR DESCRIPTION
- Corrected the filename/version in link to ASP.NET and WindowsDesktop. 
- Link to '.NET' was already correct.