### PR TITLE
Fix Markdown links in release-notes Readme

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -4,11 +4,11 @@ The following [.NET releases](../releases.md) are currently supported:
 
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
-| [.NET 8](release-notes/8.0/README.md) | [November 8, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-preview-2/) | [LTS][policies] | [8.0.0-preview.2][8.0.0-preview.2] | November 10, 2026 |
-| [.NET 7](./release-notes/7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS](/release-policies.md) | [7.0.4][7.0.4] | May 14, 2024 |
-| [.NET 6](./release-notes/6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS](/release-policies.md) | [6.0.15][6.0.15]  | November 12, 2024 |
+| [.NET 8](8.0/README.md) | [November 8, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-preview-2/) | [LTS][policies] | [8.0.0-preview.2][8.0.0-preview.2] | November 10, 2026 |
+| [.NET 7](7.0/README.md) | [November, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS](/release-policies.md) | [7.0.4][7.0.4] | May 14, 2024 |
+| [.NET 6](6.0/README.md) | [November, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS](/release-policies.md) | [6.0.15][6.0.15]  | November 12, 2024 |
 
-You can find release notes for all releases, including out-of-support releases, in the [release-notes](./release-notes) directory.
+You can find release notes for all releases, including out-of-support releases, in the [release-notes](.) directory.
 
 [8.0.0-preview.2]: 8.0/preview/8.0.0-preview.2.md
 [7.0.4]: 7.0/7.0.4/7.0.4.md


### PR DESCRIPTION
Broken in 89a29c44713afd2effb6123cf7ab1484f6123c34, partially fixed in 153dad780fadb29fc2d3720293f64db856258eaf