### PR TITLE
Fix links in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The following [.NET releases](../releases.md) are currently supported:
 
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
-| [.NET 7](7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-7/) | [Preview][policies] | [7.0 Preview 7][7.0 Preview 7] | May 14, 2024 |
-| [.NET 6](6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.9][6.0.9]  | November 12, 2024 |
-| [.NET Core 3.1](3.1/README.md) | [December 3, 2019](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-1/) | [LTS][policies] | [3.1.29][3.1.29] | December 13, 2022 |
+| [.NET 7](release-notes/7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-7/) | [Preview][policies] | [7.0 Preview 7][7.0 Preview 7] | May 14, 2024 |
+| [.NET 6](release-notes/6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.9][6.0.9]  | November 12, 2024 |
+| [.NET Core 3.1](release-notes/3.1/README.md) | [December 3, 2019](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-1/) | [LTS][policies] | [3.1.29][3.1.29] | December 13, 2022 |
 
 You can find release notes for all releases, including out-of-support releases, in the [release-notes](.) directory.
 
@@ -25,4 +25,4 @@ You can find release notes for all releases, including out-of-support releases, 
 * [Installation docs](https://docs.microsoft.com/dotnet/core/install/)
 
 [releases-index.json]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json
-[policies]: ../release-policies.md
+[policies]: release-policies.md


### PR DESCRIPTION
I noticed that both README files in the root directory and the `release-notes` directory have their content somewhat synced.

Some links in the root one are wrong, which this PR aims at addressing.