### PR TITLE
Api-diff between 7.0-rc1 and 7.0-rc2

### DIFF
--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2.md
@@ -1,0 +1,14 @@
+# API Difference 7.0-rc1 vs 7.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components.Routing](7.0-rc2_Microsoft.AspNetCore.Components.Routing.md)
+* [Microsoft.AspNetCore.Http](7.0-rc2_Microsoft.AspNetCore.Http.md)
+* [Microsoft.AspNetCore.Http.HttpResults](7.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md)
+* [Microsoft.AspNetCore.Http.Metadata](7.0-rc2_Microsoft.AspNetCore.Http.Metadata.md)
+* [Microsoft.AspNetCore.OutputCaching](7.0-rc2_Microsoft.AspNetCore.OutputCaching.md)
+* [Microsoft.AspNetCore.Routing](7.0-rc2_Microsoft.AspNetCore.Routing.md)
+* [Microsoft.AspNetCore.Server.Kestrel.Transport.Quic](7.0-rc2_Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.md)
+* [Microsoft.Extensions.DependencyInjection](7.0-rc2_Microsoft.Extensions.DependencyInjection.md)
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Components.Routing.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Components.Routing.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Routing {
+-    public sealed class NavigationLock : IAsyncDisposable, IComponent {
++    public sealed class NavigationLock : IAsyncDisposable, IComponent, IHandleAfterRender {
++        Task IHandleAfterRender.OnAfterRenderAsync();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md
@@ -1,0 +1,107 @@
+# Microsoft.AspNetCore.Http.HttpResults
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.HttpResults {
+     public sealed class Accepted : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Accepted<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class AcceptedAtRoute : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class AcceptedAtRoute<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class BadRequest : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class BadRequest<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Conflict : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Conflict<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Created : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Created<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class CreatedAtRoute : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class CreatedAtRoute<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public class NoContent : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class NotFound : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class NotFound<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Ok : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Ok<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Results<TResult1, TResult2> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Results<TResult1, TResult2, TResult3> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Results<TResult1, TResult2, TResult3, TResult4> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6> : IEndpointMetadataProvider, INestedHttpResult, IResult where TResult1 : IResult where TResult2 : IResult where TResult3 : IResult where TResult4 : IResult where TResult5 : IResult where TResult6 : IResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class UnprocessableEntity : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class UnprocessableEntity<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public sealed class ValidationProblem : IContentTypeHttpResult, IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<HttpValidationProblemDetails> {
+-        static void IEndpointMetadataProvider.PopulateMetadata(EndpointMetadataContext context);
++        static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.Metadata.md
@@ -1,0 +1,27 @@
+# Microsoft.AspNetCore.Http.Metadata
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Metadata {
+-    public sealed class EndpointMetadataContext {
+-        public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider applicationServices);
+-        public IServiceProvider ApplicationServices { get; }
+-        public IList<object> EndpointMetadata { get; }
+-        public MethodInfo Method { get; }
+-    }
+-    public sealed class EndpointParameterMetadataContext {
+-        public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider applicationServices);
+-        public IServiceProvider ApplicationServices { get; }
+-        public IList<object> EndpointMetadata { get; }
+-        public ParameterInfo Parameter { get; }
+-    }
+     public interface IEndpointMetadataProvider {
+-        static abstract void PopulateMetadata(EndpointMetadataContext context);
++        static abstract void PopulateMetadata(MethodInfo method, EndpointBuilder builder);
+     }
+     public interface IEndpointParameterMetadataProvider {
+-        static abstract void PopulateMetadata(EndpointParameterMetadataContext parameterContext);
++        static abstract void PopulateMetadata(ParameterInfo parameter, EndpointBuilder builder);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Http.md
@@ -1,0 +1,46 @@
+# Microsoft.AspNetCore.Http
+
+``` diff
+ namespace Microsoft.AspNetCore.Http {
+     public sealed class EndpointFilterFactoryContext {
++        public EndpointFilterFactoryContext();
+-        public EndpointFilterFactoryContext(MethodInfo methodInfo, IList<object> endpointMetadata, IServiceProvider applicationServices);
+-        public IServiceProvider ApplicationServices { get; }
++        public IServiceProvider ApplicationServices { get; set; }
+-        public IList<object> EndpointMetadata { get; }
+-        public MethodInfo MethodInfo { get; }
++        public required MethodInfo MethodInfo { get; set; }
+     }
+     [UnconditionalSuppressMessageAttribute("Trimmer", "IL2026", Justification="RequestDelegateFactory.Create requires unreferenced code.")]
+     [UnconditionalSuppressMessageAttribute("Trimmer", "IL2060", Justification="RequestDelegateFactory.Create requires unreferenced code.")]
+     [UnconditionalSuppressMessageAttribute("Trimmer", "IL2072", Justification="RequestDelegateFactory.Create requires unreferenced code.")]
+     [UnconditionalSuppressMessageAttribute("Trimmer", "IL2075", Justification="RequestDelegateFactory.Create requires unreferenced code.")]
+     [UnconditionalSuppressMessageAttribute("Trimmer", "IL2077", Justification="RequestDelegateFactory.Create requires unreferenced code.")]
+     public static class RequestDelegateFactory {
+-        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
+-        public static RequestDelegateResult Create(Delegate handler, RequestDelegateFactoryOptions? options = null);
++        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
++        public static RequestDelegateResult Create(Delegate handler, RequestDelegateFactoryOptions? options);
++        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
++        public static RequestDelegateResult Create(Delegate handler, RequestDelegateFactoryOptions? options = null, RequestDelegateMetadataResult? metadataResult = null);
+-        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
+-        public static RequestDelegateResult Create(MethodInfo methodInfo, Func<HttpContext, object>? targetFactory = null, RequestDelegateFactoryOptions? options = null);
++        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
++        public static RequestDelegateResult Create(MethodInfo methodInfo, Func<HttpContext, object>? targetFactory, RequestDelegateFactoryOptions? options);
++        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
++        public static RequestDelegateResult Create(MethodInfo methodInfo, Func<HttpContext, object>? targetFactory = null, RequestDelegateFactoryOptions? options = null, RequestDelegateMetadataResult? metadataResult = null);
++        [RequiresUnreferencedCodeAttribute("RequestDelegateFactory performs object creation, serialization and deserialization on the delegates and its parameters. This cannot be statically analyzed.")]
++        public static RequestDelegateMetadataResult InferMetadata(MethodInfo methodInfo, RequestDelegateFactoryOptions? options = null);
+     }
+     public sealed class RequestDelegateFactoryOptions {
++        public EndpointBuilder EndpointBuilder { get; set; }
+-        public IReadOnlyList<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>? EndpointFilterFactories { get; set; }
+-        public IList<object>? EndpointMetadata { get; set; }
+     }
++    public sealed class RequestDelegateMetadataResult {
++        public RequestDelegateMetadataResult();
++        public required IReadOnlyList<object> EndpointMetadata { get; set; }
++    }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.OutputCaching.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.OutputCaching.md
@@ -1,0 +1,40 @@
+# Microsoft.AspNetCore.OutputCaching
+
+``` diff
+ namespace Microsoft.AspNetCore.OutputCaching {
+     public sealed class CacheVaryByRules {
++        public string CacheKeyPrefix { get; set; }
+-        public IDictionary<string, string> VaryByCustom { get; }
++        public bool VaryByHost { get; set; }
+-        public StringValues VaryByPrefix { get; set; }
++        public IDictionary<string, string> VaryByValues { get; }
+     }
+     public class OutputCacheOptions {
++        public void AddBasePolicy(Action<OutputCachePolicyBuilder> build, bool excludeDefaultPolicy);
++        public void AddPolicy(string name, Action<OutputCachePolicyBuilder> build, bool excludeDefaultPolicy);
+     }
+     public sealed class OutputCachePolicyBuilder {
+-        public OutputCachePolicyBuilder();
+-        public OutputCachePolicyBuilder AllowLocking(bool lockResponse = true);
+-        public OutputCachePolicyBuilder Clear();
++        public OutputCachePolicyBuilder SetCacheKeyPrefix(Func<HttpContext, string> keyPrefix);
++        public OutputCachePolicyBuilder SetCacheKeyPrefix(Func<HttpContext, CancellationToken, ValueTask<string>> keyPrefix);
++        public OutputCachePolicyBuilder SetCacheKeyPrefix(string keyPrefix);
++        public OutputCachePolicyBuilder SetLocking(bool enabled);
++        public OutputCachePolicyBuilder SetVaryByHeader(string headerName, params string[] headerNames);
++        public OutputCachePolicyBuilder SetVaryByHeader(string[] headerNames);
++        public OutputCachePolicyBuilder SetVaryByHost(bool enabled);
++        public OutputCachePolicyBuilder SetVaryByQuery(string queryKey, params string[] queryKeys);
++        public OutputCachePolicyBuilder SetVaryByQuery(string[] queryKeys);
++        public OutputCachePolicyBuilder SetVaryByRouteValue(string routeValueName, params string[] routeValueNames);
++        public OutputCachePolicyBuilder SetVaryByRouteValue(string[] routeValueNames);
+-        public OutputCachePolicyBuilder VaryByHeader(params string[] headerNames);
+-        public OutputCachePolicyBuilder VaryByQuery(params string[] queryKeys);
+-        public OutputCachePolicyBuilder VaryByRouteValue(params string[] routeValueNames);
+-        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, string> varyBy);
+-        public OutputCachePolicyBuilder VaryByValue(Func<HttpContext, CancellationToken, ValueTask<string>> varyBy);
++        public OutputCachePolicyBuilder VaryByValue(string key, string value);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Routing.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Routing.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing {
+     public sealed class RouteEndpointBuilder : EndpointBuilder {
+-        public RouteEndpointBuilder(RequestDelegate requestDelegate, RoutePattern routePattern, int order);
++        public RouteEndpointBuilder(RequestDelegate? requestDelegate, RoutePattern routePattern, int order);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.md
@@ -1,0 +1,21 @@
+# Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
+
+``` diff
+ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic {
+     public sealed class QuicTransportOptions {
+-        public int MaxBidirectionalStreamCount { get; set; }
++        [RequiresPreviewFeaturesAttribute]
++        public int MaxBidirectionalStreamCount { get; set; }
+-        public long? MaxReadBufferSize { get; set; }
++        [RequiresPreviewFeaturesAttribute]
++        public long? MaxReadBufferSize { get; set; }
+-        public int MaxUnidirectionalStreamCount { get; set; }
++        [RequiresPreviewFeaturesAttribute]
++        public int MaxUnidirectionalStreamCount { get; set; }
+-        public long? MaxWriteBufferSize { get; set; }
++        [RequiresPreviewFeaturesAttribute]
++        public long? MaxWriteBufferSize { get; set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/7.0-rc2_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,10 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
+     public static class OutputCacheConventionBuilderExtensions {
++        public static TBuilder CacheOutput<TBuilder>(this TBuilder builder, Action<OutputCachePolicyBuilder> policy, bool excludeDefaultPolicy) where TBuilder : IEndpointConventionBuilder;
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.NETCore.App/7.0-rc2.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.NETCore.App/7.0-rc2.md
@@ -1,0 +1,7 @@
+# API Difference 7.0-rc1 vs 7.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Runtime.InteropServices.JavaScript](7.0-rc2_System.Runtime.InteropServices.JavaScript.md)
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.NETCore.App/7.0-rc2_System.Runtime.InteropServices.JavaScript.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.NETCore.App/7.0-rc2_System.Runtime.InteropServices.JavaScript.md
@@ -1,0 +1,18 @@
+# System.Runtime.InteropServices.JavaScript
+
+``` diff
+ namespace System.Runtime.InteropServices.JavaScript {
+     [CLSCompliantAttribute(false)]
+     [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+     [SupportedOSPlatformAttribute("browser")]
+     public struct JSMarshalerArgument {
+-        public delegate void ArgumentToJSCallback<T>(ref JSMarshalerArgument arg, T value);
++        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++        public delegate void ArgumentToJSCallback<T>(ref JSMarshalerArgument arg, T value);
+-        public delegate void ArgumentToManagedCallback<T>(ref JSMarshalerArgument arg, out T value);
++        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++        public delegate void ArgumentToManagedCallback<T>(ref JSMarshalerArgument arg, out T value);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/rc2/Microsoft.WindowsDesktop.App/7.0-rc2.md
+++ b/release-notes/7.0/preview/api-diff/rc2/Microsoft.WindowsDesktop.App/7.0-rc2.md
@@ -1,0 +1,6 @@
+# API Difference 7.0-rc1 vs 7.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+

--- a/release-notes/7.0/preview/api-diff/rc2/README.md
+++ b/release-notes/7.0/preview/api-diff/rc2/README.md
@@ -1,0 +1,7 @@
+# .NET 7.0 RC 2 API Changes
+
+The following API changes were made in .NET 7.0 RC 2:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/7.0-rc2.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/7.0-rc2.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/7.0-rc2.md)


### PR DESCRIPTION
If you see unusual diffs in this PR, please provide GitHub suggestions with the expected text. I would greatly appreciate it.

Currently excluding these attributes from showing up in the diff: [carlossanlop/arcade/AsmDiffUpdates/src/Microsoft.DotNet.AsmDiff/AttributesToExclude.txt](https://github.com/carlossanlop/arcade/blob/bc612740be9c302a65c3e57bdc2977b8af7c45d9/src/Microsoft.DotNet.AsmDiff/AttributesToExclude.txt). If you see any other attributes that you'd like me to exclude, let me know.

- ASP.NET: @dotnet/aspnet-api-review 

- WinForms: @merriemcgaw @RussKie @JeremyKuhne - Nothing showed up, please let me know if that is correct.

- WPF: @singhashish-wpf and @pchaurasia14 - Nothing showed up, please let me know if that is correct.

Libraries: @jeffhandley @karelz @ericstj @stephentoub
- System.Runtime.InteropServices.JavaScript: @dotnet/interop-contrib @pavelsavara 
