### PR TITLE
Api-diff between 7.0-preview6 and 7.0-preview7

### DIFF
--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7.md
@@ -1,0 +1,19 @@
+# API Difference 7.0-preview6 vs 7.0-preview7
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Authentication](7.0-preview7_Microsoft.AspNetCore.Authentication.md)
+* [Microsoft.AspNetCore.Authorization](7.0-preview7_Microsoft.AspNetCore.Authorization.md)
+* [Microsoft.AspNetCore.Builder](7.0-preview7_Microsoft.AspNetCore.Builder.md)
+* [Microsoft.AspNetCore.Components](7.0-preview7_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Routing](7.0-preview7_Microsoft.AspNetCore.Components.Routing.md)
+* [Microsoft.AspNetCore.Components.Web](7.0-preview7_Microsoft.AspNetCore.Components.Web.md)
+* [Microsoft.AspNetCore.Components.Web.Virtualization](7.0-preview7_Microsoft.AspNetCore.Components.Web.Virtualization.md)
+* [Microsoft.AspNetCore.Diagnostics](7.0-preview7_Microsoft.AspNetCore.Diagnostics.md)
+* [Microsoft.AspNetCore.Http](7.0-preview7_Microsoft.AspNetCore.Http.md)
+* [Microsoft.AspNetCore.Http.HttpResults](7.0-preview7_Microsoft.AspNetCore.Http.HttpResults.md)
+* [Microsoft.AspNetCore.Routing](7.0-preview7_Microsoft.AspNetCore.Routing.md)
+* [Microsoft.Extensions.DependencyInjection](7.0-preview7_Microsoft.Extensions.DependencyInjection.md)
+* [Microsoft.Net.Http.Headers](7.0-preview7_Microsoft.Net.Http.Headers.md)
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Authentication.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Authentication.md
@@ -1,0 +1,31 @@
+# Microsoft.AspNetCore.Authentication
+
+``` diff
+ namespace Microsoft.AspNetCore.Authentication {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class AuthenticationService : IAuthenticationService {
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__15))]
+-        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<AuthenticateAsync>d__14))]
++        public virtual Task<AuthenticateResult> AuthenticateAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__16))]
+-        public virtual Task ChallengeAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ChallengeAsync>d__15))]
++        public virtual Task ChallengeAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__17))]
+-        public virtual Task ForbidAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<ForbidAsync>d__16))]
++        public virtual Task ForbidAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__18))]
+-        public virtual Task SignInAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, ClaimsPrincipal principal, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignInAsync>d__17))]
++        public virtual Task SignInAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, ClaimsPrincipal principal, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
+-        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__19))]
+-        public virtual Task SignOutAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
++        [AsyncStateMachineAttribute(typeof(AuthenticationService.<SignOutAsync>d__18))]
++        public virtual Task SignOutAsync(HttpContext context, [NullableAttribute((byte)2)] string? scheme, [NullableAttribute((byte)2)] AuthenticationProperties? properties);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Authorization.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Authorization.md
@@ -1,0 +1,22 @@
+# Microsoft.AspNetCore.Authorization
+
+``` diff
+ namespace Microsoft.AspNetCore.Authorization {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public class AuthorizationBuilder {
++        public AuthorizationBuilder(IServiceCollection services);
++        public virtual IServiceCollection Services { [CompilerGeneratedAttribute] get; }
++        public virtual AuthorizationBuilder AddDefaultPolicy(string name, AuthorizationPolicy policy);
++        public virtual AuthorizationBuilder AddDefaultPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy);
++        public virtual AuthorizationBuilder AddFallbackPolicy(string name, AuthorizationPolicy policy);
++        public virtual AuthorizationBuilder AddFallbackPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy);
++        public virtual AuthorizationBuilder AddPolicy(string name, AuthorizationPolicy policy);
++        public virtual AuthorizationBuilder AddPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy);
++        public virtual AuthorizationBuilder SetDefaultPolicy(AuthorizationPolicy policy);
++        public virtual AuthorizationBuilder SetFallbackPolicy([NullableAttribute((byte)2)] AuthorizationPolicy? policy);
++        public virtual AuthorizationBuilder SetInvokeHandlersAfterFailure(bool invoke);
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Builder.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Builder.md
@@ -1,0 +1,46 @@
+# Microsoft.AspNetCore.Builder
+
+``` diff
+ namespace Microsoft.AspNetCore.Builder {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class ConfigureWebHostBuilder : ISupportsStartup, IWebHostBuilder {
+-        IWebHostBuilder ISupportsStartup.UseStartup(Type startupType);
++        IWebHostBuilder ISupportsStartup.UseStartup([DynamicallyAccessedMembersAttribute(11)] Type startupType);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class EndpointRouteBuilderExtensions {
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, RoutePattern pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, RoutePattern pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapDelete(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapDelete(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapGet(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapGet(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapMethods(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, IEnumerable<string> httpMethods, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapMethods(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, IEnumerable<string> httpMethods, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapPatch(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapPatch(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapPost(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapPost(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static IEndpointConventionBuilder MapPut(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
++        public static IEndpointConventionBuilder MapPut(this IEndpointRouteBuilder endpoints, [StringSyntaxAttribute("Route")] string pattern, RequestDelegate requestDelegate);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class WebApplicationBuilder {
+-        public AuthenticationBuilder Authentication { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Routing.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Routing.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Routing {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class LocationChangedEventArgs : EventArgs {
++        [NullableAttribute((byte)2)]
++        public string? HistoryEntryState { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] internal set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Web.Virtualization.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Web.Virtualization.md
@@ -1,0 +1,25 @@
+# Microsoft.AspNetCore.Components.Web.Virtualization
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Web.Virtualization {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class Virtualize<TItem> : ComponentBase, IAsyncDisposable, IVirtualizeJsCallbacks {
++        [ParameterAttribute]
++        public string SpacerElement { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        [AsyncStateMachineAttribute(typeof(Virtualize<>.<DisposeAsync>d__60))]
+-        public ValueTask DisposeAsync();
++        [AsyncStateMachineAttribute(typeof(Virtualize<>.<DisposeAsync>d__64))]
++        public ValueTask DisposeAsync();
+-        [AsyncStateMachineAttribute(typeof(Virtualize<>.<OnAfterRenderAsync>d__50))]
+-        protected override Task OnAfterRenderAsync(bool firstRender);
++        [AsyncStateMachineAttribute(typeof(Virtualize<>.<OnAfterRenderAsync>d__54))]
++        protected override Task OnAfterRenderAsync(bool firstRender);
+-        [AsyncStateMachineAttribute(typeof(Virtualize<>.<RefreshDataAsync>d__48))]
+-        public Task RefreshDataAsync();
++        [AsyncStateMachineAttribute(typeof(Virtualize<>.<RefreshDataAsync>d__52))]
++        public Task RefreshDataAsync();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Web.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.Web.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components.Web
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Web {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class MouseEventArgs : EventArgs {
++        public double MovementX { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public double MovementY { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,26 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class NavigationManager {
++        [NullableAttribute((byte)2)]
++        public string? HistoryEntryState { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] protected set; }
+     }
+     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+     public readonly struct NavigationOptions {
++        public string HistoryEntryState { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class RouteView : IComponent {
+-        [UnconditionalSuppressMessageAttribute("Trimming", "IL2111", Justification="Layout components are preserved because the LayoutAttribute constructor parameter is correctly annotated.")]
+-        protected virtual void Render(RenderTreeBuilder builder);
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2111", Justification="Layout components are preserved because the LayoutAttribute constructor parameter is correctly annotated.")]
++        [UnconditionalSuppressMessageAttribute("Trimming", "IL2118", Justification="Layout components are preserved because the LayoutAttribute constructor parameter is correctly annotated.")]
++        protected virtual void Render(RenderTreeBuilder builder);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Diagnostics.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Diagnostics.md
@@ -1,0 +1,14 @@
+# Microsoft.AspNetCore.Diagnostics
+
+``` diff
+ namespace Microsoft.AspNetCore.Diagnostics {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class DeveloperExceptionPageMiddleware {
+-        [AsyncStateMachineAttribute(typeof(DeveloperExceptionPageMiddleware.<Invoke>d__9))]
+-        public Task Invoke(HttpContext context);
++        public Task Invoke(HttpContext context);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Http.HttpResults.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Http.HttpResults.md
@@ -1,0 +1,245 @@
+# Microsoft.AspNetCore.Http.HttpResults
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.HttpResults {
+-    public sealed class Accepted : IEndpointMetadataProvider, IResult {
++    public sealed class Accepted : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class Accepted<TValue> : IEndpointMetadataProvider, IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class Accepted<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        object IValueHttpResult.Value { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class AcceptedAtRoute : IEndpointMetadataProvider, IResult {
++    public sealed class AcceptedAtRoute : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+-        public string RouteName { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public string? RouteName { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class AcceptedAtRoute<TValue> : IEndpointMetadataProvider, IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class AcceptedAtRoute<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        object IValueHttpResult.Value { get; }
+     }
+-    public sealed class BadRequest : IEndpointMetadataProvider, IResult {
++    public sealed class BadRequest : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class BadRequest<TValue> : IEndpointMetadataProvider, IResult {
++    public sealed class BadRequest<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
+-        public TValue Value { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public TValue? Value { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
+-    public sealed class Conflict : IEndpointMetadataProvider, IResult {
++    public sealed class Conflict : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class Conflict<TValue> : IEndpointMetadataProvider, IResult {
++    public sealed class Conflict<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
+-        public TValue Value { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public TValue? Value { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class ContentHttpResult : IResult
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class ContentHttpResult : IContentTypeHttpResult, IResult, IStatusCodeHttpResult
+-    public sealed class Created : IEndpointMetadataProvider, IResult {
++    public sealed class Created : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class Created<TValue> : IEndpointMetadataProvider, IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class Created<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        object IValueHttpResult.Value { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class CreatedAtRoute : IEndpointMetadataProvider, IResult {
++    public sealed class CreatedAtRoute : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+-        public string RouteName { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public string? RouteName { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class CreatedAtRoute<TValue> : IEndpointMetadataProvider, IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class CreatedAtRoute<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        object IValueHttpResult.Value { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class FileContentHttpResult : IResult {
++    public sealed class FileContentHttpResult : IContentTypeHttpResult, IFileHttpResult, IResult {
+-        public EntityTagHeaderValue EntityTag { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] internal set; }
++        [NullableAttribute((byte)2)]
++        public EntityTagHeaderValue? EntityTag { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] internal set; }
+-        public string FileDownloadName { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] internal set; }
++        [NullableAttribute((byte)2)]
++        public string? FileDownloadName { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] internal set; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class FileStreamHttpResult : IResult
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class FileStreamHttpResult : IContentTypeHttpResult, IFileHttpResult, IResult
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class JsonHttpResult<TValue> : IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class JsonHttpResult<TValue> : IContentTypeHttpResult, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        object IValueHttpResult.Value { get; }
+     }
+-    public class NoContent : IEndpointMetadataProvider, IResult {
++    public class NoContent : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    public sealed class NotFound : IEndpointMetadataProvider, IResult {
++    public sealed class NotFound : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class NotFound<TValue> : IEndpointMetadataProvider, IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class NotFound<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        object IValueHttpResult.Value { get; }
+     }
+-    public sealed class Ok : IEndpointMetadataProvider, IResult {
++    public sealed class Ok : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class Ok<TValue> : IEndpointMetadataProvider, IResult {
++    public sealed class Ok<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
+-        public TValue Value { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public TValue? Value { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class PhysicalFileHttpResult : IResult
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class PhysicalFileHttpResult : IContentTypeHttpResult, IFileHttpResult, IResult
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class ProblemHttpResult : IResult {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class ProblemHttpResult : IContentTypeHttpResult, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<ProblemDetails> {
++        int? IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? IValueHttpResult.Value { get; }
++        [NullableAttribute((byte)2)]
++        ProblemDetails? IValueHttpResult<ProblemDetails>.Value { get; }
+-        public int? StatusCode { get; }
++        public int StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class PushStreamHttpResult : IResult
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class PushStreamHttpResult : IContentTypeHttpResult, IFileHttpResult, IResult
+-    public sealed class Results<TResult1, TResult2> : IEndpointMetadataProvider, IResult where TResult1 : IResult where TResult2 : IResult
++    public sealed class Results<TResult1, TResult2> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult
+-    public sealed class Results<TResult1, TResult2, TResult3> : IEndpointMetadataProvider, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult
++    public sealed class Results<TResult1, TResult2, TResult3> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult
+-    public sealed class Results<TResult1, TResult2, TResult3, TResult4> : IEndpointMetadataProvider, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult
++    public sealed class Results<TResult1, TResult2, TResult3, TResult4> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult
+-    public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5> : IEndpointMetadataProvider, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult
++    public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult
+-    public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> : IEndpointMetadataProvider, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult where TResult6 : IResult
++    public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult where TResult6 : IResult
+-    public sealed class StatusCodeHttpResult : IResult {
++    public sealed class StatusCodeHttpResult : IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    public sealed class UnauthorizedHttpResult : IResult {
++    public sealed class UnauthorizedHttpResult : IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    public sealed class UnprocessableEntity : IEndpointMetadataProvider, IResult {
++    public sealed class UnprocessableEntity : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)2)]
+-    public sealed class UnprocessableEntity<TValue> : IEndpointMetadataProvider, IResult {
++    public sealed class UnprocessableEntity<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
+-        public TValue Value { [CompilerGeneratedAttribute] get; }
++        [NullableAttribute((byte)2)]
++        public TValue? Value { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; }
+     }
++    public sealed class Utf8ContentHttpResult : IContentTypeHttpResult, IResult, IStatusCodeHttpResult {
++        [NullableAttribute((byte)2)]
++        public string? ContentType { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] internal set; }
++        public ReadOnlyMemory<byte> ResponseContent { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] internal set; }
++        public int? StatusCode { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] internal set; }
++        [NullableContextAttribute((byte)1)]
++        public Task ExecuteAsync(HttpContext httpContext);
++    }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class ValidationProblem : IEndpointMetadataProvider, IResult {
++    public sealed class ValidationProblem : IContentTypeHttpResult, IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<HttpValidationProblemDetails> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        [NullableAttribute((byte)2)]
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
++        [NullableAttribute((byte)2)]
++        HttpValidationProblemDetails? IValueHttpResult<HttpValidationProblemDetails>.Value { get; }
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class VirtualFileHttpResult : IResult
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class VirtualFileHttpResult : IContentTypeHttpResult, IFileHttpResult, IResult
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Http.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Http.md
@@ -1,0 +1,182 @@
+# Microsoft.AspNetCore.Http
+
+``` diff
+ namespace Microsoft.AspNetCore.Http {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class DefaultEndpointFilterInvocationContext : EndpointFilterInvocationContext {
++        public DefaultEndpointFilterInvocationContext(HttpContext httpContext, params object[] arguments);
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        public override IList<object?> Arguments { [CompilerGeneratedAttribute] get; }
++        public override HttpContext HttpContext { [CompilerGeneratedAttribute] get; }
++        public override T GetArgument<T>(int index);
++    }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class DefaultRouteHandlerInvocationContext : RouteHandlerInvocationContext {
+-        public DefaultRouteHandlerInvocationContext(HttpContext httpContext, params object[] arguments);
+-        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
+-        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
+-        public override IList<object?> Arguments { [CompilerGeneratedAttribute] get; }
+-        public override HttpContext HttpContext { [CompilerGeneratedAttribute] get; }
+-        public override T GetArgument<T>(int index);
+-    }
++    public delegate ValueTask<object?> EndpointFilterDelegate(EndpointFilterInvocationContext context);
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public static class EndpointFilterExtensions {
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddEndpointFilter<TBuilder, TFilterType>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder where TFilterType : IEndpointFilter;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddEndpointFilter<TBuilder>(this TBuilder builder, IEndpointFilter filter) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddEndpointFilter<TBuilder>(this TBuilder builder, Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate> filterFactory) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static TBuilder AddEndpointFilter<TBuilder>(this TBuilder builder, [NullableAttribute(new byte[]{ (byte)1, (byte)1, (byte)1, (byte)0, (byte)2})] Func<EndpointFilterInvocationContext, EndpointFilterDelegate, ValueTask<object?>> routeHandlerFilter) where TBuilder : IEndpointConventionBuilder;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteHandlerBuilder AddEndpointFilter<TFilterType>(this RouteHandlerBuilder builder) where TFilterType : IEndpointFilter;
++        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
++        public static RouteGroupBuilder AddEndpointFilter<TFilterType>(this RouteGroupBuilder builder) where TFilterType : IEndpointFilter;
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class EndpointFilterFactoryContext {
++        public EndpointFilterFactoryContext(MethodInfo methodInfo, IList<object> endpointMetadata, IServiceProvider applicationServices);
++        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
++        public IList<object> EndpointMetadata { [CompilerGeneratedAttribute] get; }
++        public MethodInfo MethodInfo { [CompilerGeneratedAttribute] get; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public abstract class EndpointFilterInvocationContext {
++        protected EndpointFilterInvocationContext();
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        public abstract IList<object?> Arguments { get; }
++        public abstract HttpContext HttpContext { get; }
++        public abstract T GetArgument<T>(int index);
++    }
++    [NullableContextAttribute((byte)2)]
++    public interface IContentTypeHttpResult {
++        string ContentType { get; }
++    }
++    [NullableContextAttribute((byte)1)]
++    public interface IEndpointFilter {
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)2})]
++        ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next);
++    }
++    [NullableContextAttribute((byte)2)]
++    public interface IFileHttpResult {
++        string ContentType { get; }
++        string FileDownloadName { get; }
++    }
++    [NullableContextAttribute((byte)1)]
++    public interface INestedHttpResult {
++        IResult Result { get; }
++    }
++    [NullableContextAttribute((byte)1)]
++    public interface IProblemDetailsService {
++        ValueTask WriteAsync(ProblemDetailsContext context);
++    }
++    [NullableContextAttribute((byte)1)]
++    public interface IProblemDetailsWriter {
++        bool CanWrite(ProblemDetailsContext context);
++        ValueTask WriteAsync(ProblemDetailsContext context);
++    }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IRouteHandlerFilter {
+-        [return: NullableAttribute(new byte[]{ (byte)0, (byte)2})]
+-        ValueTask<object?> InvokeAsync(RouteHandlerInvocationContext context, RouteHandlerFilterDelegate next);
+-    }
++    public interface IStatusCodeHttpResult {
++        int? StatusCode { get; }
++    }
++    [NullableContextAttribute((byte)2)]
++    public interface IValueHttpResult {
++        object Value { get; }
++    }
++    [NullableContextAttribute((byte)2)]
++    public interface IValueHttpResult<out TValue> {
++        TValue Value { get; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class ProblemDetailsContext {
++        public ProblemDetailsContext();
++        [NullableAttribute((byte)2)]
++        public EndpointMetadataCollection? AdditionalMetadata { [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] get; [CompilerGeneratedAttribute, NullableContextAttribute((byte)2)] set; }
++        public required HttpContext HttpContext { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public ProblemDetails ProblemDetails { get; set; }
++    }
++    public class ProblemDetailsOptions {
++        public ProblemDetailsOptions();
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public Action<ProblemDetailsContext>? CustomizeProblemDetails { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++    }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public sealed class RequestDelegateFactoryOptions {
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
++        public IReadOnlyList<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>? EndpointFilterFactories { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+-        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
+-        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
+-        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})]
+-        public IReadOnlyList<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>? RouteHandlerFilterFactories { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public static class Results {
++        [NullableContextAttribute((byte)0)]
++        [return: NullableAttribute((byte)1)]
++        public static IResult Text(ReadOnlySpan<byte> utf8Content, [NullableAttribute((byte)2)] string? contentType = null, int? statusCode = default(int?));
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class RouteHandlerContext {
+-        public RouteHandlerContext(MethodInfo methodInfo, IList<object> endpointMetadata, IServiceProvider applicationServices);
+-        public IServiceProvider ApplicationServices { [CompilerGeneratedAttribute] get; }
+-        public IList<object> EndpointMetadata { [CompilerGeneratedAttribute] get; }
+-        public MethodInfo MethodInfo { [CompilerGeneratedAttribute] get; }
+-    }
+-    public delegate ValueTask<object?> RouteHandlerFilterDelegate(RouteHandlerInvocationContext context);
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public static class RouteHandlerFilterExtensions {
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static TBuilder AddRouteHandlerFilter<TBuilder, TFilterType>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder where TFilterType : IRouteHandlerFilter;
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, IRouteHandlerFilter filter) where TBuilder : IEndpointConventionBuilder;
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate> filterFactory) where TBuilder : IEndpointConventionBuilder;
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static TBuilder AddRouteHandlerFilter<TBuilder>(this TBuilder builder, [NullableAttribute(new byte[]{ (byte)1, (byte)1, (byte)1, (byte)0, (byte)2})] Func<RouteHandlerInvocationContext, RouteHandlerFilterDelegate, ValueTask<object?>> routeHandlerFilter) where TBuilder : IEndpointConventionBuilder;
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteHandlerBuilder AddRouteHandlerFilter<TFilterType>(this RouteHandlerBuilder builder) where TFilterType : IRouteHandlerFilter;
+-        [RequiresUnreferencedCodeAttribute("This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.")]
+-        public static RouteGroupBuilder AddRouteHandlerFilter<TFilterType>(this RouteGroupBuilder builder) where TFilterType : IRouteHandlerFilter;
+-    }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public abstract class RouteHandlerInvocationContext {
+-        protected RouteHandlerInvocationContext();
+-        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
+-        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
+-        public abstract IList<object?> Arguments { get; }
+-        public abstract HttpContext HttpContext { get; }
+-        public abstract T GetArgument<T>(int index);
+-    }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public static class TypedResults {
++        [NullableContextAttribute((byte)0)]
++        [return: NullableAttribute((byte)1)]
++        public static Utf8ContentHttpResult Text(ReadOnlySpan<byte> utf8Content, [NullableAttribute((byte)2)] string? contentType = null, int? statusCode = default(int?));
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Routing.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.AspNetCore.Routing.md
@@ -1,0 +1,28 @@
+# Microsoft.AspNetCore.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing {
+     [DebuggerDisplayAttribute("{DebuggerDisplayString,nq}")]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class CompositeEndpointDataSource : EndpointDataSource, IDisposable {
+-        public override IReadOnlyList<Endpoint> GetEndpointGroup(RouteGroupContext context);
++        public override IReadOnlyList<Endpoint> GetGroupedEndpoints(RouteGroupContext context);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class EndpointDataSource {
+-        public virtual IReadOnlyList<Endpoint> GetEndpointGroup(RouteGroupContext context);
++        public virtual IReadOnlyList<Endpoint> GetGroupedEndpoints(RouteGroupContext context);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class RouteEndpointBuilder : EndpointBuilder {
+-        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="We surface a RequireUnreferencedCode in AddRouteHandlerFilter which is required to call unreferenced code here. The trimmer is unable to infer this.")]
+-        public override Endpoint Build();
++        [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="We surface a RequireUnreferencedCode in AddEndpointFilter which is required to call unreferenced code here. The trimmer is unable to infer this.")]
++        public override Endpoint Build();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,18 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class PolicyServiceCollectionExtensions {
++        public static AuthorizationBuilder AddAuthorizationBuilder(this IServiceCollection services);
+     }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public static class ProblemDetailsServiceCollectionExtensions {
++        public static IServiceCollection AddProblemDetails(this IServiceCollection services);
++        public static IServiceCollection AddProblemDetails(this IServiceCollection services, [NullableAttribute(new byte[]{ (byte)2, (byte)1})] Action<ProblemDetailsOptions>? configure);
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.Net.Http.Headers.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.AspNetCore.App/7.0-preview7_Microsoft.Net.Http.Headers.md
@@ -1,0 +1,27 @@
+# Microsoft.Net.Http.Headers
+
+``` diff
+ namespace Microsoft.Net.Http.Headers {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class HeaderNames {
+-        public static readonly string Authority;
++        [ObsoleteAttribute("This is obsolete and will be removed in a future version. Header dictionaries do not contain this key.", false)]
++        public static readonly string Authority;
+-        public static readonly string Method;
++        [ObsoleteAttribute("This is obsolete and will be removed in a future version. Header dictionaries do not contain this key.", false)]
++        public static readonly string Method;
+-        public static readonly string Path;
++        [ObsoleteAttribute("This is obsolete and will be removed in a future version. Header dictionaries do not contain this key.", false)]
++        public static readonly string Path;
+-        public static readonly string Protocol;
+-        public static readonly string Scheme;
++        [ObsoleteAttribute("This is obsolete and will be removed in a future version. Header dictionaries do not contain this key.", false)]
++        public static readonly string Scheme;
+-        public static readonly string Status;
++        [ObsoleteAttribute("This is obsolete and will be removed in a future version. Header dictionaries do not contain this key.", false)]
++        public static readonly string Status;
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7.md
@@ -1,0 +1,31 @@
+# API Difference 7.0-preview6 vs 7.0-preview7
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](7.0-preview7_System.md)
+* [System.Formats.Tar](7.0-preview7_System.Formats.Tar.md)
+* [System.IO](7.0-preview7_System.IO.md)
+* [System.Linq](7.0-preview7_System.Linq.md)
+* [System.Net.Http](7.0-preview7_System.Net.Http.md)
+* [System.Net.Http.Headers](7.0-preview7_System.Net.Http.Headers.md)
+* [System.Net.Quic](7.0-preview7_System.Net.Quic.md)
+* [System.Net.Security](7.0-preview7_System.Net.Security.md)
+* [System.Net.WebSockets](7.0-preview7_System.Net.WebSockets.md)
+* [System.Numerics](7.0-preview7_System.Numerics.md)
+* [System.Reflection.Metadata](7.0-preview7_System.Reflection.Metadata.md)
+* [System.Runtime.InteropServices](7.0-preview7_System.Runtime.InteropServices.md)
+* [System.Runtime.InteropServices.JavaScript](7.0-preview7_System.Runtime.InteropServices.JavaScript.md)
+* [System.Runtime.InteropServices.Marshalling](7.0-preview7_System.Runtime.InteropServices.Marshalling.md)
+* [System.Runtime.Intrinsics](7.0-preview7_System.Runtime.Intrinsics.md)
+* [System.Runtime.Versioning](7.0-preview7_System.Runtime.Versioning.md)
+* [System.Security.Cryptography](7.0-preview7_System.Security.Cryptography.md)
+* [System.Security.Cryptography.X509Certificates](7.0-preview7_System.Security.Cryptography.X509Certificates.md)
+* [System.Text.Json](7.0-preview7_System.Text.Json.md)
+* [System.Text.Json.Serialization](7.0-preview7_System.Text.Json.Serialization.md)
+* [System.Text.Json.Serialization.Metadata](7.0-preview7_System.Text.Json.Serialization.Metadata.md)
+* [System.Text.RegularExpressions](7.0-preview7_System.Text.RegularExpressions.md)
+* [System.Threading.Tasks.Dataflow](7.0-preview7_System.Threading.Tasks.Dataflow.md)
+* [System.Xml](7.0-preview7_System.Xml.md)
+* [System.Xml.XPath](7.0-preview7_System.Xml.XPath.md)
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Formats.Tar.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Formats.Tar.md
@@ -1,0 +1,54 @@
+# System.Formats.Tar
+
+``` diff
+ namespace System.Formats.Tar {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class TarEntry {
+-        public TarFileMode Mode { get; set; }
++        public UnixFileMode Mode { get; set; }
++        public Task ExtractToFileAsync(string destinationFileName, bool overwrite, CancellationToken cancellationToken = default(CancellationToken));
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class TarFile {
++        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default(CancellationToken));
++        public static Task ExtractToDirectoryAsync(string sourceFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default(CancellationToken));
+     }
+-    [FlagsAttribute]
+-    public enum TarFileMode {
+-        GroupExecute = 8,
+-        GroupRead = 32,
+-        GroupSpecial = 1024,
+-        GroupWrite = 16,
+-        None = 0,
+-        OtherExecute = 1,
+-        OtherRead = 4,
+-        OtherWrite = 2,
+-        StickyBit = 512,
+-        UserExecute = 64,
+-        UserRead = 256,
+-        UserSpecial = 2048,
+-        UserWrite = 128,
+-    }
+-    public sealed class TarReader : IDisposable {
++    public sealed class TarReader : IAsyncDisposable, IDisposable {
++        public ValueTask DisposeAsync();
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)2})]
++        public ValueTask<TarEntry?> GetNextEntryAsync(bool copyData = false, CancellationToken cancellationToken = default(CancellationToken));
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class TarWriter : IDisposable {
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class TarWriter : IAsyncDisposable, IDisposable {
++        public ValueTask DisposeAsync();
++        public Task WriteEntryAsync(TarEntry entry, CancellationToken cancellationToken = default(CancellationToken));
++        public Task WriteEntryAsync(string fileName, [NullableAttribute((byte)2)] string? entryName, CancellationToken cancellationToken = default(CancellationToken));
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.IO.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.IO.md
@@ -1,0 +1,25 @@
+# System.IO
+
+``` diff
+ namespace System.IO {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class File {
++        public static FileAttributes GetAttributes(SafeFileHandle fileHandle);
++        public static DateTime GetCreationTime(SafeFileHandle fileHandle);
++        public static DateTime GetCreationTimeUtc(SafeFileHandle fileHandle);
++        public static DateTime GetLastAccessTime(SafeFileHandle fileHandle);
++        public static DateTime GetLastAccessTimeUtc(SafeFileHandle fileHandle);
++        public static DateTime GetLastWriteTime(SafeFileHandle fileHandle);
++        public static DateTime GetLastWriteTimeUtc(SafeFileHandle fileHandle);
++        public static void SetAttributes(SafeFileHandle fileHandle, FileAttributes fileAttributes);
++        public static void SetCreationTime(SafeFileHandle fileHandle, DateTime creationTime);
++        public static void SetCreationTimeUtc(SafeFileHandle fileHandle, DateTime creationTimeUtc);
++        public static void SetLastAccessTime(SafeFileHandle fileHandle, DateTime lastAccessTime);
++        public static void SetLastAccessTimeUtc(SafeFileHandle fileHandle, DateTime lastAccessTimeUtc);
++        public static void SetLastWriteTime(SafeFileHandle fileHandle, DateTime lastWriteTime);
++        public static void SetLastWriteTimeUtc(SafeFileHandle fileHandle, DateTime lastWriteTimeUtc);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Linq.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Linq.md
@@ -1,0 +1,23 @@
+# System.Linq
+
+``` diff
+ namespace System.Linq {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class Enumerable {
++        public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source);
++        public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source, [NullableAttribute(new byte[]{ (byte)2, (byte)1})] IComparer<T>? comparer);
++        public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source);
++        public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source, [NullableAttribute(new byte[]{ (byte)2, (byte)1})] IComparer<T>? comparer);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class Queryable {
++        public static IOrderedQueryable<T> Order<T>(this IQueryable<T> source);
++        public static IOrderedQueryable<T> Order<T>(this IQueryable<T> source, IComparer<T> comparer);
++        public static IOrderedQueryable<T> OrderDescending<T>(this IQueryable<T> source);
++        public static IOrderedQueryable<T> OrderDescending<T>(this IQueryable<T> source, IComparer<T> comparer);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Http.Headers.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Http.Headers.md
@@ -1,0 +1,13 @@
+# System.Net.Http.Headers
+
+``` diff
+ namespace System.Net.Http.Headers {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class HttpRequestHeaders : HttpHeaders {
++        [NullableAttribute((byte)2)]
++        public string? Protocol { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Http.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Http.md
@@ -1,0 +1,17 @@
+# System.Net.Http
+
+``` diff
+ namespace System.Net.Http {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class HttpMethod : IEquatable<HttpMethod> {
++        public static HttpMethod Connect { get; }
+     }
++    public sealed class HttpProtocolException : IOException {
++        [NullableContextAttribute((byte)2)]
++        public HttpProtocolException(long errorCode, string? message, Exception? innerException);
++        public long ErrorCode { get; }
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Quic.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Quic.md
@@ -1,0 +1,147 @@
+# System.Net.Quic
+
+``` diff
++namespace System.Net.Quic {
++    [FlagsAttribute]
++    public enum QuicAbortDirection {
++        Both = 3,
++        Read = 1,
++        Write = 2,
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicClientConnectionOptions : QuicConnectionOptions {
++        public QuicClientConnectionOptions();
++        public SslClientAuthenticationOptions ClientAuthenticationOptions { get; set; }
++        [NullableAttribute((byte)2)]
++        public IPEndPoint? LocalEndPoint { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
++        public EndPoint RemoteEndPoint { get; set; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicConnection : IAsyncDisposable {
++        public static bool IsSupported { get; }
++        public IPEndPoint LocalEndPoint { get; }
++        public SslApplicationProtocol NegotiatedApplicationProtocol { get; }
++        [NullableAttribute((byte)2)]
++        public X509Certificate? RemoteCertificate { [NullableContextAttribute((byte)2)] get; }
++        public IPEndPoint RemoteEndPoint { get; }
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public ValueTask<QuicStream> AcceptInboundStreamAsync(CancellationToken cancellationToken = default(CancellationToken));
++        public ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default(CancellationToken));
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static ValueTask<QuicConnection> ConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default(CancellationToken));
++        public ValueTask DisposeAsync();
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public ValueTask<QuicStream> OpenOutboundStreamAsync(QuicStreamType type, CancellationToken cancellationToken = default(CancellationToken));
++        public override string ToString();
++    }
++    public abstract class QuicConnectionOptions {
++        public long DefaultCloseErrorCode { get; set; }
++        public long DefaultStreamErrorCode { get; set; }
++        public TimeSpan IdleTimeout { get; set; }
++        public int MaxInboundBidirectionalStreams { get; set; }
++        public int MaxInboundUnidirectionalStreams { get; set; }
++    }
++    public enum QuicError {
++        AddressInUse = 4,
++        ConnectionAborted = 2,
++        ConnectionIdle = 10,
++        ConnectionRefused = 8,
++        ConnectionTimeout = 6,
++        HostUnreachable = 7,
++        InternalError = 1,
++        InvalidAddress = 5,
++        OperationAborted = 12,
++        ProtocolError = 11,
++        StreamAborted = 3,
++        Success = 0,
++        VersionNegotiationError = 9,
++    }
++    public sealed class QuicException : IOException {
++        [NullableContextAttribute((byte)1)]
++        public QuicException(QuicError error, long? applicationErrorCode, string message);
++        public long? ApplicationErrorCode { get; }
++        public QuicError QuicError { get; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicListener : IAsyncDisposable {
++        public static bool IsSupported { get; }
++        public IPEndPoint LocalEndPoint { get; }
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public ValueTask<QuicConnection> AcceptConnectionAsync(CancellationToken cancellationToken = default(CancellationToken));
++        public ValueTask DisposeAsync();
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static ValueTask<QuicListener> ListenAsync(QuicListenerOptions options, CancellationToken cancellationToken = default(CancellationToken));
++        public override string ToString();
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicListenerOptions {
++        public QuicListenerOptions();
++        public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
++        [NullableAttribute(new byte[]{ (byte)1, (byte)1, (byte)0, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)1, (byte)1, (byte)0, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)1, (byte)1, (byte)0, (byte)1})]
++        public Func<QuicConnection, SslClientHelloInfo, CancellationToken, ValueTask<QuicServerConnectionOptions>> ConnectionOptionsCallback { get; set; }
++        public int ListenBacklog { get; set; }
++        public IPEndPoint ListenEndPoint { get; set; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicServerConnectionOptions : QuicConnectionOptions {
++        public QuicServerConnectionOptions();
++        public SslServerAuthenticationOptions ServerAuthenticationOptions { get; set; }
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class QuicStream : Stream {
++        public override bool CanRead { get; }
++        public override bool CanSeek { get; }
++        public override bool CanTimeout { get; }
++        public override bool CanWrite { get; }
++        public long Id { get; }
++        public override long Length { get; }
++        public override long Position { get; set; }
++        public Task ReadsClosed { get; }
++        public override int ReadTimeout { get; set; }
++        public QuicStreamType Type { get; }
++        public Task WritesClosed { get; }
++        public override int WriteTimeout { get; set; }
++        public void Abort(QuicAbortDirection abortDirection, long errorCode);
++        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, [NullableAttribute((byte)2)] AsyncCallback? callback, [NullableAttribute((byte)2)] object? state);
++        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, [NullableAttribute((byte)2)] AsyncCallback? callback, [NullableAttribute((byte)2)] object? state);
++        public void CompleteWrites();
++        protected override void Dispose(bool disposing);
++        public override ValueTask DisposeAsync();
++        public override int EndRead(IAsyncResult asyncResult);
++        public override void EndWrite(IAsyncResult asyncResult);
++        public override void Flush();
++        public override Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
++        public override int Read(byte[] buffer, int offset, int count);
++        [NullableContextAttribute((byte)0)]
++        public override int Read(Span<byte> buffer);
++        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default(CancellationToken));
++        [NullableContextAttribute((byte)0)]
++        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken));
++        public override int ReadByte();
++        public override long Seek(long offset, SeekOrigin origin);
++        public override void SetLength(long value);
++        public override void Write(byte[] buffer, int offset, int count);
++        [NullableContextAttribute((byte)0)]
++        public override void Write(ReadOnlySpan<byte> buffer);
++        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default(CancellationToken));
++        [NullableContextAttribute((byte)0)]
++        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool completeWrites, CancellationToken cancellationToken = default(CancellationToken));
++        [NullableContextAttribute((byte)0)]
++        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken));
++        public override void WriteByte(byte value);
++    }
++    public enum QuicStreamType {
++        Bidirectional = 1,
++        Unidirectional = 0,
++    }
++}
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Security.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.Security.md
@@ -1,0 +1,43 @@
+# System.Net.Security
+
+``` diff
+ namespace System.Net.Security {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class NegotiateAuthentication : IDisposable {
++        public TokenImpersonationLevel ImpersonationLevel { get; }
++        public NegotiateAuthenticationStatusCode Unwrap(ReadOnlySpan<byte> input, [NullableAttribute((byte)1)] IBufferWriter<byte> outputWriter, out bool wasEncrypted);
++        public NegotiateAuthenticationStatusCode UnwrapInPlace(Span<byte> input, out int unwrappedOffset, out int unwrappedLength, out bool wasEncrypted);
++        public NegotiateAuthenticationStatusCode Wrap(ReadOnlySpan<byte> input, [NullableAttribute((byte)1)] IBufferWriter<byte> outputWriter, bool requestEncryption, out bool isEncrypted);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class NegotiateAuthenticationClientOptions {
++        public TokenImpersonationLevel AllowedImpersonationLevel { get; set; }
++        public bool RequireMutualAuthentication { get; set; }
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class NegotiateAuthenticationServerOptions {
++        [NullableAttribute((byte)2)]
++        public ExtendedProtectionPolicy? Policy { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
++        public TokenImpersonationLevel RequiredImpersonationLevel { get; set; }
+     }
+     public enum NegotiateAuthenticationStatusCode {
++        ImpersonationValidationFailed = 15,
++        SecurityQosFailed = 13,
++        TargetUnknown = 14,
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public class SslClientAuthenticationOptions {
++        public X509ChainPolicy CertificateChainPolicy { get; set; }
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public class SslServerAuthenticationOptions {
++        public X509ChainPolicy CertificateChainPolicy { get; set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.WebSockets.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Net.WebSockets.md
@@ -1,0 +1,24 @@
+# System.Net.WebSockets
+
+``` diff
+ namespace System.Net.WebSockets {
+     public sealed class ClientWebSocket : WebSocket {
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
++        public IReadOnlyDictionary<string, IEnumerable<string>>? HttpResponseHeaders { get; set; }
++        public HttpStatusCode HttpStatusCode { get; }
++        public Task ConnectAsync(Uri uri, [NullableAttribute((byte)2)] HttpMessageInvoker? invoker, CancellationToken cancellationToken);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public sealed class ClientWebSocketOptions {
++        [UnsupportedOSPlatformAttribute("browser")]
++        public bool CollectHttpResponseDetails { get; set; }
++        [NullableAttribute((byte)1)]
++        public Version HttpVersion { [NullableContextAttribute((byte)1)] get; [NullableContextAttribute((byte)1), UnsupportedOSPlatformAttribute("browser")] set; }
++        public HttpVersionPolicy HttpVersionPolicy { get; [UnsupportedOSPlatformAttribute("browser")] set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Numerics.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Numerics.md
@@ -1,0 +1,146 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct BigInteger : IAdditionOperators<BigInteger, BigInteger, BigInteger>, IAdditiveIdentity<BigInteger, BigInteger>, IBinaryInteger<BigInteger>, IBinaryNumber<BigInteger>, IBitwiseOperators<BigInteger, BigInteger, BigInteger>, IComparable, IComparable<BigInteger>, IComparisonOperators<BigInteger, BigInteger>, IDecrementOperators<BigInteger>, IDivisionOperators<BigInteger, BigInteger, BigInteger>, IEqualityOperators<BigInteger, BigInteger>, IEquatable<BigInteger>, IFormattable, IIncrementOperators<BigInteger>, IModulusOperators<BigInteger, BigInteger, BigInteger>, IMultiplicativeIdentity<BigInteger, BigInteger>, IMultiplyOperators<BigInteger, BigInteger, BigInteger>, INumber<BigInteger>, INumberBase<BigInteger>, IParsable<BigInteger>, IShiftOperators<BigInteger, BigInteger>, ISignedNumber<BigInteger>, ISpanFormattable, ISpanParsable<BigInteger>, ISubtractionOperators<BigInteger, BigInteger, BigInteger>, IUnaryNegationOperators<BigInteger, BigInteger>, IUnaryPlusOperators<BigInteger, BigInteger> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct BigInteger : IAdditionOperators<BigInteger, BigInteger, BigInteger>, IAdditiveIdentity<BigInteger, BigInteger>, IBinaryInteger<BigInteger>, IBinaryNumber<BigInteger>, IBitwiseOperators<BigInteger, BigInteger, BigInteger>, IComparable, IComparable<BigInteger>, IComparisonOperators<BigInteger, BigInteger, bool>, IDecrementOperators<BigInteger>, IDivisionOperators<BigInteger, BigInteger, BigInteger>, IEqualityOperators<BigInteger, BigInteger, bool>, IEquatable<BigInteger>, IFormattable, IIncrementOperators<BigInteger>, IModulusOperators<BigInteger, BigInteger, BigInteger>, IMultiplicativeIdentity<BigInteger, BigInteger>, IMultiplyOperators<BigInteger, BigInteger, BigInteger>, INumber<BigInteger>, INumberBase<BigInteger>, IParsable<BigInteger>, IShiftOperators<BigInteger, int, BigInteger>, ISignedNumber<BigInteger>, ISpanFormattable, ISpanParsable<BigInteger>, ISubtractionOperators<BigInteger, BigInteger, BigInteger>, IUnaryNegationOperators<BigInteger, BigInteger>, IUnaryPlusOperators<BigInteger, BigInteger> {
++        static BigInteger System.Numerics.IBinaryNumber<System.Numerics.BigInteger>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static BigInteger CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static BigInteger CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static BigInteger CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Complex : IAdditionOperators<Complex, Complex, Complex>, IAdditiveIdentity<Complex, Complex>, IDecrementOperators<Complex>, IDivisionOperators<Complex, Complex, Complex>, IEqualityOperators<Complex, Complex>, IEquatable<Complex>, IFormattable, IIncrementOperators<Complex>, IMultiplicativeIdentity<Complex, Complex>, IMultiplyOperators<Complex, Complex, Complex>, INumberBase<Complex>, IParsable<Complex>, ISignedNumber<Complex>, ISpanFormattable, ISpanParsable<Complex>, ISubtractionOperators<Complex, Complex, Complex>, IUnaryNegationOperators<Complex, Complex>, IUnaryPlusOperators<Complex, Complex> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Complex : IAdditionOperators<Complex, Complex, Complex>, IAdditiveIdentity<Complex, Complex>, IDecrementOperators<Complex>, IDivisionOperators<Complex, Complex, Complex>, IEqualityOperators<Complex, Complex, bool>, IEquatable<Complex>, IFormattable, IIncrementOperators<Complex>, IMultiplicativeIdentity<Complex, Complex>, IMultiplyOperators<Complex, Complex, Complex>, INumberBase<Complex>, IParsable<Complex>, ISignedNumber<Complex>, ISpanFormattable, ISpanParsable<Complex>, ISubtractionOperators<Complex, Complex, Complex>, IUnaryNegationOperators<Complex, Complex>, IUnaryPlusOperators<Complex, Complex> {
++        [NullableContextAttribute((byte)1)]
++        public static Complex CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Complex CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Complex CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+     }
+-    public interface IBinaryFloatingPointIeee754<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBinaryNumber<TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IExponentialFunctions<TSelf>, IFloatingPoint<TSelf>, IFloatingPointIeee754<TSelf>, IFormattable, IHyperbolicFunctions<TSelf>, IIncrementOperators<TSelf>, ILogarithmicFunctions<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IPowerFunctions<TSelf>, IRootFunctions<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, ITrigonometricFunctions<TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryFloatingPointIeee754<TSelf>
++    public interface IBinaryFloatingPointIeee754<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBinaryNumber<TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IExponentialFunctions<TSelf>, IFloatingPoint<TSelf>, IFloatingPointConstants<TSelf>, IFloatingPointIeee754<TSelf>, IFormattable, IHyperbolicFunctions<TSelf>, IIncrementOperators<TSelf>, ILogarithmicFunctions<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IPowerFunctions<TSelf>, IRootFunctions<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, ITrigonometricFunctions<TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryFloatingPointIeee754<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface IBinaryInteger<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBinaryNumber<TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IShiftOperators<TSelf, TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryInteger<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface IBinaryInteger<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBinaryNumber<TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IShiftOperators<TSelf, int, TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryInteger<TSelf>
+-    public interface IBinaryNumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryNumber<TSelf> {
++    [NullableContextAttribute((byte)1)]
++    public interface IBinaryNumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IBitwiseOperators<TSelf, TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IBinaryNumber<TSelf> {
++        static abstract TSelf AllBitsSet { get; }
+     }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IComparisonOperators<TSelf, TOther> : IComparable, IComparable<TOther>, IEqualityOperators<TSelf, TOther>, IEquatable<TOther> where TSelf : IComparisonOperators<TSelf, TOther> {
+-        static abstract bool operator >(TSelf left, TOther right);
+-        static abstract bool operator >=(TSelf left, TOther right);
+-        static abstract bool operator <(TSelf left, TOther right);
+-        static abstract bool operator <=(TSelf left, TOther right);
+-    }
++    [NullableContextAttribute((byte)1)]
++    public interface IComparisonOperators<TSelf, TOther, TResult> : IEqualityOperators<TSelf, TOther, TResult> where TSelf : IComparisonOperators<TSelf, TOther, TResult> {
++        static abstract TResult operator >(TSelf left, TOther right);
++        static abstract TResult operator >=(TSelf left, TOther right);
++        static abstract TResult operator <(TSelf left, TOther right);
++        static abstract TResult operator <=(TSelf left, TOther right);
++    }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IEqualityOperators<TSelf, TOther> : IEquatable<TOther> where TSelf : IEqualityOperators<TSelf, TOther> {
+-        static abstract bool operator ==(TSelf left, TOther right);
+-        static abstract bool operator !=(TSelf left, TOther right);
+-    }
++    [NullableContextAttribute((byte)1)]
++    public interface IEqualityOperators<TSelf, TOther, TResult> where TSelf : IEqualityOperators<TSelf, TOther, TResult> {
++        static abstract TResult operator ==(TSelf left, TOther right);
++        static abstract TResult operator !=(TSelf left, TOther right);
++    }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IExponentialFunctions<TSelf> where TSelf : IExponentialFunctions<TSelf>, INumberBase<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface IExponentialFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IExponentialFunctions<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface IFloatingPoint<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPoint<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface IFloatingPoint<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPoint<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface IFloatingPointConstants<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPointConstants<TSelf> {
++        static abstract TSelf E { get; }
++        static abstract TSelf Pi { get; }
++        static abstract TSelf Tau { get; }
++    }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IFloatingPointIeee754<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IExponentialFunctions<TSelf>, IFloatingPoint<TSelf>, IFormattable, IHyperbolicFunctions<TSelf>, IIncrementOperators<TSelf>, ILogarithmicFunctions<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IPowerFunctions<TSelf>, IRootFunctions<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, ITrigonometricFunctions<TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPointIeee754<TSelf> {
++    [NullableContextAttribute((byte)1)]
++    public interface IFloatingPointIeee754<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IExponentialFunctions<TSelf>, IFloatingPoint<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IHyperbolicFunctions<TSelf>, IIncrementOperators<TSelf>, ILogarithmicFunctions<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, IPowerFunctions<TSelf>, IRootFunctions<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, ITrigonometricFunctions<TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IFloatingPointIeee754<TSelf> {
+-        static abstract TSelf E { get; }
+-        static abstract TSelf Pi { get; }
+-        static abstract TSelf Tau { get; }
++        static abstract TSelf Atan2(TSelf y, TSelf x);
++        static abstract TSelf Atan2Pi(TSelf y, TSelf x);
+     }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IHyperbolicFunctions<TSelf> where TSelf : IHyperbolicFunctions<TSelf>, INumberBase<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface IHyperbolicFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IHyperbolicFunctions<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface ILogarithmicFunctions<TSelf> where TSelf : ILogarithmicFunctions<TSelf>, INumberBase<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface ILogarithmicFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : ILogarithmicFunctions<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface INumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumber<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface INumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumber<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface INumberBase<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumberBase<TSelf>
++    [NullableContextAttribute((byte)1)]
++    public interface INumberBase<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumberBase<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface IPowerFunctions<TSelf> where TSelf : IPowerFunctions<TSelf>, INumberBase<TSelf>
++    public interface IPowerFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IPowerFunctions<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface IRootFunctions<TSelf> where TSelf : IRootFunctions<TSelf>, INumberBase<TSelf> {
++    [NullableContextAttribute((byte)1)]
++    public interface IRootFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IRootFunctions<TSelf> {
+-        static abstract TSelf Root(TSelf x, int n);
++        static abstract TSelf RootN(TSelf x, int n);
+     }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IShiftOperators<TSelf, TResult> where TSelf : IShiftOperators<TSelf, TResult> {
+-        static abstract TResult operator <<(TSelf value, int shiftAmount);
+-        static abstract TResult operator >>(TSelf value, int shiftAmount);
+-        static abstract TResult operator >>>(TSelf value, int shiftAmount);
+-    }
++    [NullableContextAttribute((byte)1)]
++    public interface IShiftOperators<TSelf, TOther, TResult> where TSelf : IShiftOperators<TSelf, TOther, TResult> {
++        static abstract TResult operator <<(TSelf value, TOther shiftAmount);
++        static abstract TResult operator >>(TSelf value, TOther shiftAmount);
++        static abstract TResult operator >>>(TSelf value, TOther shiftAmount);
++    }
+-    [NullableContextAttribute((byte)1)]
+-    public interface ISignedNumber<TSelf> where TSelf : INumberBase<TSelf>, ISignedNumber<TSelf>
++    public interface ISignedNumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : ISignedNumber<TSelf>
+-    [NullableContextAttribute((byte)1)]
+-    public interface ITrigonometricFunctions<TSelf> where TSelf : ITrigonometricFunctions<TSelf>, INumberBase<TSelf> {
++    [NullableContextAttribute((byte)1)]
++    public interface ITrigonometricFunctions<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : ITrigonometricFunctions<TSelf> {
+-        static abstract TSelf Atan2(TSelf y, TSelf x);
+-        static abstract TSelf Atan2Pi(TSelf y, TSelf x);
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1, (byte)1})]
++        static abstract (TSelf SinPi, TSelf CosPi) SinCosPi(TSelf x);
+     }
+-    [NullableContextAttribute((byte)1)]
+-    public interface IUnsignedNumber<TSelf> where TSelf : INumberBase<TSelf>, IUnsignedNumber<TSelf>
++    public interface IUnsignedNumber<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : IUnsignedNumber<TSelf>
+     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+     public readonly struct Vector<T> : IEquatable<Vector<T>>, IFormattable where T : struct {
++        public static bool IsSupported { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Reflection.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Reflection.Metadata.md
@@ -1,0 +1,12 @@
+# System.Reflection.Metadata
+
+``` diff
+ namespace System.Reflection.Metadata {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class MetadataReader {
++        public static AssemblyName GetAssemblyName(string assemblyFile);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.JavaScript.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.JavaScript.md
@@ -1,0 +1,280 @@
+# System.Runtime.InteropServices.JavaScript
+
+``` diff
++namespace System.Runtime.InteropServices.JavaScript {
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSException : Exception {
++        [NullableContextAttribute((byte)1)]
++        public JSException(string msg);
++    }
++    [AttributeUsageAttribute(AttributeTargets.Method, Inherited=false, AllowMultiple=false)]
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSExportAttribute : Attribute {
++        public JSExportAttribute();
++    }
++    [CLSCompliantAttribute(false)]
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSFunctionBinding {
++        public JSFunctionBinding();
++        [NullableContextAttribute((byte)1)]
++        public static JSFunctionBinding BindJSFunction(string functionName, string moduleName, [NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<JSMarshalerType> signatures);
++        [NullableContextAttribute((byte)1)]
++        public static JSFunctionBinding BindManagedFunction(string fullyQualifiedName, int signatureHash, [NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<JSMarshalerType> signatures);
++        public static void InvokeJS([NullableAttribute((byte)1)] JSFunctionBinding signature, Span<JSMarshalerArgument> arguments);
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [SupportedOSPlatformAttribute("browser")]
++    public static class JSHost {
++        public static JSObject DotnetInstance { get; }
++        public static JSObject GlobalThis { get; }
++        public static Task<JSObject> ImportAsync(string moduleName, string moduleUrl, CancellationToken cancellationToken = default(CancellationToken));
++    }
++    [AttributeUsageAttribute(AttributeTargets.Method, Inherited=false, AllowMultiple=false)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSImportAttribute : Attribute {
++        public JSImportAttribute(string functionName);
++        public JSImportAttribute(string functionName, string moduleName);
++        public string FunctionName { get; }
++        [NullableAttribute((byte)2)]
++        public string? ModuleName { [NullableContextAttribute((byte)2)] get; }
++    }
++    [AttributeUsageAttribute(AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited=false, AllowMultiple=false)]
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSMarshalAsAttribute<T> : Attribute where T : JSType {
++        public JSMarshalAsAttribute();
++    }
++    [CLSCompliantAttribute(false)]
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    [SupportedOSPlatformAttribute("browser")]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
++    public struct JSMarshalerArgument {
++        public void Initialize();
++        public void ToJS(Action value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(ArraySegment<byte> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(ArraySegment<double> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(ArraySegment<int> value);
++        public void ToJS(bool value);
++        public void ToJS(byte value);
++        public void ToJS(byte[] value);
++        public void ToJS(char value);
++        public void ToJS(DateTime value);
++        public void ToJS(DateTimeOffset value);
++        public void ToJS(double value);
++        public void ToJS(double[] value);
++        public void ToJS(Exception value);
++        public void ToJS(short value);
++        public void ToJS(int value);
++        public void ToJS(int[] value);
++        public void ToJS(long value);
++        public void ToJS(IntPtr value);
++        public void ToJS(bool? value);
++        public void ToJS(byte? value);
++        public void ToJS(char? value);
++        public void ToJS(DateTime? value);
++        public void ToJS(DateTimeOffset? value);
++        public void ToJS(double? value);
++        public void ToJS(short? value);
++        public void ToJS(int? value);
++        public void ToJS(long? value);
++        public void ToJS(IntPtr? value);
++        public void ToJS(float? value);
++        public void ToJS(object value);
++        public void ToJS(object[] value);
++        public void ToJS(JSObject value);
++        public void ToJS(JSObject[] value);
++        public void ToJS(float value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(Span<byte> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(Span<double> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToJS(Span<int> value);
++        public void ToJS(string value);
++        public void ToJS(string[] value);
++        public void ToJS(Task value);
++        [NullableContextAttribute((byte)0)]
++        public unsafe void ToJS(void* value);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1})] Func<T, TResult>? value, JSMarshalerArgument.ArgumentToManagedCallback<T> arg1Marshaler, JSMarshalerArgument.ArgumentToJSCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T1, T2, T3, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})] Func<T1, T2, T3, TResult>? value, JSMarshalerArgument.ArgumentToManagedCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T3> arg3Marshaler, JSMarshalerArgument.ArgumentToJSCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T1, T2, T3>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})] Action<T1, T2, T3>? value, JSMarshalerArgument.ArgumentToManagedCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T3> arg3Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T1, T2, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})] Func<T1, T2, TResult>? value, JSMarshalerArgument.ArgumentToManagedCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToJSCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T1, T2>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1})] Action<T1, T2>? value, JSMarshalerArgument.ArgumentToManagedCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<T2> arg2Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] Action<T>? value, JSMarshalerArgument.ArgumentToManagedCallback<T> arg1Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<T>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] Task<T>? value, JSMarshalerArgument.ArgumentToJSCallback<T> marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToJS<TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] Func<TResult>? value, JSMarshalerArgument.ArgumentToJSCallback<TResult> resMarshaler);
++        public void ToJSBig(long value);
++        public void ToJSBig(long? value);
++        public void ToManaged(out Action value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out ArraySegment<byte> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out ArraySegment<double> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out ArraySegment<int> value);
++        public void ToManaged(out bool value);
++        public void ToManaged(out byte value);
++        public void ToManaged(out byte[] value);
++        public void ToManaged(out char value);
++        public void ToManaged(out DateTime value);
++        public void ToManaged(out DateTimeOffset value);
++        public void ToManaged(out double value);
++        public void ToManaged(out double[] value);
++        public void ToManaged(out Exception value);
++        public void ToManaged(out short value);
++        public void ToManaged(out int value);
++        public void ToManaged(out int[] value);
++        public void ToManaged(out long value);
++        public void ToManaged(out IntPtr value);
++        public void ToManaged(out bool? value);
++        public void ToManaged(out byte? value);
++        public void ToManaged(out char? value);
++        public void ToManaged(out DateTime? value);
++        public void ToManaged(out DateTimeOffset? value);
++        public void ToManaged(out double? value);
++        public void ToManaged(out short? value);
++        public void ToManaged(out int? value);
++        public void ToManaged(out long? value);
++        public void ToManaged(out IntPtr? value);
++        public void ToManaged(out float? value);
++        public void ToManaged(out object value);
++        public void ToManaged(out object[] value);
++        public void ToManaged(out JSObject value);
++        public void ToManaged(out JSObject[] value);
++        public void ToManaged(out float value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out Span<byte> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out Span<double> value);
++        [NullableContextAttribute((byte)0)]
++        public void ToManaged(out Span<int> value);
++        public void ToManaged(out string value);
++        public void ToManaged(out string[] value);
++        public void ToManaged(out Task value);
++        [NullableContextAttribute((byte)0)]
++        public unsafe void ToManaged(out void* value);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1})] out Func<T, TResult>? value, JSMarshalerArgument.ArgumentToJSCallback<T> arg1Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T1, T2, T3, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1, (byte)1})] out Func<T1, T2, T3, TResult>? value, JSMarshalerArgument.ArgumentToJSCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T3> arg3Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T1, T2, T3>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})] out Action<T1, T2, T3>? value, JSMarshalerArgument.ArgumentToJSCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T3> arg3Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T1, T2, TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})] out Func<T1, T2, TResult>? value, JSMarshalerArgument.ArgumentToJSCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T2> arg2Marshaler, JSMarshalerArgument.ArgumentToManagedCallback<TResult> resMarshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T1, T2>([NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1})] out Action<T1, T2>? value, JSMarshalerArgument.ArgumentToJSCallback<T1> arg1Marshaler, JSMarshalerArgument.ArgumentToJSCallback<T2> arg2Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] out Action<T>? value, JSMarshalerArgument.ArgumentToJSCallback<T> arg1Marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<T>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] out Task<T>? value, JSMarshalerArgument.ArgumentToManagedCallback<T> marshaler);
++        [NullableContextAttribute((byte)1)]
++        public void ToManaged<TResult>([NullableAttribute(new byte[]{ (byte)2, (byte)1})] out Func<TResult>? value, JSMarshalerArgument.ArgumentToManagedCallback<TResult> resMarshaler);
++        public void ToManagedBig(out long value);
++        public void ToManagedBig(out long? value);
++        [NullableContextAttribute((byte)0)]
++        public delegate void ArgumentToJSCallback<T>(ref JSMarshalerArgument arg, T value);
++        [NullableContextAttribute((byte)0)]
++        public delegate void ArgumentToManagedCallback<T>(ref JSMarshalerArgument arg, out T value);
++    }
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [SupportedOSPlatformAttribute("browser")]
++    public sealed class JSMarshalerType {
++        public static JSMarshalerType BigInt64 { get; }
++        public static JSMarshalerType Boolean { get; }
++        public static JSMarshalerType Byte { get; }
++        public static JSMarshalerType Char { get; }
++        public static JSMarshalerType DateTime { get; }
++        public static JSMarshalerType DateTimeOffset { get; }
++        public static JSMarshalerType Discard { get; }
++        public static JSMarshalerType Double { get; }
++        public static JSMarshalerType Exception { get; }
++        public static JSMarshalerType Int16 { get; }
++        public static JSMarshalerType Int32 { get; }
++        public static JSMarshalerType Int52 { get; }
++        public static JSMarshalerType IntPtr { get; }
++        public static JSMarshalerType JSObject { get; }
++        public static JSMarshalerType Object { get; }
++        public static JSMarshalerType Single { get; }
++        public static JSMarshalerType String { get; }
++        public static JSMarshalerType Void { get; }
++        public static JSMarshalerType Action();
++        public static JSMarshalerType Action(JSMarshalerType arg1);
++        public static JSMarshalerType Action(JSMarshalerType arg1, JSMarshalerType arg2);
++        public static JSMarshalerType Action(JSMarshalerType arg1, JSMarshalerType arg2, JSMarshalerType arg3);
++        public static JSMarshalerType Array(JSMarshalerType element);
++        public static JSMarshalerType ArraySegment(JSMarshalerType element);
++        public static JSMarshalerType Function(JSMarshalerType result);
++        public static JSMarshalerType Function(JSMarshalerType arg1, JSMarshalerType result);
++        public static JSMarshalerType Function(JSMarshalerType arg1, JSMarshalerType arg2, JSMarshalerType result);
++        public static JSMarshalerType Function(JSMarshalerType arg1, JSMarshalerType arg2, JSMarshalerType arg3, JSMarshalerType result);
++        public static JSMarshalerType Nullable(JSMarshalerType primitive);
++        public static JSMarshalerType Span(JSMarshalerType element);
++        public static JSMarshalerType Task();
++        public static JSMarshalerType Task(JSMarshalerType result);
++    }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [SupportedOSPlatformAttribute("browser")]
++    public class JSObject : IDisposable {
++        public bool IsDisposed { get; }
++        public void Dispose();
++        public bool GetPropertyAsBoolean(string propertyName);
++        [return: NullableAttribute((byte)2)]
++        public byte[]? GetPropertyAsByteArray(string propertyName);
++        public double GetPropertyAsDouble(string propertyName);
++        public int GetPropertyAsInt32(string propertyName);
++        [return: NullableAttribute((byte)2)]
++        public JSObject? GetPropertyAsJSObject(string propertyName);
++        [return: NullableAttribute((byte)2)]
++        public string? GetPropertyAsString(string propertyName);
++        public string GetTypeOfProperty(string propertyName);
++        public bool HasProperty(string propertyName);
++        public void SetProperty(string propertyName, bool value);
++        public void SetProperty(string propertyName, [NullableAttribute((byte)2)] byte[]? value);
++        public void SetProperty(string propertyName, double value);
++        public void SetProperty(string propertyName, int value);
++        public void SetProperty(string propertyName, [NullableAttribute((byte)2)] JSObject? value);
++        public void SetProperty(string propertyName, [NullableAttribute((byte)2)] string? value);
++    }
++    [SupportedOSPlatformAttribute("browser")]
++    public abstract class JSType {
++        public sealed class Any : JSType
++        public sealed class Array<T> : JSType where T : JSType
++        public sealed class BigInt : JSType
++        public sealed class Boolean : JSType
++        public sealed class Date : JSType
++        public sealed class Discard : JSType
++        public sealed class Error : JSType
++        public sealed class Function : JSType
++        public sealed class Function<T> : JSType where T : JSType
++        public sealed class Function<T1, T2> : JSType where T1 : JSType where T2 : JSType
++        public sealed class Function<T1, T2, T3> : JSType where T1 : JSType where T2 : JSType where T3 : JSType
++        public sealed class Function<T1, T2, T3, T4> : JSType where T1 : JSType where T2 : JSType where T3 : JSType where T4 : JSType
++        public sealed class MemoryView : JSType
++        public sealed class Number : JSType
++        public sealed class Object : JSType
++        public sealed class Promise<T> : JSType where T : JSType
++        public sealed class String : JSType
++        public sealed class Void : JSType
++    }
++}
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.Marshalling.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.Marshalling.md
@@ -1,0 +1,319 @@
+# System.Runtime.InteropServices.Marshalling
+
+``` diff
+ namespace System.Runtime.InteropServices.Marshalling {
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(string), CustomTypeMarshallerKind.Value, BufferSize=256, Features=CustomTypeMarshallerFeatures.CallerAllocatedBuffer | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct AnsiStringMarshaller {
++    [CLSCompliantAttribute(false)]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.Default, typeof(AnsiStringMarshaller))]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.ManagedToUnmanagedIn, typeof(AnsiStringMarshaller.ManagedToUnmanagedIn))]
++    public static class AnsiStringMarshaller {
+-        [NullableContextAttribute((byte)2)]
+-        public AnsiStringMarshaller(string? str);
+-        public AnsiStringMarshaller([NullableAttribute((byte)2)] string? str, Span<byte> buffer);
++        [return: NullableAttribute((byte)2)]
++        public unsafe static string? ConvertToManaged(byte* unmanaged);
++        public unsafe static byte* ConvertToUnmanaged([NullableAttribute((byte)2)] string? managed);
++        public unsafe static void Free(byte* unmanaged);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(byte* value);
+-        [NullableContextAttribute((byte)2)]
+-        public string? ToManaged();
+-        public unsafe byte* ToNativeValue();
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute((byte)2)] string? managed, Span<byte> buffer);
++            public unsafe byte* ToUnmanaged();
++        }
+     }
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(CustomTypeMarshallerAttribute.GenericPlaceholder[]), CustomTypeMarshallerKind.LinearCollection, BufferSize=512, Features=CustomTypeMarshallerFeatures.CallerAllocatedBuffer | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct ArrayMarshaller<T> {
+-        public ArrayMarshaller(int sizeOfNativeElement);
+-        public ArrayMarshaller([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? array, int sizeOfNativeElement);
+-        public ArrayMarshaller([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? array, Span<byte> buffer, int sizeOfNativeElement);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(byte* value);
+-        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
+-        public Span<T> GetManagedValuesDestination(int length);
+-        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
+-        public ReadOnlySpan<T> GetManagedValuesSource();
+-        public Span<byte> GetNativeValuesDestination();
+-        public ReadOnlySpan<byte> GetNativeValuesSource(int length);
+-        public ref byte GetPinnableReference();
+-        [return: NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+-        public T[]? ToManaged();
+-        public unsafe byte* ToNativeValue();
+-    }
++    [CLSCompliantAttribute(false)]
++    [ContiguousCollectionMarshallerAttribute]
++    [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder[]), MarshalMode.Default, typeof(ArrayMarshaller<,>))]
++    [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder[]), MarshalMode.ManagedToUnmanagedIn, typeof(ArrayMarshaller<,>.ManagedToUnmanagedIn))]
++    public static class ArrayMarshaller<T, TUnmanagedElement> where TUnmanagedElement : struct {
++        [return: NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public unsafe static T[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? managed, out int numElements);
++        public unsafe static void Free(TUnmanagedElement* unmanaged);
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static Span<T> GetManagedValuesDestination([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? managed);
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static ReadOnlySpan<T> GetManagedValuesSource([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? managed);
++        public unsafe static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements);
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? array, Span<TUnmanagedElement> buffer);
++            [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++            public ReadOnlySpan<T> GetManagedValuesSource();
++            public ref TUnmanagedElement GetPinnableReference();
++            [NullableContextAttribute((byte)1)]
++            public static ref T GetPinnableReference([NullableAttribute(new byte[]{ (byte)2, (byte)1})] T[]? array);
++            public Span<TUnmanagedElement> GetUnmanagedValuesDestination();
++            public unsafe TUnmanagedElement* ToUnmanaged();
++        }
++    }
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(string), CustomTypeMarshallerKind.Value, BufferSize=256, Features=CustomTypeMarshallerFeatures.CallerAllocatedBuffer | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct BStrStringMarshaller {
++    [CLSCompliantAttribute(false)]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.Default, typeof(BStrStringMarshaller))]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.ManagedToUnmanagedIn, typeof(BStrStringMarshaller.ManagedToUnmanagedIn))]
++    public static class BStrStringMarshaller {
+-        [NullableContextAttribute((byte)2)]
+-        public BStrStringMarshaller(string? str);
+-        public BStrStringMarshaller([NullableAttribute((byte)2)] string? str, Span<ushort> buffer);
++        [return: NullableAttribute((byte)2)]
++        public unsafe static string? ConvertToManaged(ushort* unmanaged);
++        public unsafe static ushort* ConvertToUnmanaged([NullableAttribute((byte)2)] string? managed);
++        public unsafe static void Free(ushort* unmanaged);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(void* value);
+-        [NullableContextAttribute((byte)2)]
+-        public string? ToManaged();
+-        public unsafe void* ToNativeValue();
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute((byte)2)] string? managed, Span<byte> buffer);
++            public unsafe ushort* ToUnmanaged();
++        }
+     }
++    [AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct)]
++    public sealed class ContiguousCollectionMarshallerAttribute : Attribute {
++        public ContiguousCollectionMarshallerAttribute();
++    }
++    [AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple=true)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public sealed class CustomMarshallerAttribute : Attribute {
++        public CustomMarshallerAttribute(Type managedType, MarshalMode marshalMode, Type marshallerType);
++        public Type ManagedType { get; }
++        public Type MarshallerType { get; }
++        public MarshalMode MarshalMode { get; }
++        [NullableContextAttribute((byte)0)]
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
++        public struct GenericPlaceholder
++    }
+-    [AttributeUsageAttribute(AttributeTargets.Struct)]
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public sealed class CustomTypeMarshallerAttribute : Attribute {
+-        public CustomTypeMarshallerAttribute(Type managedType, CustomTypeMarshallerKind marshallerKind = CustomTypeMarshallerKind.Value);
+-        public int BufferSize { get; set; }
+-        public CustomTypeMarshallerDirection Direction { get; set; }
+-        public CustomTypeMarshallerFeatures Features { get; set; }
+-        public Type ManagedType { get; }
+-        public CustomTypeMarshallerKind MarshallerKind { get; }
+-        [NullableContextAttribute((byte)0)]
+-        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-        public struct GenericPlaceholder
+-    }
+-    [FlagsAttribute]
+-    public enum CustomTypeMarshallerDirection {
+-        In = 1,
+-        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+-        None = 0,
+-        Out = 2,
+-        Ref = 3,
+-    }
+-    [FlagsAttribute]
+-    public enum CustomTypeMarshallerFeatures {
+-        CallerAllocatedBuffer = 2,
+-        None = 0,
+-        TwoStageMarshalling = 4,
+-        UnmanagedResources = 1,
+-    }
+-    public enum CustomTypeMarshallerKind {
+-        LinearCollection = 1,
+-        Value = 0,
+-    }
++    public enum MarshalMode {
++        Default = 0,
++        ElementIn = 7,
++        ElementOut = 9,
++        ElementRef = 8,
++        ManagedToUnmanagedIn = 1,
++        ManagedToUnmanagedOut = 3,
++        ManagedToUnmanagedRef = 2,
++        UnmanagedToManagedIn = 4,
++        UnmanagedToManagedOut = 6,
++        UnmanagedToManagedRef = 5,
++    }
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(CustomTypeMarshallerAttribute.GenericPlaceholder*[]), CustomTypeMarshallerKind.LinearCollection, BufferSize=512, Features=CustomTypeMarshallerFeatures.CallerAllocatedBuffer | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct PointerArrayMarshaller<T> where T : struct {
+-        public PointerArrayMarshaller(int sizeOfNativeElement);
+-        public PointerArrayMarshaller([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? array, int sizeOfNativeElement);
+-        public PointerArrayMarshaller([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? array, Span<byte> buffer, int sizeOfNativeElement);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(byte* value);
+-        public Span<IntPtr> GetManagedValuesDestination(int length);
+-        public ReadOnlySpan<IntPtr> GetManagedValuesSource();
+-        public Span<byte> GetNativeValuesDestination();
+-        public ReadOnlySpan<byte> GetNativeValuesSource(int length);
+-        public ref byte GetPinnableReference();
+-        [return: NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})]
+-        public T*[]? ToManaged();
+-        public unsafe byte* ToNativeValue();
+-    }
++    [CLSCompliantAttribute(false)]
++    [ContiguousCollectionMarshallerAttribute]
++    [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder*[]), MarshalMode.Default, typeof(PointerArrayMarshaller<,>))]
++    [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder*[]), MarshalMode.ManagedToUnmanagedIn, typeof(PointerArrayMarshaller<,>.ManagedToUnmanagedIn))]
++    public static class PointerArrayMarshaller<T, TUnmanagedElement> where T : struct where TUnmanagedElement : struct {
++        [return: NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})]
++        public unsafe static T*[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? managed, out int numElements);
++        public unsafe static void Free(TUnmanagedElement* unmanaged);
++        public static Span<IntPtr> GetManagedValuesDestination([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? managed);
++        public static ReadOnlySpan<IntPtr> GetManagedValuesSource([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? managed);
++        public unsafe static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements);
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? array, Span<TUnmanagedElement> buffer);
++            public ReadOnlySpan<IntPtr> GetManagedValuesSource();
++            public ref TUnmanagedElement GetPinnableReference();
++            public static ref byte GetPinnableReference([NullableAttribute(new byte[]{ (byte)2, (byte)0, (byte)0})] T*[]? array);
++            public Span<TUnmanagedElement> GetUnmanagedValuesDestination();
++            public unsafe TUnmanagedElement* ToUnmanaged();
++        }
++    }
++    [CLSCompliantAttribute(false)]
++    [ContiguousCollectionMarshallerAttribute]
++    [CustomMarshallerAttribute(typeof(ReadOnlySpan<>), MarshalMode.ManagedToUnmanagedIn, typeof(ReadOnlySpanMarshaller<,>.ManagedToUnmanagedIn))]
++    [CustomMarshallerAttribute(typeof(ReadOnlySpan<>), MarshalMode.UnmanagedToManagedOut, typeof(ReadOnlySpanMarshaller<,>.UnmanagedToManagedOut))]
++    public static class ReadOnlySpanMarshaller<T, TUnmanagedElement> where TUnmanagedElement : struct {
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<T> managed, Span<TUnmanagedElement> buffer);
++            [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++            public ReadOnlySpan<T> GetManagedValuesSource();
++            public ref TUnmanagedElement GetPinnableReference();
++            [NullableContextAttribute((byte)1)]
++            public static ref T GetPinnableReference([NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<T> managed);
++            public Span<TUnmanagedElement> GetUnmanagedValuesDestination();
++            public unsafe TUnmanagedElement* ToUnmanaged();
++        }
++        public static class UnmanagedToManagedOut {
++            public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements([NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<T> managed, out int numElements);
++            [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++            public static ReadOnlySpan<T> GetManagedValuesSource([NullableAttribute(new byte[]{ (byte)0, (byte)1})] ReadOnlySpan<T> managed);
++            public unsafe static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements);
++        }
++    }
++    [CLSCompliantAttribute(false)]
++    [ContiguousCollectionMarshallerAttribute]
++    [CustomMarshallerAttribute(typeof(Span<>), MarshalMode.Default, typeof(SpanMarshaller<,>))]
++    [CustomMarshallerAttribute(typeof(Span<>), MarshalMode.ManagedToUnmanagedIn, typeof(SpanMarshaller<,>.ManagedToUnmanagedIn))]
++    public static class SpanMarshaller<T, TUnmanagedElement> where TUnmanagedElement : struct {
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public unsafe static Span<T> AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements([NullableAttribute(new byte[]{ (byte)0, (byte)1})] Span<T> managed, out int numElements);
++        public unsafe static void Free(TUnmanagedElement* unmanaged);
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static Span<T> GetManagedValuesDestination([NullableAttribute(new byte[]{ (byte)0, (byte)1})] Span<T> managed);
++        [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++        public static ReadOnlySpan<T> GetManagedValuesSource([NullableAttribute(new byte[]{ (byte)0, (byte)1})] Span<T> managed);
++        public unsafe static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements);
++        public unsafe static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanaged, int numElements);
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute(new byte[]{ (byte)0, (byte)1})] Span<T> managed, Span<TUnmanagedElement> buffer);
++            [return: NullableAttribute(new byte[]{ (byte)0, (byte)1})]
++            public ReadOnlySpan<T> GetManagedValuesSource();
++            public ref TUnmanagedElement GetPinnableReference();
++            [NullableContextAttribute((byte)1)]
++            public static ref T GetPinnableReference([NullableAttribute(new byte[]{ (byte)0, (byte)1})] Span<T> managed);
++            public Span<TUnmanagedElement> GetUnmanagedValuesDestination();
++            public unsafe TUnmanagedElement* ToUnmanaged();
++        }
++    }
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(string), CustomTypeMarshallerKind.Value, Features=CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct Utf16StringMarshaller {
++    [CLSCompliantAttribute(false)]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.Default, typeof(Utf16StringMarshaller))]
++    public static class Utf16StringMarshaller {
+-        [NullableContextAttribute((byte)2)]
+-        public Utf16StringMarshaller(string? str);
++        [return: NullableAttribute((byte)2)]
++        public unsafe static string? ConvertToManaged(ushort* unmanaged);
++        public unsafe static ushort* ConvertToUnmanaged([NullableAttribute((byte)2)] string? managed);
++        public unsafe static void Free(ushort* unmanaged);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(void* value);
++        [NullableContextAttribute((byte)2)]
++        public static ref readonly char GetPinnableReference(string? str);
+-        [NullableContextAttribute((byte)2)]
+-        public string? ToManaged();
+-        public unsafe void* ToNativeValue();
+     }
+-    [CLSCompliantAttribute(false)]
+-    [CustomTypeMarshallerAttribute(typeof(string), CustomTypeMarshallerKind.Value, BufferSize=256, Features=CustomTypeMarshallerFeatures.CallerAllocatedBuffer | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.UnmanagedResources)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+-    public ref struct Utf8StringMarshaller {
++    [CLSCompliantAttribute(false)]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.Default, typeof(Utf8StringMarshaller))]
++    [CustomMarshallerAttribute(typeof(string), MarshalMode.ManagedToUnmanagedIn, typeof(Utf8StringMarshaller.ManagedToUnmanagedIn))]
++    public static class Utf8StringMarshaller {
+-        [NullableContextAttribute((byte)2)]
+-        public Utf8StringMarshaller(string? str);
+-        public Utf8StringMarshaller([NullableAttribute((byte)2)] string? str, Span<byte> buffer);
++        [return: NullableAttribute((byte)2)]
++        public unsafe static string? ConvertToManaged(byte* unmanaged);
++        public unsafe static byte* ConvertToUnmanaged([NullableAttribute((byte)2)] string? managed);
++        public unsafe static void Free(byte* unmanaged);
+-        public void FreeNative();
+-        public unsafe void FromNativeValue(byte* value);
+-        [NullableContextAttribute((byte)2)]
+-        public string? ToManaged();
+-        public unsafe byte* ToNativeValue();
++        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
++        public ref struct ManagedToUnmanagedIn {
++            public static int BufferSize { get; }
++            public void Free();
++            public void FromManaged([NullableAttribute((byte)2)] string? managed, Span<byte> buffer);
++            public unsafe byte* ToUnmanaged();
++        }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.InteropServices.md
@@ -1,0 +1,31 @@
+# System.Runtime.InteropServices
+
+``` diff
+ namespace System.Runtime.InteropServices {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class Marshal {
+-        public static IntPtr GetHINSTANCE(Module m);
++        [RequiresAssemblyFilesAttribute("Windows only assigns HINSTANCE to assemblies loaded from disk. This API will return -1 for modules without a file on disk.")]
++        public static IntPtr GetHINSTANCE(Module m);
++        public static string GetLastPInvokeErrorMessage();
++        public static string GetPInvokeErrorMessage(int error);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat, bool>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat, bool>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointConstants<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat> {
++        static NFloat System.Numerics.IBinaryNumber<System.Runtime.InteropServices.NFloat>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static NFloat CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static NFloat CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static NFloat CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+-        public static NFloat Root(NFloat x, int n);
++        public static NFloat RootN(NFloat x, int n);
++        public static (NFloat SinPi, NFloat CosPi) SinCosPi(NFloat x);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.Intrinsics.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.Intrinsics.md
@@ -1,0 +1,19 @@
+# System.Runtime.Intrinsics
+
+``` diff
+ namespace System.Runtime.Intrinsics {
+     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+     public readonly struct Vector128<T> : IEquatable<Vector128<T>> where T : struct {
++        public static bool IsSupported { get; }
+     }
+     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+     public readonly struct Vector256<T> : IEquatable<Vector256<T>> where T : struct {
++        public static bool IsSupported { get; }
+     }
+     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+     public readonly struct Vector64<T> : IEquatable<Vector64<T>> where T : struct {
++        public static bool IsSupported { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.Versioning.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Runtime.Versioning.md
@@ -1,0 +1,24 @@
+# System.Runtime.Versioning
+
+``` diff
+ namespace System.Runtime.Versioning {
++    [AttributeUsageAttribute(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)2)]
++    public sealed class ObsoletedInOSPlatformAttribute : OSPlatformAttribute {
++        [NullableContextAttribute((byte)1)]
++        public ObsoletedInOSPlatformAttribute(string platformName);
++        [NullableContextAttribute((byte)1)]
++        public ObsoletedInOSPlatformAttribute(string platformName, [NullableAttribute((byte)2)] string? message);
++        public string Message { get; }
++        public string Url { get; set; }
++    }
+     [AttributeUsageAttribute(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
+     public sealed class UnsupportedOSPlatformAttribute : OSPlatformAttribute {
++        public UnsupportedOSPlatformAttribute(string platformName, [NullableAttribute((byte)2)] string? message);
++        [NullableAttribute((byte)2)]
++        public string? Message { [NullableContextAttribute((byte)2)] get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Security.Cryptography.X509Certificates.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Security.Cryptography.X509Certificates.md
@@ -1,0 +1,13 @@
+# System.Security.Cryptography.X509Certificates
+
+``` diff
+ namespace System.Security.Cryptography.X509Certificates {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class X509ChainPolicy {
++        public bool VerificationTimeIgnored { get; set; }
++        public X509ChainPolicy Clone();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Security.Cryptography.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Security.Cryptography.md
@@ -1,0 +1,279 @@
+# System.Security.Cryptography
+
+``` diff
+ namespace System.Security.Cryptography {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class Aes : SymmetricAlgorithm {
+-        [UnsupportedOSPlatformAttribute("browser")]
+-        public static new Aes Create();
++        public static new Aes Create();
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new Aes? Create(string algorithmName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new Aes? Create(string algorithmName);
+     }
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     [ObsoleteAttribute("Derived cryptographic types are obsolete. Use the Create method on the base type instead.", DiagnosticId="SYSLIB0021", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+     public sealed class AesCryptoServiceProvider : Aes {
+-        [UnsupportedOSPlatformAttribute("browser")]
+-        public AesCryptoServiceProvider();
++        public AesCryptoServiceProvider();
+     }
+-    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    [ObsoleteAttribute("Derived cryptographic types are obsolete. Use the Create method on the base type instead.", DiagnosticId="SYSLIB0021", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public sealed class AesManaged : Aes
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [ObsoleteAttribute("Derived cryptographic types are obsolete. Use the Create method on the base type instead.", DiagnosticId="SYSLIB0021", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++    public sealed class AesManaged : Aes
+     public abstract class AsymmetricAlgorithm : IDisposable {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static AsymmetricAlgorithm? Create(string algName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static AsymmetricAlgorithm? Create(string algName);
+     }
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class DES : SymmetricAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new DES? Create(string algName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new DES? Create(string algName);
+     }
+     public abstract class DSA : AsymmetricAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new DSA? Create(string algName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new DSA? Create(string algName);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class ECDiffieHellman : ECAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new ECDiffieHellman? Create(string algorithm);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new ECDiffieHellman? Create(string algorithm);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class ECDsa : ECAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new ECDsa? Create(string algorithm);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new ECDsa? Create(string algorithm);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class HashAlgorithm : ICryptoTransform, IDisposable {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static HashAlgorithm? Create(string hashName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static HashAlgorithm? Create(string hashName);
+     }
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public static class HKDF
++    public static class HKDF
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class HMAC : KeyedHashAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new HMAC? Create(string algorithmName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new HMAC? Create(string algorithmName);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class KeyedHashAlgorithm : HashAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new KeyedHashAlgorithm? Create(string algName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new KeyedHashAlgorithm? Create(string algName);
+     }
+     [UnsupportedOSPlatformAttribute("browser")]
+     public abstract class MD5 : HashAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new MD5? Create(string algName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new MD5? Create(string algName);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class RandomNumberGenerator : IDisposable {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static RandomNumberGenerator? Create(string rngName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static RandomNumberGenerator? Create(string rngName);
+     }
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class RC2 : SymmetricAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new RC2? Create(string AlgName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new RC2? Create(string AlgName);
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public class Rfc2898DeriveBytes : DeriveBytes
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public class Rfc2898DeriveBytes : DeriveBytes
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     [ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.", DiagnosticId="SYSLIB0022", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+     public abstract class Rijndael : SymmetricAlgorithm {
+-        [UnsupportedOSPlatformAttribute("browser")]
+-        public static new Rijndael Create();
++        public static new Rijndael Create();
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new Rijndael? Create(string algName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new Rijndael? Create(string algName);
+     }
+-    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    [ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.", DiagnosticId="SYSLIB0022", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+-    [UnsupportedOSPlatformAttribute("browser")]
+-    public sealed class RijndaelManaged : Rijndael
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [ObsoleteAttribute("The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.", DiagnosticId="SYSLIB0022", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++    public sealed class RijndaelManaged : Rijndael
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class RSA : AsymmetricAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new RSA? Create(string algName);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new RSA? Create(string algName);
+     }
+     public abstract class SHA1 : HashAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new SHA1? Create(string hashName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new SHA1? Create(string hashName);
+     }
+     public abstract class SHA256 : HashAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new SHA256? Create(string hashName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new SHA256? Create(string hashName);
+     }
+     public abstract class SHA384 : HashAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new SHA384? Create(string hashName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new SHA384? Create(string hashName);
+     }
+     public abstract class SHA512 : HashAlgorithm {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new SHA512? Create(string hashName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new SHA512? Create(string hashName);
+     }
+     public abstract class SymmetricAlgorithm : IDisposable {
+-        [NullableContextAttribute((byte)1)]
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static SymmetricAlgorithm? Create(string algName);
++        [NullableContextAttribute((byte)1)]
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static SymmetricAlgorithm? Create(string algName);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class TripleDES : SymmetricAlgorithm {
+-        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
+-        [return: NullableAttribute((byte)2)]
+-        public static new TripleDES? Create(string str);
++        [ObsoleteAttribute("Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.", DiagnosticId="SYSLIB0045", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        [RequiresUnreferencedCodeAttribute("The default algorithm implementations might be removed, use strong type references like 'RSA.Create()' instead.")]
++        [return: NullableAttribute((byte)2)]
++        public static new TripleDES? Create(string str);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.Serialization.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.Serialization.Metadata.md
@@ -1,0 +1,89 @@
+# System.Text.Json.Serialization.Metadata
+
+``` diff
+ namespace System.Text.Json.Serialization.Metadata {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver {
+-        public IList<Action<JsonTypeInfo>> Modifiers { [CompilerGeneratedAttribute] get; }
++        public IList<Action<JsonTypeInfo>> Modifiers { get; }
+     }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct JsonDerivedType {
++        public JsonDerivedType(Type derivedType);
++        public JsonDerivedType(Type derivedType, int typeDiscriminator);
++        public JsonDerivedType(Type derivedType, string typeDiscriminator);
++        public Type DerivedType { get; }
++        [NullableAttribute((byte)2)]
++        public object? TypeDiscriminator { [NullableContextAttribute((byte)2)] get; }
++    }
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class JsonMetadataServices {
+-        public static JsonConverter<object> ObjectConverter { get; }
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        [NullableAttribute(new byte[]{ (byte)1, (byte)2})]
++        public static JsonConverter<object?> ObjectConverter { get; }
+     }
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    public class JsonPolymorphismOptions {
++        public JsonPolymorphismOptions();
++        public IList<JsonDerivedType> DerivedTypes { get; }
++        public bool IgnoreUnrecognizedTypeDiscriminators { get; set; }
++        [AllowNullAttribute]
++        public string TypeDiscriminatorPropertyName { get; set; }
++        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; }
++    }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class JsonPropertyInfo {
++        [NullableAttribute((byte)2)]
++        public ICustomAttributeProvider? AttributeProvider { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
++        public bool IsExtensionData { get; set; }
++        public int Order { get; set; }
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class JsonTypeInfo {
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public Action<object>? OnDeserialized { get; set; }
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public Action<object>? OnDeserializing { get; set; }
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public Action<object>? OnSerialized { get; set; }
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        [NullableAttribute(new byte[]{ (byte)2, (byte)1})]
++        public Action<object>? OnSerializing { get; set; }
++        [NullableAttribute((byte)2)]
++        public JsonPolymorphismOptions? PolymorphismOptions { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
+-        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name);
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name);
+-        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+-        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+-        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options);
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options);
+-        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+-        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
+-        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options);
++        [RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
++        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.Serialization.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.Serialization.md
@@ -1,0 +1,37 @@
+# System.Text.Json.Serialization
+
+``` diff
+ namespace System.Text.Json.Serialization {
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public class JsonPolymorphicTypeConfiguration : ICollection<(Type, object?)>, IEnumerable, IEnumerable<(Type, object?)> {
+-        public JsonPolymorphicTypeConfiguration(Type baseType);
+-        public Type BaseType { get; }
+-        public bool IgnoreUnrecognizedTypeDiscriminators { get; set; }
+-        int ICollection<(Type, object?)>.Count { get; }
+-        bool ICollection<(Type, object?)>.IsReadOnly { get; }
+-        [NullableAttribute((byte)2)]
+-        public string? TypeDiscriminatorPropertyName { [NullableContextAttribute((byte)2)] get; [NullableContextAttribute((byte)2)] set; }
+-        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; }
+-        void ICollection<(Type, object?)>.Add((Type DerivedType, object TypeDiscriminator) item);
+-        void ICollection<(Type, object?)>.Clear();
+-        bool ICollection<(Type, object?)>.Contains((Type DerivedType, object TypeDiscriminator) item);
+-        void ICollection<(Type, object?)>.CopyTo((Type DerivedType, object TypeDiscriminator)[] array, int arrayIndex);
+-        bool ICollection<(Type, object?)>.Remove((Type DerivedType, object TypeDiscriminator) item);
+-        IEnumerator<(Type DerivedType, object TypeDiscriminator)> IEnumerable<(Type, object?)>.GetEnumerator();
+-        IEnumerator IEnumerable.GetEnumerator();
+-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType);
+-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, int typeDiscriminator);
+-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string typeDiscriminator);
+-    }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    public class JsonPolymorphicTypeConfiguration<TBaseType> : JsonPolymorphicTypeConfiguration where TBaseType : class {
+-        public JsonPolymorphicTypeConfiguration();
+-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>() where TDerivedType : TBaseType;
+-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminator) where TDerivedType : TBaseType;
+-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminator) where TDerivedType : TBaseType;
+-    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.Json.md
@@ -1,0 +1,22 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public sealed class JsonSerializerOptions {
+-        [NullableAttribute((byte)1)]
+-        public static JsonSerializerOptions Default { [NullableContextAttribute((byte)1)] get; }
++        [NullableAttribute((byte)1)]
++        public static JsonSerializerOptions Default { [NullableContextAttribute((byte)1), RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get; }
+-        [NullableAttribute((byte)1)]
+-        public IList<JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations { [NullableContextAttribute((byte)1)] get; }
+-        [NullableAttribute((byte)1)]
+-        public IJsonTypeInfoResolver TypeInfoResolver { [NullableContextAttribute((byte)1), RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get; [NullableContextAttribute((byte)1)] set; }
++        public IJsonTypeInfoResolver TypeInfoResolver { get; set; }
++        [NullableContextAttribute((byte)1)]
++        public JsonTypeInfo GetTypeInfo(Type type);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.RegularExpressions.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Text.RegularExpressions.md
@@ -1,0 +1,17 @@
+# System.Text.RegularExpressions
+
+``` diff
+ namespace System.Text.RegularExpressions {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class Regex : ISerializable {
++        [NullableContextAttribute((byte)0)]
++        public int Count(ReadOnlySpan<char> input, int startat);
++        [NullableContextAttribute((byte)0)]
++        public Regex.ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, int startat);
++        [NullableContextAttribute((byte)0)]
++        public bool IsMatch(ReadOnlySpan<char> input, int startat);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Threading.Tasks.Dataflow.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Threading.Tasks.Dataflow.md
@@ -1,0 +1,13 @@
+# System.Threading.Tasks.Dataflow
+
+``` diff
+ namespace System.Threading.Tasks.Dataflow {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class TransformManyBlock<TInput, TOutput> : IDataflowBlock, IPropagatorBlock<TInput, TOutput>, IReceivableSourceBlock<TOutput>, ISourceBlock<TOutput>, ITargetBlock<TInput> {
++        public TransformManyBlock(Func<TInput, IAsyncEnumerable<TOutput>> transform);
++        public TransformManyBlock(Func<TInput, IAsyncEnumerable<TOutput>> transform, ExecutionDataflowBlockOptions dataflowBlockOptions);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Xml.XPath.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Xml.XPath.md
@@ -1,0 +1,26 @@
+# System.Xml.XPath
+
+``` diff
+ namespace System.Xml.XPath {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public abstract class XPathNavigator : XPathItem, ICloneable, IXmlNamespaceResolver, IXPathNavigable {
+-        public virtual void AppendChildElement(string prefix, string localName, string namespaceURI, string value);
++        [NullableContextAttribute((byte)2)]
++        public virtual void AppendChildElement(string? prefix, [NullableAttribute((byte)1)] string localName, string? namespaceURI, string? value);
+-        public virtual void CreateAttribute(string prefix, string localName, string namespaceURI, string value);
++        [NullableContextAttribute((byte)2)]
++        public virtual void CreateAttribute(string? prefix, [NullableAttribute((byte)1)] string localName, string? namespaceURI, string? value);
+-        public virtual void InsertElementAfter(string prefix, string localName, string namespaceURI, string value);
++        [NullableContextAttribute((byte)2)]
++        public virtual void InsertElementAfter(string? prefix, [NullableAttribute((byte)1)] string localName, string? namespaceURI, string? value);
+-        public virtual void InsertElementBefore(string prefix, string localName, string namespaceURI, string value);
++        [NullableContextAttribute((byte)2)]
++        public virtual void InsertElementBefore(string? prefix, [NullableAttribute((byte)1)] string localName, string? namespaceURI, string? value);
+-        public virtual void PrependChildElement(string prefix, string localName, string namespaceURI, string value);
++        [NullableContextAttribute((byte)2)]
++        public virtual void PrependChildElement(string? prefix, [NullableAttribute((byte)1)] string localName, string? namespaceURI, string? value);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Xml.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.Xml.md
@@ -1,0 +1,13 @@
+# System.Xml
+
+``` diff
+ namespace System.Xml {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public class XmlElement : XmlLinkedNode {
+-        protected internal XmlElement(string prefix, string localName, [NullableAttribute((byte)2)] string? namespaceURI, XmlDocument doc);
++        protected internal XmlElement([NullableAttribute((byte)2)] string? prefix, string localName, [NullableAttribute((byte)2)] string? namespaceURI, XmlDocument doc);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.NETCore.App/7.0-preview7_System.md
@@ -1,0 +1,468 @@
+# System
+
+``` diff
+ namespace System {
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Byte : IAdditionOperators<byte, byte, byte>, IAdditiveIdentity<byte, byte>, IBinaryInteger<byte>, IBinaryNumber<byte>, IBitwiseOperators<byte, byte, byte>, IComparable, IComparable<byte>, IComparisonOperators<byte, byte>, IConvertible, IDecrementOperators<byte>, IDivisionOperators<byte, byte, byte>, IEqualityOperators<byte, byte>, IEquatable<byte>, IFormattable, IIncrementOperators<byte>, IMinMaxValue<byte>, IModulusOperators<byte, byte, byte>, IMultiplicativeIdentity<byte, byte>, IMultiplyOperators<byte, byte, byte>, INumber<byte>, INumberBase<byte>, IParsable<byte>, IShiftOperators<byte, byte>, ISpanFormattable, ISpanParsable<byte>, ISubtractionOperators<byte, byte, byte>, IUnaryNegationOperators<byte, byte>, IUnaryPlusOperators<byte, byte>, IUnsignedNumber<byte> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Byte : IAdditionOperators<byte, byte, byte>, IAdditiveIdentity<byte, byte>, IBinaryInteger<byte>, IBinaryNumber<byte>, IBitwiseOperators<byte, byte, byte>, IComparable, IComparable<byte>, IComparisonOperators<byte, byte, bool>, IConvertible, IDecrementOperators<byte>, IDivisionOperators<byte, byte, byte>, IEqualityOperators<byte, byte, bool>, IEquatable<byte>, IFormattable, IIncrementOperators<byte>, IMinMaxValue<byte>, IModulusOperators<byte, byte, byte>, IMultiplicativeIdentity<byte, byte>, IMultiplyOperators<byte, byte, byte>, INumber<byte>, INumberBase<byte>, IParsable<byte>, IShiftOperators<byte, int, byte>, ISpanFormattable, ISpanParsable<byte>, ISubtractionOperators<byte, byte, byte>, IUnaryNegationOperators<byte, byte>, IUnaryPlusOperators<byte, byte>, IUnsignedNumber<byte> {
++        static byte System.Numerics.IBinaryNumber<System.Byte>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static byte CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static byte CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static byte CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<byte, byte, bool>.operator >(byte left, byte right);
++        static bool IComparisonOperators<byte, byte, bool>.operator >=(byte left, byte right);
++        static bool IComparisonOperators<byte, byte, bool>.operator <(byte left, byte right);
++        static bool IComparisonOperators<byte, byte, bool>.operator <=(byte left, byte right);
+-        static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right);
+-        static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right);
+-        static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right);
+-        static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right);
++        static bool IEqualityOperators<byte, byte, bool>.operator ==(byte left, byte right);
++        static bool IEqualityOperators<byte, byte, bool>.operator !=(byte left, byte right);
+-        static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right);
+-        static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right);
+-        static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount);
+-        static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount);
+-        static byte IShiftOperators<byte, byte>.operator >>>(byte value, int shiftAmount);
++        static byte IShiftOperators<byte, int, byte>.operator <<(byte value, int shiftAmount);
++        static byte IShiftOperators<byte, int, byte>.operator >>(byte value, int shiftAmount);
++        static byte IShiftOperators<byte, int, byte>.operator >>>(byte value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Char : IAdditionOperators<char, char, char>, IAdditiveIdentity<char, char>, IBinaryInteger<char>, IBinaryNumber<char>, IBitwiseOperators<char, char, char>, IComparable, IComparable<char>, IComparisonOperators<char, char>, IConvertible, IDecrementOperators<char>, IDivisionOperators<char, char, char>, IEqualityOperators<char, char>, IEquatable<char>, IFormattable, IIncrementOperators<char>, IMinMaxValue<char>, IModulusOperators<char, char, char>, IMultiplicativeIdentity<char, char>, IMultiplyOperators<char, char, char>, INumber<char>, INumberBase<char>, IParsable<char>, IShiftOperators<char, char>, ISpanFormattable, ISpanParsable<char>, ISubtractionOperators<char, char, char>, IUnaryNegationOperators<char, char>, IUnaryPlusOperators<char, char>, IUnsignedNumber<char> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Char : IAdditionOperators<char, char, char>, IAdditiveIdentity<char, char>, IBinaryInteger<char>, IBinaryNumber<char>, IBitwiseOperators<char, char, char>, IComparable, IComparable<char>, IComparisonOperators<char, char, bool>, IConvertible, IDecrementOperators<char>, IDivisionOperators<char, char, char>, IEqualityOperators<char, char, bool>, IEquatable<char>, IFormattable, IIncrementOperators<char>, IMinMaxValue<char>, IModulusOperators<char, char, char>, IMultiplicativeIdentity<char, char>, IMultiplyOperators<char, char, char>, INumber<char>, INumberBase<char>, IParsable<char>, IShiftOperators<char, int, char>, ISpanFormattable, ISpanParsable<char>, ISubtractionOperators<char, char, char>, IUnaryNegationOperators<char, char>, IUnaryPlusOperators<char, char>, IUnsignedNumber<char> {
++        static char System.Numerics.IBinaryNumber<System.Char>.AllBitsSet { get; }
++        static bool IComparisonOperators<char, char, bool>.operator >(char left, char right);
++        static bool IComparisonOperators<char, char, bool>.operator >=(char left, char right);
++        static bool IComparisonOperators<char, char, bool>.operator <(char left, char right);
++        static bool IComparisonOperators<char, char, bool>.operator <=(char left, char right);
+-        static bool IComparisonOperators<char, char>.operator >(char left, char right);
+-        static bool IComparisonOperators<char, char>.operator >=(char left, char right);
+-        static bool IComparisonOperators<char, char>.operator <(char left, char right);
+-        static bool IComparisonOperators<char, char>.operator <=(char left, char right);
++        static bool IEqualityOperators<char, char, bool>.operator ==(char left, char right);
++        static bool IEqualityOperators<char, char, bool>.operator !=(char left, char right);
+-        static bool IEqualityOperators<char, char>.operator ==(char left, char right);
+-        static bool IEqualityOperators<char, char>.operator !=(char left, char right);
+-        static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount);
+-        static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount);
+-        static char IShiftOperators<char, char>.operator >>>(char value, int shiftAmount);
++        static char IShiftOperators<char, int, char>.operator <<(char value, int shiftAmount);
++        static char IShiftOperators<char, int, char>.operator >>(char value, int shiftAmount);
++        static char IShiftOperators<char, int, char>.operator >>>(char value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Decimal : IAdditionOperators<decimal, decimal, decimal>, IAdditiveIdentity<decimal, decimal>, IComparable, IComparable<decimal>, IComparisonOperators<decimal, decimal>, IConvertible, IDecrementOperators<decimal>, IDeserializationCallback, IDivisionOperators<decimal, decimal, decimal>, IEqualityOperators<decimal, decimal>, IEquatable<decimal>, IFloatingPoint<decimal>, IFormattable, IIncrementOperators<decimal>, IMinMaxValue<decimal>, IModulusOperators<decimal, decimal, decimal>, IMultiplicativeIdentity<decimal, decimal>, IMultiplyOperators<decimal, decimal, decimal>, INumber<decimal>, INumberBase<decimal>, IParsable<decimal>, ISerializable, ISignedNumber<decimal>, ISpanFormattable, ISpanParsable<decimal>, ISubtractionOperators<decimal, decimal, decimal>, IUnaryNegationOperators<decimal, decimal>, IUnaryPlusOperators<decimal, decimal> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Decimal : IAdditionOperators<decimal, decimal, decimal>, IAdditiveIdentity<decimal, decimal>, IComparable, IComparable<decimal>, IComparisonOperators<decimal, decimal, bool>, IConvertible, IDecrementOperators<decimal>, IDeserializationCallback, IDivisionOperators<decimal, decimal, decimal>, IEqualityOperators<decimal, decimal, bool>, IEquatable<decimal>, IFloatingPoint<decimal>, IFloatingPointConstants<decimal>, IFormattable, IIncrementOperators<decimal>, IMinMaxValue<decimal>, IModulusOperators<decimal, decimal, decimal>, IMultiplicativeIdentity<decimal, decimal>, IMultiplyOperators<decimal, decimal, decimal>, INumber<decimal>, INumberBase<decimal>, IParsable<decimal>, ISerializable, ISignedNumber<decimal>, ISpanFormattable, ISpanParsable<decimal>, ISubtractionOperators<decimal, decimal, decimal>, IUnaryNegationOperators<decimal, decimal>, IUnaryPlusOperators<decimal, decimal> {
++        static decimal System.Numerics.IFloatingPointConstants<System.Decimal>.E { get; }
++        static decimal System.Numerics.IFloatingPointConstants<System.Decimal>.Pi { get; }
++        static decimal System.Numerics.IFloatingPointConstants<System.Decimal>.Tau { get; }
++        [NullableContextAttribute((byte)1)]
++        public static decimal CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static decimal CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static decimal CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Double : IAdditionOperators<double, double, double>, IAdditiveIdentity<double, double>, IBinaryFloatingPointIeee754<double>, IBinaryNumber<double>, IBitwiseOperators<double, double, double>, IComparable, IComparable<double>, IComparisonOperators<double, double>, IConvertible, IDecrementOperators<double>, IDivisionOperators<double, double, double>, IEqualityOperators<double, double>, IEquatable<double>, IExponentialFunctions<double>, IFloatingPoint<double>, IFloatingPointIeee754<double>, IFormattable, IHyperbolicFunctions<double>, IIncrementOperators<double>, ILogarithmicFunctions<double>, IMinMaxValue<double>, IModulusOperators<double, double, double>, IMultiplicativeIdentity<double, double>, IMultiplyOperators<double, double, double>, INumber<double>, INumberBase<double>, IParsable<double>, IPowerFunctions<double>, IRootFunctions<double>, ISignedNumber<double>, ISpanFormattable, ISpanParsable<double>, ISubtractionOperators<double, double, double>, ITrigonometricFunctions<double>, IUnaryNegationOperators<double, double>, IUnaryPlusOperators<double, double> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Double : IAdditionOperators<double, double, double>, IAdditiveIdentity<double, double>, IBinaryFloatingPointIeee754<double>, IBinaryNumber<double>, IBitwiseOperators<double, double, double>, IComparable, IComparable<double>, IComparisonOperators<double, double, bool>, IConvertible, IDecrementOperators<double>, IDivisionOperators<double, double, double>, IEqualityOperators<double, double, bool>, IEquatable<double>, IExponentialFunctions<double>, IFloatingPoint<double>, IFloatingPointConstants<double>, IFloatingPointIeee754<double>, IFormattable, IHyperbolicFunctions<double>, IIncrementOperators<double>, ILogarithmicFunctions<double>, IMinMaxValue<double>, IModulusOperators<double, double, double>, IMultiplicativeIdentity<double, double>, IMultiplyOperators<double, double, double>, INumber<double>, INumberBase<double>, IParsable<double>, IPowerFunctions<double>, IRootFunctions<double>, ISignedNumber<double>, ISpanFormattable, ISpanParsable<double>, ISubtractionOperators<double, double, double>, ITrigonometricFunctions<double>, IUnaryNegationOperators<double, double>, IUnaryPlusOperators<double, double> {
++        static double System.Numerics.IBinaryNumber<System.Double>.AllBitsSet { get; }
++        static double System.Numerics.IFloatingPointConstants<System.Double>.E { get; }
++        static double System.Numerics.IFloatingPointConstants<System.Double>.Pi { get; }
++        static double System.Numerics.IFloatingPointConstants<System.Double>.Tau { get; }
+-        static double System.Numerics.IFloatingPointIeee754<System.Double>.E { get; }
+-        static double System.Numerics.IFloatingPointIeee754<System.Double>.Pi { get; }
+-        static double System.Numerics.IFloatingPointIeee754<System.Double>.Tau { get; }
++        [NullableContextAttribute((byte)1)]
++        public static double CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static double CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static double CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+-        public static double Root(double x, int n);
++        public static double RootN(double x, int n);
++        public static (double SinPi, double CosPi) SinCosPi(double x);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public static class GC {
++        public static IReadOnlyDictionary<string, object> GetConfigurationVariables();
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Half : IAdditionOperators<Half, Half, Half>, IAdditiveIdentity<Half, Half>, IBinaryFloatingPointIeee754<Half>, IBinaryNumber<Half>, IBitwiseOperators<Half, Half, Half>, IComparable, IComparable<Half>, IComparisonOperators<Half, Half>, IDecrementOperators<Half>, IDivisionOperators<Half, Half, Half>, IEqualityOperators<Half, Half>, IEquatable<Half>, IExponentialFunctions<Half>, IFloatingPoint<Half>, IFloatingPointIeee754<Half>, IFormattable, IHyperbolicFunctions<Half>, IIncrementOperators<Half>, ILogarithmicFunctions<Half>, IMinMaxValue<Half>, IModulusOperators<Half, Half, Half>, IMultiplicativeIdentity<Half, Half>, IMultiplyOperators<Half, Half, Half>, INumber<Half>, INumberBase<Half>, IParsable<Half>, IPowerFunctions<Half>, IRootFunctions<Half>, ISignedNumber<Half>, ISpanFormattable, ISpanParsable<Half>, ISubtractionOperators<Half, Half, Half>, ITrigonometricFunctions<Half>, IUnaryNegationOperators<Half, Half>, IUnaryPlusOperators<Half, Half> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Half : IAdditionOperators<Half, Half, Half>, IAdditiveIdentity<Half, Half>, IBinaryFloatingPointIeee754<Half>, IBinaryNumber<Half>, IBitwiseOperators<Half, Half, Half>, IComparable, IComparable<Half>, IComparisonOperators<Half, Half, bool>, IDecrementOperators<Half>, IDivisionOperators<Half, Half, Half>, IEqualityOperators<Half, Half, bool>, IEquatable<Half>, IExponentialFunctions<Half>, IFloatingPoint<Half>, IFloatingPointConstants<Half>, IFloatingPointIeee754<Half>, IFormattable, IHyperbolicFunctions<Half>, IIncrementOperators<Half>, ILogarithmicFunctions<Half>, IMinMaxValue<Half>, IModulusOperators<Half, Half, Half>, IMultiplicativeIdentity<Half, Half>, IMultiplyOperators<Half, Half, Half>, INumber<Half>, INumberBase<Half>, IParsable<Half>, IPowerFunctions<Half>, IRootFunctions<Half>, ISignedNumber<Half>, ISpanFormattable, ISpanParsable<Half>, ISubtractionOperators<Half, Half, Half>, ITrigonometricFunctions<Half>, IUnaryNegationOperators<Half, Half>, IUnaryPlusOperators<Half, Half> {
++        static Half System.Numerics.IBinaryNumber<System.Half>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static Half CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Half CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Half CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+-        public static Half Root(Half x, int n);
++        public static Half RootN(Half x, int n);
++        public static (Half SinPi, Half CosPi) SinCosPi(Half x);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Int128 : IAdditionOperators<Int128, Int128, Int128>, IAdditiveIdentity<Int128, Int128>, IBinaryInteger<Int128>, IBinaryNumber<Int128>, IBitwiseOperators<Int128, Int128, Int128>, IComparable, IComparable<Int128>, IComparisonOperators<Int128, Int128>, IDecrementOperators<Int128>, IDivisionOperators<Int128, Int128, Int128>, IEqualityOperators<Int128, Int128>, IEquatable<Int128>, IFormattable, IIncrementOperators<Int128>, IMinMaxValue<Int128>, IModulusOperators<Int128, Int128, Int128>, IMultiplicativeIdentity<Int128, Int128>, IMultiplyOperators<Int128, Int128, Int128>, INumber<Int128>, INumberBase<Int128>, IParsable<Int128>, IShiftOperators<Int128, Int128>, ISignedNumber<Int128>, ISpanFormattable, ISpanParsable<Int128>, ISubtractionOperators<Int128, Int128, Int128>, IUnaryNegationOperators<Int128, Int128>, IUnaryPlusOperators<Int128, Int128> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Int128 : IAdditionOperators<Int128, Int128, Int128>, IAdditiveIdentity<Int128, Int128>, IBinaryInteger<Int128>, IBinaryNumber<Int128>, IBitwiseOperators<Int128, Int128, Int128>, IComparable, IComparable<Int128>, IComparisonOperators<Int128, Int128, bool>, IDecrementOperators<Int128>, IDivisionOperators<Int128, Int128, Int128>, IEqualityOperators<Int128, Int128, bool>, IEquatable<Int128>, IFormattable, IIncrementOperators<Int128>, IMinMaxValue<Int128>, IModulusOperators<Int128, Int128, Int128>, IMultiplicativeIdentity<Int128, Int128>, IMultiplyOperators<Int128, Int128, Int128>, INumber<Int128>, INumberBase<Int128>, IParsable<Int128>, IShiftOperators<Int128, int, Int128>, ISignedNumber<Int128>, ISpanFormattable, ISpanParsable<Int128>, ISubtractionOperators<Int128, Int128, Int128>, IUnaryNegationOperators<Int128, Int128>, IUnaryPlusOperators<Int128, Int128> {
++        static Int128 System.Numerics.IBinaryNumber<System.Int128>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static Int128 CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Int128 CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static Int128 CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Int16 : IAdditionOperators<short, short, short>, IAdditiveIdentity<short, short>, IBinaryInteger<short>, IBinaryNumber<short>, IBitwiseOperators<short, short, short>, IComparable, IComparable<short>, IComparisonOperators<short, short>, IConvertible, IDecrementOperators<short>, IDivisionOperators<short, short, short>, IEqualityOperators<short, short>, IEquatable<short>, IFormattable, IIncrementOperators<short>, IMinMaxValue<short>, IModulusOperators<short, short, short>, IMultiplicativeIdentity<short, short>, IMultiplyOperators<short, short, short>, INumber<short>, INumberBase<short>, IParsable<short>, IShiftOperators<short, short>, ISignedNumber<short>, ISpanFormattable, ISpanParsable<short>, ISubtractionOperators<short, short, short>, IUnaryNegationOperators<short, short>, IUnaryPlusOperators<short, short> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Int16 : IAdditionOperators<short, short, short>, IAdditiveIdentity<short, short>, IBinaryInteger<short>, IBinaryNumber<short>, IBitwiseOperators<short, short, short>, IComparable, IComparable<short>, IComparisonOperators<short, short, bool>, IConvertible, IDecrementOperators<short>, IDivisionOperators<short, short, short>, IEqualityOperators<short, short, bool>, IEquatable<short>, IFormattable, IIncrementOperators<short>, IMinMaxValue<short>, IModulusOperators<short, short, short>, IMultiplicativeIdentity<short, short>, IMultiplyOperators<short, short, short>, INumber<short>, INumberBase<short>, IParsable<short>, IShiftOperators<short, int, short>, ISignedNumber<short>, ISpanFormattable, ISpanParsable<short>, ISubtractionOperators<short, short, short>, IUnaryNegationOperators<short, short>, IUnaryPlusOperators<short, short> {
++        static short System.Numerics.IBinaryNumber<System.Int16>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static short CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static short CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static short CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<short, short, bool>.operator >(short left, short right);
++        static bool IComparisonOperators<short, short, bool>.operator >=(short left, short right);
++        static bool IComparisonOperators<short, short, bool>.operator <(short left, short right);
++        static bool IComparisonOperators<short, short, bool>.operator <=(short left, short right);
+-        static bool IComparisonOperators<short, short>.operator >(short left, short right);
+-        static bool IComparisonOperators<short, short>.operator >=(short left, short right);
+-        static bool IComparisonOperators<short, short>.operator <(short left, short right);
+-        static bool IComparisonOperators<short, short>.operator <=(short left, short right);
++        static bool IEqualityOperators<short, short, bool>.operator ==(short left, short right);
++        static bool IEqualityOperators<short, short, bool>.operator !=(short left, short right);
+-        static bool IEqualityOperators<short, short>.operator ==(short left, short right);
+-        static bool IEqualityOperators<short, short>.operator !=(short left, short right);
+-        static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount);
+-        static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount);
+-        static short IShiftOperators<short, short>.operator >>>(short value, int shiftAmount);
++        static short IShiftOperators<short, int, short>.operator <<(short value, int shiftAmount);
++        static short IShiftOperators<short, int, short>.operator >>(short value, int shiftAmount);
++        static short IShiftOperators<short, int, short>.operator >>>(short value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Int32 : IAdditionOperators<int, int, int>, IAdditiveIdentity<int, int>, IBinaryInteger<int>, IBinaryNumber<int>, IBitwiseOperators<int, int, int>, IComparable, IComparable<int>, IComparisonOperators<int, int>, IConvertible, IDecrementOperators<int>, IDivisionOperators<int, int, int>, IEqualityOperators<int, int>, IEquatable<int>, IFormattable, IIncrementOperators<int>, IMinMaxValue<int>, IModulusOperators<int, int, int>, IMultiplicativeIdentity<int, int>, IMultiplyOperators<int, int, int>, INumber<int>, INumberBase<int>, IParsable<int>, IShiftOperators<int, int>, ISignedNumber<int>, ISpanFormattable, ISpanParsable<int>, ISubtractionOperators<int, int, int>, IUnaryNegationOperators<int, int>, IUnaryPlusOperators<int, int> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Int32 : IAdditionOperators<int, int, int>, IAdditiveIdentity<int, int>, IBinaryInteger<int>, IBinaryNumber<int>, IBitwiseOperators<int, int, int>, IComparable, IComparable<int>, IComparisonOperators<int, int, bool>, IConvertible, IDecrementOperators<int>, IDivisionOperators<int, int, int>, IEqualityOperators<int, int, bool>, IEquatable<int>, IFormattable, IIncrementOperators<int>, IMinMaxValue<int>, IModulusOperators<int, int, int>, IMultiplicativeIdentity<int, int>, IMultiplyOperators<int, int, int>, INumber<int>, INumberBase<int>, IParsable<int>, IShiftOperators<int, int, int>, ISignedNumber<int>, ISpanFormattable, ISpanParsable<int>, ISubtractionOperators<int, int, int>, IUnaryNegationOperators<int, int>, IUnaryPlusOperators<int, int> {
++        static int System.Numerics.IBinaryNumber<System.Int32>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static int CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static int CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static int CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<int, int, bool>.operator >(int left, int right);
++        static bool IComparisonOperators<int, int, bool>.operator >=(int left, int right);
++        static bool IComparisonOperators<int, int, bool>.operator <(int left, int right);
++        static bool IComparisonOperators<int, int, bool>.operator <=(int left, int right);
+-        static bool IComparisonOperators<int, int>.operator >(int left, int right);
+-        static bool IComparisonOperators<int, int>.operator >=(int left, int right);
+-        static bool IComparisonOperators<int, int>.operator <(int left, int right);
+-        static bool IComparisonOperators<int, int>.operator <=(int left, int right);
++        static bool IEqualityOperators<int, int, bool>.operator ==(int left, int right);
++        static bool IEqualityOperators<int, int, bool>.operator !=(int left, int right);
+-        static bool IEqualityOperators<int, int>.operator ==(int left, int right);
+-        static bool IEqualityOperators<int, int>.operator !=(int left, int right);
++        static int IShiftOperators<int, int, int>.operator <<(int value, int shiftAmount);
++        static int IShiftOperators<int, int, int>.operator >>(int value, int shiftAmount);
++        static int IShiftOperators<int, int, int>.operator >>>(int value, int shiftAmount);
+-        static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount);
+-        static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount);
+-        static int IShiftOperators<int, int>.operator >>>(int value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Int64 : IAdditionOperators<long, long, long>, IAdditiveIdentity<long, long>, IBinaryInteger<long>, IBinaryNumber<long>, IBitwiseOperators<long, long, long>, IComparable, IComparable<long>, IComparisonOperators<long, long>, IConvertible, IDecrementOperators<long>, IDivisionOperators<long, long, long>, IEqualityOperators<long, long>, IEquatable<long>, IFormattable, IIncrementOperators<long>, IMinMaxValue<long>, IModulusOperators<long, long, long>, IMultiplicativeIdentity<long, long>, IMultiplyOperators<long, long, long>, INumber<long>, INumberBase<long>, IParsable<long>, IShiftOperators<long, long>, ISignedNumber<long>, ISpanFormattable, ISpanParsable<long>, ISubtractionOperators<long, long, long>, IUnaryNegationOperators<long, long>, IUnaryPlusOperators<long, long> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Int64 : IAdditionOperators<long, long, long>, IAdditiveIdentity<long, long>, IBinaryInteger<long>, IBinaryNumber<long>, IBitwiseOperators<long, long, long>, IComparable, IComparable<long>, IComparisonOperators<long, long, bool>, IConvertible, IDecrementOperators<long>, IDivisionOperators<long, long, long>, IEqualityOperators<long, long, bool>, IEquatable<long>, IFormattable, IIncrementOperators<long>, IMinMaxValue<long>, IModulusOperators<long, long, long>, IMultiplicativeIdentity<long, long>, IMultiplyOperators<long, long, long>, INumber<long>, INumberBase<long>, IParsable<long>, IShiftOperators<long, int, long>, ISignedNumber<long>, ISpanFormattable, ISpanParsable<long>, ISubtractionOperators<long, long, long>, IUnaryNegationOperators<long, long>, IUnaryPlusOperators<long, long> {
++        static long System.Numerics.IBinaryNumber<System.Int64>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static long CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static long CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static long CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<long, long, bool>.operator >(long left, long right);
++        static bool IComparisonOperators<long, long, bool>.operator >=(long left, long right);
++        static bool IComparisonOperators<long, long, bool>.operator <(long left, long right);
++        static bool IComparisonOperators<long, long, bool>.operator <=(long left, long right);
+-        static bool IComparisonOperators<long, long>.operator >(long left, long right);
+-        static bool IComparisonOperators<long, long>.operator >=(long left, long right);
+-        static bool IComparisonOperators<long, long>.operator <(long left, long right);
+-        static bool IComparisonOperators<long, long>.operator <=(long left, long right);
++        static bool IEqualityOperators<long, long, bool>.operator ==(long left, long right);
++        static bool IEqualityOperators<long, long, bool>.operator !=(long left, long right);
+-        static bool IEqualityOperators<long, long>.operator ==(long left, long right);
+-        static bool IEqualityOperators<long, long>.operator !=(long left, long right);
++        static long IShiftOperators<long, int, long>.operator <<(long value, int shiftAmount);
++        static long IShiftOperators<long, int, long>.operator >>(long value, int shiftAmount);
++        static long IShiftOperators<long, int, long>.operator >>>(long value, int shiftAmount);
+-        static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount);
+-        static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount);
+-        static long IShiftOperators<long, long>.operator >>>(long value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct IntPtr : IAdditionOperators<IntPtr, IntPtr, IntPtr>, IAdditiveIdentity<IntPtr, IntPtr>, IBinaryInteger<IntPtr>, IBinaryNumber<IntPtr>, IBitwiseOperators<IntPtr, IntPtr, IntPtr>, IComparable, IComparable<IntPtr>, IComparisonOperators<IntPtr, IntPtr>, IDecrementOperators<IntPtr>, IDivisionOperators<IntPtr, IntPtr, IntPtr>, IEqualityOperators<IntPtr, IntPtr>, IEquatable<IntPtr>, IFormattable, IIncrementOperators<IntPtr>, IMinMaxValue<IntPtr>, IModulusOperators<IntPtr, IntPtr, IntPtr>, IMultiplicativeIdentity<IntPtr, IntPtr>, IMultiplyOperators<IntPtr, IntPtr, IntPtr>, INumber<IntPtr>, INumberBase<IntPtr>, IParsable<IntPtr>, ISerializable, IShiftOperators<IntPtr, IntPtr>, ISignedNumber<IntPtr>, ISpanFormattable, ISpanParsable<IntPtr>, ISubtractionOperators<IntPtr, IntPtr, IntPtr>, IUnaryNegationOperators<IntPtr, IntPtr>, IUnaryPlusOperators<IntPtr, IntPtr> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct IntPtr : IAdditionOperators<IntPtr, IntPtr, IntPtr>, IAdditiveIdentity<IntPtr, IntPtr>, IBinaryInteger<IntPtr>, IBinaryNumber<IntPtr>, IBitwiseOperators<IntPtr, IntPtr, IntPtr>, IComparable, IComparable<IntPtr>, IComparisonOperators<IntPtr, IntPtr, bool>, IDecrementOperators<IntPtr>, IDivisionOperators<IntPtr, IntPtr, IntPtr>, IEqualityOperators<IntPtr, IntPtr, bool>, IEquatable<IntPtr>, IFormattable, IIncrementOperators<IntPtr>, IMinMaxValue<IntPtr>, IModulusOperators<IntPtr, IntPtr, IntPtr>, IMultiplicativeIdentity<IntPtr, IntPtr>, IMultiplyOperators<IntPtr, IntPtr, IntPtr>, INumber<IntPtr>, INumberBase<IntPtr>, IParsable<IntPtr>, ISerializable, IShiftOperators<IntPtr, int, IntPtr>, ISignedNumber<IntPtr>, ISpanFormattable, ISpanParsable<IntPtr>, ISubtractionOperators<IntPtr, IntPtr, IntPtr>, IUnaryNegationOperators<IntPtr, IntPtr>, IUnaryPlusOperators<IntPtr, IntPtr> {
++        static IntPtr System.Numerics.IBinaryNumber<nint>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static IntPtr CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static IntPtr CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static IntPtr CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<IntPtr, IntPtr, bool>.operator >(IntPtr left, IntPtr right);
++        static bool IComparisonOperators<IntPtr, IntPtr, bool>.operator >=(IntPtr left, IntPtr right);
++        static bool IComparisonOperators<IntPtr, IntPtr, bool>.operator <(IntPtr left, IntPtr right);
++        static bool IComparisonOperators<IntPtr, IntPtr, bool>.operator <=(IntPtr left, IntPtr right);
+-        static bool IComparisonOperators<IntPtr, IntPtr>.operator >(IntPtr left, IntPtr right);
+-        static bool IComparisonOperators<IntPtr, IntPtr>.operator >=(IntPtr left, IntPtr right);
+-        static bool IComparisonOperators<IntPtr, IntPtr>.operator <(IntPtr left, IntPtr right);
+-        static bool IComparisonOperators<IntPtr, IntPtr>.operator <=(IntPtr left, IntPtr right);
+-        static IntPtr IShiftOperators<IntPtr, IntPtr>.operator <<(IntPtr value, int shiftAmount);
+-        static IntPtr IShiftOperators<IntPtr, IntPtr>.operator >>(IntPtr value, int shiftAmount);
+-        static IntPtr IShiftOperators<IntPtr, IntPtr>.operator >>>(IntPtr value, int shiftAmount);
++        static IntPtr IShiftOperators<IntPtr, int, IntPtr>.operator <<(IntPtr value, int shiftAmount);
++        static IntPtr IShiftOperators<IntPtr, int, IntPtr>.operator >>(IntPtr value, int shiftAmount);
++        static IntPtr IShiftOperators<IntPtr, int, IntPtr>.operator >>>(IntPtr value, int shiftAmount);
+     }
+     [NullableContextAttribute((byte)1)]
+     public interface IParsable<TSelf> where TSelf : IParsable<TSelf> {
+-        [NullableContextAttribute((byte)2)]
+-        static abstract bool TryParse([NotNullWhenAttribute(true)] string? s, IFormatProvider? provider, [NullableAttribute((byte)1)] out TSelf result);
++        [NullableContextAttribute((byte)2)]
++        static abstract bool TryParse([NotNullWhenAttribute(true)] string? s, IFormatProvider? provider, [MaybeNullWhenAttribute(false), NullableAttribute((byte)1)] out TSelf result);
+     }
+     public interface ISpanParsable<TSelf> : IParsable<TSelf> where TSelf : ISpanParsable<TSelf> {
+-        static abstract bool TryParse(ReadOnlySpan<char> s, [NullableAttribute((byte)2)] IFormatProvider? provider, [NullableAttribute((byte)1)] out TSelf result);
++        static abstract bool TryParse(ReadOnlySpan<char> s, [NullableAttribute((byte)2)] IFormatProvider? provider, [MaybeNullWhenAttribute(false), NullableAttribute((byte)1)] out TSelf result);
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly ref struct ReadOnlySpan<T> {
++    [NativeMarshallingAttribute(typeof(ReadOnlySpanMarshaller<,>))]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly ref struct ReadOnlySpan<T> {
++        public ReadOnlySpan(in T reference);
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct SByte : IAdditionOperators<sbyte, sbyte, sbyte>, IAdditiveIdentity<sbyte, sbyte>, IBinaryInteger<sbyte>, IBinaryNumber<sbyte>, IBitwiseOperators<sbyte, sbyte, sbyte>, IComparable, IComparable<sbyte>, IComparisonOperators<sbyte, sbyte>, IConvertible, IDecrementOperators<sbyte>, IDivisionOperators<sbyte, sbyte, sbyte>, IEqualityOperators<sbyte, sbyte>, IEquatable<sbyte>, IFormattable, IIncrementOperators<sbyte>, IMinMaxValue<sbyte>, IModulusOperators<sbyte, sbyte, sbyte>, IMultiplicativeIdentity<sbyte, sbyte>, IMultiplyOperators<sbyte, sbyte, sbyte>, INumber<sbyte>, INumberBase<sbyte>, IParsable<sbyte>, IShiftOperators<sbyte, sbyte>, ISignedNumber<sbyte>, ISpanFormattable, ISpanParsable<sbyte>, ISubtractionOperators<sbyte, sbyte, sbyte>, IUnaryNegationOperators<sbyte, sbyte>, IUnaryPlusOperators<sbyte, sbyte> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct SByte : IAdditionOperators<sbyte, sbyte, sbyte>, IAdditiveIdentity<sbyte, sbyte>, IBinaryInteger<sbyte>, IBinaryNumber<sbyte>, IBitwiseOperators<sbyte, sbyte, sbyte>, IComparable, IComparable<sbyte>, IComparisonOperators<sbyte, sbyte, bool>, IConvertible, IDecrementOperators<sbyte>, IDivisionOperators<sbyte, sbyte, sbyte>, IEqualityOperators<sbyte, sbyte, bool>, IEquatable<sbyte>, IFormattable, IIncrementOperators<sbyte>, IMinMaxValue<sbyte>, IModulusOperators<sbyte, sbyte, sbyte>, IMultiplicativeIdentity<sbyte, sbyte>, IMultiplyOperators<sbyte, sbyte, sbyte>, INumber<sbyte>, INumberBase<sbyte>, IParsable<sbyte>, IShiftOperators<sbyte, int, sbyte>, ISignedNumber<sbyte>, ISpanFormattable, ISpanParsable<sbyte>, ISubtractionOperators<sbyte, sbyte, sbyte>, IUnaryNegationOperators<sbyte, sbyte>, IUnaryPlusOperators<sbyte, sbyte> {
++        static sbyte System.Numerics.IBinaryNumber<System.SByte>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static sbyte CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static sbyte CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static sbyte CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<sbyte, sbyte, bool>.operator >(sbyte left, sbyte right);
++        static bool IComparisonOperators<sbyte, sbyte, bool>.operator >=(sbyte left, sbyte right);
++        static bool IComparisonOperators<sbyte, sbyte, bool>.operator <(sbyte left, sbyte right);
++        static bool IComparisonOperators<sbyte, sbyte, bool>.operator <=(sbyte left, sbyte right);
+-        static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right);
+-        static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right);
+-        static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right);
+-        static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right);
++        static bool IEqualityOperators<sbyte, sbyte, bool>.operator ==(sbyte left, sbyte right);
++        static bool IEqualityOperators<sbyte, sbyte, bool>.operator !=(sbyte left, sbyte right);
+-        static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right);
+-        static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right);
++        static sbyte IShiftOperators<sbyte, int, sbyte>.operator <<(sbyte value, int shiftAmount);
++        static sbyte IShiftOperators<sbyte, int, sbyte>.operator >>(sbyte value, int shiftAmount);
++        static sbyte IShiftOperators<sbyte, int, sbyte>.operator >>>(sbyte value, int shiftAmount);
+-        static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount);
+-        static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount);
+-        static sbyte IShiftOperators<sbyte, sbyte>.operator >>>(sbyte value, int shiftAmount);
+     }
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct Single : IAdditionOperators<float, float, float>, IAdditiveIdentity<float, float>, IBinaryFloatingPointIeee754<float>, IBinaryNumber<float>, IBitwiseOperators<float, float, float>, IComparable, IComparable<float>, IComparisonOperators<float, float>, IConvertible, IDecrementOperators<float>, IDivisionOperators<float, float, float>, IEqualityOperators<float, float>, IEquatable<float>, IExponentialFunctions<float>, IFloatingPoint<float>, IFloatingPointIeee754<float>, IFormattable, IHyperbolicFunctions<float>, IIncrementOperators<float>, ILogarithmicFunctions<float>, IMinMaxValue<float>, IModulusOperators<float, float, float>, IMultiplicativeIdentity<float, float>, IMultiplyOperators<float, float, float>, INumber<float>, INumberBase<float>, IParsable<float>, IPowerFunctions<float>, IRootFunctions<float>, ISignedNumber<float>, ISpanFormattable, ISpanParsable<float>, ISubtractionOperators<float, float, float>, ITrigonometricFunctions<float>, IUnaryNegationOperators<float, float>, IUnaryPlusOperators<float, float> {
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct Single : IAdditionOperators<float, float, float>, IAdditiveIdentity<float, float>, IBinaryFloatingPointIeee754<float>, IBinaryNumber<float>, IBitwiseOperators<float, float, float>, IComparable, IComparable<float>, IComparisonOperators<float, float, bool>, IConvertible, IDecrementOperators<float>, IDivisionOperators<float, float, float>, IEqualityOperators<float, float, bool>, IEquatable<float>, IExponentialFunctions<float>, IFloatingPoint<float>, IFloatingPointConstants<float>, IFloatingPointIeee754<float>, IFormattable, IHyperbolicFunctions<float>, IIncrementOperators<float>, ILogarithmicFunctions<float>, IMinMaxValue<float>, IModulusOperators<float, float, float>, IMultiplicativeIdentity<float, float>, IMultiplyOperators<float, float, float>, INumber<float>, INumberBase<float>, IParsable<float>, IPowerFunctions<float>, IRootFunctions<float>, ISignedNumber<float>, ISpanFormattable, ISpanParsable<float>, ISubtractionOperators<float, float, float>, ITrigonometricFunctions<float>, IUnaryNegationOperators<float, float>, IUnaryPlusOperators<float, float> {
++        static float System.Numerics.IBinaryNumber<System.Single>.AllBitsSet { get; }
++        static float System.Numerics.IFloatingPointConstants<System.Single>.E { get; }
++        static float System.Numerics.IFloatingPointConstants<System.Single>.Pi { get; }
++        static float System.Numerics.IFloatingPointConstants<System.Single>.Tau { get; }
+-        static float System.Numerics.IFloatingPointIeee754<System.Single>.E { get; }
+-        static float System.Numerics.IFloatingPointIeee754<System.Single>.Pi { get; }
+-        static float System.Numerics.IFloatingPointIeee754<System.Single>.Tau { get; }
++        [NullableContextAttribute((byte)1)]
++        public static float CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static float CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static float CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+-        public static float Root(float x, int n);
++        public static float RootN(float x, int n);
++        public static (float SinPi, float CosPi) SinCosPi(float x);
+     }
+-    [NullableAttribute((byte)0)]
+-    [NullableContextAttribute((byte)1)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly ref struct Span<T> {
++    [NativeMarshallingAttribute(typeof(SpanMarshaller<,>))]
++    [NullableAttribute((byte)0)]
++    [NullableContextAttribute((byte)1)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly ref struct Span<T> {
++        public Span(ref T reference);
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct UInt128 : IAdditionOperators<UInt128, UInt128, UInt128>, IAdditiveIdentity<UInt128, UInt128>, IBinaryInteger<UInt128>, IBinaryNumber<UInt128>, IBitwiseOperators<UInt128, UInt128, UInt128>, IComparable, IComparable<UInt128>, IComparisonOperators<UInt128, UInt128>, IDecrementOperators<UInt128>, IDivisionOperators<UInt128, UInt128, UInt128>, IEqualityOperators<UInt128, UInt128>, IEquatable<UInt128>, IFormattable, IIncrementOperators<UInt128>, IMinMaxValue<UInt128>, IModulusOperators<UInt128, UInt128, UInt128>, IMultiplicativeIdentity<UInt128, UInt128>, IMultiplyOperators<UInt128, UInt128, UInt128>, INumber<UInt128>, INumberBase<UInt128>, IParsable<UInt128>, IShiftOperators<UInt128, UInt128>, ISpanFormattable, ISpanParsable<UInt128>, ISubtractionOperators<UInt128, UInt128, UInt128>, IUnaryNegationOperators<UInt128, UInt128>, IUnaryPlusOperators<UInt128, UInt128>, IUnsignedNumber<UInt128> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct UInt128 : IAdditionOperators<UInt128, UInt128, UInt128>, IAdditiveIdentity<UInt128, UInt128>, IBinaryInteger<UInt128>, IBinaryNumber<UInt128>, IBitwiseOperators<UInt128, UInt128, UInt128>, IComparable, IComparable<UInt128>, IComparisonOperators<UInt128, UInt128, bool>, IDecrementOperators<UInt128>, IDivisionOperators<UInt128, UInt128, UInt128>, IEqualityOperators<UInt128, UInt128, bool>, IEquatable<UInt128>, IFormattable, IIncrementOperators<UInt128>, IMinMaxValue<UInt128>, IModulusOperators<UInt128, UInt128, UInt128>, IMultiplicativeIdentity<UInt128, UInt128>, IMultiplyOperators<UInt128, UInt128, UInt128>, INumber<UInt128>, INumberBase<UInt128>, IParsable<UInt128>, IShiftOperators<UInt128, int, UInt128>, ISpanFormattable, ISpanParsable<UInt128>, ISubtractionOperators<UInt128, UInt128, UInt128>, IUnaryNegationOperators<UInt128, UInt128>, IUnaryPlusOperators<UInt128, UInt128>, IUnsignedNumber<UInt128> {
++        static UInt128 System.Numerics.IBinaryNumber<System.UInt128>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static UInt128 CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static UInt128 CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static UInt128 CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct UInt16 : IAdditionOperators<ushort, ushort, ushort>, IAdditiveIdentity<ushort, ushort>, IBinaryInteger<ushort>, IBinaryNumber<ushort>, IBitwiseOperators<ushort, ushort, ushort>, IComparable, IComparable<ushort>, IComparisonOperators<ushort, ushort>, IConvertible, IDecrementOperators<ushort>, IDivisionOperators<ushort, ushort, ushort>, IEqualityOperators<ushort, ushort>, IEquatable<ushort>, IFormattable, IIncrementOperators<ushort>, IMinMaxValue<ushort>, IModulusOperators<ushort, ushort, ushort>, IMultiplicativeIdentity<ushort, ushort>, IMultiplyOperators<ushort, ushort, ushort>, INumber<ushort>, INumberBase<ushort>, IParsable<ushort>, IShiftOperators<ushort, ushort>, ISpanFormattable, ISpanParsable<ushort>, ISubtractionOperators<ushort, ushort, ushort>, IUnaryNegationOperators<ushort, ushort>, IUnaryPlusOperators<ushort, ushort>, IUnsignedNumber<ushort> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct UInt16 : IAdditionOperators<ushort, ushort, ushort>, IAdditiveIdentity<ushort, ushort>, IBinaryInteger<ushort>, IBinaryNumber<ushort>, IBitwiseOperators<ushort, ushort, ushort>, IComparable, IComparable<ushort>, IComparisonOperators<ushort, ushort, bool>, IConvertible, IDecrementOperators<ushort>, IDivisionOperators<ushort, ushort, ushort>, IEqualityOperators<ushort, ushort, bool>, IEquatable<ushort>, IFormattable, IIncrementOperators<ushort>, IMinMaxValue<ushort>, IModulusOperators<ushort, ushort, ushort>, IMultiplicativeIdentity<ushort, ushort>, IMultiplyOperators<ushort, ushort, ushort>, INumber<ushort>, INumberBase<ushort>, IParsable<ushort>, IShiftOperators<ushort, int, ushort>, ISpanFormattable, ISpanParsable<ushort>, ISubtractionOperators<ushort, ushort, ushort>, IUnaryNegationOperators<ushort, ushort>, IUnaryPlusOperators<ushort, ushort>, IUnsignedNumber<ushort> {
++        static ushort System.Numerics.IBinaryNumber<System.UInt16>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static ushort CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static ushort CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static ushort CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<ushort, ushort, bool>.operator >(ushort left, ushort right);
++        static bool IComparisonOperators<ushort, ushort, bool>.operator >=(ushort left, ushort right);
++        static bool IComparisonOperators<ushort, ushort, bool>.operator <(ushort left, ushort right);
++        static bool IComparisonOperators<ushort, ushort, bool>.operator <=(ushort left, ushort right);
+-        static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right);
+-        static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right);
+-        static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right);
+-        static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right);
++        static bool IEqualityOperators<ushort, ushort, bool>.operator ==(ushort left, ushort right);
++        static bool IEqualityOperators<ushort, ushort, bool>.operator !=(ushort left, ushort right);
+-        static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right);
+-        static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right);
++        static ushort IShiftOperators<ushort, int, ushort>.operator <<(ushort value, int shiftAmount);
++        static ushort IShiftOperators<ushort, int, ushort>.operator >>(ushort value, int shiftAmount);
++        static ushort IShiftOperators<ushort, int, ushort>.operator >>>(ushort value, int shiftAmount);
+-        static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount);
+-        static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount);
+-        static ushort IShiftOperators<ushort, ushort>.operator >>>(ushort value, int shiftAmount);
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct UInt32 : IAdditionOperators<uint, uint, uint>, IAdditiveIdentity<uint, uint>, IBinaryInteger<uint>, IBinaryNumber<uint>, IBitwiseOperators<uint, uint, uint>, IComparable, IComparable<uint>, IComparisonOperators<uint, uint>, IConvertible, IDecrementOperators<uint>, IDivisionOperators<uint, uint, uint>, IEqualityOperators<uint, uint>, IEquatable<uint>, IFormattable, IIncrementOperators<uint>, IMinMaxValue<uint>, IModulusOperators<uint, uint, uint>, IMultiplicativeIdentity<uint, uint>, IMultiplyOperators<uint, uint, uint>, INumber<uint>, INumberBase<uint>, IParsable<uint>, IShiftOperators<uint, uint>, ISpanFormattable, ISpanParsable<uint>, ISubtractionOperators<uint, uint, uint>, IUnaryNegationOperators<uint, uint>, IUnaryPlusOperators<uint, uint>, IUnsignedNumber<uint> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct UInt32 : IAdditionOperators<uint, uint, uint>, IAdditiveIdentity<uint, uint>, IBinaryInteger<uint>, IBinaryNumber<uint>, IBitwiseOperators<uint, uint, uint>, IComparable, IComparable<uint>, IComparisonOperators<uint, uint, bool>, IConvertible, IDecrementOperators<uint>, IDivisionOperators<uint, uint, uint>, IEqualityOperators<uint, uint, bool>, IEquatable<uint>, IFormattable, IIncrementOperators<uint>, IMinMaxValue<uint>, IModulusOperators<uint, uint, uint>, IMultiplicativeIdentity<uint, uint>, IMultiplyOperators<uint, uint, uint>, INumber<uint>, INumberBase<uint>, IParsable<uint>, IShiftOperators<uint, int, uint>, ISpanFormattable, ISpanParsable<uint>, ISubtractionOperators<uint, uint, uint>, IUnaryNegationOperators<uint, uint>, IUnaryPlusOperators<uint, uint>, IUnsignedNumber<uint> {
++        static uint System.Numerics.IBinaryNumber<System.UInt32>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static uint CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static uint CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static uint CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<uint, uint, bool>.operator >(uint left, uint right);
++        static bool IComparisonOperators<uint, uint, bool>.operator >=(uint left, uint right);
++        static bool IComparisonOperators<uint, uint, bool>.operator <(uint left, uint right);
++        static bool IComparisonOperators<uint, uint, bool>.operator <=(uint left, uint right);
+-        static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right);
+-        static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right);
+-        static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right);
+-        static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right);
++        static bool IEqualityOperators<uint, uint, bool>.operator ==(uint left, uint right);
++        static bool IEqualityOperators<uint, uint, bool>.operator !=(uint left, uint right);
+-        static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right);
+-        static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right);
++        static uint IShiftOperators<uint, int, uint>.operator <<(uint value, int shiftAmount);
++        static uint IShiftOperators<uint, int, uint>.operator >>(uint value, int shiftAmount);
++        static uint IShiftOperators<uint, int, uint>.operator >>>(uint value, int shiftAmount);
+-        static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount);
+-        static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount);
+-        static uint IShiftOperators<uint, uint>.operator >>>(uint value, int shiftAmount);
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct UInt64 : IAdditionOperators<ulong, ulong, ulong>, IAdditiveIdentity<ulong, ulong>, IBinaryInteger<ulong>, IBinaryNumber<ulong>, IBitwiseOperators<ulong, ulong, ulong>, IComparable, IComparable<ulong>, IComparisonOperators<ulong, ulong>, IConvertible, IDecrementOperators<ulong>, IDivisionOperators<ulong, ulong, ulong>, IEqualityOperators<ulong, ulong>, IEquatable<ulong>, IFormattable, IIncrementOperators<ulong>, IMinMaxValue<ulong>, IModulusOperators<ulong, ulong, ulong>, IMultiplicativeIdentity<ulong, ulong>, IMultiplyOperators<ulong, ulong, ulong>, INumber<ulong>, INumberBase<ulong>, IParsable<ulong>, IShiftOperators<ulong, ulong>, ISpanFormattable, ISpanParsable<ulong>, ISubtractionOperators<ulong, ulong, ulong>, IUnaryNegationOperators<ulong, ulong>, IUnaryPlusOperators<ulong, ulong>, IUnsignedNumber<ulong> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct UInt64 : IAdditionOperators<ulong, ulong, ulong>, IAdditiveIdentity<ulong, ulong>, IBinaryInteger<ulong>, IBinaryNumber<ulong>, IBitwiseOperators<ulong, ulong, ulong>, IComparable, IComparable<ulong>, IComparisonOperators<ulong, ulong, bool>, IConvertible, IDecrementOperators<ulong>, IDivisionOperators<ulong, ulong, ulong>, IEqualityOperators<ulong, ulong, bool>, IEquatable<ulong>, IFormattable, IIncrementOperators<ulong>, IMinMaxValue<ulong>, IModulusOperators<ulong, ulong, ulong>, IMultiplicativeIdentity<ulong, ulong>, IMultiplyOperators<ulong, ulong, ulong>, INumber<ulong>, INumberBase<ulong>, IParsable<ulong>, IShiftOperators<ulong, int, ulong>, ISpanFormattable, ISpanParsable<ulong>, ISubtractionOperators<ulong, ulong, ulong>, IUnaryNegationOperators<ulong, ulong>, IUnaryPlusOperators<ulong, ulong>, IUnsignedNumber<ulong> {
++        static ulong System.Numerics.IBinaryNumber<System.UInt64>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static ulong CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static ulong CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static ulong CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<ulong, ulong, bool>.operator >(ulong left, ulong right);
++        static bool IComparisonOperators<ulong, ulong, bool>.operator >=(ulong left, ulong right);
++        static bool IComparisonOperators<ulong, ulong, bool>.operator <(ulong left, ulong right);
++        static bool IComparisonOperators<ulong, ulong, bool>.operator <=(ulong left, ulong right);
+-        static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right);
+-        static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right);
+-        static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right);
+-        static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right);
++        static bool IEqualityOperators<ulong, ulong, bool>.operator ==(ulong left, ulong right);
++        static bool IEqualityOperators<ulong, ulong, bool>.operator !=(ulong left, ulong right);
+-        static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right);
+-        static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right);
++        static ulong IShiftOperators<ulong, int, ulong>.operator <<(ulong value, int shiftAmount);
++        static ulong IShiftOperators<ulong, int, ulong>.operator >>(ulong value, int shiftAmount);
++        static ulong IShiftOperators<ulong, int, ulong>.operator >>>(ulong value, int shiftAmount);
+-        static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount);
+-        static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount);
+-        static ulong IShiftOperators<ulong, ulong>.operator >>>(ulong value, int shiftAmount);
+     }
+-    [CLSCompliantAttribute(false)]
+-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+-    public readonly struct UIntPtr : IAdditionOperators<UIntPtr, UIntPtr, UIntPtr>, IAdditiveIdentity<UIntPtr, UIntPtr>, IBinaryInteger<UIntPtr>, IBinaryNumber<UIntPtr>, IBitwiseOperators<UIntPtr, UIntPtr, UIntPtr>, IComparable, IComparable<UIntPtr>, IComparisonOperators<UIntPtr, UIntPtr>, IDecrementOperators<UIntPtr>, IDivisionOperators<UIntPtr, UIntPtr, UIntPtr>, IEqualityOperators<UIntPtr, UIntPtr>, IEquatable<UIntPtr>, IFormattable, IIncrementOperators<UIntPtr>, IMinMaxValue<UIntPtr>, IModulusOperators<UIntPtr, UIntPtr, UIntPtr>, IMultiplicativeIdentity<UIntPtr, UIntPtr>, IMultiplyOperators<UIntPtr, UIntPtr, UIntPtr>, INumber<UIntPtr>, INumberBase<UIntPtr>, IParsable<UIntPtr>, ISerializable, IShiftOperators<UIntPtr, UIntPtr>, ISpanFormattable, ISpanParsable<UIntPtr>, ISubtractionOperators<UIntPtr, UIntPtr, UIntPtr>, IUnaryNegationOperators<UIntPtr, UIntPtr>, IUnaryPlusOperators<UIntPtr, UIntPtr>, IUnsignedNumber<UIntPtr> {
++    [CLSCompliantAttribute(false)]
++    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
++    public readonly struct UIntPtr : IAdditionOperators<UIntPtr, UIntPtr, UIntPtr>, IAdditiveIdentity<UIntPtr, UIntPtr>, IBinaryInteger<UIntPtr>, IBinaryNumber<UIntPtr>, IBitwiseOperators<UIntPtr, UIntPtr, UIntPtr>, IComparable, IComparable<UIntPtr>, IComparisonOperators<UIntPtr, UIntPtr, bool>, IDecrementOperators<UIntPtr>, IDivisionOperators<UIntPtr, UIntPtr, UIntPtr>, IEqualityOperators<UIntPtr, UIntPtr, bool>, IEquatable<UIntPtr>, IFormattable, IIncrementOperators<UIntPtr>, IMinMaxValue<UIntPtr>, IModulusOperators<UIntPtr, UIntPtr, UIntPtr>, IMultiplicativeIdentity<UIntPtr, UIntPtr>, IMultiplyOperators<UIntPtr, UIntPtr, UIntPtr>, INumber<UIntPtr>, INumberBase<UIntPtr>, IParsable<UIntPtr>, ISerializable, IShiftOperators<UIntPtr, int, UIntPtr>, ISpanFormattable, ISpanParsable<UIntPtr>, ISubtractionOperators<UIntPtr, UIntPtr, UIntPtr>, IUnaryNegationOperators<UIntPtr, UIntPtr>, IUnaryPlusOperators<UIntPtr, UIntPtr>, IUnsignedNumber<UIntPtr> {
++        static UIntPtr System.Numerics.IBinaryNumber<nuint>.AllBitsSet { get; }
++        [NullableContextAttribute((byte)1)]
++        public static UIntPtr CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static UIntPtr CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        [NullableContextAttribute((byte)1)]
++        public static UIntPtr CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
++        static bool IComparisonOperators<UIntPtr, UIntPtr, bool>.operator >(UIntPtr left, UIntPtr right);
++        static bool IComparisonOperators<UIntPtr, UIntPtr, bool>.operator >=(UIntPtr left, UIntPtr right);
++        static bool IComparisonOperators<UIntPtr, UIntPtr, bool>.operator <(UIntPtr left, UIntPtr right);
++        static bool IComparisonOperators<UIntPtr, UIntPtr, bool>.operator <=(UIntPtr left, UIntPtr right);
+-        static bool IComparisonOperators<UIntPtr, UIntPtr>.operator >(UIntPtr left, UIntPtr right);
+-        static bool IComparisonOperators<UIntPtr, UIntPtr>.operator >=(UIntPtr left, UIntPtr right);
+-        static bool IComparisonOperators<UIntPtr, UIntPtr>.operator <(UIntPtr left, UIntPtr right);
+-        static bool IComparisonOperators<UIntPtr, UIntPtr>.operator <=(UIntPtr left, UIntPtr right);
+-        static UIntPtr IShiftOperators<UIntPtr, UIntPtr>.operator <<(UIntPtr value, int shiftAmount);
+-        static UIntPtr IShiftOperators<UIntPtr, UIntPtr>.operator >>(UIntPtr value, int shiftAmount);
+-        static UIntPtr IShiftOperators<UIntPtr, UIntPtr>.operator >>>(UIntPtr value, int shiftAmount);
++        static UIntPtr IShiftOperators<UIntPtr, int, UIntPtr>.operator <<(UIntPtr value, int shiftAmount);
++        static UIntPtr IShiftOperators<UIntPtr, int, UIntPtr>.operator >>(UIntPtr value, int shiftAmount);
++        static UIntPtr IShiftOperators<UIntPtr, int, UIntPtr>.operator >>>(UIntPtr value, int shiftAmount);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7.md
@@ -1,0 +1,9 @@
+# API Difference 7.0-preview6 vs 7.0-preview7
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Drawing](7.0-preview7_System.Drawing.md)
+* [System.Drawing.Imaging](7.0-preview7_System.Drawing.Imaging.md)
+* [System.Windows.Forms](7.0-preview7_System.Windows.Forms.md)
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Drawing.Imaging.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Drawing.Imaging.md
@@ -1,0 +1,16 @@
+# System.Drawing.Imaging
+
+``` diff
+ namespace System.Drawing.Imaging {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     [TypeConverterAttribute(typeof(ImageFormatConverter))]
+     public sealed class ImageFormat {
++        [SupportedOSPlatformAttribute("windows10.0.17763.0")]
++        public static ImageFormat Heif { get; }
++        [SupportedOSPlatformAttribute("windows10.0.17763.0")]
++        public static ImageFormat Webp { get; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Drawing.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Drawing.md
@@ -1,0 +1,15 @@
+# System.Drawing
+
+``` diff
+ namespace System.Drawing {
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)1)]
+     public sealed class Graphics : MarshalByRefObject, IDeviceContext, IDisposable {
+-        [NullableContextAttribute((byte)0)]
+-        public delegate bool EnumerateMetafileProc(EmfPlusRecordType recordType, int flags, int dataSize, IntPtr data, PlayRecordCallback callbackData);
++        [NullableContextAttribute((byte)0)]
++        public delegate bool EnumerateMetafileProc(EmfPlusRecordType recordType, int flags, int dataSize, IntPtr data, PlayRecordCallback? callbackData);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Windows.Forms.md
+++ b/release-notes/7.0/preview/api-diff/preview7/Microsoft.WindowsDesktop.App/7.0-preview7_System.Windows.Forms.md
@@ -1,0 +1,60 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+     [DefaultEventAttribute("Click")]
+     [DefaultPropertyAttribute("Text")]
+     [DesignerAttribute("System.Windows.Forms.Design.ControlDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DesignerSerializerAttribute("System.Windows.Forms.Design.ControlCodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.ComponentModel.Design.Serialization.CodeDomSerializer, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     [ToolboxItemFilterAttribute("System.Windows.Forms")]
+     public class Control : Component, IArrangedElement, IBindableComponent, IComponent, IDisposable, IDropTarget, IHandle, IKeyboardToolTip, Interop.Ole32.IOleControl, Interop.Ole32.IOleInPlaceActiveObject, Interop.Ole32.IOleInPlaceObject, Interop.Ole32.IOleObject, Interop.Ole32.IOleWindow, Interop.Ole32.IPersist, Interop.Ole32.IPersistStorage, Interop.Ole32.IPersistStreamInit, Interop.Ole32.IQuickActivate, Interop.Ole32.IViewObject, Interop.Ole32.IViewObject2, Interop.Oleaut32.IPersistPropertyBag, ISupportOleDropSource, ISynchronizeInvoke, IWin32Window {
++        [NullableContextAttribute((byte)0)]
++        public DragDropEffects DoDragDrop(object data, DragDropEffects allowedEffects, Bitmap dragImage, Point cursorOffset, bool useDefaultDragImage);
+     }
+     [NullableAttribute((byte)0)]
+     [NullableContextAttribute((byte)2)]
+     public class DragEventArgs : EventArgs {
++        [NullableContextAttribute((byte)1)]
++        public DragEventArgs([NullableAttribute((byte)2)] IDataObject? data, int keyState, int x, int y, DragDropEffects allowedEffect, DragDropEffects effect, DropImageType dropImageType, string message, string messageReplacementToken);
++        public DropImageType DropImageType { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public string Message { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public string MessageReplacementToken { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
++    public enum DropImageType {
++        Copy = 1,
++        Invalid = -1,
++        Label = 6,
++        Link = 4,
++        Move = 2,
++        NoImage = 8,
++        None = 0,
++        Warning = 7,
++    }
+     public class GiveFeedbackEventArgs : EventArgs {
++        public GiveFeedbackEventArgs(DragDropEffects effect, bool useDefaultCursors, Bitmap dragImage, Point cursorOffset, bool useDefaultDragImage);
++        public Point CursorOffset { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public Bitmap DragImage { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
++        public bool UseDefaultDragImage { [CompilerGeneratedAttribute] get; [CompilerGeneratedAttribute] set; }
+     }
+     [DefaultEventAttribute("Click")]
+     [DefaultPropertyAttribute("Text")]
+     [DesignTimeVisibleAttribute(false)]
+     [DesignerAttribute("System.Windows.Forms.Design.ToolStripItemDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [ToolboxItemAttribute(false)]
+     public abstract class ToolStripItem : Component, IArrangedElement, IComponent, IDisposable, IDropTarget, IKeyboardToolTip, ISupportOleDropSource {
++        [EditorBrowsableAttribute(2)]
++        public DragDropEffects DoDragDrop(object data, DragDropEffects allowedEffects, Bitmap dragImage, Point cursorOffset, bool useDefaultDragImage);
+     }
+     [DefaultEventAttribute("DocumentCompleted")]
+     [DefaultPropertyAttribute("Url")]
+     [DesignerAttribute("System.Windows.Forms.Design.WebBrowserDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [DockingAttribute(DockingBehavior.AutoDock)]
+     [SRDescriptionAttribute("DescriptionWebBrowser")]
+     public class WebBrowser : WebBrowserBase {
++        protected override AccessibleObject CreateAccessibilityInstance();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/preview7/README.md
+++ b/release-notes/7.0/preview/api-diff/preview7/README.md
@@ -1,0 +1,7 @@
+# .NET 7.0 Preview 7 API Changes
+
+The following API changes were made in .NET 7.0 Preview 7:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/7.0-preview7.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/7.0-preview7.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/7.0-preview7.md)


### PR DESCRIPTION
If you see unusual diffs in this PR, please help fixing it by offering suggestions. I would greatly appreciate it.

Notes:
- APIs that have diffs and are decorated with attributes, are getting the attribute included in the diff.
- Cci is not letting me ignore the `AsyncStateMachineAttribute` attribute, unlike other attributes.

ASP.NET: https://github.com/orgs/dotnet/teams/aspnet-api-review

WinForms: @merriemcgaw @RussKie @JeremyKuhne

WPF: @singhashish-wpf and @pchaurasia14

Libraries: @danmoseley @jeffhandley @karelz @ericstj @stephentoub

System.Formats.Tar @dotnet/area-system-io @carlossanlop 
@dotnet/area-system-io 
@dotnet/area-system-linq 
System.Net @dotnet/ncl
@dotnet/area-system-numerics 
@dotnet/area-system-reflection-metadata 
System.Runtime.InteropServices @dotnet/interop-contrib 
@dotnet/area-system-runtime-intrinsics 
System.Versioning @dotnet/area-system-runtime @buyaa-n 
@dotnet/area-system-security 
@dotnet/area-system-text-json 
@dotnet/area-system-text-regularexpressions 
@dotnet/area-system-threading-tasks 
@dotnet/area-system-xml 
System @dotnet/area-system-runtime 
