### PR TITLE
Remove link to nonexistent VSCode Extension

### DIFF
--- a/Documentation/microsoft-team.md
+++ b/Documentation/microsoft-team.md
@@ -42,7 +42,6 @@ The following tool makes it easier to use open source and participate in open-so
 
 * [Browser Extension](https://docs.opensource.microsoft.com/tools/browser.html) -- Identifies Microsoft employees on GitHub.
 
-The browser extension is recommended.
 ## Get write permissions to repos (optional)
 
 Join teams to gain write access to repos:

--- a/Documentation/microsoft-team.md
+++ b/Documentation/microsoft-team.md
@@ -43,7 +43,6 @@ The following tool makes it easier to use open source and participate in open-so
 * [Browser Extension](https://docs.opensource.microsoft.com/tools/browser.html) -- Identifies Microsoft employees on GitHub.
 
 The browser extension is recommended.
-
 ## Get write permissions to repos (optional)
 
 Join teams to gain write access to repos:

--- a/Documentation/microsoft-team.md
+++ b/Documentation/microsoft-team.md
@@ -41,9 +41,8 @@ After you join the teams:
 The tools make it easier to use open source and participate in open source projects:
 
 * [Browser Extension](https://docs.opensource.microsoft.com/tools/browser.html) -- Identifies Microsoft employees on GitHub.
-* [VS Code Extension](https://docs.opensource.microsoft.com/tools/vscode.html) --  Provides information about known vulnerabilities.
 
-The browser extension is recommended. The VS code extension is optional.
+The browser extension is recommended.
 
 ## Get write permissions to repos (optional)
 

--- a/Documentation/microsoft-team.md
+++ b/Documentation/microsoft-team.md
@@ -38,7 +38,7 @@ After you join the teams:
 
 ## Install Microsoft open source tools (recommended)
 
-The tools make it easier to use open source and participate in open source projects:
+The following tool makes it easier to use open source and participate in open-source projects:
 
 * [Browser Extension](https://docs.opensource.microsoft.com/tools/browser.html) -- Identifies Microsoft employees on GitHub.
 


### PR DESCRIPTION
The extension appears to be discontinued, per this message:

> Sorry, the VSCode extension (in internal preview release in 2018-2019) is no longer available.
>
> The Open Source Engineering team hopes to offer a similar set of shift-left experiences in the future. For more information, please contact OpenSourceEngSupport@microsoft.com.

Given that, we should remove this link.