### PR TITLE
Update RunApiDiff.ps1 script .NET executable version

### DIFF
--- a/release-notes/RunApiDiff.ps1
+++ b/release-notes/RunApiDiff.ps1
@@ -444,7 +444,7 @@ VerifyPathOrExit $windowsDesktopAfterDllFolder
 
 $asmDiffProjectPath = [IO.Path]::Combine($ArcadeRepo, "src", "Microsoft.DotNet.AsmDiff", "Microsoft.DotNet.AsmDiff.csproj")
 $asmDiffArtifactsPath = [IO.Path]::Combine($ArcadeRepo ,"artifacts", "bin", "Microsoft.DotNet.AsmDiff")
-$asmDiffExe = [IO.Path]::Combine($asmDiffArtifactsPath, "Release", "netcoreapp3.1", "Microsoft.DotNet.AsmDiff.exe")
+$asmDiffExe = [IO.Path]::Combine($asmDiffArtifactsPath, "Release", "net7.0", "Microsoft.DotNet.AsmDiff.exe")
 ReBuildIfExeNotFound $asmDiffExe $asmDiffProjectPath $asmDiffArtifactsPath
 
 


### PR DESCRIPTION
The arcade projects recently got all bumped to consume .NET 7.0.

This script was still assuming the executable would get placed in the netcoreapp3.1 folder.