### PR TITLE
Update supported Windows versions for .NET 7

### DIFF
--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -8,14 +8,11 @@ For issues with .NET on operating systems not listed here, please open a GitHub 
 
 OS                                    | Version                 | Architectures   | Lifecycle
 --------------------------------------|-------------------------|-----------------|----------
-[Windows Client][Windows-client]      | 7 SP1(**\***), 8.1      | x64, x86        | [Windows][Windows-lifecycle]
 [Windows 10 Client][Windows-client]   | Version 1607+           | x64, x86, Arm64 | [Windows][Windows-lifecycle]
 [Windows 11][Windows-client]   | Version 22000+           | x64, x86, Arm64 | [Windows][Windows-lifecycle]
 [Windows Server][Windows-Server]      | 2012+                | x64, x86        | [Windows Server][Windows-Server-lifecycle]
 [Windows Server Core][Windows-Server] | 2012+                | x64, x86        | [Windows Server][Windows-Server-lifecycle]
 [Nano Server][Nano-Server]            | Version 1809+           | x64             | [Windows Server][Windows-Server-lifecycle]
-
-**\*** Windows 7 SP1 is supported with [Extended Security Updates](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq) installed.
 
 [Windows-client]: https://www.microsoft.com/windows/
 [Windows-lifecycle]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
@@ -102,7 +99,9 @@ OS                            | Version                 | Architectures     |
 
 The following operating systems are no longer supported, starting with .NET 7.0.
 
-None yet.
+OS                                    | Version                 | Architectures     |
+--------------------------------------|-------------------------|-------------------|
+[Windows Client][Windows-client]      | 7 SP1(**\***), 8.1      | x64, x86          |
 
 ## Out of support OS versions
 


### PR DESCRIPTION
Removing Windows 7 and Windows 8.1 from support matrix. They were copied over from .NET 6 by accident and just noticed now.