### PR TITLE
feat: Add GitHub Actions to Dependabot generator

### DIFF
--- a/samples/dependadotnet/Program.cs
+++ b/samples/dependadotnet/Program.cs
@@ -25,6 +25,17 @@ updates:";
 
 WriteLine(topMatter);
 
+// Entry to update GitHub Actions
+string githubActions = 
+@"  - package-ecosystem: "github-actions" # Core GitHub Actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10";
+
+WriteLine(githubActions);
+        
 /* Generate the following pattern for each project file:
 
   Note: Wednesday was chosen for quick response to .NET patch Tuesday updates


### PR DESCRIPTION
This will add the snippet to keep the Actions in the `.github` folders in sync