### PR TITLE
Fix mention of 8.0 instead of 7.0

### DIFF
--- a/release-notes/8.0/preview/8.0.0-preview.1.md
+++ b/release-notes/8.0/preview/8.0.0-preview.1.md
@@ -4,7 +4,7 @@ The .NET 8.0.0 Preview 1 and .NET SDK 8.0.100-preview.1.23115.2 releases are ava
 
 ## What's new in .NET 8 Preview 1
 
-.NET 8 is the next major release of .NET following .NET 8.0. You can see some of the new features available with .NET 8 Preview 1 at [dotnet/core #8133](https://github.com/dotnet/core/issues/8133).
+.NET 8 is the next major release of .NET following .NET 7.0. You can see some of the new features available with .NET 8 Preview 1 at [dotnet/core #8133](https://github.com/dotnet/core/issues/8133).
 
 See the [.NET][dotnet-blog], [EF Core][ef-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 1.

--- a/release-notes/8.0/preview/8.0.0-preview.2.md
+++ b/release-notes/8.0/preview/8.0.0-preview.2.md
@@ -4,7 +4,7 @@ The .NET 8.0.0 Preview 2 and .NET SDK 8.0.100-preview.2.23157.25 releases are av
 
 ## What's new in .NET 8 Preview 2
 
-.NET 8 is the next major release of .NET following .NET 8.0. You can see some of the new features available with .NET 8 Preview 2 at [dotnet/core #8134](https://github.com/dotnet/core/issues/8134).
+.NET 8 is the next major release of .NET following .NET 7.0. You can see some of the new features available with .NET 8 Preview 2 at [dotnet/core #8134](https://github.com/dotnet/core/issues/8134).
 
 See the [.NET][dotnet-blog], [EF Core][ef-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 2.

--- a/release-notes/8.0/preview/8.0.0-preview.3.md
+++ b/release-notes/8.0/preview/8.0.0-preview.3.md
@@ -4,7 +4,7 @@ The .NET 8.0.0 Preview 3 and .NET SDK 8.0.100-preview.3.23178.7 releases are ava
 
 ## What's new in .NET 8 Preview 3
 
-.NET 8 is the next major release of .NET following .NET 8.0. You can see some of the new features available with .NET 8 Preview 3 at [dotnet/core #8135](https://github.com/dotnet/core/issues/8135).
+.NET 8 is the next major release of .NET following .NET 7.0. You can see some of the new features available with .NET 8 Preview 3 at [dotnet/core #8135](https://github.com/dotnet/core/issues/8135).
 
 See the [.NET][dotnet-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 3.

--- a/release-notes/8.0/preview/8.0.0-preview.4.md
+++ b/release-notes/8.0/preview/8.0.0-preview.4.md
@@ -4,7 +4,7 @@ The .NET 8.0.0 Preview 4 and .NET SDK 8.0.100-preview.4.23260.5 releases are ava
 
 ## What's new in .NET 8 Preview 4
 
-.NET 8 is the next major release of .NET following .NET 8.0. You can see some of the new features available with .NET 8 Preview 4 at [dotnet/core #8234](https://github.com/dotnet/core/issues/8234).
+.NET 8 is the next major release of .NET following .NET 7.0. You can see some of the new features available with .NET 8 Preview 4 at [dotnet/core #8234](https://github.com/dotnet/core/issues/8234).
 
 See the [.NET][dotnet-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 4.

--- a/release-notes/8.0/preview/8.0.0-preview.5.md
+++ b/release-notes/8.0/preview/8.0.0-preview.5.md
@@ -4,7 +4,7 @@ The .NET 8.0.0 Preview 5 and .NET SDK 8.0.100-preview.5.23303.2 releases are ava
 
 ## What's new in .NET 8 Preview 5
 
-.NET 8 is the next major release of .NET following .NET 8.0. You can see some of the new features available with .NET 8 Preview 5 at [dotnet/core #8436](https://github.com/dotnet/core/issues/8436).
+.NET 8 is the next major release of .NET following .NET 7.0. You can see some of the new features available with .NET 8 Preview 5 at [dotnet/core #8436](https://github.com/dotnet/core/issues/8436).
 
 See the [.NET][dotnet-blog] and [ASP.NET Core][aspnet-blog] blogs for additional details.
 Here is list of some of the additions and updates we're excited to bring in Preview 4.


### PR DESCRIPTION
The release notes for the 8.0 previews say that .NET 8 is the next major release of .NET following .NET 8.0.

This fixes them to say it's the next major release of .NET following .NET 7.0.