### PR TITLE
Fix release-index.json support-phase

### DIFF
--- a/releases-index.json
+++ b/releases-index.json
@@ -9,7 +9,7 @@
             "latest-sdk": "8.0.100-preview.1.23115.2",
             "product": ".NET",
             "release-type" : "lts",
-            "support-phase": "active",
+            "support-phase": "preview",
             "eol-date": null,
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json"
         },


### PR DESCRIPTION
8.0 is in "preview" support, not "active"