### PR TITLE
Update EOL dates

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -10,9 +10,9 @@ The following table lists in-support .NET releases.
 
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
-| [.NET 7](release-notes/7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-3/) | [Preview][policies] | [7.0 Preview 3][7.0 Preview 3] | May 2024 |
+| [.NET 7](release-notes/7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-3/) | [Preview][policies] | [7.0 Preview 3][7.0 Preview 3] | May 14, 2024 |
 | [.NET 6](release-notes/6.0/README.md) | [November 8, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.4][6.0.4] | November 08, 2024 |
-| [.NET 5](release-notes/5.0/README.md) | [November 10, 2020](https://devblogs.microsoft.com/dotnet/announcing-net-5-0/) | [Maintenance][policies] | [5.0.16][5.0.16] | May 08, 2022 |
+| [.NET 5](release-notes/5.0/README.md) | [November 10, 2020](https://devblogs.microsoft.com/dotnet/announcing-net-5-0/) | [Maintenance][policies] | [5.0.16][5.0.16] | May 10, 2022 |
 | [.NET Core 3.1](release-notes/3.1/README.md) | [December 3, 2019](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-1/) | [LTS][policies] | [3.1.24][3.1.24] | December 3, 2022 |
 
 [7.0 Preview 3]: release-notes/7.0/preview/7.0.0-preview.3.md


### PR DESCRIPTION
- EOL dates (going forward) will align with Update Tuesday.
- That means we will publish a last update on that day (assuming fixes apply to that version).
- For containers, we will support the images we publish until the following Update Tuesday.