### PR TITLE
Update glibc compat for Linux arm64

### DIFF
--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -32,7 +32,7 @@ OS                                    | Version               | Architectures   
 [Debian][Debian]                      | 10+                   | x64, Arm64, Arm32 | [Debian][Debian-lifecycle]
 [Fedora][Fedora]                      | 33+                   | x64               | [Fedora][Fedora-lifecycle]
 [openSUSE][OpenSUSE]                  | 15+                   | x64               | [OpenSUSE][OpenSUSE-lifecycle]
-[Oracle Linux][Oracle-Linux]                  | 7+                   | x64               | [Oracle][Oracle-lifecycle]
+[Oracle Linux][Oracle-Linux]          | 7+                    | x64               | [Oracle][Oracle-lifecycle]
 [Red Hat Enterprise Linux][RHEL]      | 7+                    | x64, Arm64        | [Red Hat][RHEL-lifecycle]
 [SUSE Enterprise Linux (SLES)][SLES]  | 12 SP2+               | x64               | [SUSE][SLES-lifecycle]
 [Ubuntu][Ubuntu]                      | 18.04+                | x64, Arm64, Arm32 | [Ubuntu][Ubuntu-lifecycle]
@@ -42,7 +42,9 @@ Other distributions are supported at best effort, per [.NET Support and Compatib
 ### Libc compatibility
 
 - x64: [glibc][glibc] 2.17 (from CentOS 7)
-- Arm32, Arm64: [glibc][glibc] 2.27 (from Ubuntu 18.04)
+- Arm32 [glibc][glibc] 2.27 (from Ubuntu 18.04)
+- Arm64: [glibc][glibc] 2.23 (from Ubuntu 16.04)
+  - Starting in 7.0.4. In 7.0.3 and earlier: [glibc][glibc] 2.27 (from Ubuntu 18.04)
 - Alpine (x64 and Arm64): [musl][musl] 1.2.2 (from Alpine 3.15)
 
 [Alpine]: https://alpinelinux.org/

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -44,7 +44,7 @@ Other distributions are supported at best effort, per [.NET Support and Compatib
 - x64: [glibc][glibc] 2.17 (from CentOS 7)
 - Arm32 [glibc][glibc] 2.27 (from Ubuntu 18.04)
 - Arm64: [glibc][glibc] 2.23 (from Ubuntu 16.04)
-  - Starting in 7.0.4. In 7.0.3 and earlier: [glibc][glibc] 2.27 (from Ubuntu 18.04)
+- Arm64: [glibc][glibc] 2.27 (applies to 7.0.3 and earlier)
 - Alpine (x64 and Arm64): [musl][musl] 1.2.2 (from Alpine 3.15)
 
 [Alpine]: https://alpinelinux.org/


### PR DESCRIPTION
The update reflects the change made in https://github.com/dotnet/runtime/pull/80866.