### PR TITLE
Use correct null value for preview eol-date

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -9,7 +9,7 @@
             "latest-sdk": "7.0.100-preview.1.22110.4",
             "product": ".NET",
             "support-phase": "preview",
-            "eol-date": "null",
+            "eol-date": null,
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json"
         },
         {


### PR DESCRIPTION
Per [the schema](https://github.com/dotnet/deployment-tools/blob/main/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs#L40-L44) this value can be null, but not "null".

Closes https://github.com/dotnet/sdk/issues/23998