### PR TITLE
Bump Release Notes output of `dotnet --version` from 7.0.200 to 7.0.300 in release notes example

### DIFF
--- a/release-notes/7.0/7.0.3/7.0.3.md
+++ b/release-notes/7.0/7.0.3/7.0.3.md
@@ -24,7 +24,7 @@ You can check your .NET SDK version by running the following command. The exampl
 
 ```console
 $ dotnet --version
-7.0.300
+7.0.201
 ```
 
 ## Docker Images

--- a/release-notes/7.0/7.0.3/7.0.3.md
+++ b/release-notes/7.0/7.0.3/7.0.3.md
@@ -24,7 +24,7 @@ You can check your .NET SDK version by running the following command. The exampl
 
 ```console
 $ dotnet --version
-7.0.200
+7.0.300
 ```
 
 ## Docker Images


### PR DESCRIPTION
I noticed the sentence above states output is for current version, corrected output so it is accurate.