### PR TITLE
Use "Close Stale Issues" for no-response.yml

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -15,12 +15,16 @@ on:
 jobs:
   noResponse:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: actions/stale@v5
         with:
-          token: ${{ github.token }}
-          daysUntilClose: 7 # Number of days of inactivity before an Issue is closed for lack of response
-          responseRequiredLabel: "needs-more-info" # Label indicating that a response from the original author is required
-          closeComment: >
-            This issue has been automatically closed due to no response from the original author.
-            Please feel free to reopen it if you have more information that can help us investigate the issue further.
+          days-before-issue-stale: 7
+          days-before-issue-close: 3
+          only-labels: "needs-more-info"
+          stale-issue-message: "This issue is stale because there has been no request to a response for more information for 7 days."
+          close-issue-message: "This issue was closed because there was no response to a request for more information for 10 days."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Uses "official" [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action as it is better maintained and has a lot more features
* Sets `issues: write` permission to [allow comment / close on issues](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)

If you want to stay with the original action, I can update this to just set the permissions.

Since this action has a few more options, I went with this policy:
* After 7 days, set a "Stale" tag and add a stale comment
* After 3 more days, close the issue with a closing comment

This seems like a nicer user experience, is more standard (since a lot of repos use this action), and allows filtering on / excluding by the Stale label.