### PR TITLE
Assorted releases.json fixes

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -714,7 +714,7 @@
         "version": "6.0.201",
         "version-display": "6.0.201",
         "runtime-version": "6.0.3",
-        "vs-version": "17.1",
+        "vs-version": "17.1.1",
         "vs-mac-version": "8.10",
         "vs-support": "Visual Studio 2022 (v17.1)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.0 latest preview)",

--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -343,7 +343,7 @@
           "version-display": "6.0.104",
           "runtime-version": "6.0.4",
           "vs-version": "17.0.8",
-          "vs-mac-version": "Visual Studio 2022 (v17.0)",
+          "vs-mac-version": "17.0",
           "vs-support": "17.0",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.0 latest preview)",
           "csharp-version": "9.0-preview",

--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -6175,13 +6175,13 @@
         },
         {
         "name": "dotnet-sdk-osx-arm64.pkg",
-        "rid": "osx-x64",
+        "rid": "osx-arm64",
         "url": "https://download.visualstudio.microsoft.com/download/pr/e5cbc909-e705-4bc1-9327-15c9f905a149/6da57e95a58cef98444698fa72378e23/dotnet-sdk-6.0.100-preview.2.21155.3-osx-arm64.pkg",
         "hash": "b76cf55453269c34b19797aa86f84a176ae3c87de58f11edb1e57831f76c672f5d0fe64a61a98b97bf3b2081e7975136a1d0f4c5f6d14f2b3d98febfb6c9bbaf"
         },
         {
         "name": "dotnet-sdk-osx-arm64.tar.gz",
-        "rid": "osx-x64",
+        "rid": "osx-arm64",
         "url": "https://download.visualstudio.microsoft.com/download/pr/37b33b92-1f3e-4f72-a636-d82fd01bb725/792c44980047c5c77a8a07916db87783/dotnet-sdk-6.0.100-preview.2.21155.3-osx-arm64.tar.gz",
         "hash": "7e38c4a5d586458aad5b81378ac1245368d95a403047878bec49103d96ba3b24b51f991f4d01b7b36220c77cbe041da7708763f7011553eb3948624932a719f4"
         },

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -1,14 +1,14 @@
 {
   "channel-version": "7.0",
   "latest-release": "7.0.0-preview.3",
-  "latest-release-date": "2022-11-07",
+  "latest-release-date": "2022-04-13",
   "latest-runtime": "7.0.0-preview.3.22175.4",
   "latest-sdk": "7.0.100-preview.3.22179.4",
   "support-phase": "preview",
   "lifecycle-policy": "https://aka.ms/dotnetcoresupport",
   "releases": [
     {
-      "release-date": "2022-11-07",
+      "release-date": "2022-04-13",
       "release-version": "7.0.0-preview.3",
       "security": false,
       "cve-list": [],


### PR DESCRIPTION
Fixes a vs-mac-version that did not contain a version number, the release date 7.0.0-preview.3 (that's today, not in November, the index was already correct) and some small inconsistencies I noticed.

Also: I don't think the language versions for the latest 6.0 release are correct. I'm pretty sure C# 9 and F# 5 are out of preview now, and that release actually ships with versions 10 and 6 😉