### PR TITLE
Update .NET 8 libc compat

### DIFF
--- a/linux-support.md
+++ b/linux-support.md
@@ -20,6 +20,7 @@ Microsoft builds supports both [glibc](https://www.gnu.org/software/libc/)-based
 
 - [.NET 6 minimum libc](release-notes/6.0/supported-os.md#libc-compatibility)
 - [.NET 7 minimum libc](release-notes/7.0/supported-os.md#libc-compatibility)
+- [.NET 8 minimum libc](release-notes/8.0/supported-os.md#libc-compatibility)
 
 You can use the following pattern to determine the libc version provided for your distribution.
 

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -38,9 +38,8 @@ Other distributions are supported at best effort, per [.NET Support and Compatib
 
 ### Libc compatibility
 
-- x64: [glibc][glibc] 2.17 (from CentOS 7)
-- Arm32, Arm64: [glibc][glibc] 2.27 (from Ubuntu 18.04)
-- Alpine (x64 and Arm64): [musl][musl] 1.2.2 (from Alpine 3.15)
+- [glibc][glibc] 2.23 (from Ubuntu 16.04)
+- Alpine: [musl][musl] 1.2.2 (from Alpine 3.13)
 
 [Alpine]: https://alpinelinux.org/
 [Alpine-lifecycle]: https://alpinelinux.org/releases/


### PR DESCRIPTION
To reflect the plan in https://github.com/dotnet/runtime/issues/83428, and changes made in https://github.com/dotnet/runtime/pull/84148.