### PR TITLE
Fix 3.1 support phase/EOL and 5.0 EOL

### DIFF
--- a/release-notes/3.1/releases.json
+++ b/release-notes/3.1/releases.json
@@ -4,7 +4,7 @@
   "latest-release-date": "2022-04-12",
   "latest-runtime": "3.1.24",
   "latest-sdk": "3.1.418",
-  "support-phase": "maintenance",
+  "support-phase": "lts",
   "eol-date": "2022-12-03",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [

--- a/release-notes/3.1/releases.json
+++ b/release-notes/3.1/releases.json
@@ -5,7 +5,7 @@
   "latest-runtime": "3.1.24",
   "latest-sdk": "3.1.418",
   "support-phase": "lts",
-  "eol-date": "2022-12-03",
+  "eol-date": "2022-12-13",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [
     {

--- a/release-notes/5.0/releases.json
+++ b/release-notes/5.0/releases.json
@@ -5,7 +5,7 @@
   "latest-runtime": "5.0.16",
   "latest-sdk": "5.0.407",
   "support-phase": "maintenance",
-  "eol-date": "2022-05-08",
+  "eol-date": "2022-05-10",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [
     {
@@ -537,7 +537,7 @@
       "release-date": "2022-03-08",
       "release-version": "5.0.15",
       "security": true,
-      "cve-list": [        
+      "cve-list": [
         {
           "cve-id": "CVE-2022-24464",
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24464"

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -45,7 +45,7 @@
             "latest-sdk": "3.1.418",
             "product": ".NET Core",
             "support-phase": "lts",
-            "eol-date": "2022-12-03",
+            "eol-date": "2022-12-13",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
         },
         {

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -44,7 +44,7 @@
             "latest-runtime": "3.1.24",
             "latest-sdk": "3.1.418",
             "product": ".NET Core",
-            "support-phase": "maintenance",
+            "support-phase": "lts",
             "eol-date": "2022-12-03",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
         },

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -33,7 +33,7 @@
             "latest-sdk": "5.0.407",
             "product": ".NET",
             "support-phase": "maintenance",
-            "eol-date":"2022-05-08",
+            "eol-date":"2022-05-10",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
         },
         {


### PR DESCRIPTION
@jamshedd according to what we discussed today, 3.1 would only enter maintenance phase in June. Let me know if my understanding is correct. 6 months before the release is out of support.