### PR TITLE
Releases.json fixes

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -929,7 +929,7 @@
           "version": "6.0.402",
           "version-display": "6.0.402",
           "runtime-version": "6.0.10",
-          "vs-version": "17.3.6, 17.4.0 Preview 3",
+          "vs-version": "17.3.6",
           "vs-mac-version": "17.3.7",
           "vs-support": "Visual Studio 2022 (v17.3)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.3)",

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -489,7 +489,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41032"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.0-rc.2.22472.3/7.0.0-rc.2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/7.0/preview/7.0.0-rc.2.md",
       "runtime": {
         "version": "7.0.0-rc.2.22472.3",
         "version-display": "7.0.0-rc.2",


### PR DESCRIPTION
Fixes the 7.0-rc2 release note url and a small inconsistency with the 6.0.402 sdk