### PR TITLE
updating C# versions

### DIFF
--- a/release-notes/7.0/preview/7.0.0-preview.1.md
+++ b/release-notes/7.0/preview/7.0.0-preview.1.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.2.md
+++ b/release-notes/7.0/preview/7.0.0-preview.2.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.3.md
+++ b/release-notes/7.0/preview/7.0.0-preview.3.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.4.md
+++ b/release-notes/7.0/preview/7.0.0-preview.4.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.5.md
+++ b/release-notes/7.0/preview/7.0.0-preview.5.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.6.md
+++ b/release-notes/7.0/preview/7.0.0-preview.6.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.3 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/preview/7.0.0-preview.7.md
+++ b/release-notes/7.0/preview/7.0.0-preview.7.md
@@ -55,7 +55,7 @@ The following repos have been updated.
 
 ## Visual Studio Compatibility
 
-You need [Visual Studio 17.2 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 9.
+You need [Visual Studio 17.4 latest preview](https://visualstudio.microsoft.com) to use .NET 7.0 on Windows. On macOS, you need the latest version of [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 7.0 and C# 11.
 
 
 ## Feedback

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -123,9 +123,9 @@
         "runtime-version": "7.0.0-preview.7.22375.6",
         "vs-version": "",
         "vs-mac-version": "",
-        "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
+        "vs-support": "Visual Studio 2022 (v17.4 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -234,9 +234,9 @@
           "runtime-version": "7.0.0-preview.7.22375.6",
           "vs-version": "",
           "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
+          "vs-support": "Visual Studio 2022 (v17.4 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -593,9 +593,9 @@
         "runtime-version": "7.0.0-preview.6.22324.4",
         "vs-version": "",
         "vs-mac-version": "",
-        "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
+        "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -704,9 +704,9 @@
           "runtime-version": "7.0.0-preview.6.22324.4",
           "vs-version": "",
           "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
+          "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1063,9 +1063,9 @@
         "runtime-version": "7.0.0-preview.5.22301.12",
         "vs-version": "",
         "vs-mac-version": "",
-        "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
+        "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -1174,9 +1174,9 @@
           "runtime-version": "7.0.0-preview.5.22301.12",
           "vs-version": "",
           "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
+          "vs-support": "Visual Studio 2022 (v17.3 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1535,7 +1535,7 @@
         "vs-mac-version": "",
         "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -1646,7 +1646,7 @@
           "vs-mac-version": "",
           "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2005,7 +2005,7 @@
         "vs-mac-version": "",
         "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -2116,7 +2116,7 @@
           "vs-mac-version": "",
           "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2475,7 +2475,7 @@
         "vs-mac-version": "",
         "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -2586,7 +2586,7 @@
           "vs-mac-version": "",
           "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2945,7 +2945,7 @@
         "vs-mac-version": "",
         "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
         "vs-mac-support": "",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -3056,7 +3056,7 @@
           "vs-mac-version": "",
           "vs-support": "Visual Studio 2022 (v17.2 latest preview)",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [


### PR DESCRIPTION
Updating the .NET 7 preview release notes to update the C# version to C#11. Initially brought up in https://github.com/dotnet/core/issues/7702