### PR TITLE
Fix .NET 8 preview 4 release date

### DIFF
--- a/release-notes/8.0/releases.json
+++ b/release-notes/8.0/releases.json
@@ -9,7 +9,7 @@
   "lifecycle-policy": "https://aka.ms/dotnetcoresupport",
   "releases": [
     {
-      "release-date": "2023-11-14",
+      "release-date": "2023-05-16",
       "release-version": "8.0.0-preview.4",
       "security": false,
       "cve-list": [],


### PR DESCRIPTION
Update the date to not be in the future.

I spotted this because I have some update automation that was giving me negative values instead of 0 days - putting today's date matches the other previews.

![image](https://github.com/dotnet/core/assets/1439341/37c22b0e-5273-4439-acc2-4ca794986c55)
