### PR TITLE
Fix vs version for 6.0.104 SDK

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -344,7 +344,7 @@
           "runtime-version": "6.0.4",
           "vs-version": "17.0.8",
           "vs-mac-version": "17.0",
-          "vs-support": "17.0",
+          "vs-support": "Visual Studio 2022 (v17.0)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.0 latest preview)",
           "csharp-version": "10.0",
           "fsharp-version": "6.0",


### PR DESCRIPTION
Information is being displayed differently than other versions

![image](https://user-images.githubusercontent.com/12971179/163868946-2bcfa02d-eabc-4503-9a8b-a0f72a49743b.png)
