### PR TITLE
Revert "Update .NET 7.0 EOL date"

### DIFF
--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -5,7 +5,6 @@
   "latest-runtime": "7.0.0-preview.4.22229.4",
   "latest-sdk": "7.0.100-preview.4.22252.9",
   "support-phase": "preview",
-  "eol-date": "2024-05-14",
   "lifecycle-policy": "https://aka.ms/dotnetcoresupport",
   "releases": [
     {

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -9,7 +9,7 @@
             "latest-sdk": "7.0.100-preview.4.22252.9",
             "product": ".NET",
             "support-phase": "preview",
-            "eol-date": "2024-05-14",
+            "eol-date": null,
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json"
         },
         {


### PR DESCRIPTION
Reverts dotnet/core#7492

We shouldn't have EOL yet since it's not a supported product yet. 
It's causing the main download page to show .NET 7 as supported with the recent changes we made:
https://dotnet.microsoft.com/en-us/download/dotnet