### PR TITLE
Add back the PATH known issue

### DIFF
--- a/release-notes/6.0/known-issues.md
+++ b/release-notes/6.0/known-issues.md
@@ -86,7 +86,7 @@ SPA apps on Azure App Service with all the following:
 - Individual authentication and requires login for every page.
 - A custom domain such as `https://MyDomain.com`:
 
-Sometimes return the following error `WWW-Authenticate: Bearer error="invalid_token", error_description="The issuer 'https://MyDomain.com' is invalid"`. If the app is accessed from the Azure DNS (MyDomain.azurewebsites.net), authentication is successful. Subsequent requests to `https://MyDomain.com` succeed.  Alternatively, stopping and starting the app, enables authentication to succeed. This error can occur with [`Always On`](/azure/app-service/configure-common) set to `true` or `false`.
+Sometimes return the following error `WWW-Authenticate: Bearer error="invalid_token", error_description="The issuer 'https://MyDomain.com' is invalid"`. If the app is accessed from the Azure DNS (MyDomain.azurewebsites.net), authentication is successful. Subsequent requests to `https://MyDomain.com` succeed.  Alternatively, stopping and starting the app, enables authentication to succeed. This error can occur with [`Always On`](https://learn.microsoft.com/azure/app-service/configure-common) set to `true` or `false`.
 
 To prevent this problem without having to stop and restart the app:
 

--- a/release-notes/6.0/known-issues.md
+++ b/release-notes/6.0/known-issues.md
@@ -51,6 +51,9 @@ In 2021, .NET Runtime and .NET SDK were changed to no longer add the `program fi
 
 **Behavior**
 `The SDK 'Microsoft.NET.Sdk' specified could not be found`
+<img width="438" alt="image" src="https://github.com/dotnet/core/assets/12663534/1e6fdd30-cc33-4296-bb81-da9d26482f66">
+
+
 
 ```
 dotnet --info
@@ -62,7 +65,7 @@ Host:
 ```
 
 #### Workarounds
-
+See https://github.com/dotnet/core/issues/5962#issuecomment-780084535 for more details
 - Edit the system environment variables
 - Environment Variables
 - Double click `Path` under System variables

--- a/release-notes/6.0/known-issues.md
+++ b/release-notes/6.0/known-issues.md
@@ -45,29 +45,28 @@ If you build .NET 6 projects with MSBuild 16.11, for example, you will see the f
 
 You can use the .net 6 SDK to target downlevel runtimes in 16.11.
 
-### 1. Windows admin installs of the .NET 6.0.400 SDK will not correctly update .NET SDK optional workloads
+### 1. Repair or update of VS or old .NET versions can lead to bad `PATH` configuration on windows
 
-Commands like `dotnet workload install` and `dotnet workload update` will not correctly update to the latest versions of the workloads on the first try. This is because a timing issue in the workload manifest update code causes the SDK to stop early typically only updating 0-1 manifests.
+In 2021, .NET Runtime and .NET SDK were changed to no longer add the `program files (x86)\dotnet` location to the global machine `PATH` but not all prior versions were updated. Some customers may still have an old version of 2.1 or older runtime and any repair of Visual Studio or that SDK will set the x86 path. Customers can end up in a state where the x86 path ends up ahead of the x64 `program files\dotnet` path which Visual Studio should be using.
+
+**Behavior**
+`The SDK 'Microsoft.NET.Sdk' specified could not be found`
+
+```
+dotnet --info
+
+Host:
+  Version:      7.0.5
+  Architecture: **x86**
+  Commit:       8042d61b17
+```
 
 #### Workarounds
 
-1. Run `dotnet workload update` again and again until all workloads are updated.
-2. Run `dotnet workload update --from-rollback-file` specifying the exact workload versions you want to install.
-
-Example rollback file for 6.0.400
-
-```console
-{
-  "microsoft.net.sdk.android": "32.0.448/6.0.400",
-  "microsoft.net.sdk.ios": "15.4.447/6.0.400",
-  "microsoft.net.sdk.maccatalyst": "15.4.447/6.0.400",
-  "microsoft.net.sdk.macos": "12.3.447/6.0.400",
-  "microsoft.net.sdk.maui": "6.0.486/6.0.400",
-  "microsoft.net.sdk.tvos": "15.4.447/6.0.400",
-  "microsoft.net.workload.mono.toolchain": "6.0.8/6.0.300",
-  "microsoft.net.workload.emscripten": "6.0.4/6.0.300"
-}
-```
+- Edit the system environment variables
+- Environment Variables
+- Double click `Path` under System variables
+- Delete the `program files (x86)\dotnet path`
 
 ## ASP.NET Core
 


### PR DESCRIPTION
We see a couple of customers a month who still hit this. I assume it's because we didn't update 2.1 and that version is still getting installed even by 17.0 and repair could be added the PATH.

https://developercommunity.visualstudio.com/t/The-SDK-MicrosoftNETSdk-specified-co/10372391