### PR TITLE
Update .NET 6 EOL

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -5,7 +5,7 @@
   "latest-runtime": "6.0.4",
   "latest-sdk": "6.0.202",
   "support-phase": "lts",
-  "eol-date": "2024-11-08",
+  "eol-date": "2024-11-12",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [
     {

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -21,7 +21,7 @@
             "latest-sdk": "6.0.202",
             "product": ".NET",
             "support-phase": "lts",
-            "eol-date": "2024-11-08",
+            "eol-date": "2024-11-12",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
         },
         {


### PR DESCRIPTION
We aligned .NET Core 3.1 and .NET 5 to Patch Tuesday. Aligning .NET 6 as well.

/cc @jamshedd 