### PR TITLE
Add back iOS minimum OS versions in 8.0/supported-os.md

### DIFF
--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -21,6 +21,8 @@ OS                                    | Version                 | Architectures 
 [Nano-Server]: https://learn.microsoft.com/windows-server/get-started/getting-started-with-nano-server
 [Windows-Server]: https://learn.microsoft.com/windows-server/
 
+.NET 8 is supported in the x64 emulator on Windows 11 Arm64.
+
 ## Linux
 
 OS                                    | Version               | Architectures     | Lifecycle
@@ -80,6 +82,8 @@ OS                            | Version                   | Architectures     |
 ------------------------------|---------------------------|-------------------|
 [macOS][macOS]                | 10.15+                    | x64, Arm64        |
 
+.NET 8 is supported in the Rosetta 2 x64 emulator.
+
 [macOS]: https://support.apple.com/macos
 
 ## Android
@@ -90,13 +94,22 @@ OS                            | Version                 | Architectures     |
 
 [Android]: https://support.google.com/android
 
-## iOS / tvOS
+## iOS / tvOS / MacCatalyst
 
 OS                            | Version                 | Architectures     |
 ------------------------------|-------------------------|-------------------|
-[iOS][iOS]                    | 10.0+                   | x64, Arm32, Arm64 |
+[iOS][iOS]                    | 11.0+                   | Arm64             |
+[iOS Simulator][iOS]          | 11.0+                   | x64, Arm64        |
+[tvOS][tvOS]                  | 11.0+                   | Arm64             |
+[tvOS Simulator][tvOS]        | 11.0+                   | x64, Arm64        |
+[MacCatalyst][macOS]          | 10.15+, 11.0+ on Arm64  | x64, Arm64        |
 
 [iOS]: https://support.apple.com/ios
+[tvOS]: https://support.apple.com/apple-tv
+
+## QEMU
+
+.NET 8 is not supported being run (emulated) via [QEMU](https://www.qemu.org/). QEMU is used, for example, to emulate Arm64 containers on x64, and vice versa.
 
 ## Support changes from .NET 6.0
 


### PR DESCRIPTION
Looks like they were accidentally reverted to the previous state in https://github.com/dotnet/core/commit/f696399b76a100540b60b48ba96766eb8f58ed75.

Also restored lines about emulation and QEMU that were removed.

/cc @rbhanda 