### PR TITLE
Update Alpine arm32 minimum version to 3.13

### DIFF
--- a/release-notes/5.0/5.0-supported-os.md
+++ b/release-notes/5.0/5.0-supported-os.md
@@ -29,6 +29,7 @@ OS                                    | Version                 | Architectures 
 OS                                    | Version               | Architectures     | Lifecycle
 --------------------------------------|-----------------------|-------------------|----------
 [Alpine Linux][Alpine]                | 3.12+                 | x64, Arm64        | [Alpine][Alpine-lifecycle]
+&nbsp;                                | 3.13+                 | Arm32             |
 [CentOS][CentOS]                      | 7+                    | x64               | [CentOS][CentOS-lifecycle]
 [Debian][Debian]                      | 9+                    | x64, Arm32, Arm64 | [Debian][Debian-lifecycle]
 [Fedora][Fedora]                      | 33+                   | x64               | [Fedora][Fedora-lifecycle]

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -28,7 +28,8 @@ OS                                    | Version                 | Architectures 
 
 OS                                    | Version               | Architectures     | Lifecycle
 --------------------------------------|-----------------------|-------------------|----------
-[Alpine Linux][Alpine]                | 3.12+                 | x64, Arm64, Arm32 | [Alpine][Alpine-lifecycle]
+[Alpine Linux][Alpine]                | 3.12+                 | x64, Arm64        | [Alpine][Alpine-lifecycle]
+&nbsp;                                | 3.13+                 | Arm32             |
 [CentOS][CentOS]                      | 7+                    | x64               | [CentOS][CentOS-lifecycle]
 [Debian][Debian]                      | 10+                   | x64, Arm64, Arm32 | [Debian][Debian-lifecycle]
 [Fedora][Fedora]                      | 33+                   | x64               | [Fedora][Fedora-lifecycle]


### PR DESCRIPTION
This came up in https://github.com/dotnet/sdk/issues/24448#issuecomment-1073888341. The minimum supported version of musl libc in `linux-musl-arm` package is 1.2.0 (Alpine 3.13) due to the time64 change.

cc @jkotas