### PR TITLE
API-diff between 7.0 RC2 and 7.0 GA

### DIFF
--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga.md
@@ -1,0 +1,9 @@
+# API Difference 7.0-rc2 vs 7.0-ga
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components](7.0-ga_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.CompilerServices](7.0-ga_Microsoft.AspNetCore.Components.CompilerServices.md)
+* [System.Threading.RateLimiting](7.0-ga_System.Threading.RateLimiting.md)
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_Microsoft.AspNetCore.Components.CompilerServices.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_Microsoft.AspNetCore.Components.CompilerServices.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.CompilerServices
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.CompilerServices {
+     public static class RuntimeHelpers {
++        public static Func<T, Task> CreateInferredBindSetter<T>(Action<T?> callback, T value);
++        public static Func<T, Task> CreateInferredBindSetter<T>(Func<T, Task> callback, T value);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_Microsoft.AspNetCore.Components.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,73 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
+     public static class EventCallbackFactoryBinderExtensions {
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<bool> setter, bool existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly> setter, DateOnly existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly> setter, DateOnly existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime> setter, DateTime existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime> setter, DateTime existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset> setter, DateTimeOffset existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset> setter, DateTimeOffset existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<decimal> setter, decimal existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<double> setter, double existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<short> setter, short existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<int> setter, int existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<long> setter, long existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<bool?> setter, bool? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly?> setter, DateOnly? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateOnly?> setter, DateOnly? existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime?> setter, DateTime? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTime?> setter, DateTime? existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset?> setter, DateTimeOffset? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<DateTimeOffset?> setter, DateTimeOffset? existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<decimal?> setter, decimal? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<double?> setter, double? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<short?> setter, short? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<int?> setter, int? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<long?> setter, long? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<float?> setter, float? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly?> setter, TimeOnly? existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly?> setter, TimeOnly? existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<float> setter, float existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<string?> setter, string existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly> setter, TimeOnly existingValue, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, EventCallback<TimeOnly> setter, TimeOnly existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<bool, Task> setter, bool existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateOnly, Task> setter, DateOnly existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateOnly, Task> setter, DateOnly existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTime, Task> setter, DateTime existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTime, Task> setter, DateTime existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTimeOffset, Task> setter, DateTimeOffset existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTimeOffset, Task> setter, DateTimeOffset existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<decimal, Task> setter, decimal existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<double, Task> setter, double existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<short, Task> setter, short existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<int, Task> setter, int existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<long, Task> setter, long existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<bool?, Task> setter, bool? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateOnly?, Task> setter, DateOnly? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateOnly?, Task> setter, DateOnly? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTime?, Task> setter, DateTime? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTime?, Task> setter, DateTime? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTimeOffset?, Task> setter, DateTimeOffset? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<DateTimeOffset?, Task> setter, DateTimeOffset? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<decimal?, Task> setter, decimal? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<double?, Task> setter, double? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<short?, Task> setter, short? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<int?, Task> setter, int? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<long?, Task> setter, long? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<float?, Task> setter, float? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<TimeOnly?, Task> setter, TimeOnly? existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<TimeOnly?, Task> setter, TimeOnly? existingValue, string format, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<float, Task> setter, float existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<string?, Task> setter, string existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<TimeOnly, Task> setter, TimeOnly existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder(this EventCallbackFactory factory, object receiver, Func<TimeOnly, Task> setter, TimeOnly existingValue, string format, CultureInfo? culture = null);
+-        public static EventCallback<ChangeEventArgs> CreateBinder<T>(this EventCallbackFactory factory, object receiver, EventCallback<T> setter, T existingValue, CultureInfo? culture = null);
++        public static EventCallback<ChangeEventArgs> CreateBinder<T>(this EventCallbackFactory factory, object receiver, Func<T, Task> setter, T existingValue, CultureInfo? culture = null);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_System.Threading.RateLimiting.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.AspNetCore.App/7.0-ga_System.Threading.RateLimiting.md
@@ -1,0 +1,19 @@
+# System.Threading.RateLimiting
+
+``` diff
+ namespace System.Threading.RateLimiting {
+     public sealed class FixedWindowRateLimiter : ReplenishingRateLimiter {
+-        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default(CancellationToken));
++        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken = default(CancellationToken));
+-        protected override RateLimitLease AttemptAcquireCore(int requestCount);
++        protected override RateLimitLease AttemptAcquireCore(int permitCount);
+     }
+     public sealed class SlidingWindowRateLimiter : ReplenishingRateLimiter {
+-        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default(CancellationToken));
++        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken = default(CancellationToken));
+-        protected override RateLimitLease AttemptAcquireCore(int requestCount);
++        protected override RateLimitLease AttemptAcquireCore(int permitCount);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga.md
@@ -1,0 +1,9 @@
+# API Difference 7.0-rc2 vs 7.0-ga
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Numerics](7.0-ga_System.Numerics.md)
+* [System.Text.Json.Serialization.Metadata](7.0-ga_System.Text.Json.Serialization.Metadata.md)
+* [System.Transactions](7.0-ga_System.Transactions.md)
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Numerics.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Numerics.md
@@ -1,0 +1,13 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+     public interface INumberBase<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFormattable, IIncrementOperators<TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, IParsable<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf> where TSelf : INumberBase<TSelf>? {
+-        static abstract bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out TSelf result);
++        static abstract bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhenAttribute(false)] out TSelf result);
+-        static abstract bool TryParse([NotNullWhenAttribute(true)] string? s, NumberStyles style, IFormatProvider? provider, out TSelf result);
++        static abstract bool TryParse([NotNullWhenAttribute(true)] string? s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhenAttribute(false)] out TSelf result);
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Text.Json.Serialization.Metadata.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Text.Json.Serialization.Metadata.md
@@ -1,0 +1,11 @@
+# System.Text.Json.Serialization.Metadata
+
+``` diff
+ namespace System.Text.Json.Serialization.Metadata {
+     public abstract class JsonTypeInfo {
++        public bool IsReadOnly { get; }
++        public void MakeReadOnly();
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Transactions.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.NETCore.App/7.0-ga_System.Transactions.md
@@ -1,0 +1,10 @@
+# System.Transactions
+
+``` diff
+ namespace System.Transactions {
+     public static class TransactionManager {
++        public static bool ImplicitDistributedTransactions { get; [RequiresUnreferencedCodeAttribute("Distributed transactions support may not be compatible with trimming. If your program creates a distributed transaction via System.Transactions, the correctness of the application cannot be guaranteed after trimming."), SupportedOSPlatformAttribute("windows")] set; }
+     }
+ }
+```
+

--- a/release-notes/7.0/preview/api-diff/ga/Microsoft.WindowsDesktop.App/7.0-ga.md
+++ b/release-notes/7.0/preview/api-diff/ga/Microsoft.WindowsDesktop.App/7.0-ga.md
@@ -1,0 +1,3 @@
+# API Difference 7.0-rc2 vs 7.0-ga
+
+No new APIs.

--- a/release-notes/7.0/preview/api-diff/ga/README.md
+++ b/release-notes/7.0/preview/api-diff/ga/README.md
@@ -1,0 +1,7 @@
+# .NET 7.0 GA API Changes
+
+The following API changes were made in .NET 7.0 GA:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/7.0-ga.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/7.0-ga.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/7.0-ga.md)


### PR DESCRIPTION
**Brace yourselves**: I will submit a _separate_ PR with the diff between 6.0 and 7.0.

If you see unusual diffs in this PR, please provide GitHub suggestions with the expected text. I would greatly appreciate it.

Currently excluding these attributes from showing up in the diff: [carlossanlop/arcade/AsmDiffUpdates/src/Microsoft.DotNet.AsmDiff/AttributesToExclude.txt](https://github.com/carlossanlop/arcade/blob/bc612740be9c302a65c3e57bdc2977b8af7c45d9/src/Microsoft.DotNet.AsmDiff/AttributesToExclude.txt). If you see any other attributes that you'd like me to exclude, let me know.

### ASP.NET

@dotnet/aspnet-api-review 

- System.Threading.RateLimiting: @rafikiassumani-msft @BrennanConroy @halter73 - Is it correct that the APIs showed up in the ASP.NET folder?

### WinForms

@merriemcgaw @RussKie - Nothing showed up, please let me know if that is correct.

### WPF

@singhashish-wpf and @pchaurasia14 - Nothing showed up, please let me know if that is correct.

### Libraries

@jeffhandley @karelz @ericstj @stephentoub

- System.Numerics: @dotnet/area-system-numerics 
- System.Text.Json: @dotnet/area-system-text-json 
- System.Transactions: @HongGit @roji
