### PR TITLE
API-diff between 7.0-preview5 and 7.0-preview6

### DIFF
--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6.md
@@ -1,0 +1,30 @@
+# API Difference 7.0-preview5 vs 7.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Authentication](7.0-preview6_Microsoft.AspNetCore.Authentication.md)
+* [Microsoft.AspNetCore.Authentication.Cookies](7.0-preview6_Microsoft.AspNetCore.Authentication.Cookies.md)
+* [Microsoft.AspNetCore.Builder](7.0-preview6_Microsoft.AspNetCore.Builder.md)
+* [Microsoft.AspNetCore.Components](7.0-preview6_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.CompilerServices](7.0-preview6_Microsoft.AspNetCore.Components.CompilerServices.md)
+* [Microsoft.AspNetCore.Http](7.0-preview6_Microsoft.AspNetCore.Http.md)
+* [Microsoft.AspNetCore.Http.Features](7.0-preview6_Microsoft.AspNetCore.Http.Features.md)
+* [Microsoft.AspNetCore.Http.Metadata](7.0-preview6_Microsoft.AspNetCore.Http.Metadata.md)
+* [Microsoft.AspNetCore.HttpLogging](7.0-preview6_Microsoft.AspNetCore.HttpLogging.md)
+* [Microsoft.AspNetCore.Mvc](7.0-preview6_Microsoft.AspNetCore.Mvc.md)
+* [Microsoft.AspNetCore.Mvc.ApplicationModels](7.0-preview6_Microsoft.AspNetCore.Mvc.ApplicationModels.md)
+* [Microsoft.AspNetCore.Mvc.ModelBinding](7.0-preview6_Microsoft.AspNetCore.Mvc.ModelBinding.md)
+* [Microsoft.AspNetCore.Mvc.RazorPages](7.0-preview6_Microsoft.AspNetCore.Mvc.RazorPages.md)
+* [Microsoft.AspNetCore.Mvc.Routing](7.0-preview6_Microsoft.AspNetCore.Mvc.Routing.md)
+* [Microsoft.AspNetCore.OutputCaching](7.0-preview6_Microsoft.AspNetCore.OutputCaching.md)
+* [Microsoft.AspNetCore.RequestDecompression](7.0-preview6_Microsoft.AspNetCore.RequestDecompression.md)
+* [Microsoft.AspNetCore.Routing](7.0-preview6_Microsoft.AspNetCore.Routing.md)
+* [Microsoft.AspNetCore.Routing.Patterns](7.0-preview6_Microsoft.AspNetCore.Routing.Patterns.md)
+* [Microsoft.AspNetCore.SignalR](7.0-preview6_Microsoft.AspNetCore.SignalR.md)
+* [Microsoft.Extensions.DependencyInjection](7.0-preview6_Microsoft.Extensions.DependencyInjection.md)
+* [Microsoft.Extensions.Hosting](7.0-preview6_Microsoft.Extensions.Hosting.md)
+* [Microsoft.Extensions.Logging.Console](7.0-preview6_Microsoft.Extensions.Logging.Console.md)
+* [Microsoft.JSInterop.Infrastructure](7.0-preview6_Microsoft.JSInterop.Infrastructure.md)
+* [Microsoft.Net.Http.Headers](7.0-preview6_Microsoft.Net.Http.Headers.md)
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.Cookies.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.Cookies.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Authentication.Cookies
+
+``` diff
+ namespace Microsoft.AspNetCore.Authentication.Cookies {
+     public interface ITicketStore {
++        Task RemoveAsync(string key, HttpContext httpContext, CancellationToken cancellationToken);
++        Task RenewAsync(string key, AuthenticationTicket ticket, HttpContext httpContext, CancellationToken cancellationToken);
++        Task<AuthenticationTicket?> RetrieveAsync(string key, HttpContext httpContext, CancellationToken cancellationToken);
++        Task<string> StoreAsync(AuthenticationTicket ticket, HttpContext httpContext, CancellationToken cancellationToken);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.md
@@ -5,28 +5,6 @@
 +    public static class AuthenticationConfigurationProviderExtensions {
 +        public static IConfiguration GetSchemeConfiguration(this IAuthenticationConfigurationProvider provider, string authenticationScheme);
 +    }
-     public class AuthenticationService : IAuthenticationService {
--        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__14))]
--        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme);
-+        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__15))]
-+        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme);
--        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__15))]
--        public virtual Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
-+        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__16))]
-+        public virtual Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
--        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__16))]
--        public virtual Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
-+        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__17))]
-+        public virtual Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
--        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__17))]
--        public virtual Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties);
-+        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__18))]
-+        public virtual Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties);
--        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__18))]
--        public virtual Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
-+        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__19))]
-+        public virtual Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
-     }
      public interface IAuthenticationConfigurationProvider {
 +        IConfiguration AuthenticationConfiguration { get; }
 -        IConfiguration GetAuthenticationSchemeConfiguration(string authenticationScheme);

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Authentication.md
@@ -1,0 +1,36 @@
+# Microsoft.AspNetCore.Authentication
+
+``` diff
+ namespace Microsoft.AspNetCore.Authentication {
++    public static class AuthenticationConfigurationProviderExtensions {
++        public static IConfiguration GetSchemeConfiguration(this IAuthenticationConfigurationProvider provider, string authenticationScheme);
++    }
+     public class AuthenticationService : IAuthenticationService {
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__14))]
+-        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__15))]
++        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__15))]
+-        public virtual Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__16))]
++        public virtual Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__16))]
+-        public virtual Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__17))]
++        public virtual Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__17))]
+-        public virtual Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__18))]
++        public virtual Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__18))]
+-        public virtual Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__19))]
++        public virtual Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties);
+     }
+     public interface IAuthenticationConfigurationProvider {
++        IConfiguration AuthenticationConfiguration { get; }
+-        IConfiguration GetAuthenticationSchemeConfiguration(string authenticationScheme);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Builder.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Builder.md
@@ -1,0 +1,150 @@
+# Microsoft.AspNetCore.Builder
+
+``` diff
+ namespace Microsoft.AspNetCore.Builder {
+     public static class ControllerEndpointRouteBuilderExtensions {
+-        public static ControllerActionEndpointConventionBuilder MapAreaControllerRoute(this IEndpointRouteBuilder endpoints, string name, string areaName, string pattern, object? defaults = null, object? constraints = null, object? dataTokens = null);
++        public static ControllerActionEndpointConventionBuilder MapAreaControllerRoute(this IEndpointRouteBuilder endpoints, string name, string areaName, [StringSyntaxAttribute("Route")] string pattern, object? defaults = null, object? constraints = null, object? dataTokens = null);
+-        public static ControllerActionEndpointConventionBuilder MapControllerRoute(this IEndpointRouteBuilder endpoints, string name, string pattern, object? defaults = null, object? constraints = null, object? dataTokens = null);
++        public static ControllerActionEndpointConventionBuilder MapControllerRoute(this IEndpointRouteBuilder endpoints, string name, [StringSyntaxAttribute("Route")] string pattern, object? defaults = null, object? constraints = null, object? dataTokens = null);
+-        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern) where TTransformer : DynamicRouteValueTransformer;
++        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern) where TTransformer : DynamicRouteValueTransformer;
+-        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object? state) where TTransformer : DynamicRouteValueTransformer;
++        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, object? state) where TTransformer : DynamicRouteValueTransformer;
+-        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object state, int order) where TTransformer : DynamicRouteValueTransformer;
++        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, object state, int order) where TTransformer : DynamicRouteValueTransformer;
+-        public static IEndpointConventionBuilder MapFallbackToAreaController(this IEndpointRouteBuilder endpoints, string pattern, string action, string controller, string area);
++        public static IEndpointConventionBuilder MapFallbackToAreaController(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, string action, string controller, string area);
+-        public static IEndpointConventionBuilder MapFallbackToController(this IEndpointRouteBuilder endpoints, string pattern, string action, string controller);
++        public static IEndpointConventionBuilder MapFallbackToController(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, string action, string controller);
+     }
+     public abstract class EndpointBuilder {
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        public string DisplayName { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public string? DisplayName { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        public RequestDelegate RequestDelegate { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public RequestDelegate? RequestDelegate { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        public IServiceProvider ServiceProvider { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     public static class EndpointRouteBuilderExtensions {
+-        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, RoutePattern pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, RoutePattern pattern, RequestDelegate requestDelegate);
+-        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder Map(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder Map(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        public static IEndpointConventionBuilder MapDelete(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapDelete(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapDelete(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapDelete(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapFallback(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapFallback(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapGet(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapGet(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapGet(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        public static GroupRouteBuilder MapGroup(this IEndpointRouteBuilder endpoints, RoutePattern prefix);
++        public static RouteGroupBuilder MapGroup(this IEndpointRouteBuilder endpoints, RoutePattern prefix);
+-        public static GroupRouteBuilder MapGroup(this IEndpointRouteBuilder endpoints, string prefix);
++        public static RouteGroupBuilder MapGroup(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string prefix);
+-        public static IEndpointConventionBuilder MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapMethods(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, IEnumerable<string> httpMethods, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapMethods(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, IEnumerable<string> httpMethods, Delegate handler);
+-        public static IEndpointConventionBuilder MapPatch(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapPatch(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapPatch(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapPatch(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        public static IEndpointConventionBuilder MapPost(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapPost(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapPost(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+-        public static IEndpointConventionBuilder MapPut(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapPut(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder MapPut(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder MapPut(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, Delegate handler);
+     }
+     public static class FallbackEndpointRouteBuilderExtensions {
+-        public static IEndpointConventionBuilder MapFallback(this IEndpointRouteBuilder endpoints, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapFallback(this IEndpointRouteBuilder endpoints, RequestDelegate requestDelegate);
+-        public static IEndpointConventionBuilder MapFallback(this IEndpointRouteBuilder endpoints, string pattern, RequestDelegate requestDelegate);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static IEndpointConventionBuilder MapFallback(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+     }
+     public static class MapRouteRouteBuilderExtensions {
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
+-        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string? name, string? template);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
++        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string? name, [StringSyntaxAttribute("Route")] string? template);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
+-        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, string template, object defaults);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
++        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, [StringSyntaxAttribute("Route")] string template, object defaults);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
+-        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, string template, object defaults, object constraints);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
++        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, [StringSyntaxAttribute("Route")] string template, object defaults, object constraints);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
+-        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, string template, object defaults, object constraints, object dataTokens);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameter which may be trimmed if not referenced directly.")]
++        public static IRouteBuilder MapRoute(this IRouteBuilder routeBuilder, string name, [StringSyntaxAttribute("Route")] string template, object defaults, object constraints, object dataTokens);
+     }
+     public static class MvcAreaRouteBuilderExtensions {
+-        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, string? template);
++        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, [StringSyntaxAttribute("Route")] string? template);
+-        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, string? template, object? defaults);
++        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, [StringSyntaxAttribute("Route")] string? template, object? defaults);
+-        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, string? template, object? defaults, object? constraints);
++        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, [StringSyntaxAttribute("Route")] string? template, object? defaults, object? constraints);
+-        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, string? template, object? defaults, object? constraints, object? dataTokens);
++        public static IRouteBuilder MapAreaRoute(this IRouteBuilder routeBuilder, string name, string areaName, [StringSyntaxAttribute("Route")] string? template, object? defaults, object? constraints, object? dataTokens);
+     }
++    public static class OutputCacheApplicationBuilderExtensions {
++        public static IApplicationBuilder UseOutputCache(this IApplicationBuilder app);
++    }
++    public static class RequestDecompressionBuilderExtensions {
++        public static IApplicationBuilder UseRequestDecompression(this IApplicationBuilder builder);
++    }
+     public static class StaticFilesEndpointRouteBuilderExtensions {
+-        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string filePath);
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="MapFallbackToFile RequireUnreferencedCode if the RequestDelegate has a Task<T> return type which is not the case here.")]
++        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string filePath);
+-        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string filePath, StaticFileOptions options);
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="MapFallbackToFile RequireUnreferencedCode if the RequestDelegate has a Task<T> return type which is not the case here.")]
++        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string filePath, StaticFileOptions options);
+-        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string pattern, string filePath);
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="MapFallbackToFile RequireUnreferencedCode if the RequestDelegate has a Task<T> return type which is not the case here.")]
++        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, string filePath);
+-        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, string pattern, string filePath, StaticFileOptions options);
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="MapFallbackToFile RequireUnreferencedCode if the RequestDelegate has a Task<T> return type which is not the case.")]
++        public static IEndpointConventionBuilder MapFallbackToFile(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, string filePath, StaticFileOptions options);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Components.CompilerServices.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Components.CompilerServices.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components.CompilerServices
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.CompilerServices {
+     public static class RuntimeHelpers {
++        public static EventCallback<T> CreateInferredEventCallback<T>(object receiver, EventCallback<T> callback, T value);
++        public static Task InvokeAsynchronousDelegate(Action callback);
++        public static Task InvokeAsynchronousDelegate(Func<Task> callback);
++        public static void InvokeSynchronousDelegate(Action callback);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Components.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,56 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
+     public class DynamicComponent : IComponent {
+-        public Task SetParametersAsync(ParameterView parameters);
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2072", Justification="We expect that types used with DynamicComponent will be defined in assemblies that don't get trimmed.")]
++        public Task SetParametersAsync(ParameterView parameters);
+     }
+     public static class EventCallbackFactoryBinderExtensions {
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<bool> setter, bool existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly> setter, DateOnly existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly> setter, DateOnly existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime> setter, DateTime existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime> setter, DateTime existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset> setter, DateTimeOffset existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset> setter, DateTimeOffset existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<decimal> setter, decimal existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<double> setter, double existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<short> setter, short existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<int> setter, int existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<long> setter, long existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<bool?> setter, bool? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly?> setter, DateOnly? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly?> setter, DateOnly? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime?> setter, DateTime? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime?> setter, DateTime? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset?> setter, DateTimeOffset? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset?> setter, DateTimeOffset? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<decimal?> setter, decimal? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<double?> setter, double? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<short?> setter, short? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<int?> setter, int? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<long?> setter, long? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<float?> setter, float? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly?> setter, TimeOnly? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly?> setter, TimeOnly? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<float> setter, float existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<string?> setter, string existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly> setter, TimeOnly existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly> setter, TimeOnly existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder<T>(this EventCallbackFactory factory, object receiver, EventCallback<T> setter, T existingValue, CultureInfo? culture = null);
+     }
+     [AttributeUsageAttribute(4, AllowMultiple=false, Inherited=true)]
+     public sealed class LayoutAttribute : Attribute {
+-        public LayoutAttribute(Type layoutType);
++        public LayoutAttribute([DynamicallyAccessedMembersAttribute(-1)] Type layoutType);
+     }
+     public class RouteView : IComponent {
+-        protected virtual void Render(RenderTreeBuilder builder);
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2111", Justification="Layout components are preserved because the LayoutAttribute constructor parameter is correctly annotated.")]
++        protected virtual void Render(RenderTreeBuilder builder);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.Features.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.Features.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Http.Features
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Features {
++    public interface IHttpExtendedConnectFeature {
++        [MemberNotNullWhenAttribute(true, "Protocol")]
++        bool IsExtendedConnect { [MemberNotNullWhenAttribute(true, "Protocol")] get; }
++        string Protocol { get; }
++        ValueTask<Stream> AcceptAsync();
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.Metadata.md
@@ -1,0 +1,22 @@
+# Microsoft.AspNetCore.Http.Metadata
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Metadata {
+     public sealed class EndpointMetadataContext {
+-        public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? services);
++        public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider applicationServices);
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
+-        public IServiceProvider? Services { [CompilerGeneratedAttribute] get; }
+     }
+     public sealed class EndpointParameterMetadataContext {
+-        public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? services);
++        public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider applicationServices);
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
+-        public IServiceProvider? Services { [CompilerGeneratedAttribute] get; }
+     }
++    public interface IRequestSizeLimitMetadata {
++        long? MaxRequestBodySize { get; }
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Http.md
@@ -1,0 +1,115 @@
+# Microsoft.AspNetCore.Http
+
+``` diff
+ namespace Microsoft.AspNetCore.Http {
+     public class CookieBuilder {
++        public IList<string> Extensions { get; }
+     }
+     public class CookieOptions {
++        public CookieOptions(CookieOptions options);
++        public IList<string> Extensions { get; }
++        public SetCookieHeaderValue CreateCookieHeader(string name, string value);
+     }
+     public static class HttpResponseJsonExtensions {
+-        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+-        public static Task WriteAsJsonAsync<TValue>(this HttpResponse response, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, string? contentType = null, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task WriteAsJsonAsync<TValue>(this HttpResponse response, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, string? contentType = null, CancellationToken cancellationToken = default(CancellationToken));
+     }
++    public interface IBindableFromHttpContext<TSelf> where TSelf : class, IBindableFromHttpContext<TSelf> {
++        static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
++    }
+     public interface IRequestCookieCollection : IEnumerable, IEnumerable<KeyValuePair<string, string>> {
+-        bool TryGetValue(string key, [MaybeNullWhenAttribute(false)] out string? value);
++        bool TryGetValue(string key, [NotNullWhenAttribute(true)] out string? value);
+     }
+     public static class OpenApiRouteHandlerBuilderExtensions {
++        public static TBuilder ExcludeFromDescription<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder;
+-        public static RouteHandlerBuilder WithDescription(this RouteHandlerBuilder builder, string description);
++        public static TBuilder WithDescription<TBuilder>(this TBuilder builder, string description) where TBuilder : IEndpointConventionBuilder;
+-        public static RouteHandlerBuilder WithSummary(this RouteHandlerBuilder builder, string summary);
++        public static TBuilder WithSummary<TBuilder>(this TBuilder builder, string summary) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder WithTags<TBuilder>(this TBuilder builder, params string[] tags) where TBuilder : IEndpointConventionBuilder;
+     }
+     public sealed class RequestDelegateFactoryOptions {
++        public IList<object>? EndpointMetadata { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        public IEnumerable<object>? InitialEndpointMetadata { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     public static class Results {
+-        public static IResult Accepted(string? uri = null, object? value = null);
++        public static IResult Accepted(string uri = null, object value = null);
++        public static IResult Accepted<TValue>(string uri = null, TValue value = null);
+-        public static IResult AcceptedAtRoute(string? routeName = null, object? routeValues = null, object? value = null);
++        public static IResult AcceptedAtRoute(string routeName = null, object routeValues = null, object value = null);
++        public static IResult AcceptedAtRoute<TValue>(string routeName = null, object routeValues = null, TValue value = null);
++        public static IResult BadRequest<TValue>(TValue error);
+-        public static IResult Bytes(byte[] contents, string? contentType = null, string? fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null);
++        public static IResult Bytes(byte[] contents, string contentType = null, string fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null);
+-        public static IResult Bytes(ReadOnlyMemory<byte> contents, string? contentType = null, string? fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null);
++        public static IResult Bytes(ReadOnlyMemory<byte> contents, string contentType = null, string fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null);
++        public static IResult Conflict<TValue>(TValue error);
+-        public static IResult Content(string? content, string? contentType, Encoding? contentEncoding);
++        public static IResult Content(string content, string contentType, Encoding contentEncoding);
+-        public static IResult Content(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = default(int?));
++        public static IResult Content(string content, string contentType = null, Encoding contentEncoding = null, int? statusCode = default(int?));
++        public static IResult Created<TValue>(string uri, TValue? value);
++        public static IResult Created<TValue>(Uri uri, TValue? value);
+-        public static IResult CreatedAtRoute(string? routeName = null, object? routeValues = null, object? value = null);
++        public static IResult CreatedAtRoute(string routeName = null, object routeValues = null, object value = null);
++        public static IResult CreatedAtRoute<TValue>(string routeName = null, object routeValues = null, TValue value = null);
+-        public static IResult File(byte[] fileContents, string? contentType = null, string? fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null);
++        public static IResult File(byte[] fileContents, string contentType = null, string fileDownloadName = null, bool enableRangeProcessing = false, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null);
+-        public static IResult File(Stream fileStream, string? contentType = null, string? fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false);
++        public static IResult File(Stream fileStream, string contentType = null, string fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null, bool enableRangeProcessing = false);
+-        public static IResult File(string path, string? contentType = null, string? fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false);
++        public static IResult File(string path, string contentType = null, string fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null, bool enableRangeProcessing = false);
+-        public static IResult Json(object? data, JsonSerializerOptions? options = null, string? contentType = null, int? statusCode = default(int?));
++        public static IResult Json(object data, JsonSerializerOptions options = null, string contentType = null, int? statusCode = default(int?));
++        public static IResult Json<TValue>(TValue data, JsonSerializerOptions options = null, string contentType = null, int? statusCode = default(int?));
++        public static IResult NotFound<TValue>(TValue value);
++        public static IResult Ok<TValue>(TValue value);
+-        public static IResult Problem(string? detail = null, string? instance = null, int? statusCode = default(int?), string? title = null, string? type = null, IDictionary<string, object?>? extensions = null);
++        public static IResult Problem(string detail = null, string instance = null, int? statusCode = default(int?), string title = null, string type = null, IDictionary<string, object?>? extensions = null);
+-        public static IResult RedirectToRoute(string? routeName = null, object? routeValues = null, bool permanent = false, bool preserveMethod = false, string? fragment = null);
++        public static IResult RedirectToRoute(string routeName = null, object routeValues = null, bool permanent = false, bool preserveMethod = false, string fragment = null);
+-        public static IResult Stream(Func<Stream, Task> streamWriterCallback, string? contentType = null, string? fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null);
++        public static IResult Stream(Func<Stream, Task> streamWriterCallback, string contentType = null, string fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null);
+-        public static IResult Stream(PipeReader pipeReader, string? contentType = null, string? fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false);
++        public static IResult Stream(PipeReader pipeReader, string contentType = null, string fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null, bool enableRangeProcessing = false);
+-        public static IResult Stream(Stream stream, string? contentType = null, string? fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false);
++        public static IResult Stream(Stream stream, string contentType = null, string fileDownloadName = null, DateTimeOffset? lastModified = default(DateTimeOffset?), EntityTagHeaderValue entityTag = null, bool enableRangeProcessing = false);
+-        public static IResult Text(string? content, string? contentType, Encoding? contentEncoding);
++        public static IResult Text(string content, string contentType, Encoding contentEncoding);
+-        public static IResult Text(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = default(int?));
++        public static IResult Text(string content, string contentType = null, Encoding contentEncoding = null, int? statusCode = default(int?));
++        public static IResult UnprocessableEntity<TValue>(TValue error);
+-        public static IResult ValidationProblem(IDictionary<string, string[]> errors, string? detail = null, string? instance = null, int? statusCode = default(int?), string? title = null, string? type = null, IDictionary<string, object?>? extensions = null);
++        public static IResult ValidationProblem(IDictionary<string, string[]> errors, string detail = null, string instance = null, int? statusCode = default(int?), string title = null, string type = null, IDictionary<string, object?>? extensions = null);
+     }
+     public sealed class RouteHandlerContext {
+-        public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata);
++        public RouteHandlerContext(MethodInfo methodInfo, IList<object> endpointMetadata, IServiceProvider applicationServices);
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
+-        public EndpointMetadataCollection EndpointMetadata { [CompilerGeneratedAttribute] get; }
++        public IList<object> EndpointMetadata { [CompilerGeneratedAttribute] get; }
+     }
+     public static class RouteHandlerFilterExtensions {
+-        public static RouteHandlerBuilder AddFilter(this RouteHandlerBuilder builder, IRouteHandlerFilter filter);
+-        public static RouteHandlerBuilder AddFilter(this RouteHandlerBuilder builder, Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate> filterFactory);
+-        public static RouteHandlerBuilder AddFilter(this RouteHandlerBuilder builder, Func<RouteHandlerInvocationContext, RouteHandlerFilterDelegate, ValueTask<object?>> routeHandlerFilter);
+-        public static RouteHandlerBuilder AddFilter<TFilterType>(this RouteHandlerBuilder builder) where TFilterType : IRouteHandlerFilter;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddRouteHandlerFilter<TBuilder, TFilterType>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder where TFilterType : IRouteHandlerFilter;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, IRouteHandlerFilter filter) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate> filterFactory) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, Func<RouteHandlerInvocationContext, RouteHandlerFilterDelegate, ValueTask<object?>> routeHandlerFilter) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder AddRouteHandlerFilter<TFilterType>(this RouteHandlerBuilder builder) where TFilterType : IRouteHandlerFilter;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteGroupBuilder AddRouteHandlerFilter<TFilterType>(this RouteGroupBuilder builder) where TFilterType : IRouteHandlerFilter;
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.HttpLogging.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.HttpLogging.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.HttpLogging
+
+``` diff
+ namespace Microsoft.AspNetCore.HttpLogging {
+     public sealed class W3CLoggerOptions {
++        public ISet<string> AdditionalRequestHeaders { [CompilerGeneratedAttribute] get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.ApplicationModels.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.ApplicationModels.md
@@ -1,0 +1,18 @@
+# Microsoft.AspNetCore.Mvc.ApplicationModels
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.ApplicationModels {
+     public class AttributeRouteModel {
+-        public string Template { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        [StringSyntaxAttribute("Route")]
++        public string Template { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        public static string CombineTemplates(string prefix, string template);
++        public static string CombineTemplates([StringSyntaxAttribute("Route")] string prefix, [StringSyntaxAttribute("Route")] string template);
+-        public static bool IsOverridePattern(string template);
++        public static bool IsOverridePattern([StringSyntaxAttribute("Route")] string template);
+-        public static string ReplaceTokens(string template, IDictionary<string, string?> values, IOutboundParameterTransformer? routeTokenTransformer);
++        public static string ReplaceTokens([StringSyntaxAttribute("Route")] string template, IDictionary<string, string?> values, IOutboundParameterTransformer? routeTokenTransformer);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.ModelBinding.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.ModelBinding.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Mvc.ModelBinding
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.ModelBinding {
+     public class DefaultPropertyFilterProvider<TModel> : IPropertyFilterProvider where TModel : class {
+-        public virtual IEnumerable<Expression<Func<TModel, object>>>? PropertyIncludeExpressions { get; }
++        public virtual IEnumerable<Expression<Func<TModel, object?>>>? PropertyIncludeExpressions { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.RazorPages.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.RazorPages.md
@@ -1,0 +1,24 @@
+# Microsoft.AspNetCore.Mvc.RazorPages
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.RazorPages {
+     public abstract class PageBase : RazorPageBase {
+-        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, IValueProvider valueProvider, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, IValueProvider valueProvider, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+-        [AsyncStateMachineAttribute(typeof(PageBase.<TryUpdateModelAsync>d__122<>))]
+-        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        [AsyncStateMachineAttribute(typeof(PageBase.<TryUpdateModelAsync>d__122<>))]
++        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+     }
+     [PageModelAttribute]
+     public abstract class PageModel : IAsyncPageFilter, IFilterMetadata, IPageFilter {
+-        protected internal Task<bool> TryUpdateModelAsync<TModel>(TModel model, string name, IValueProvider valueProvider, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        protected internal Task<bool> TryUpdateModelAsync<TModel>(TModel model, string name, IValueProvider valueProvider, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+-        [AsyncStateMachineAttribute(typeof(PageModel.<TryUpdateModelAsync>d__39<>))]
+-        protected internal Task<bool> TryUpdateModelAsync<TModel>(TModel model, string name, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        [AsyncStateMachineAttribute(typeof(PageModel.<TryUpdateModelAsync>d__39<>))]
++        protected internal Task<bool> TryUpdateModelAsync<TModel>(TModel model, string name, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.Routing.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.Routing.md
@@ -1,0 +1,20 @@
+# Microsoft.AspNetCore.Mvc.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Routing {
+     [AttributeUsageAttribute(64, AllowMultiple=true, Inherited=true)]
+     public abstract class HttpMethodAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider {
+-        public HttpMethodAttribute(IEnumerable<string> httpMethods, string? template);
++        public HttpMethodAttribute(IEnumerable<string> httpMethods, [StringSyntaxAttribute("Route")] string? template);
+-        public string Template { [CompilerGeneratedAttribute] get; }
++        [StringSyntaxAttribute("Route")]
++        public string Template { [CompilerGeneratedAttribute] get; }
+     }
+     public interface IRouteTemplateProvider {
+-        string Template { get; }
++        [StringSyntaxAttribute("Route")]
++        string Template { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Mvc.md
@@ -1,0 +1,74 @@
+# Microsoft.AspNetCore.Mvc
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc {
+     [AttributeUsageAttribute(64, AllowMultiple=true, Inherited=true)]
+     public sealed class AcceptVerbsAttribute : Attribute, IActionHttpMethodProvider, IRouteTemplateProvider {
+-        public string Route { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        [StringSyntaxAttribute("Route")]
++        public string Route { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     [ControllerAttribute]
+     public abstract class ControllerBase {
+-        [NonActionAttribute]
+-        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, IValueProvider valueProvider, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        [NonActionAttribute]
++        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, IValueProvider valueProvider, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+-        [AsyncStateMachineAttribute(typeof(ControllerBase.<TryUpdateModelAsync>d__190<>))]
+-        [NonActionAttribute]
+-        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, params Expression<Func<TModel, object>>[] includeExpressions) where TModel : class;
++        [AsyncStateMachineAttribute(typeof(ControllerBase.<TryUpdateModelAsync>d__190<>))]
++        [NonActionAttribute]
++        public Task<bool> TryUpdateModelAsync<TModel>(TModel model, string prefix, params Expression<Func<TModel, object?>>[] includeExpressions) where TModel : class;
+     }
+-    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
+-    public class DisableRequestSizeLimitAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter {
++    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
++    public class DisableRequestSizeLimitAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter, IRequestSizeLimitMetadata {
++        long? Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata.MaxRequestBodySize { get; }
+     }
+     public class HttpDeleteAttribute : HttpMethodAttribute {
+-        public HttpDeleteAttribute(string template);
++        public HttpDeleteAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpGetAttribute : HttpMethodAttribute {
+-        public HttpGetAttribute(string template);
++        public HttpGetAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpHeadAttribute : HttpMethodAttribute {
+-        public HttpHeadAttribute(string template);
++        public HttpHeadAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpOptionsAttribute : HttpMethodAttribute {
+-        public HttpOptionsAttribute(string template);
++        public HttpOptionsAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpPatchAttribute : HttpMethodAttribute {
+-        public HttpPatchAttribute(string template);
++        public HttpPatchAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpPostAttribute : HttpMethodAttribute {
+-        public HttpPostAttribute(string template);
++        public HttpPostAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+     public class HttpPutAttribute : HttpMethodAttribute {
+-        public HttpPutAttribute(string template);
++        public HttpPutAttribute([StringSyntaxAttribute("Route")] string template);
+     }
+-    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
+-    public class RequestSizeLimitAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter {
++    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
++    public class RequestSizeLimitAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter, IRequestSizeLimitMetadata {
++        long? Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata.MaxRequestBodySize { get; }
+     }
+     [AttributeUsageAttribute(68, AllowMultiple=true, Inherited=true)]
+     public class RouteAttribute : Attribute, IRouteTemplateProvider {
+-        public RouteAttribute(string template);
++        public RouteAttribute([StringSyntaxAttribute("Route")] string template);
+-        public string Template { [CompilerGeneratedAttribute] get; }
++        [StringSyntaxAttribute("Route")]
++        public string Template { [CompilerGeneratedAttribute] get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.OutputCaching.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.OutputCaching.md
@@ -1,0 +1,77 @@
+# Microsoft.AspNetCore.OutputCaching
+
+``` diff
++namespace Microsoft.AspNetCore.OutputCaching {
++    public sealed class CacheVaryByRules {
++        public CacheVaryByRules();
++        public StringValues Headers { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public StringValues QueryKeys { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public IDictionary<string, string> VaryByCustom { get; }
++        public StringValues VaryByPrefix { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++    }
++    public interface IOutputCacheFeature {
++        OutputCacheContext Context { get; }
++    }
++    public interface IOutputCachePolicy {
++        ValueTask CacheRequestAsync(OutputCacheContext context, CancellationToken cancellation);
++        ValueTask ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellation);
++        ValueTask ServeResponseAsync(OutputCacheContext context, CancellationToken cancellation);
++    }
++    public interface IOutputCacheStore {
++        ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken);
++        ValueTask<byte[]?> GetAsync(string key, CancellationToken cancellationToken);
++        ValueTask SetAsync(string key, byte[] value, string[]? tags, TimeSpan validFor, CancellationToken cancellationToken);
++    }
++    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
++    public sealed class OutputCacheAttribute : Attribute {
++        public OutputCacheAttribute();
++        public int Duration { get; set; }
++        public bool NoStore { get; set; }
++        public string PolicyName { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public string[]? VaryByHeaders { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public string[]? VaryByQueryKeys { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++    }
++    public sealed class OutputCacheContext {
++        public bool AllowCacheLookup { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public bool AllowCacheStorage { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public bool AllowLocking { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public CacheVaryByRules CacheVaryByRules { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public bool EnableOutputCaching { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public HttpContext HttpContext { [CompilerGeneratedAttribute] get; }
++        public TimeSpan? ResponseExpirationTimeSpan { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public DateTimeOffset? ResponseTime { [CompilerGeneratedAttribute] get; }
++        public HashSet<string> Tags { [CompilerGeneratedAttribute] get; }
++    }
++    public class OutputCacheOptions {
++        public OutputCacheOptions();
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
++        public TimeSpan DefaultExpirationTimeSpan { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public long MaximumBodySize { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public long SizeLimit { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public bool UseCaseSensitivePaths { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public void AddBasePolicy(IOutputCachePolicy policy);
++        public void AddBasePolicy(Action<OutputCachePolicyBuilder> build);
++        public void AddPolicy(string name, IOutputCachePolicy policy);
++        public void AddPolicy(string name, Action<OutputCachePolicyBuilder> build);
++    }
++    public sealed class OutputCachePolicyBuilder {
++        public OutputCachePolicyBuilder();
++        public OutputCachePolicyBuilder AddPolicy([DynamicallyAccessedMembersAttribute(3)] Type policyType);
++        public OutputCachePolicyBuilder AddPolicy<T>() where T : IOutputCachePolicy;
++        public OutputCachePolicyBuilder AllowLocking(bool lockResponse = true);
++        public OutputCachePolicyBuilder Clear();
++        public OutputCachePolicyBuilder Expire(TimeSpan expiration);
++        public OutputCachePolicyBuilder NoCache();
++        public OutputCachePolicyBuilder Tag(params string[] tags);
++        public OutputCachePolicyBuilder VaryByHeader(params string[] headers);
++        public OutputCachePolicyBuilder VaryByQuery(params string[] queryKeys);
++        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, KeyValuePair<string, string>> varyBy);
++        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, string> varyBy);
++        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, CancellationToken, ValueTask<KeyValuePair<string, string>>> varyBy);
++        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, CancellationToken, ValueTask<string>> varyBy);
++        public OutputCachePolicyBuilder With(Func<OutputCacheContext, bool> predicate);
++        public OutputCachePolicyBuilder With(Func<OutputCacheContext, CancellationToken, Task<bool>> predicate);
++    }
++}
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.RequestDecompression.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.RequestDecompression.md
@@ -1,0 +1,17 @@
+# Microsoft.AspNetCore.RequestDecompression
+
+``` diff
++namespace Microsoft.AspNetCore.RequestDecompression {
++    public interface IDecompressionProvider {
++        Stream GetDecompressionStream(Stream stream);
++    }
++    public interface IRequestDecompressionProvider {
++        Stream? GetDecompressionStream(HttpContext context);
++    }
++    public sealed class RequestDecompressionOptions {
++        public RequestDecompressionOptions();
++        public IDictionary<string, IDecompressionProvider> DecompressionProviders { [CompilerGeneratedAttribute] get; }
++    }
++}
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Routing.Patterns.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Routing.Patterns.md
@@ -1,0 +1,27 @@
+# Microsoft.AspNetCore.Routing.Patterns
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing.Patterns {
+     public sealed class RoutePatternException : Exception {
+-        public RoutePatternException(string pattern, string message);
++        public RoutePatternException([StringSyntaxAttribute("Route")] string pattern, string message);
+     }
+     public static class RoutePatternFactory {
+-        public static RoutePattern Parse(string pattern);
++        public static RoutePattern Parse([StringSyntaxAttribute("Route")] string pattern);
+-        public static RoutePattern Parse(string pattern, RouteValueDictionary? defaults, RouteValueDictionary? parameterPolicies);
++        public static RoutePattern Parse([StringSyntaxAttribute("Route")] string pattern, RouteValueDictionary? defaults, RouteValueDictionary? parameterPolicies);
+-        public static RoutePattern Parse(string pattern, RouteValueDictionary? defaults, RouteValueDictionary? parameterPolicies, RouteValueDictionary? requiredValues);
++        public static RoutePattern Parse([StringSyntaxAttribute("Route")] string pattern, RouteValueDictionary? defaults, RouteValueDictionary? parameterPolicies, RouteValueDictionary? requiredValues);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameters which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
+-        public static RoutePattern Parse(string pattern, object? defaults, object? parameterPolicies);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameters which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
++        public static RoutePattern Parse([StringSyntaxAttribute("Route")] string pattern, object? defaults, object? parameterPolicies);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameters which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
+-        public static RoutePattern Parse(string pattern, object? defaults, object? parameterPolicies, object? requiredValues);
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on supplied parameters which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
++        public static RoutePattern Parse([StringSyntaxAttribute("Route")] string pattern, object? defaults, object? parameterPolicies, object? requiredValues);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Routing.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.Routing.md
@@ -1,0 +1,92 @@
+# Microsoft.AspNetCore.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing {
+-    [DebuggerDisplayAttribute("{DebuggerDisplayString,nq}")]
+-    public sealed class CompositeEndpointDataSource : EndpointDataSource {
++    [DebuggerDisplayAttribute("{DebuggerDisplayString,nq}")]
++    public sealed class CompositeEndpointDataSource : EndpointDataSource, IDisposable {
++        public void Dispose();
++        public override IReadOnlyList<Endpoint> GetEndpointGroup(RouteGroupContext context);
+     }
+-    public sealed class DefaultEndpointDataSource : EndpointDataSource
++    [DebuggerDisplayAttribute("{DebuggerDisplayString,nq}")]
++    public sealed class DefaultEndpointDataSource : EndpointDataSource
+     public abstract class EndpointDataSource {
++        public virtual IReadOnlyList<Endpoint> GetEndpointGroup(RouteGroupContext context);
+     }
+-    public sealed class GroupRouteBuilder : IEndpointConventionBuilder, IEndpointRouteBuilder {
+-        public RoutePattern GroupPrefix { [CompilerGeneratedAttribute] get; }
+-        ICollection<EndpointDataSource> IEndpointRouteBuilder.DataSources { get; }
+-        IServiceProvider IEndpointRouteBuilder.ServiceProvider { get; }
+-        void IEndpointConventionBuilder.Add(Action<EndpointBuilder> convention);
+-        IApplicationBuilder IEndpointRouteBuilder.CreateApplicationBuilder();
+-    }
+     public static class RequestDelegateRouteBuilderExtensions {
+-        public static IRouteBuilder MapDelete(this IRouteBuilder builder, string template, RequestDelegate handler);
++        public static IRouteBuilder MapDelete(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapDelete(this IRouteBuilder builder, string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
++        public static IRouteBuilder MapDelete(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
+-        public static IRouteBuilder MapGet(this IRouteBuilder builder, string template, RequestDelegate handler);
++        public static IRouteBuilder MapGet(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapGet(this IRouteBuilder builder, string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
++        public static IRouteBuilder MapGet(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
+-        public static IRouteBuilder MapMiddlewareDelete(this IRouteBuilder builder, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewareDelete(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapMiddlewareGet(this IRouteBuilder builder, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewareGet(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapMiddlewarePost(this IRouteBuilder builder, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewarePost(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapMiddlewarePut(this IRouteBuilder builder, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewarePut(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapMiddlewareRoute(this IRouteBuilder builder, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewareRoute(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapMiddlewareVerb(this IRouteBuilder builder, string verb, string template, Action<IApplicationBuilder> action);
++        public static IRouteBuilder MapMiddlewareVerb(this IRouteBuilder builder, string verb, [StringSyntaxAttribute("Route")] string template, Action<IApplicationBuilder> action);
+-        public static IRouteBuilder MapPost(this IRouteBuilder builder, string template, RequestDelegate handler);
++        public static IRouteBuilder MapPost(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapPost(this IRouteBuilder builder, string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
++        public static IRouteBuilder MapPost(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
+-        public static IRouteBuilder MapPut(this IRouteBuilder builder, string template, RequestDelegate handler);
++        public static IRouteBuilder MapPut(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapPut(this IRouteBuilder builder, string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
++        public static IRouteBuilder MapPut(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
+-        public static IRouteBuilder MapRoute(this IRouteBuilder builder, string template, RequestDelegate handler);
++        public static IRouteBuilder MapRoute(this IRouteBuilder builder, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapVerb(this IRouteBuilder builder, string verb, string template, RequestDelegate handler);
++        public static IRouteBuilder MapVerb(this IRouteBuilder builder, string verb, [StringSyntaxAttribute("Route")] string template, RequestDelegate handler);
+-        public static IRouteBuilder MapVerb(this IRouteBuilder builder, string verb, string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
++        public static IRouteBuilder MapVerb(this IRouteBuilder builder, string verb, [StringSyntaxAttribute("Route")] string template, Func<HttpRequest, HttpResponse, RouteData, Task> handler);
+     }
+     public class Route : RouteBase {
+-        public Route(IRouter target, string routeTemplate, IInlineConstraintResolver inlineConstraintResolver);
++        public Route(IRouter target, [StringSyntaxAttribute("Route")] string routeTemplate, IInlineConstraintResolver inlineConstraintResolver);
+-        public Route(IRouter target, string routeTemplate, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens, IInlineConstraintResolver inlineConstraintResolver);
++        public Route(IRouter target, [StringSyntaxAttribute("Route")] string routeTemplate, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens, IInlineConstraintResolver inlineConstraintResolver);
+-        public Route(IRouter target, string? routeName, string? routeTemplate, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens, IInlineConstraintResolver inlineConstraintResolver);
++        public Route(IRouter target, string? routeName, [StringSyntaxAttribute("Route")] string? routeTemplate, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens, IInlineConstraintResolver inlineConstraintResolver);
+     }
+     public abstract class RouteBase : INamedRouter, IRouter {
+-        public RouteBase(string? template, string? name, IInlineConstraintResolver constraintResolver, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens);
++        public RouteBase([StringSyntaxAttribute("Route")] string? template, string? name, IInlineConstraintResolver constraintResolver, RouteValueDictionary? defaults, IDictionary<string, object>? constraints, RouteValueDictionary? dataTokens);
+     }
+     public sealed class RouteEndpointBuilder : EndpointBuilder {
+-        public override Endpoint Build();
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="We surface a RequireUnreferencedCode in AddRouteHandlerFilter which is required to call unreferenced code here. The trimmer is unable to infer this.")]
++        public override Endpoint Build();
+     }
++    public sealed class RouteGroupBuilder : IEndpointConventionBuilder, IEndpointRouteBuilder {
++        ICollection<EndpointDataSource> Microsoft.AspNetCore.Routing.IEndpointRouteBuilder.DataSources { get; }
++        IServiceProvider Microsoft.AspNetCore.Routing.IEndpointRouteBuilder.ServiceProvider { get; }
++        void IEndpointConventionBuilder.Add(Action<EndpointBuilder> convention);
++        IApplicationBuilder IEndpointRouteBuilder.CreateApplicationBuilder();
++    }
++    public sealed class RouteGroupContext {
++        public RouteGroupContext(RoutePattern prefix, IReadOnlyList<Action<EndpointBuilder>> conventions, IServiceProvider applicationServices);
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
++        public IReadOnlyList<Action<EndpointBuilder>> Conventions { [CompilerGeneratedAttribute] get; }
++        public RoutePattern Prefix { [CompilerGeneratedAttribute] get; }
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.SignalR.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.AspNetCore.SignalR.md
@@ -1,0 +1,19 @@
+# Microsoft.AspNetCore.SignalR
+
+``` diff
+ namespace Microsoft.AspNetCore.SignalR {
+     public interface IHubCallerClients : IHubCallerClients<IClientProxy>, IHubClients<IClientProxy> {
++        new ISingleClientProxy Caller { get; }
++        new ISingleClientProxy Client(string connectionId);
+-        new ISingleClientProxy Single(string connectionId);
+     }
+     public interface IHubClients : IHubClients<IClientProxy> {
++        new ISingleClientProxy Client(string connectionId);
+-        new ISingleClientProxy Single(string connectionId);
+     }
+     public interface IHubClients<T> {
+-        T Single(string connectionId);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,27 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
++    public static class OutputCacheConventionBuilderExtensions {
++        public static TBuilder CacheOutput<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder CacheOutput<TBuilder>(this TBuilder builder, IOutputCachePolicy policy) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder CacheOutput<TBuilder>(this TBuilder builder, Action<OutputCachePolicyBuilder> policy) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder CacheOutput<TBuilder>(this TBuilder builder, string policyName) where TBuilder : IEndpointConventionBuilder;
++    }
++    public static class OutputCacheServiceCollectionExtensions {
++        public static IServiceCollection AddOutputCache(this IServiceCollection services);
++        public static IServiceCollection AddOutputCache(this IServiceCollection services, Action<OutputCacheOptions> configureOptions);
++    }
+     public static class PageConventionCollectionExtensions {
+-        public static PageConventionCollection AddAreaPageRoute(this PageConventionCollection conventions, string areaName, string pageName, string route);
++        public static PageConventionCollection AddAreaPageRoute(this PageConventionCollection conventions, string areaName, string pageName, [StringSyntaxAttribute("Route")] string route);
+-        public static PageConventionCollection AddPageRoute(this PageConventionCollection conventions, string pageName, string route);
++        public static PageConventionCollection AddPageRoute(this PageConventionCollection conventions, string pageName, [StringSyntaxAttribute("Route")] string route);
+     }
++    public static class RequestDecompressionServiceExtensions {
++        public static IServiceCollection AddRequestDecompression(this IServiceCollection services);
++        public static IServiceCollection AddRequestDecompression(this IServiceCollection services, Action<RequestDecompressionOptions> configureOptions);
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.Hosting.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.Hosting.md
@@ -1,0 +1,12 @@
+# Microsoft.Extensions.Hosting
+
+``` diff
+ namespace Microsoft.Extensions.Hosting {
++    public sealed class HostAbortedException : Exception {
++        public HostAbortedException();
++        public HostAbortedException(string message);
++        public HostAbortedException(string message, Exception innerException);
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.Logging.Console.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Extensions.Logging.Console.md
@@ -1,0 +1,15 @@
+# Microsoft.Extensions.Logging.Console
+
+``` diff
+ namespace Microsoft.Extensions.Logging.Console {
+     public class ConsoleLoggerOptions {
++        public int MaxQueueLength { get; set; }
++        public ConsoleLoggerQueueFullMode QueueFullMode { get; set; }
+     }
++    public enum ConsoleLoggerQueueFullMode {
++        DropWrite = 1,
++        Wait = 0,
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.JSInterop.Infrastructure.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.JSInterop.Infrastructure.md
@@ -1,0 +1,15 @@
+# Microsoft.JSInterop.Infrastructure
+
+``` diff
+ namespace Microsoft.JSInterop.Infrastructure {
+     public static class DotNetDispatcher {
+-        public static void BeginInvokeDotNet(JSRuntime jsRuntime, DotNetInvocationInfo invocationInfo, string argsJson);
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2026", Justification="We expect application code is configured to ensure return types of JSInvokable methods are retained.")]
++        public static void BeginInvokeDotNet(JSRuntime jsRuntime, DotNetInvocationInfo invocationInfo, string argsJson);
+-        public static string? Invoke(JSRuntime jsRuntime, in DotNetInvocationInfo invocationInfo, string argsJson);
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2026", Justification="We expect application code is configured to ensure return types of JSInvokable methods are retained.")]
++        public static string? Invoke(JSRuntime jsRuntime, in DotNetInvocationInfo invocationInfo, string argsJson);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Net.Http.Headers.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/7.0-preview6_Microsoft.Net.Http.Headers.md
@@ -1,0 +1,14 @@
+# Microsoft.Net.Http.Headers
+
+``` diff
+ namespace Microsoft.Net.Http.Headers {
+     public static class HeaderNames {
++        public static readonly string Protocol;
+     }
+     public class SetCookieHeaderValue {
+-        public IList<StringSegment> Extensions { [CompilerGeneratedAttribute] get; }
++        public IList<StringSegment> Extensions { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6.md
@@ -1,0 +1,25 @@
+# API Difference 7.0-preview5 vs 7.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](7.0-preview6_System.md)
+* [System.ComponentModel](7.0-preview6_System.ComponentModel.md)
+* [System.Data.Common](7.0-preview6_System.Data.Common.md)
+* [System.Formats.Tar](7.0-preview6_System.Formats.Tar.md)
+* [System.IO](7.0-preview6_System.IO.md)
+* [System.IO.Compression](7.0-preview6_System.IO.Compression.md)
+* [System.Linq](7.0-preview6_System.Linq.md)
+* [System.Net.Http.Json](7.0-preview6_System.Net.Http.Json.md)
+* [System.Net.Mail](7.0-preview6_System.Net.Mail.md)
+* [System.Net.Security](7.0-preview6_System.Net.Security.md)
+* [System.Numerics](7.0-preview6_System.Numerics.md)
+* [System.Reflection](7.0-preview6_System.Reflection.md)
+* [System.Reflection.Emit](7.0-preview6_System.Reflection.Emit.md)
+* [System.Runtime.CompilerServices](7.0-preview6_System.Runtime.CompilerServices.md)
+* [System.Runtime.InteropServices](7.0-preview6_System.Runtime.InteropServices.md)
+* [System.Security.Cryptography](7.0-preview6_System.Security.Cryptography.md)
+* [System.Text.Json](7.0-preview6_System.Text.Json.md)
+* [System.Text.Json.Serialization](7.0-preview6_System.Text.Json.Serialization.md)
+* [System.Text.Json.Serialization.Metadata](7.0-preview6_System.Text.Json.Serialization.Metadata.md)
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.ComponentModel.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.ComponentModel.md
@@ -1,0 +1,30 @@
+# System.ComponentModel
+
+``` diff
+ namespace System.ComponentModel {
++    public class DateOnlyConverter : TypeConverter {
++        public DateOnlyConverter();
++        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType);
++        public override bool CanConvertTo(ITypeDescriptorContext context, [NotNullWhenAttribute(true)] Type destinationType);
++        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value);
++        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType);
++    }
++    public class HalfConverter : BaseNumberConverter {
++        public HalfConverter();
++    }
++    public class Int128Converter : BaseNumberConverter {
++        public Int128Converter();
++    }
++    public class TimeOnlyConverter : TypeConverter {
++        public TimeOnlyConverter();
++        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType);
++        public override bool CanConvertTo(ITypeDescriptorContext context, [NotNullWhenAttribute(true)] Type destinationType);
++        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value);
++        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType);
++    }
++    public class UInt128Converter : BaseNumberConverter {
++        public UInt128Converter();
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Data.Common.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Data.Common.md
@@ -1,0 +1,28 @@
+# System.Data.Common
+
+``` diff
+ namespace System.Data.Common {
++    public abstract class DbDataSource : IAsyncDisposable, IDisposable {
++        protected DbDataSource();
++        public abstract string ConnectionString { get; }
++        public DbBatch CreateBatch();
++        public DbCommand CreateCommand(string? commandText = null);
++        public DbConnection CreateConnection();
++        protected virtual DbBatch CreateDbBatch();
++        protected virtual DbCommand CreateDbCommand(string? commandText = null);
++        protected abstract DbConnection CreateDbConnection();
++        public void Dispose();
++        protected virtual void Dispose(bool disposing);
++        public ValueTask DisposeAsync();
++        protected virtual ValueTask DisposeAsyncCore();
++        public DbConnection OpenConnection();
++        public ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default(CancellationToken));
++        protected virtual DbConnection OpenDbConnection();
++        protected virtual ValueTask<DbConnection> OpenDbConnectionAsync(CancellationToken cancellationToken = default(CancellationToken));
++    }
+     public abstract class DbProviderFactory {
++        public virtual DbDataSource CreateDataSource(string connectionString);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Formats.Tar.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Formats.Tar.md
@@ -1,0 +1,53 @@
+# System.Formats.Tar
+
+``` diff
+ namespace System.Formats.Tar {
+     public sealed class GnuTarEntry : PosixTarEntry {
++        public GnuTarEntry(TarEntry other);
+     }
++    public sealed class PaxGlobalExtendedAttributesTarEntry : PosixTarEntry {
++        public PaxGlobalExtendedAttributesTarEntry(IEnumerable<KeyValuePair<string, string>> globalExtendedAttributes);
++        public IReadOnlyDictionary<string, string> GlobalExtendedAttributes { get; }
++    }
+     public sealed class PaxTarEntry : PosixTarEntry {
++        public PaxTarEntry(TarEntry other);
+     }
+     public abstract class TarEntry {
++        public TarEntryFormat Format { get; }
+     }
++    public enum TarEntryFormat {
++        Gnu = 4,
++        Pax = 3,
++        Unknown = 0,
++        Ustar = 2,
++        V7 = 1,
++    }
+-    public enum TarFormat {
+-        Gnu = 4,
+-        Pax = 3,
+-        Unknown = 0,
+-        Ustar = 2,
+-        V7 = 1,
+-    }
+     public sealed class TarReader : IDisposable {
+-        public TarFormat Format { get; }
+-        public IReadOnlyDictionary<string, string>? GlobalExtendedAttributes { get; }
+     }
+     public sealed class TarWriter : IDisposable {
++        public TarWriter(Stream archiveStream);
++        public TarWriter(Stream archiveStream, bool leaveOpen = false);
+-        public TarWriter(Stream archiveStream, IEnumerable<KeyValuePair<string, string>>? globalExtendedAttributes = null, bool leaveOpen = false);
++        public TarWriter(Stream archiveStream, TarEntryFormat format = TarEntryFormat.Pax, bool leaveOpen = false);
+-        public TarWriter(Stream archiveStream, TarFormat archiveFormat, bool leaveOpen = false);
+-        public TarFormat Format { get; }
++        public TarEntryFormat Format { get; }
+     }
+     public sealed class UstarTarEntry : PosixTarEntry {
++        public UstarTarEntry(TarEntry other);
+     }
+     public sealed class V7TarEntry : TarEntry {
++        public V7TarEntry(TarEntry other);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.IO.Compression.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.IO.Compression.md
@@ -1,0 +1,10 @@
+# System.IO.Compression
+
+``` diff
+ namespace System.IO.Compression {
+     public class ZipArchiveEntry {
++        public bool IsEncrypted { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.IO.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.IO.md
@@ -1,0 +1,43 @@
+# System.IO
+
+``` diff
+ namespace System.IO {
+     public static class Directory {
++        [UnsupportedOSPlatformAttribute("windows")]
++        public static DirectoryInfo CreateDirectory(string path, UnixFileMode unixCreateMode);
+     }
+     public static class File {
++        [UnsupportedOSPlatformAttribute("windows")]
++        public static UnixFileMode GetUnixFileMode(SafeFileHandle fileHandle);
++        [UnsupportedOSPlatformAttribute("windows")]
++        public static UnixFileMode GetUnixFileMode(string path);
++        [UnsupportedOSPlatformAttribute("windows")]
++        public static void SetUnixFileMode(SafeFileHandle fileHandle, UnixFileMode mode);
++        [UnsupportedOSPlatformAttribute("windows")]
++        public static void SetUnixFileMode(string path, UnixFileMode mode);
+     }
+     public sealed class FileStreamOptions {
++        public UnixFileMode? UnixCreateMode { get; [UnsupportedOSPlatformAttribute("windows")] set; }
+     }
+     public abstract class FileSystemInfo : MarshalByRefObject, ISerializable {
++        public UnixFileMode UnixFileMode { get; [UnsupportedOSPlatformAttribute("windows")] set; }
+     }
++    [FlagsAttribute]
++    public enum UnixFileMode {
++        GroupExecute = 8,
++        GroupRead = 32,
++        GroupWrite = 16,
++        None = 0,
++        OtherExecute = 1,
++        OtherRead = 4,
++        OtherWrite = 2,
++        SetGroup = 1024,
++        SetUser = 2048,
++        StickyBit = 512,
++        UserExecute = 64,
++        UserRead = 256,
++        UserWrite = 128,
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Linq.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Linq.md
@@ -1,0 +1,11 @@
+# System.Linq
+
+``` diff
+ namespace System.Linq {
+     public static class Queryable {
+-        public static IQueryable<TSource> DefaultIfEmpty<TSource>(this IQueryable<TSource> source);
++        public static IQueryable<TSource?> DefaultIfEmpty<TSource>(this IQueryable<TSource> source);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Http.Json.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Http.Json.md
@@ -1,0 +1,21 @@
+# System.Net.Http.Json
+
+``` diff
+ namespace System.Net.Http.Json {
+     public static class HttpClientJsonExtensions {
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, Type type, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default(CancellationToken));
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Mail.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Mail.md
@@ -1,0 +1,15 @@
+# System.Net.Mail
+
+``` diff
+ namespace System.Net.Mail {
+     public class MailAddress {
+-        public static bool TryCreate(string address, [NotNullWhenAttribute(true)] out MailAddress? result);
++        public static bool TryCreate([NotNullWhenAttribute(true)] string? address, [NotNullWhenAttribute(true)] out MailAddress? result);
+-        public static bool TryCreate(string address, string? displayName, [NotNullWhenAttribute(true)] out MailAddress? result);
++        public static bool TryCreate([NotNullWhenAttribute(true)] string? address, string? displayName, [NotNullWhenAttribute(true)] out MailAddress? result);
+-        public static bool TryCreate(string address, string? displayName, Encoding? displayNameEncoding, [NotNullWhenAttribute(true)] out MailAddress? result);
++        public static bool TryCreate([NotNullWhenAttribute(true)] string? address, string? displayName, Encoding? displayNameEncoding, [NotNullWhenAttribute(true)] out MailAddress? result);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Security.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Net.Security.md
@@ -1,0 +1,53 @@
+# System.Net.Security
+
+``` diff
+ namespace System.Net.Security {
++    public sealed class NegotiateAuthentication : IDisposable {
++        public NegotiateAuthentication(NegotiateAuthenticationClientOptions clientOptions);
++        public NegotiateAuthentication(NegotiateAuthenticationServerOptions serverOptions);
++        public bool IsAuthenticated { get; }
++        public bool IsEncrypted { get; }
++        public bool IsMutuallyAuthenticated { get; }
++        public bool IsServer { get; }
++        public bool IsSigned { get; }
++        public string Package { get; }
++        public ProtectionLevel ProtectionLevel { get; }
++        public IIdentity RemoteIdentity { get; }
++        public string? TargetName { get; }
++        public void Dispose();
++        public byte[]? GetOutgoingBlob(ReadOnlySpan<byte> incomingBlob, out NegotiateAuthenticationStatusCode statusCode);
++        public string? GetOutgoingBlob(string? incomingBlob, out NegotiateAuthenticationStatusCode statusCode);
++    }
++    public class NegotiateAuthenticationClientOptions {
++        public NegotiateAuthenticationClientOptions();
++        public ChannelBinding? Binding { get; set; }
++        public NetworkCredential Credential { get; set; }
++        public string Package { get; set; }
++        public ProtectionLevel RequiredProtectionLevel { get; set; }
++        public string? TargetName { get; set; }
++    }
++    public class NegotiateAuthenticationServerOptions {
++        public NegotiateAuthenticationServerOptions();
++        public ChannelBinding? Binding { get; set; }
++        public NetworkCredential Credential { get; set; }
++        public string Package { get; set; }
++        public ProtectionLevel RequiredProtectionLevel { get; set; }
++    }
++    public enum NegotiateAuthenticationStatusCode {
++        BadBinding = 3,
++        Completed = 0,
++        ContextExpired = 6,
++        ContinueNeeded = 1,
++        CredentialsExpired = 7,
++        GenericFailure = 2,
++        InvalidCredentials = 8,
++        InvalidToken = 9,
++        MessageAltered = 5,
++        OutOfSequence = 12,
++        QopNotSupported = 11,
++        UnknownCredentials = 10,
++        Unsupported = 4,
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Numerics.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Numerics.md
@@ -1,0 +1,136 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+     public readonly struct BigInteger : IAdditionOperators<BigInteger, BigInteger, BigInteger>, IAdditiveIdentity<BigInteger, BigInteger>, IBinaryInteger<BigInteger>, IBinaryNumber<BigInteger>, IBitwiseOperators<BigInteger, BigInteger, BigInteger>, IComparable, IComparable<BigInteger>, IComparisonOperators<BigInteger, BigInteger>, IDecrementOperators<BigInteger>, IDivisionOperators<BigInteger, BigInteger, BigInteger>, IEqualityOperators<BigInteger, BigInteger>, IEquatable<BigInteger>, IFormattable, IIncrementOperators<BigInteger>, IModulusOperators<BigInteger, BigInteger, BigInteger>, IMultiplicativeIdentity<BigInteger, BigInteger>, IMultiplyOperators<BigInteger, BigInteger, BigInteger>, INumber<BigInteger>, INumberBase<BigInteger>, IParsable<BigInteger>, IShiftOperators<BigInteger, BigInteger>, ISignedNumber<BigInteger>, ISpanFormattable, ISpanParsable<BigInteger>, ISubtractionOperators<BigInteger, BigInteger, BigInteger>, IUnaryNegationOperators<BigInteger, BigInteger>, IUnaryPlusOperators<BigInteger, BigInteger> {
+-        static BigInteger IAdditionOperators<BigInteger, BigInteger, BigInteger>.operator checked +(BigInteger left, BigInteger right);
+-        static BigInteger IDecrementOperators<BigInteger>.operator checked --(BigInteger value);
+-        static BigInteger IDivisionOperators<BigInteger, BigInteger, BigInteger>.operator checked /(BigInteger left, BigInteger right);
+-        static BigInteger IIncrementOperators<BigInteger>.operator checked ++(BigInteger value);
+-        static BigInteger IMultiplyOperators<BigInteger, BigInteger, BigInteger>.operator checked *(BigInteger left, BigInteger right);
+-        static BigInteger ISubtractionOperators<BigInteger, BigInteger, BigInteger>.operator checked -(BigInteger left, BigInteger right);
+-        static BigInteger IUnaryNegationOperators<BigInteger, BigInteger>.operator checked -(BigInteger value);
+     }
+     public readonly struct Complex : IAdditionOperators<Complex, Complex, Complex>, IAdditiveIdentity<Complex, Complex>, IDecrementOperators<Complex>, IDivisionOperators<Complex, Complex, Complex>, IEqualityOperators<Complex, Complex>, IEquatable<Complex>, IFormattable, IIncrementOperators<Complex>, IMultiplicativeIdentity<Complex, Complex>, IMultiplyOperators<Complex, Complex, Complex>, INumberBase<Complex>, IParsable<Complex>, ISignedNumber<Complex>, ISpanFormattable, ISpanParsable<Complex>, ISubtractionOperators<Complex, Complex, Complex>, IUnaryNegationOperators<Complex, Complex>, IUnaryPlusOperators<Complex, Complex> {
+-        static Complex IAdditionOperators<Complex, Complex, Complex>.operator checked +(Complex left, Complex right);
+-        static Complex IDecrementOperators<Complex>.operator checked --(Complex value);
+-        static Complex IDivisionOperators<Complex, Complex, Complex>.operator checked /(Complex left, Complex right);
+-        static Complex IIncrementOperators<Complex>.operator checked ++(Complex value);
+-        static Complex IMultiplyOperators<Complex, Complex, Complex>.operator checked *(Complex left, Complex right);
+-        static Complex ISubtractionOperators<Complex, Complex, Complex>.operator checked -(Complex left, Complex right);
+-        static Complex IUnaryNegationOperators<Complex, Complex>.operator checked -(Complex value);
+     }
+     public interface IAdditionOperators<TSelf, TOther, TResult> where TSelf : IAdditionOperators<TSelf, TOther, TResult> {
+-        static abstract TResult operator checked +(TSelf left, TOther right);
++        static TResult operator checked +(TSelf left, TOther right);
+     }
+     public interface IBinaryInteger<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBinaryNumber<TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IShiftOperators<TSelf, TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryInteger<TSelf> {
+-        static abstract (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right);
++        static (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right);
+-        static abstract TSelf LeadingZeroCount(TSelf value);
++        static TSelf LeadingZeroCount(TSelf value);
+-        static abstract TSelf RotateLeft(TSelf value, int rotateAmount);
++        static TSelf RotateLeft(TSelf value, int rotateAmount);
+-        static abstract TSelf RotateRight(TSelf value, int rotateAmount);
++        static TSelf RotateRight(TSelf value, int rotateAmount);
+     }
+     public interface IDecrementOperators<TSelf> where TSelf : IDecrementOperators<TSelf> {
+-        static abstract TSelf operator checked --(TSelf value);
++        static TSelf operator checked --(TSelf value);
+     }
+     public interface IDivisionOperators<TSelf, TOther, TResult> where TSelf : IDivisionOperators<TSelf, TOther, TResult> {
+-        static abstract TResult operator checked /(TSelf left, TOther right);
++        static TResult operator checked /(TSelf left, TOther right);
+     }
+-    public interface IExponentialFunctions<TSelf> where TSelf : IExponentialFunctions<TSelf> {
++    public interface IExponentialFunctions<TSelf> where TSelf : IExponentialFunctions<TSelf>, INumberBase<TSelf> {
+-        static abstract TSelf Exp10M1(TSelf x);
++        static TSelf Exp10M1(TSelf x);
+-        static abstract TSelf Exp2M1(TSelf x);
++        static TSelf Exp2M1(TSelf x);
+-        static abstract TSelf ExpM1(TSelf x);
++        static TSelf ExpM1(TSelf x);
+     }
+     public interface IFloatingPoint<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPoint<TSelf> {
+-        static abstract TSelf Ceiling(TSelf x);
++        static TSelf Ceiling(TSelf x);
+-        static abstract TSelf Floor(TSelf x);
++        static TSelf Floor(TSelf x);
+-        static abstract TSelf Round(TSelf x);
++        static TSelf Round(TSelf x);
+-        static abstract TSelf Round(TSelf x, int digits);
++        static TSelf Round(TSelf x, int digits);
+-        static abstract TSelf Round(TSelf x, MidpointRounding mode);
++        static TSelf Round(TSelf x, MidpointRounding mode);
+-        static abstract TSelf Truncate(TSelf x);
++        static TSelf Truncate(TSelf x);
+     }
+     public interface IFloatingPointIeee754<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IExponentialFunctions<TSelf>, IFloatingPoint<TSelf>, IFormattable, IHyperbolicFunctions<TSelf>, IIncrementOperators<TSelf>, ILogarithmicFunctions<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IPowerFunctions<TSelf>, IRootFunctions<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, ITrigonometricFunctions<TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPointIeee754<TSelf> {
+-        static abstract TSelf ReciprocalEstimate(TSelf x);
++        static TSelf ReciprocalEstimate(TSelf x);
+-        static abstract TSelf ReciprocalSqrtEstimate(TSelf x);
++        static TSelf ReciprocalSqrtEstimate(TSelf x);
+     }
+-    public interface IHyperbolicFunctions<TSelf> where TSelf : IHyperbolicFunctions<TSelf>
++    public interface IHyperbolicFunctions<TSelf> where TSelf : IHyperbolicFunctions<TSelf>, INumberBase<TSelf>
+     public interface IIncrementOperators<TSelf> where TSelf : IIncrementOperators<TSelf> {
+-        static abstract TSelf operator checked ++(TSelf value);
++        static TSelf operator checked ++(TSelf value);
+     }
+-    public interface ILogarithmicFunctions<TSelf> where TSelf : ILogarithmicFunctions<TSelf> {
++    public interface ILogarithmicFunctions<TSelf> where TSelf : ILogarithmicFunctions<TSelf>, INumberBase<TSelf> {
+-        static abstract TSelf Log10P1(TSelf x);
++        static TSelf Log10P1(TSelf x);
+-        static abstract TSelf Log2P1(TSelf x);
++        static TSelf Log2P1(TSelf x);
+-        static abstract TSelf LogP1(TSelf x);
++        static TSelf LogP1(TSelf x);
+     }
+     public interface IMultiplyOperators<TSelf, TOther, TResult> where TSelf : IMultiplyOperators<TSelf, TOther, TResult> {
+-        static abstract TResult operator checked *(TSelf left, TOther right);
++        static TResult operator checked *(TSelf left, TOther right);
+     }
+     public interface INumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumber<TSelf> {
+-        static abstract TSelf Clamp(TSelf value, TSelf min, TSelf max);
++        static TSelf Clamp(TSelf value, TSelf min, TSelf max);
+-        static abstract TSelf CopySign(TSelf value, TSelf sign);
++        static TSelf CopySign(TSelf value, TSelf sign);
+-        static abstract TSelf Max(TSelf x, TSelf y);
++        static TSelf Max(TSelf x, TSelf y);
+-        static abstract TSelf MaxNumber(TSelf x, TSelf y);
++        static TSelf MaxNumber(TSelf x, TSelf y);
+-        static abstract TSelf Min(TSelf x, TSelf y);
++        static TSelf Min(TSelf x, TSelf y);
+-        static abstract TSelf MinNumber(TSelf x, TSelf y);
++        static TSelf MinNumber(TSelf x, TSelf y);
+-        static abstract int Sign(TSelf value);
++        static int Sign(TSelf value);
+     }
+-    public interface IPowerFunctions<TSelf> where TSelf : IPowerFunctions<TSelf>
++    public interface IPowerFunctions<TSelf> where TSelf : IPowerFunctions<TSelf>, INumberBase<TSelf>
+-    public interface IRootFunctions<TSelf> where TSelf : IRootFunctions<TSelf> {
++    public interface IRootFunctions<TSelf> where TSelf : IRootFunctions<TSelf>, INumberBase<TSelf> {
++        static abstract TSelf Hypot(TSelf x, TSelf y);
++        static abstract TSelf Root(TSelf x, int n);
+     }
+     public interface ISubtractionOperators<TSelf, TOther, TResult> where TSelf : ISubtractionOperators<TSelf, TOther, TResult> {
+-        static abstract TResult operator checked -(TSelf left, TOther right);
++        static TResult operator checked -(TSelf left, TOther right);
+     }
+-    public interface ITrigonometricFunctions<TSelf> where TSelf : ITrigonometricFunctions<TSelf> {
++    public interface ITrigonometricFunctions<TSelf> where TSelf : ITrigonometricFunctions<TSelf>, INumberBase<TSelf> {
++        static abstract TSelf AcosPi(TSelf x);
++        static abstract TSelf AsinPi(TSelf x);
++        static abstract TSelf Atan2Pi(TSelf y, TSelf x);
++        static abstract TSelf AtanPi(TSelf x);
++        static abstract TSelf CosPi(TSelf x);
++        static abstract TSelf SinPi(TSelf x);
++        static abstract TSelf TanPi(TSelf x);
+     }
+     public interface IUnaryNegationOperators<TSelf, TResult> where TSelf : IUnaryNegationOperators<TSelf, TResult> {
+-        static abstract TResult operator checked -(TSelf value);
++        static TResult operator checked -(TSelf value);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Reflection.Emit.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Reflection.Emit.md
@@ -1,0 +1,11 @@
+# System.Reflection.Emit
+
+``` diff
+ namespace System.Reflection.Emit {
+     public class ILGenerator {
+-        public virtual void BeginCatchBlock(Type exceptionType);
++        public virtual void BeginCatchBlock(Type? exceptionType);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Reflection.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Reflection.md
@@ -1,0 +1,17 @@
+# System.Reflection
+
+``` diff
+ namespace System.Reflection {
+     public sealed class AssemblyName : ICloneable, IDeserializationCallback, ISerializable {
+-        public string CodeBase { [RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")] get; set; }
++        [ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.", DiagnosticId="SYSLIB0044", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        public string CodeBase { [RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")] get; set; }
+-        [RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")]
+-        public string EscapedCodeBase { get; }
++        [ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.", DiagnosticId="SYSLIB0044", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")]
++        public string EscapedCodeBase { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.CompilerServices.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.CompilerServices.md
@@ -1,0 +1,11 @@
+# System.Runtime.CompilerServices
+
+``` diff
+ namespace System.Runtime.CompilerServices {
++    public class MetadataUpdateOriginalTypeAttribute : Attribute {
++        public MetadataUpdateOriginalTypeAttribute(Type originalType);
++        public Type OriginalType { get; }
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.InteropServices.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.InteropServices.md
@@ -1,0 +1,29 @@
+# System.Runtime.InteropServices
+
+``` diff
+ namespace System.Runtime.InteropServices {
+     public enum Architecture {
++        Ppc64le = 8,
+     }
+     public static class NativeMemory {
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Clear(void* ptr, UIntPtr byteCount);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void ZeroMemory(void* ptr, UIntPtr byteCount);
+     }
+     public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat> {
++        public static NFloat AcosPi(NFloat x);
++        public static NFloat AsinPi(NFloat x);
++        public static NFloat Atan2Pi(NFloat y, NFloat x);
++        public static NFloat AtanPi(NFloat x);
+-        public static NFloat CopySign(NFloat x, NFloat y);
++        public static NFloat CopySign(NFloat value, NFloat sign);
++        public static NFloat CosPi(NFloat x);
++        public static NFloat Hypot(NFloat x, NFloat y);
++        public static NFloat Root(NFloat x, int n);
++        public static NFloat SinPi(NFloat x);
++        public static NFloat TanPi(NFloat x);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.InteropServices.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Runtime.InteropServices.md
@@ -7,9 +7,9 @@
      }
      public static class NativeMemory {
 +        [CLSCompliantAttribute(false)]
-+        public unsafe static void Clear(void* ptr, UIntPtr byteCount);
++        public unsafe static void Clear(void* ptr, nuint byteCount);
 -        [CLSCompliantAttribute(false)]
--        public unsafe static void ZeroMemory(void* ptr, UIntPtr byteCount);
+-        public unsafe static void ZeroMemory(void* ptr, nuint byteCount);
      }
      public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat> {
 +        public static NFloat AcosPi(NFloat x);

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Security.Cryptography.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Security.Cryptography.md
@@ -1,0 +1,30 @@
+# System.Security.Cryptography
+
+``` diff
+ namespace System.Security.Cryptography {
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public class HMACSHA1 : HMAC
++    public class HMACSHA1 : HMAC
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public class HMACSHA256 : HMAC
++    public class HMACSHA256 : HMAC
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public class HMACSHA384 : HMAC
++    public class HMACSHA384 : HMAC
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public class HMACSHA512 : HMAC
++    public class HMACSHA512 : HMAC
+     public sealed class IncrementalHash : IDisposable {
+-        [UnsupportedOSPlatformAttribute("browser")]
+-        public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, byte[] key);
++        public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, byte[] key);
+-        [UnsupportedOSPlatformAttribute("browser")]
+-        public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key);
++        public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key);
+     }
+     public static class PemEncoding {
++        public static string WriteString(ReadOnlySpan<char> label, ReadOnlySpan<byte> data);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.Serialization.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.Serialization.Metadata.md
@@ -1,0 +1,56 @@
+# System.Text.Json.Serialization.Metadata
+
+``` diff
+ namespace System.Text.Json.Serialization.Metadata {
++    public class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver {
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        public DefaultJsonTypeInfoResolver();
++        public IList<Action<JsonTypeInfo>> Modifiers { get; }
++        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options);
++    }
++    public interface IJsonTypeInfoResolver {
++        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
++    }
+     public static class JsonMetadataServices {
++        public static JsonConverter<T?> GetNullableConverter<T>(JsonSerializerOptions options) where T : struct;
+     }
+     public abstract class JsonPropertyInfo {
++        public JsonConverter? CustomConverter { get; set; }
++        public Func<object, object?>? Get { get; set; }
++        public string Name { get; set; }
++        public JsonNumberHandling? NumberHandling { get; set; }
++        public JsonSerializerOptions Options { get; }
++        public Type PropertyType { get; }
++        public Action<object, object?>? Set { get; set; }
++        public Func<object, object?, bool>? ShouldSerialize { get; set; }
+     }
+-    public class JsonTypeInfo {
++    public abstract class JsonTypeInfo {
++        public JsonConverter Converter { get; }
++        public Func<object>? CreateObject { get; set; }
++        public JsonTypeInfoKind Kind { get; }
++        public JsonNumberHandling? NumberHandling { get; set; }
++        public JsonSerializerOptions Options { get; }
++        public IList<JsonPropertyInfo> Properties { get; }
++        public Type Type { get; }
++        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name);
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
++        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options);
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
++        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options);
+     }
+     public abstract class JsonTypeInfo<T> : JsonTypeInfo {
++        public new Func<T>? CreateObject { get; set; }
+     }
++    public enum JsonTypeInfoKind {
++        Dictionary = 3,
++        Enumerable = 2,
++        None = 0,
++        Object = 1,
++    }
++    public static class JsonTypeInfoResolver {
++        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver[] resolvers);
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.Serialization.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.Serialization.md
@@ -1,0 +1,11 @@
+# System.Text.Json.Serialization
+
+``` diff
+ namespace System.Text.Json.Serialization {
+-    public abstract class JsonSerializerContext {
++    public abstract class JsonSerializerContext : IJsonTypeInfoResolver {
++        JsonTypeInfo IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.Text.Json.md
@@ -1,0 +1,10 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     public sealed class JsonSerializerOptions {
++        public IJsonTypeInfoResolver TypeInfoResolver { [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")] get; set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.NETCore.App/7.0-preview6_System.md
@@ -1,0 +1,125 @@
+# System
+
+``` diff
+ namespace System {
+     public readonly struct Byte : IAdditionOperators<byte, byte, byte>, IAdditiveIdentity<byte, byte>, IBinaryInteger<byte>, IBinaryNumber<byte>, IBitwiseOperators<byte, byte, byte>, IComparable, IComparable<byte>, IComparisonOperators<byte, byte>, IConvertible, IDecrementOperators<byte>, IDivisionOperators<byte, byte, byte>, IEqualityOperators<byte, byte>, IEquatable<byte>, IFormattable, IIncrementOperators<byte>, IMinMaxValue<byte>, IModulusOperators<byte, byte, byte>, IMultiplicativeIdentity<byte, byte>, IMultiplyOperators<byte, byte, byte>, INumber<byte>, INumberBase<byte>, IParsable<byte>, IShiftOperators<byte, byte>, ISpanFormattable, ISpanParsable<byte>, ISubtractionOperators<byte, byte, byte>, IUnaryNegationOperators<byte, byte>, IUnaryPlusOperators<byte, byte>, IUnsignedNumber<byte> {
+-        static byte IDivisionOperators<byte, byte, byte>.operator checked /(byte left, byte right);
+     }
+     public readonly struct Char : IAdditionOperators<char, char, char>, IAdditiveIdentity<char, char>, IBinaryInteger<char>, IBinaryNumber<char>, IBitwiseOperators<char, char, char>, IComparable, IComparable<char>, IComparisonOperators<char, char>, IConvertible, IDecrementOperators<char>, IDivisionOperators<char, char, char>, IEqualityOperators<char, char>, IEquatable<char>, IFormattable, IIncrementOperators<char>, IMinMaxValue<char>, IModulusOperators<char, char, char>, IMultiplicativeIdentity<char, char>, IMultiplyOperators<char, char, char>, INumber<char>, INumberBase<char>, IParsable<char>, IShiftOperators<char, char>, ISpanFormattable, ISpanParsable<char>, ISubtractionOperators<char, char, char>, IUnaryNegationOperators<char, char>, IUnaryPlusOperators<char, char>, IUnsignedNumber<char> {
+-        static (char Quotient, char Remainder) IBinaryInteger<char>.DivRem(char left, char right);
+-        static char IDivisionOperators<char, char, char>.operator checked /(char left, char right);
+-        static char INumber<char>.Clamp(char value, char min, char max);
+-        static char INumber<char>.CopySign(char value, char sign);
+-        static char INumber<char>.Max(char x, char y);
+-        static char INumber<char>.MaxNumber(char x, char y);
+-        static char INumber<char>.Min(char x, char y);
+-        static char INumber<char>.MinNumber(char x, char y);
+-        static int INumber<char>.Sign(char value);
+     }
+     public readonly struct Decimal : IAdditionOperators<decimal, decimal, decimal>, IAdditiveIdentity<decimal, decimal>, IComparable, IComparable<decimal>, IComparisonOperators<decimal, decimal>, IConvertible, IDecrementOperators<decimal>, IDeserializationCallback, IDivisionOperators<decimal, decimal, decimal>, IEqualityOperators<decimal, decimal>, IEquatable<decimal>, IFloatingPoint<decimal>, IFormattable, IIncrementOperators<decimal>, IMinMaxValue<decimal>, IModulusOperators<decimal, decimal, decimal>, IMultiplicativeIdentity<decimal, decimal>, IMultiplyOperators<decimal, decimal, decimal>, INumber<decimal>, INumberBase<decimal>, IParsable<decimal>, ISerializable, ISignedNumber<decimal>, ISpanFormattable, ISpanParsable<decimal>, ISubtractionOperators<decimal, decimal, decimal>, IUnaryNegationOperators<decimal, decimal>, IUnaryPlusOperators<decimal, decimal> {
+-        public static decimal operator checked *(decimal left, decimal right);
+-        static decimal IAdditionOperators<decimal, decimal, decimal>.operator checked +(decimal left, decimal right);
+-        static decimal IDecrementOperators<decimal>.operator checked --(decimal value);
+-        static decimal IDivisionOperators<decimal, decimal, decimal>.operator checked /(decimal left, decimal right);
+-        static decimal IIncrementOperators<decimal>.operator checked ++(decimal value);
+-        static decimal ISubtractionOperators<decimal, decimal, decimal>.operator checked -(decimal left, decimal right);
+-        static decimal IUnaryNegationOperators<decimal, decimal>.operator checked -(decimal value);
+     }
+     public readonly struct Double : IAdditionOperators<double, double, double>, IAdditiveIdentity<double, double>, IBinaryFloatingPointIeee754<double>, IBinaryNumber<double>, IBitwiseOperators<double, double, double>, IComparable, IComparable<double>, IComparisonOperators<double, double>, IConvertible, IDecrementOperators<double>, IDivisionOperators<double, double, double>, IEqualityOperators<double, double>, IEquatable<double>, IExponentialFunctions<double>, IFloatingPoint<double>, IFloatingPointIeee754<double>, IFormattable, IHyperbolicFunctions<double>, IIncrementOperators<double>, ILogarithmicFunctions<double>, IMinMaxValue<double>, IModulusOperators<double, double, double>, IMultiplicativeIdentity<double, double>, IMultiplyOperators<double, double, double>, INumber<double>, INumberBase<double>, IParsable<double>, IPowerFunctions<double>, IRootFunctions<double>, ISignedNumber<double>, ISpanFormattable, ISpanParsable<double>, ISubtractionOperators<double, double, double>, ITrigonometricFunctions<double>, IUnaryNegationOperators<double, double>, IUnaryPlusOperators<double, double> {
++        public static double AcosPi(double x);
++        public static double AsinPi(double x);
++        public static double Atan2Pi(double y, double x);
++        public static double AtanPi(double x);
+-        public static double CopySign(double x, double y);
++        public static double CopySign(double value, double sign);
++        public static double CosPi(double x);
++        public static double Hypot(double x, double y);
++        public static double Root(double x, int n);
++        public static double SinPi(double x);
+-        static double IAdditionOperators<double, double, double>.operator checked +(double left, double right);
+-        static double IDecrementOperators<double>.operator checked --(double value);
+-        static double IDivisionOperators<double, double, double>.operator checked /(double left, double right);
+-        static double IIncrementOperators<double>.operator checked ++(double value);
+-        static double IMultiplyOperators<double, double, double>.operator checked *(double left, double right);
+-        static double ISubtractionOperators<double, double, double>.operator checked -(double left, double right);
+-        static double IUnaryNegationOperators<double, double>.operator checked -(double value);
++        public static double TanPi(double x);
+     }
+     public enum GCCollectionMode {
++        Aggressive = 3,
+     }
+     public readonly struct Half : IAdditionOperators<Half, Half, Half>, IAdditiveIdentity<Half, Half>, IBinaryFloatingPointIeee754<Half>, IBinaryNumber<Half>, IBitwiseOperators<Half, Half, Half>, IComparable, IComparable<Half>, IComparisonOperators<Half, Half>, IDecrementOperators<Half>, IDivisionOperators<Half, Half, Half>, IEqualityOperators<Half, Half>, IEquatable<Half>, IExponentialFunctions<Half>, IFloatingPoint<Half>, IFloatingPointIeee754<Half>, IFormattable, IHyperbolicFunctions<Half>, IIncrementOperators<Half>, ILogarithmicFunctions<Half>, IMinMaxValue<Half>, IModulusOperators<Half, Half, Half>, IMultiplicativeIdentity<Half, Half>, IMultiplyOperators<Half, Half, Half>, INumber<Half>, INumberBase<Half>, IParsable<Half>, IPowerFunctions<Half>, IRootFunctions<Half>, ISignedNumber<Half>, ISpanFormattable, ISpanParsable<Half>, ISubtractionOperators<Half, Half, Half>, ITrigonometricFunctions<Half>, IUnaryNegationOperators<Half, Half>, IUnaryPlusOperators<Half, Half> {
++        public static Half AcosPi(Half x);
++        public static Half AsinPi(Half x);
++        public static Half Atan2Pi(Half y, Half x);
++        public static Half AtanPi(Half x);
+-        public static Half CopySign(Half x, Half y);
++        public static Half CopySign(Half value, Half sign);
++        public static Half CosPi(Half x);
++        public static Half Hypot(Half x, Half y);
++        public static Half Root(Half x, int n);
++        public static Half SinPi(Half x);
+-        static Half IAdditionOperators<Half, Half, Half>.operator checked +(Half left, Half right);
+-        static Half IDecrementOperators<Half>.operator checked --(Half value);
+-        static Half IDivisionOperators<Half, Half, Half>.operator checked /(Half left, Half right);
+-        static Half IIncrementOperators<Half>.operator checked ++(Half value);
+-        static Half IMultiplyOperators<Half, Half, Half>.operator checked *(Half left, Half right);
+-        static Half ISubtractionOperators<Half, Half, Half>.operator checked -(Half left, Half right);
+-        static Half IUnaryNegationOperators<Half, Half>.operator checked -(Half value);
++        public static Half TanPi(Half x);
+     }
+     public readonly struct Int16 : IAdditionOperators<short, short, short>, IAdditiveIdentity<short, short>, IBinaryInteger<short>, IBinaryNumber<short>, IBitwiseOperators<short, short, short>, IComparable, IComparable<short>, IComparisonOperators<short, short>, IConvertible, IDecrementOperators<short>, IDivisionOperators<short, short, short>, IEqualityOperators<short, short>, IEquatable<short>, IFormattable, IIncrementOperators<short>, IMinMaxValue<short>, IModulusOperators<short, short, short>, IMultiplicativeIdentity<short, short>, IMultiplyOperators<short, short, short>, INumber<short>, INumberBase<short>, IParsable<short>, IShiftOperators<short, short>, ISignedNumber<short>, ISpanFormattable, ISpanParsable<short>, ISubtractionOperators<short, short, short>, IUnaryNegationOperators<short, short>, IUnaryPlusOperators<short, short> {
+-        static short IDivisionOperators<short, short, short>.operator checked /(short left, short right);
+     }
+     public readonly struct Int32 : IAdditionOperators<int, int, int>, IAdditiveIdentity<int, int>, IBinaryInteger<int>, IBinaryNumber<int>, IBitwiseOperators<int, int, int>, IComparable, IComparable<int>, IComparisonOperators<int, int>, IConvertible, IDecrementOperators<int>, IDivisionOperators<int, int, int>, IEqualityOperators<int, int>, IEquatable<int>, IFormattable, IIncrementOperators<int>, IMinMaxValue<int>, IModulusOperators<int, int, int>, IMultiplicativeIdentity<int, int>, IMultiplyOperators<int, int, int>, INumber<int>, INumberBase<int>, IParsable<int>, IShiftOperators<int, int>, ISignedNumber<int>, ISpanFormattable, ISpanParsable<int>, ISubtractionOperators<int, int, int>, IUnaryNegationOperators<int, int>, IUnaryPlusOperators<int, int> {
+-        static int IDivisionOperators<int, int, int>.operator checked /(int left, int right);
+     }
+     public readonly struct Int64 : IAdditionOperators<long, long, long>, IAdditiveIdentity<long, long>, IBinaryInteger<long>, IBinaryNumber<long>, IBitwiseOperators<long, long, long>, IComparable, IComparable<long>, IComparisonOperators<long, long>, IConvertible, IDecrementOperators<long>, IDivisionOperators<long, long, long>, IEqualityOperators<long, long>, IEquatable<long>, IFormattable, IIncrementOperators<long>, IMinMaxValue<long>, IModulusOperators<long, long, long>, IMultiplicativeIdentity<long, long>, IMultiplyOperators<long, long, long>, INumber<long>, INumberBase<long>, IParsable<long>, IShiftOperators<long, long>, ISignedNumber<long>, ISpanFormattable, ISpanParsable<long>, ISubtractionOperators<long, long, long>, IUnaryNegationOperators<long, long>, IUnaryPlusOperators<long, long> {
+-        static long IDivisionOperators<long, long, long>.operator checked /(long left, long right);
+     }
+     public readonly struct IntPtr : IAdditionOperators<IntPtr, IntPtr, IntPtr>, IAdditiveIdentity<IntPtr, IntPtr>, IBinaryInteger<IntPtr>, IBinaryNumber<IntPtr>, IBitwiseOperators<IntPtr, IntPtr, IntPtr>, IComparable, IComparable<IntPtr>, IComparisonOperators<IntPtr, IntPtr>, IDecrementOperators<IntPtr>, IDivisionOperators<IntPtr, IntPtr, IntPtr>, IEqualityOperators<IntPtr, IntPtr>, IEquatable<IntPtr>, IFormattable, IIncrementOperators<IntPtr>, IMinMaxValue<IntPtr>, IModulusOperators<IntPtr, IntPtr, IntPtr>, IMultiplicativeIdentity<IntPtr, IntPtr>, IMultiplyOperators<IntPtr, IntPtr, IntPtr>, INumber<IntPtr>, INumberBase<IntPtr>, IParsable<IntPtr>, ISerializable, IShiftOperators<IntPtr, IntPtr>, ISignedNumber<IntPtr>, ISpanFormattable, ISpanParsable<IntPtr>, ISubtractionOperators<IntPtr, IntPtr, IntPtr>, IUnaryNegationOperators<IntPtr, IntPtr>, IUnaryPlusOperators<IntPtr, IntPtr> {
+-        static IntPtr IDivisionOperators<IntPtr, IntPtr, IntPtr>.operator checked /(IntPtr left, IntPtr right);
+     }
+     [CLSCompliantAttribute(false)]
+     public readonly struct SByte : IAdditionOperators<sbyte, sbyte, sbyte>, IAdditiveIdentity<sbyte, sbyte>, IBinaryInteger<sbyte>, IBinaryNumber<sbyte>, IBitwiseOperators<sbyte, sbyte, sbyte>, IComparable, IComparable<sbyte>, IComparisonOperators<sbyte, sbyte>, IConvertible, IDecrementOperators<sbyte>, IDivisionOperators<sbyte, sbyte, sbyte>, IEqualityOperators<sbyte, sbyte>, IEquatable<sbyte>, IFormattable, IIncrementOperators<sbyte>, IMinMaxValue<sbyte>, IModulusOperators<sbyte, sbyte, sbyte>, IMultiplicativeIdentity<sbyte, sbyte>, IMultiplyOperators<sbyte, sbyte, sbyte>, INumber<sbyte>, INumberBase<sbyte>, IParsable<sbyte>, IShiftOperators<sbyte, sbyte>, ISignedNumber<sbyte>, ISpanFormattable, ISpanParsable<sbyte>, ISubtractionOperators<sbyte, sbyte, sbyte>, IUnaryNegationOperators<sbyte, sbyte>, IUnaryPlusOperators<sbyte, sbyte> {
+-        static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator checked /(sbyte left, sbyte right);
+     }
+     public readonly struct Single : IAdditionOperators<float, float, float>, IAdditiveIdentity<float, float>, IBinaryFloatingPointIeee754<float>, IBinaryNumber<float>, IBitwiseOperators<float, float, float>, IComparable, IComparable<float>, IComparisonOperators<float, float>, IConvertible, IDecrementOperators<float>, IDivisionOperators<float, float, float>, IEqualityOperators<float, float>, IEquatable<float>, IExponentialFunctions<float>, IFloatingPoint<float>, IFloatingPointIeee754<float>, IFormattable, IHyperbolicFunctions<float>, IIncrementOperators<float>, ILogarithmicFunctions<float>, IMinMaxValue<float>, IModulusOperators<float, float, float>, IMultiplicativeIdentity<float, float>, IMultiplyOperators<float, float, float>, INumber<float>, INumberBase<float>, IParsable<float>, IPowerFunctions<float>, IRootFunctions<float>, ISignedNumber<float>, ISpanFormattable, ISpanParsable<float>, ISubtractionOperators<float, float, float>, ITrigonometricFunctions<float>, IUnaryNegationOperators<float, float>, IUnaryPlusOperators<float, float> {
++        public static float AcosPi(float x);
++        public static float AsinPi(float x);
++        public static float Atan2Pi(float y, float x);
++        public static float AtanPi(float x);
+-        public static float CopySign(float x, float y);
++        public static float CopySign(float value, float sign);
++        public static float CosPi(float x);
++        public static float Hypot(float x, float y);
++        public static float Root(float x, int n);
++        public static float SinPi(float x);
+-        static float IAdditionOperators<float, float, float>.operator checked +(float left, float right);
+-        static float IDecrementOperators<float>.operator checked --(float value);
+-        static float IDivisionOperators<float, float, float>.operator checked /(float left, float right);
+-        static float IIncrementOperators<float>.operator checked ++(float value);
+-        static float IMultiplyOperators<float, float, float>.operator checked *(float left, float right);
+-        static float ISubtractionOperators<float, float, float>.operator checked -(float left, float right);
+-        static float IUnaryNegationOperators<float, float>.operator checked -(float value);
++        public static float TanPi(float x);
+     }
+     [CLSCompliantAttribute(false)]
+     public readonly struct UInt16 : IAdditionOperators<ushort, ushort, ushort>, IAdditiveIdentity<ushort, ushort>, IBinaryInteger<ushort>, IBinaryNumber<ushort>, IBitwiseOperators<ushort, ushort, ushort>, IComparable, IComparable<ushort>, IComparisonOperators<ushort, ushort>, IConvertible, IDecrementOperators<ushort>, IDivisionOperators<ushort, ushort, ushort>, IEqualityOperators<ushort, ushort>, IEquatable<ushort>, IFormattable, IIncrementOperators<ushort>, IMinMaxValue<ushort>, IModulusOperators<ushort, ushort, ushort>, IMultiplicativeIdentity<ushort, ushort>, IMultiplyOperators<ushort, ushort, ushort>, INumber<ushort>, INumberBase<ushort>, IParsable<ushort>, IShiftOperators<ushort, ushort>, ISpanFormattable, ISpanParsable<ushort>, ISubtractionOperators<ushort, ushort, ushort>, IUnaryNegationOperators<ushort, ushort>, IUnaryPlusOperators<ushort, ushort>, IUnsignedNumber<ushort> {
+-        static ushort IDivisionOperators<ushort, ushort, ushort>.operator checked /(ushort left, ushort right);
+     }
+     [CLSCompliantAttribute(false)]
+     public readonly struct UInt32 : IAdditionOperators<uint, uint, uint>, IAdditiveIdentity<uint, uint>, IBinaryInteger<uint>, IBinaryNumber<uint>, IBitwiseOperators<uint, uint, uint>, IComparable, IComparable<uint>, IComparisonOperators<uint, uint>, IConvertible, IDecrementOperators<uint>, IDivisionOperators<uint, uint, uint>, IEqualityOperators<uint, uint>, IEquatable<uint>, IFormattable, IIncrementOperators<uint>, IMinMaxValue<uint>, IModulusOperators<uint, uint, uint>, IMultiplicativeIdentity<uint, uint>, IMultiplyOperators<uint, uint, uint>, INumber<uint>, INumberBase<uint>, IParsable<uint>, IShiftOperators<uint, uint>, ISpanFormattable, ISpanParsable<uint>, ISubtractionOperators<uint, uint, uint>, IUnaryNegationOperators<uint, uint>, IUnaryPlusOperators<uint, uint>, IUnsignedNumber<uint> {
+-        static uint IDivisionOperators<uint, uint, uint>.operator checked /(uint left, uint right);
+     }
+     [CLSCompliantAttribute(false)]
+     public readonly struct UInt64 : IAdditionOperators<ulong, ulong, ulong>, IAdditiveIdentity<ulong, ulong>, IBinaryInteger<ulong>, IBinaryNumber<ulong>, IBitwiseOperators<ulong, ulong, ulong>, IComparable, IComparable<ulong>, IComparisonOperators<ulong, ulong>, IConvertible, IDecrementOperators<ulong>, IDivisionOperators<ulong, ulong, ulong>, IEqualityOperators<ulong, ulong>, IEquatable<ulong>, IFormattable, IIncrementOperators<ulong>, IMinMaxValue<ulong>, IModulusOperators<ulong, ulong, ulong>, IMultiplicativeIdentity<ulong, ulong>, IMultiplyOperators<ulong, ulong, ulong>, INumber<ulong>, INumberBase<ulong>, IParsable<ulong>, IShiftOperators<ulong, ulong>, ISpanFormattable, ISpanParsable<ulong>, ISubtractionOperators<ulong, ulong, ulong>, IUnaryNegationOperators<ulong, ulong>, IUnaryPlusOperators<ulong, ulong>, IUnsignedNumber<ulong> {
+-        static ulong IDivisionOperators<ulong, ulong, ulong>.operator checked /(ulong left, ulong right);
+     }
+     [CLSCompliantAttribute(false)]
+     public readonly struct UIntPtr : IAdditionOperators<UIntPtr, UIntPtr, UIntPtr>, IAdditiveIdentity<UIntPtr, UIntPtr>, IBinaryInteger<UIntPtr>, IBinaryNumber<UIntPtr>, IBitwiseOperators<UIntPtr, UIntPtr, UIntPtr>, IComparable, IComparable<UIntPtr>, IComparisonOperators<UIntPtr, UIntPtr>, IDecrementOperators<UIntPtr>, IDivisionOperators<UIntPtr, UIntPtr, UIntPtr>, IEqualityOperators<UIntPtr, UIntPtr>, IEquatable<UIntPtr>, IFormattable, IIncrementOperators<UIntPtr>, IMinMaxValue<UIntPtr>, IModulusOperators<UIntPtr, UIntPtr, UIntPtr>, IMultiplicativeIdentity<UIntPtr, UIntPtr>, IMultiplyOperators<UIntPtr, UIntPtr, UIntPtr>, INumber<UIntPtr>, INumberBase<UIntPtr>, IParsable<UIntPtr>, ISerializable, IShiftOperators<UIntPtr, UIntPtr>, ISpanFormattable, ISpanParsable<UIntPtr>, ISubtractionOperators<UIntPtr, UIntPtr, UIntPtr>, IUnaryNegationOperators<UIntPtr, UIntPtr>, IUnaryPlusOperators<UIntPtr, UIntPtr>, IUnsignedNumber<UIntPtr> {
+-        static UIntPtr IDivisionOperators<UIntPtr, UIntPtr, UIntPtr>.operator checked /(UIntPtr left, UIntPtr right);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6.md
@@ -1,0 +1,8 @@
+# API Difference 7.0-preview5 vs 7.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Windows.Forms](7.0-preview6_System.Windows.Forms.md)
+* [System.Windows.Forms.Design](7.0-preview6_System.Windows.Forms.Design.md)
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.Design.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.Design.md
@@ -1,0 +1,22 @@
+# System.Windows.Forms.Design
+
+``` diff
+ namespace System.Windows.Forms.Design {
+     [ToolboxItemAttribute(false)]
+     public class ComponentEditorForm : Form {
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public new event EventHandler AutoSizeChanged;
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        public new event EventHandler? AutoSizeChanged;
+-        protected virtual void OnSelChangeSelector(object source, TreeViewEventArgs e);
++        protected virtual void OnSelChangeSelector(object? source, TreeViewEventArgs e);
+-        public virtual DialogResult ShowForm(IWin32Window owner);
++        public virtual DialogResult ShowForm(IWin32Window? owner);
+-        public virtual DialogResult ShowForm(IWin32Window owner, int page);
++        public virtual DialogResult ShowForm(IWin32Window? owner, int page);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.Design.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.Design.md
@@ -4,11 +4,9 @@
  namespace System.Windows.Forms.Design {
      [ToolboxItemAttribute(false)]
      public class ComponentEditorForm : Form {
--        [BrowsableAttribute(false)]
--        [EditorBrowsableAttribute(1)]
+         [BrowsableAttribute(false)]
+         [EditorBrowsableAttribute(1)]
 -        public new event EventHandler AutoSizeChanged;
-+        [BrowsableAttribute(false)]
-+        [EditorBrowsableAttribute(1)]
 +        public new event EventHandler? AutoSizeChanged;
 -        protected virtual void OnSelChangeSelector(object source, TreeViewEventArgs e);
 +        protected virtual void OnSelChangeSelector(object? source, TreeViewEventArgs e);

--- a/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.md
+++ b/release-notes/7.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/7.0-preview6_System.Windows.Forms.md
@@ -1,0 +1,485 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+     public class AccessibleObject : StandardOleMarshalObject, IAccessible, Interop.Ole32.IOleWindow, Interop.Ole32.IServiceProvider, Interop.Oleaut32.IEnumVariant, Interop.UiaCore.IAccessibleEx, Interop.UiaCore.IExpandCollapseProvider, Interop.UiaCore.IGridItemProvider, Interop.UiaCore.IGridProvider, Interop.UiaCore.IInvokeProvider, Interop.UiaCore.ILegacyIAccessibleProvider, Interop.UiaCore.IMultipleViewProvider, Interop.UiaCore.IRangeValueProvider, Interop.UiaCore.IRawElementProviderFragment, Interop.UiaCore.IRawElementProviderFragmentRoot, Interop.UiaCore.IRawElementProviderHwndOverride, Interop.UiaCore.IRawElementProviderSimple, Interop.UiaCore.IScrollItemProvider, Interop.UiaCore.ISelectionItemProvider, Interop.UiaCore.ISelectionProvider, Interop.UiaCore.ITableItemProvider, Interop.UiaCore.ITableProvider, Interop.UiaCore.ITextProvider, Interop.UiaCore.ITextProvider2, Interop.UiaCore.IToggleProvider, Interop.UiaCore.IValueProvider, IReflect {
+-        FieldInfo? IReflect.GetField(string name, BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(96)]
++        FieldInfo? IReflect.GetField(string name, BindingFlags bindingAttr);
+-        FieldInfo[] IReflect.GetFields(BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(96)]
++        FieldInfo[] IReflect.GetFields(BindingFlags bindingAttr);
+-        MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(8191)]
++        MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr);
+-        MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(8191)]
++        MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr);
+-        MethodInfo? IReflect.GetMethod(string name, BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(24)]
++        MethodInfo? IReflect.GetMethod(string name, BindingFlags bindingAttr);
+-        MethodInfo IReflect.GetMethod(string name, BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers);
++        [DynamicallyAccessedMembersAttribute(24)]
++        MethodInfo IReflect.GetMethod(string name, BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers);
+-        MethodInfo[] IReflect.GetMethods(BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(24)]
++        MethodInfo[] IReflect.GetMethods(BindingFlags bindingAttr);
+-        PropertyInfo[] IReflect.GetProperties(BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(1536)]
++        PropertyInfo[] IReflect.GetProperties(BindingFlags bindingAttr);
+-        PropertyInfo? IReflect.GetProperty(string name, BindingFlags bindingAttr);
++        [DynamicallyAccessedMembersAttribute(1536)]
++        PropertyInfo? IReflect.GetProperty(string name, BindingFlags bindingAttr);
+-        PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers);
++        [DynamicallyAccessedMembersAttribute(1536)]
++        PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers);
+-        object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[]? namedParameters);
++        [DynamicallyAccessedMembersAttribute(-1)]
++        object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[]? namedParameters);
+     }
+     [DefaultEventAttribute("Enter")]
+     [DesignTimeVisibleAttribute(false)]
+     [DesignerAttribute("System.Windows.Forms.Design.AxHostDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [ToolboxItemAttribute(false)]
+     public abstract class AxHost : Control, ICustomTypeDescriptor, ISupportInitialize {
+-        [EditorBrowsableAttribute(2)]
+-        TypeConverter ICustomTypeDescriptor.GetConverter();
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
++        TypeConverter ICustomTypeDescriptor.GetConverter();
+-        [EditorBrowsableAttribute(2)]
+-        EventDescriptor ICustomTypeDescriptor.GetDefaultEvent();
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]
++        EventDescriptor ICustomTypeDescriptor.GetDefaultEvent();
+-        [EditorBrowsableAttribute(2)]
+-        PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty();
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("PropertyDescriptor's PropertyType cannot be statically discovered.")]
++        PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty();
+-        [EditorBrowsableAttribute(2)]
+-        object ICustomTypeDescriptor.GetEditor(Type editorBaseType);
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("Editors registered in TypeDescriptor.AddEditorTable may be trimmed.")]
++        object ICustomTypeDescriptor.GetEditor(Type editorBaseType);
+-        [EditorBrowsableAttribute(2)]
+-        EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes);
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++        EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes);
+-        [EditorBrowsableAttribute(2)]
+-        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties();
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("PropertyDescriptor's PropertyType cannot be statically discovered.")]
++        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties();
+-        [EditorBrowsableAttribute(2)]
+-        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes);
++        [EditorBrowsableAttribute(2)]
++        [RequiresUnreferencedCodeAttribute("PropertyDescriptor's PropertyType cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes);
+     }
+     public abstract class BindingManagerBase {
+-        protected virtual PropertyDescriptorCollection? GetItemProperties(Type listType, int offset, ArrayList dataSources, ArrayList listAccessors);
++        protected virtual PropertyDescriptorCollection? GetItemProperties([DynamicallyAccessedMembersAttribute(-1)] Type listType, int offset, ArrayList dataSources, ArrayList listAccessors);
+     }
+     [ComplexBindingPropertiesAttribute("DataSource", "DataMember")]
+     [DefaultEventAttribute("CurrentChanged")]
+     [DefaultPropertyAttribute("DataSource")]
+     [DesignerAttribute("System.Windows.Forms.Design.BindingSourceDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public class BindingSource : Component, IBindingList, IBindingListView, ICancelAddNew, ICollection, ICurrencyManagerProvider, IEnumerable, IList, ISupportInitialize, ISupportInitializeNotification, ITypedList {
+-        [DefaultValueAttribute(null)]
+-        public virtual string Filter { get; set; }
++        [DefaultValueAttribute(null)]
++        public virtual string Filter { get; [RequiresUnreferencedCodeAttribute("Members of types used in the filter expression might be trimmed.")] set; }
+     }
+     [DesignerAttribute("System.Windows.Forms.Design.ButtonBaseDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public abstract class ButtonBase : Control {
+-        [EditorAttribute("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
+-        [SettingsBindableAttribute(true)]
+-        public override string Text { get; set; }
++        [EditorAttribute("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
++        [SettingsBindableAttribute(true)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+-    [DefaultPropertyAttribute("Text")]
+-    [DesignTimeVisibleAttribute(false)]
+-    [ToolboxItemAttribute(false)]
+-    [TypeConverterAttribute(typeof(ColumnHeaderConverter))]
+-    public class ColumnHeader : Component, ICloneable
++    [DefaultPropertyAttribute("Text")]
++    [DesignTimeVisibleAttribute(false)]
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxItemAttribute(false)]
++    [TypeConverterAttribute(typeof(ColumnHeaderConverter))]
++    public class ColumnHeader : Component, ICloneable
+     [DefaultEventAttribute("Click")]
+     [DefaultPropertyAttribute("Text")]
+     [DesignerAttribute("System.Windows.Forms.Design.ControlDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DesignerSerializerAttribute("System.Windows.Forms.Design.ControlCodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.ComponentModel.Design.Serialization.CodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [ToolboxItemFilterAttribute("System.Windows.Forms")]
+     public class Control : Component, IBindableComponent, IComponent, IDisposable, IDropTarget, Interop.Ole32.IOleControl, Interop.Ole32.IOleInPlaceActiveObject, Interop.Ole32.IOleInPlaceObject, Interop.Ole32.IOleObject, Interop.Ole32.IOleWindow, Interop.Ole32.IPersist, Interop.Ole32.IPersistStorage, Interop.Ole32.IPersistStreamInit, Interop.Ole32.IQuickActivate, Interop.Ole32.IViewObject, Interop.Ole32.IViewObject2, Interop.Oleaut32.IPersistPropertyBag, ISynchronizeInvoke, IWin32Window {
+-        public Control(string? text);
++        public Control(string text);
+-        public Control(string? text, int left, int top, int width, int height);
++        public Control(string text, int left, int top, int width, int height);
+-        public Control(Control? parent, string? text);
++        public Control(Control parent, string text);
+-        public Control(Control? parent, string? text, int left, int top, int width, int height);
++        public Control(Control parent, string text, int left, int top, int width, int height);
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(2)]
+-        public string? AccessibleDefaultActionDescription { get; set; }
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(2)]
++        public string AccessibleDefaultActionDescription { get; set; }
+-        [DefaultValueAttribute(null)]
+-        [LocalizableAttribute(true)]
+-        public string? AccessibleDescription { get; set; }
++        [DefaultValueAttribute(null)]
++        [LocalizableAttribute(true)]
++        public string AccessibleDescription { get; set; }
+-        [DefaultValueAttribute(null)]
+-        [LocalizableAttribute(true)]
+-        public string? AccessibleName { get; set; }
++        [DefaultValueAttribute(null)]
++        [LocalizableAttribute(true)]
++        public string AccessibleName { get; set; }
+-        [DefaultValueAttribute(null)]
+-        [LocalizableAttribute(true)]
+-        public virtual Image? BackgroundImage { get; set; }
++        [DefaultValueAttribute(null)]
++        [LocalizableAttribute(true)]
++        public virtual Image BackgroundImage { get; set; }
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(2)]
+-        public virtual BindingContext? BindingContext { get; set; }
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(2)]
++        public virtual BindingContext BindingContext { get; set; }
+-        [DefaultValueAttribute(null)]
+-        public virtual ContextMenuStrip? ContextMenuStrip { get; set; }
++        [DefaultValueAttribute(null)]
++        public virtual ContextMenuStrip ContextMenuStrip { get; set; }
+-        [BrowsableAttribute(false)]
+-        public string Name { get; set; }
++        [BrowsableAttribute(false)]
++        [AllowNullAttribute]
++        public string Name { get; set; }
+-        [BindableAttribute(true)]
+-        [DispIdAttribute(-517)]
+-        [LocalizableAttribute(true)]
+-        public virtual string Text { get; set; }
++        [BindableAttribute(true)]
++        [DispIdAttribute(-517)]
++        [LocalizableAttribute(true)]
++        [AllowNullAttribute]
++        public virtual string Text { get; set; }
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public event EventHandler? AutoSizeChanged;
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        public event EventHandler AutoSizeChanged;
+-        public event EventHandler? BackColorChanged;
++        public event EventHandler BackColorChanged;
+-        public event EventHandler? BackgroundImageChanged;
++        public event EventHandler BackgroundImageChanged;
+-        public event EventHandler? BackgroundImageLayoutChanged;
++        public event EventHandler BackgroundImageLayoutChanged;
+-        public event EventHandler? BindingContextChanged;
++        public event EventHandler BindingContextChanged;
+-        public event EventHandler? CausesValidationChanged;
++        public event EventHandler CausesValidationChanged;
+-        public event EventHandler? ClientSizeChanged;
++        public event EventHandler ClientSizeChanged;
+-        public event EventHandler? ContextMenuStripChanged;
++        public event EventHandler ContextMenuStripChanged;
+-        public event EventHandler? CursorChanged;
++        public event EventHandler CursorChanged;
+-        public event EventHandler? DockChanged;
++        public event EventHandler DockChanged;
+-        public event EventHandler? EnabledChanged;
++        public event EventHandler EnabledChanged;
+-        public event EventHandler? FontChanged;
++        public event EventHandler FontChanged;
+-        public event EventHandler? ForeColorChanged;
++        public event EventHandler ForeColorChanged;
+-        protected virtual AccessibleObject? GetAccessibilityObjectById(int objectId);
++        protected virtual AccessibleObject GetAccessibilityObjectById(int objectId);
+-        public bool SelectNextControl(Control? ctl, bool forward, bool tabStopOnly, bool nested, bool wrap);
++        public bool SelectNextControl(Control ctl, bool forward, bool tabStopOnly, bool nested, bool wrap);
+     }
+-    public class DataGridViewBand : DataGridViewElement, ICloneable, IDisposable
++    [DynamicallyAccessedMembersAttribute(1)]
++    public class DataGridViewBand : DataGridViewElement, ICloneable, IDisposable
+-    public class DataGridViewButtonCell : DataGridViewCell {
++    [DynamicallyAccessedMembersAttribute(1)]
++    public class DataGridViewButtonCell : DataGridViewCell {
+-        public override Type EditType { get; }
++        [DynamicallyAccessedMembersAttribute(8193)]
++        public override Type EditType { get; }
+     }
+-    [ToolboxBitmapAttribute(typeof(DataGridViewButtonColumn), "DataGridViewButtonColumn")]
+-    public class DataGridViewButtonColumn : DataGridViewColumn
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxBitmapAttribute(typeof(DataGridViewButtonColumn), "DataGridViewButtonColumn")]
++    public class DataGridViewButtonColumn : DataGridViewColumn
+-    [TypeConverterAttribute(typeof(DataGridViewCellConverter))]
+-    public abstract class DataGridViewCell : DataGridViewElement, ICloneable, IDisposable {
++    [DynamicallyAccessedMembersAttribute(8193)]
++    [TypeConverterAttribute(typeof(DataGridViewCellConverter))]
++    public abstract class DataGridViewCell : DataGridViewElement, ICloneable, IDisposable {
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(2)]
+-        public virtual Type EditType { get; }
++        [BrowsableAttribute(false)]
++        [DynamicallyAccessedMembersAttribute(8193)]
++        [EditorBrowsableAttribute(2)]
++        public virtual Type EditType { get; }
+     }
+-    public class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewEditingCell {
++    [DynamicallyAccessedMembersAttribute(1)]
++    public class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewEditingCell {
+-        public override Type EditType { get; }
++        [DynamicallyAccessedMembersAttribute(8193)]
++        public override Type EditType { get; }
+     }
+-    [DesignTimeVisibleAttribute(false)]
+-    [DesignerAttribute("System.Windows.Forms.Design.DataGridViewColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+-    [ToolboxItemAttribute(false)]
+-    [TypeConverterAttribute(typeof(DataGridViewColumnConverter))]
+-    public class DataGridViewColumn : DataGridViewBand, IComponent, IDisposable
++    [DesignTimeVisibleAttribute(false)]
++    [DesignerAttribute("System.Windows.Forms.Design.DataGridViewColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxItemAttribute(false)]
++    [TypeConverterAttribute(typeof(DataGridViewColumnConverter))]
++    public class DataGridViewColumn : DataGridViewBand, IComponent, IDisposable
+-    public class DataGridViewComboBoxCell : DataGridViewCell {
++    [DynamicallyAccessedMembersAttribute(1)]
++    public class DataGridViewComboBoxCell : DataGridViewCell {
+-        public override Type EditType { get; }
++        [DynamicallyAccessedMembersAttribute(8193)]
++        public override Type EditType { get; }
+     }
+-    [DesignerAttribute("System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+-    [ToolboxBitmapAttribute(typeof(DataGridViewComboBoxColumn), "DataGridViewComboBoxColumn")]
+-    public class DataGridViewComboBoxColumn : DataGridViewColumn
++    [DesignerAttribute("System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxBitmapAttribute(typeof(DataGridViewComboBoxColumn), "DataGridViewComboBoxColumn")]
++    public class DataGridViewComboBoxColumn : DataGridViewColumn
+     public class DataGridViewImageCell : DataGridViewCell {
+-        public override Type EditType { get; }
++        [DynamicallyAccessedMembersAttribute(8193)]
++        public override Type EditType { get; }
+     }
+-    [ToolboxBitmapAttribute(typeof(DataGridViewImageColumn), "DataGridViewImageColumn")]
+-    public class DataGridViewImageColumn : DataGridViewColumn
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxBitmapAttribute(typeof(DataGridViewImageColumn), "DataGridViewImageColumn")]
++    public class DataGridViewImageColumn : DataGridViewColumn
+     public class DataGridViewLinkCell : DataGridViewCell {
+-        public override Type EditType { get; }
++        [DynamicallyAccessedMembersAttribute(8193)]
++        public override Type EditType { get; }
+     }
+-    [ToolboxBitmapAttribute(typeof(DataGridViewLinkColumn), "DataGridViewLinkColumn")]
+-    public class DataGridViewLinkColumn : DataGridViewColumn
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxBitmapAttribute(typeof(DataGridViewLinkColumn), "DataGridViewLinkColumn")]
++    public class DataGridViewLinkColumn : DataGridViewColumn
+     public class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewEditingControl {
+-        public virtual DataGridView EditingControlDataGridView { get; set; }
++        public virtual DataGridView? EditingControlDataGridView { get; set; }
+     }
+     [DefaultEventAttribute("Enter")]
+     [DefaultPropertyAttribute("Text")]
+     [DesignerAttribute("System.Windows.Forms.Design.GroupBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public class GroupBox : Control {
+-        [LocalizableAttribute(true)]
+-        public override string Text { get; set; }
++        [LocalizableAttribute(true)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+     public interface IDataGridViewEditingControl {
+-        DataGridView EditingControlDataGridView { get; set; }
++        DataGridView? EditingControlDataGridView { get; set; }
+     }
+     [TypeConverterAttribute(typeof(LinkArea.LinkAreaConverter))]
+     public struct LinkArea : IEquatable<LinkArea> {
+         public class LinkAreaConverter : TypeConverter {
+-            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
++            [RequiresUnreferencedCodeAttribute("The Type of value cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
+         }
+     }
+     [DefaultBindingPropertyAttribute("SelectedValue")]
+     [DefaultEventAttribute("SelectedIndexChanged")]
+     [DefaultPropertyAttribute("Items")]
+     [DesignerAttribute("System.Windows.Forms.Design.ListBoxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public class ListBox : ListControl {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(2)]
+-        public override string? Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(2)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+     [DefaultEventAttribute("SelectedIndexChanged")]
+     [DefaultPropertyAttribute("Items")]
+     [DesignerAttribute("System.Windows.Forms.Design.ListViewDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DockingAttribute(DockingBehavior.Ask)]
+     public class ListView : Control {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public override string Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+-    [DefaultPropertyAttribute("Text")]
+-    [DesignTimeVisibleAttribute(false)]
+-    [ToolboxItemAttribute(false)]
+-    [TypeConverterAttribute(typeof(ListViewItemConverter))]
+-    public class ListViewItem : ICloneable, ISerializable
++    [DefaultPropertyAttribute("Text")]
++    [DesignTimeVisibleAttribute(false)]
++    [DynamicallyAccessedMembersAttribute(1)]
++    [ToolboxItemAttribute(false)]
++    [TypeConverterAttribute(typeof(ListViewItemConverter))]
++    public class ListViewItem : ICloneable, ISerializable
+     public struct Message : IEquatable<Message> {
+-        public object? GetLParam(Type cls);
++        public object? GetLParam([DynamicallyAccessedMembersAttribute(7)] Type cls);
+     }
+     public class PaddingConverter : TypeConverter {
+-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
++        [RequiresUnreferencedCodeAttribute("The Type of value cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
+     }
+     [DefaultPropertyAttribute("Document")]
+     public class PrintPreviewControl : Control {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(1)]
+-        public override string Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+     [DefaultBindingPropertyAttribute("Value")]
+     [DefaultPropertyAttribute("Value")]
+     public class ProgressBar : Control {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public override string Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+     [DesignerAttribute("System.Windows.Forms.Design.ScrollableControlDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public class ScrollableControl : Control, IComponent, IDisposable {
+         public class DockPaddingEdgesConverter : TypeConverter {
+-            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
++            [RequiresUnreferencedCodeAttribute("The Type of value cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
+         }
+     }
+     [DefaultEventAttribute("Scroll")]
+     [DefaultPropertyAttribute("Value")]
+     public abstract class ScrollBar : Control {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(1)]
+-        public override string Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+     public class SelectionRangeConverter : TypeConverter {
+-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
++        [RequiresUnreferencedCodeAttribute("The Type of value cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
++        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes);
+     }
+     [DesignerAttribute("System.Windows.Forms.Design.SplitterPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DockingAttribute(DockingBehavior.Never)]
+     [ToolboxItemAttribute(false)]
+     public sealed class SplitterPanel : Panel {
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [EditorBrowsableAttribute(1)]
+-        public new string Name { get; set; }
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public new string Name { get; set; }
+     }
+     [DefaultPropertyAttribute("ColumnCount")]
+     [DesignerAttribute("System.Windows.Forms.Design.TableLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DesignerSerializerAttribute("System.Windows.Forms.Design.TableLayoutPanelCodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.ComponentModel.Design.Serialization.CodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DockingAttribute(DockingBehavior.Never)]
+     [ProvidePropertyAttribute("CellPosition", typeof(Control))]
+     [ProvidePropertyAttribute("Column", typeof(Control))]
+     [ProvidePropertyAttribute("ColumnSpan", typeof(Control))]
+     [ProvidePropertyAttribute("Row", typeof(Control))]
+     [ProvidePropertyAttribute("RowSpan", typeof(Control))]
+     public class TableLayoutPanel : Panel, IExtenderProvider {
+-        public event TableLayoutCellPaintEventHandler CellPaint;
++        public event TableLayoutCellPaintEventHandler? CellPaint;
+-        public Control GetControlFromPosition(int column, int row);
++        public Control? GetControlFromPosition(int column, int row);
+-        public TableLayoutPanelCellPosition GetPositionFromControl(Control control);
++        public TableLayoutPanelCellPosition GetPositionFromControl(Control? control);
+     }
+     [DefaultBindingPropertyAttribute("Value")]
+     [DefaultEventAttribute("Scroll")]
+     [DefaultPropertyAttribute("Value")]
+     [DesignerAttribute("System.Windows.Forms.Design.TrackBarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public class TrackBar : Control, ISupportInitialize {
+-        [BindableAttribute(false)]
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public override string Text { get; set; }
++        [BindableAttribute(false)]
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        [AllowNullAttribute]
++        public override string Text { get; set; }
+     }
+-    [DefaultPropertyAttribute("Text")]
+-    [TypeConverterAttribute(typeof(TreeNodeConverter))]
+-    public class TreeNode : MarshalByRefObject, ICloneable, ISerializable
++    [DefaultPropertyAttribute("Text")]
++    [DynamicallyAccessedMembersAttribute(1)]
++    [TypeConverterAttribute(typeof(TreeNodeConverter))]
++    public class TreeNode : MarshalByRefObject, ICloneable, ISerializable
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview6/README.md
+++ b/release-notes/7.0/preview/api-diff/preview6/README.md
@@ -1,0 +1,7 @@
+# .NET 7.0 Preview 6 API Changes
+
+The following API changes were made in .NET 7.0 Preview 6:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/7.0-preview6.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/7.0-preview6.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/7.0-preview6.md)


### PR DESCRIPTION
I fixed the bug preventing detection of attributes. It might not be perfect, so please point out any unexpected diffs you see. If you can provide a suggested change, even better.

ASP.NET: @dotnet/aspnet-api-review 

WinForms: @merriemcgaw @RussKie @JeremyKuhne 

WPF: @singhashish-wpf and @pchaurasia14 

Libraries: @danmoseley @jeffhandley @karelz @ericstj @stephentoub

@dotnet/area-system-componentmodel 
System.Data @ajcvickers @DavoudEshtehari @David-Engel
System.Formats.Tar @carlossanlop @dotnet/area-system-io 
@dotnet/area-system-io-compression 
@dotnet/area-system-linq 
@dotnet/ncl 
@dotnet/area-system-numerics 
@dotnet/area-system-reflection 
@dotnet/area-system-reflection-emit 
@dotnet/area-system-runtime-compilerservices 
@dotnet/interop-contrib 
@dotnet/area-system-security 
@dotnet/area-system-text-json 
System @dotnet/area-system-runtime @dotnet/area-system-numerics @dotnet/gc 