### PR TITLE
Fix version README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The following [.NET releases](../releases.md) are currently supported:
 
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
-| [.NET 7](7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS][policies] | [7.0.1][7.0.1] | May 14, 2024 |
-| [.NET 6](6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.12][6.0.12]  | November 12, 2024 |
+| [.NET 7](release-notes/7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS][policies] | [7.0.1][7.0.1] | May 14, 2024 |
+| [.NET 6](release-notes/6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.12][6.0.12]  | November 12, 2024 |
 
 You can find release notes for all releases, including out-of-support releases, in the [release-notes](.) directory.
 


### PR DESCRIPTION
The links in the Version column of the README do not currently work. This fixes the links to point to, what I think, are the correct READMEs.