### PR TITLE
Remove broken link

### DIFF
--- a/release-notes/7.0/preview/7.0.0-preview.2.md
+++ b/release-notes/7.0/preview/7.0.0-preview.2.md
@@ -6,7 +6,7 @@ The .NET 7.0.0 Preview 2 and .NET SDK 7.0.100-preview.2.22153.17 releases are av
 
 .NET 7 is the next major release of .NET following .NET 6.0. You can see some of the new features available with .NET 7 Preview 2 at [dotnet/core #7107](https://github.com/dotnet/core/issues/7107).
 
-See the [.NET][dotnet-blog], [EF Core][ef-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
+See the [.NET][dotnet-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 2.
 
 * EntityFramework Core: [bugs][ef_bugs] | [features][ef_features]
@@ -74,7 +74,6 @@ Your feedback is important and appreciated. We've created an issue at [dotnet/co
 
 [dotnet-blog]:  https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-2/
 [aspnet-blog]: https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-dotnet-7-preview-2
-[ef-blog]: https://devblogs.microsoft.com/dotnet/announcing-entity-framework-7-preview-2
 [ef_bugs]: https://github.com/dotnet/efcore/issues?q=is%3Aissue+milestone%3A7.0.0-preview2+is%3Aclosed+label%3Atype-bug
 [ef_features]: https://github.com/dotnet/efcore/issues?q=is%3Aissue+milestone%3A7.0.0-preview2+is%3Aclosed+label%3Atype-enhancement
 


### PR DESCRIPTION
It seems we haven't published a blog post for EF Core in .NET 7 Preview 2 

My new GH action caught this broken link 