### PR TITLE
API diff between .NET 8 Preview 5 and .NET 8 Preview 6

### DIFF
--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6.md
@@ -1,0 +1,28 @@
+# API Difference 8.0-preview5 vs 8.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Authentication.BearerToken](8.0-preview6_Microsoft.AspNetCore.Authentication.BearerToken.md)
+* [Microsoft.AspNetCore.Builder](8.0-preview6_Microsoft.AspNetCore.Builder.md)
+* [Microsoft.AspNetCore.Components](8.0-preview6_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Binding](8.0-preview6_Microsoft.AspNetCore.Components.Binding.md)
+* [Microsoft.AspNetCore.Components.Endpoints](8.0-preview6_Microsoft.AspNetCore.Components.Endpoints.md)
+* [Microsoft.AspNetCore.Components.Rendering](8.0-preview6_Microsoft.AspNetCore.Components.Rendering.md)
+* [Microsoft.AspNetCore.Components.RenderTree](8.0-preview6_Microsoft.AspNetCore.Components.RenderTree.md)
+* [Microsoft.AspNetCore.Components.Sections](8.0-preview6_Microsoft.AspNetCore.Components.Sections.md)
+* [Microsoft.AspNetCore.Connections.Features](8.0-preview6_Microsoft.AspNetCore.Connections.Features.md)
+* [Microsoft.AspNetCore.Http.Connections](8.0-preview6_Microsoft.AspNetCore.Http.Connections.md)
+* [Microsoft.AspNetCore.Identity](8.0-preview6_Microsoft.AspNetCore.Identity.md)
+* [Microsoft.AspNetCore.OutputCaching](8.0-preview6_Microsoft.AspNetCore.OutputCaching.md)
+* [Microsoft.AspNetCore.Server.HttpSys](8.0-preview6_Microsoft.AspNetCore.Server.HttpSys.md)
+* [Microsoft.Extensions.Caching.Memory](8.0-preview6_Microsoft.Extensions.Caching.Memory.md)
+* [Microsoft.Extensions.Configuration](8.0-preview6_Microsoft.Extensions.Configuration.md)
+* [Microsoft.Extensions.DependencyInjection](8.0-preview6_Microsoft.Extensions.DependencyInjection.md)
+* [Microsoft.Extensions.Diagnostics.Metrics](8.0-preview6_Microsoft.Extensions.Diagnostics.Metrics.md)
+* [Microsoft.Extensions.Hosting](8.0-preview6_Microsoft.Extensions.Hosting.md)
+* [Microsoft.Extensions.Logging](8.0-preview6_Microsoft.Extensions.Logging.md)
+* [Microsoft.Extensions.Logging.Console](8.0-preview6_Microsoft.Extensions.Logging.Console.md)
+* [Microsoft.Extensions.Options](8.0-preview6_Microsoft.Extensions.Options.md)
+* [Microsoft.Extensions.Primitives](8.0-preview6_Microsoft.Extensions.Primitives.md)
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Authentication.BearerToken.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Authentication.BearerToken.md
@@ -1,0 +1,17 @@
+# Microsoft.AspNetCore.Authentication.BearerToken
+
+``` diff
+ namespace Microsoft.AspNetCore.Authentication.BearerToken {
+     public class BearerTokenEvents {
+-        public virtual Task MessageReceived(MessageReceivedContext context);
++        public virtual Task MessageReceivedAsync(MessageReceivedContext context);
+     }
+     public sealed class BearerTokenOptions : AuthenticationSchemeOptions {
+-        public ISecureDataFormat<AuthenticationTicket>? BearerTokenProtector { get; set; }
++        public ISecureDataFormat<AuthenticationTicket> BearerTokenProtector { get; set; }
++        public TimeSpan RefreshTokenExpiration { get; set; }
++        public ISecureDataFormat<AuthenticationTicket> RefreshTokenProtector { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Builder.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Builder.md
@@ -1,0 +1,22 @@
+# Microsoft.AspNetCore.Builder
+
+``` diff
+ namespace Microsoft.AspNetCore.Builder {
+-    public class ApplicationBuilder : IApplicationBuilder
++    [DebuggerDisplayAttribute("Middleware = {MiddlewareCount}")]
++    [DebuggerTypeProxyAttribute(typeof(ApplicationBuilder.ApplicationBuilderDebugView))]
++    public class ApplicationBuilder : IApplicationBuilder
+-    public sealed class WebApplication : IApplicationBuilder, IAsyncDisposable, IDisposable, IEndpointRouteBuilder, IHost
++    [DebuggerDisplayAttribute("{DebuggerToString(),nq}")]
++    [DebuggerTypeProxyAttribute(typeof(WebApplication.WebApplicationDebugView))]
++    public sealed class WebApplication : IApplicationBuilder, IAsyncDisposable, IDisposable, IEndpointRouteBuilder, IHost
+-    public sealed class WebApplicationBuilder {
++    public sealed class WebApplicationBuilder : IHostApplicationBuilder {
++        IConfigurationManager IHostApplicationBuilder.Configuration { get; }
++        IHostEnvironment IHostApplicationBuilder.Environment { get; }
++        IDictionary<object, object> IHostApplicationBuilder.Properties { get; }
++        void IHostApplicationBuilder.ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder> configure);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Binding.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Binding.md
@@ -1,0 +1,50 @@
+# Microsoft.AspNetCore.Components.Binding
+
+``` diff
++namespace Microsoft.AspNetCore.Components.Binding {
++    public sealed class CascadingFormModelBindingProvider : CascadingModelBindingProvider {
++        public CascadingFormModelBindingProvider(IFormValueSupplier formValueSupplier);
++        protected internal override bool AreValuesFixed { get; }
++        protected internal override bool CanSupplyValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal override object? GetCurrentValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal override bool SupportsCascadingParameterAttributeType(Type attributeType);
++        protected internal override bool SupportsParameterType(Type type);
++    }
++    public abstract class CascadingModelBindingProvider {
++        protected CascadingModelBindingProvider();
++        protected internal abstract bool AreValuesFixed { get; }
++        protected internal abstract bool CanSupplyValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal abstract object? GetCurrentValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal virtual void Subscribe(ComponentState subscriber);
++        protected internal abstract bool SupportsCascadingParameterAttributeType(Type attributeType);
++        protected internal abstract bool SupportsParameterType(Type parameterType);
++        protected internal virtual void Unsubscribe(ComponentState subscriber);
++    }
++    public sealed class CascadingQueryModelBindingProvider : CascadingModelBindingProvider, IDisposable {
++        public CascadingQueryModelBindingProvider(NavigationManager navigationManager);
++        protected internal override bool AreValuesFixed { get; }
++        protected internal override bool CanSupplyValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal override object? GetCurrentValue(ModelBindingContext? bindingContext, in CascadingParameterInfo parameterInfo);
++        protected internal override void Subscribe(ComponentState subscriber);
++        protected internal override bool SupportsCascadingParameterAttributeType(Type attributeType);
++        protected internal override bool SupportsParameterType(Type type);
++        void IDisposable.Dispose();
++        protected internal override void Unsubscribe(ComponentState subscriber);
++    }
++    public class FormValueSupplierContext {
++        public FormValueSupplierContext(string formName, Type valueType, string parameterName);
++        public string FormName { get; }
++        public Action<string, object>? MapErrorToContainer { get; set; }
++        public Action<string, FormattableString, string?>? OnError { get; set; }
++        public string ParameterName { get; }
++        public object? Result { get; }
++        public Type ValueType { get; }
++        public void SetResult(object? result);
++    }
++    public interface IFormValueSupplier {
++        void Bind(FormValueSupplierContext context);
++        bool CanBind(Type valueType, string? formName = null);
++    }
++}
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Endpoints.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Endpoints.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.Endpoints
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Endpoints {
++    public sealed class WebAssemblyComponentsEndpointOptions {
++        public WebAssemblyComponentsEndpointOptions();
++        public PathString PathPrefix { get; set; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.RenderTree.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.RenderTree.md
@@ -1,0 +1,22 @@
+# Microsoft.AspNetCore.Components.RenderTree
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.RenderTree {
++    [FlagsAttribute]
++    public enum ComponentFrameFlags : byte {
++        HasCallerSpecifiedRenderMode = (byte)1,
++    }
+     public abstract class Renderer : IAsyncDisposable, IDisposable {
+-        protected internal virtual IComponent ResolveComponentForRenderMode(Type componentType, int? parentComponentId, IComponentActivator componentActivator, IComponentRenderMode componentTypeRenderMode);
++        protected internal virtual IComponent ResolveComponentForRenderMode(Type componentType, int? parentComponentId, IComponentActivator componentActivator, IComponentRenderMode renderMode);
+     }
+     public struct RenderTreeFrame {
++        public ComponentFrameFlags ComponentFrameFlags { get; }
++        public IComponentRenderMode ComponentRenderMode { get; }
+     }
+     public enum RenderTreeFrameType : short {
++        ComponentRenderMode = (short)9,
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Rendering.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Rendering.md
@@ -1,0 +1,15 @@
+# Microsoft.AspNetCore.Components.Rendering
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Rendering {
+     [DebuggerDisplayAttribute("{GetDebuggerDisplay(),nq}")]
+     public class ComponentState : IAsyncDisposable {
++        public ComponentState? LogicalParentComponentState { get; }
+     }
+     public sealed class RenderTreeBuilder : IDisposable {
++        public void AddComponentParameter(int sequence, string name, IComponentRenderMode renderMode);
++        public void AddComponentRenderMode(int sequence, IComponentRenderMode renderMode);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Sections.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.Sections.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Sections
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Sections {
+-    [StreamRenderingAttribute(true)]
+-    public sealed class SectionOutlet : IComponent, IDisposable, ISectionContentSubscriber
++    public sealed class SectionOutlet : IComponent, IDisposable
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,50 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
++    public class BindingError {
++        public string? AttemptedValue { get; }
++        public object Container { get; internal set; }
++        public IReadOnlyList<FormattableString> ErrorMessages { get; }
++        public string Name { get; }
++        public string Path { get; }
++    }
+-    [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+-    public sealed class CascadingParameterAttribute : Attribute {
++    [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
++    public sealed class CascadingParameterAttribute : CascadingParameterAttributeBase {
+-        public string Name { get; set; }
++        public override string Name { get; set; }
+     }
++    public abstract class CascadingParameterAttributeBase : Attribute {
++        protected CascadingParameterAttributeBase();
++        public abstract string Name { get; set; }
++    }
++    public readonly struct CascadingParameterInfo {
++        public CascadingParameterAttributeBase Attribute { get; }
++        public string PropertyName { get; }
++        public Type PropertyType { get; }
++    }
+     public sealed class ModelBindingContext {
++        public IEnumerable<BindingError> GetAllErrors();
++        public IEnumerable<BindingError> GetAllErrors(string formName);
++        public string? GetAttemptedValue(string key);
++        public string? GetAttemptedValue(string formName, string key);
++        public BindingError? GetErrors(string key);
++        public BindingError? GetErrors(string formName, string key);
+     }
++    [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
++    public sealed class SupplyParameterFromFormAttribute : CascadingParameterAttributeBase {
++        public SupplyParameterFromFormAttribute();
++        public override string Name { get; set; }
++    }
+-    [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+-    public sealed class SupplyParameterFromQueryAttribute : Attribute {
++    [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
++    public sealed class SupplyParameterFromQueryAttribute : CascadingParameterAttributeBase {
+-        public string Name { get; set; }
++        public override string Name { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Connections.Features.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Connections.Features.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Connections.Features
+
+``` diff
+ namespace Microsoft.AspNetCore.Connections.Features {
+     public interface ITlsHandshakeFeature {
++        string HostName { get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Http.Connections.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Http.Connections.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Http.Connections
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Connections {
+     public class HttpConnectionDispatcherOptions {
++        public bool AllowAcks { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Identity.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Identity.md
@@ -1,0 +1,17 @@
+# Microsoft.AspNetCore.Identity
+
+``` diff
+ namespace Microsoft.AspNetCore.Identity {
+-    public static class IdentityApiEndpointsIdentityBuilderExtensions {
+-        public static IdentityBuilder AddApiEndpoints(this IdentityBuilder builder);
+-    }
++    public static class IdentityAuthenticationBuilderExtensions {
++        public static AuthenticationBuilder AddIdentityBearerToken<TUser>(this AuthenticationBuilder builder) where TUser : class, new();
++        public static AuthenticationBuilder AddIdentityBearerToken<TUser>(this AuthenticationBuilder builder, Action<BearerTokenOptions> configureOptions) where TUser : class, new();
++    }
+     public static class IdentityBuilderExtensions {
++        public static IdentityBuilder AddApiEndpoints(this IdentityBuilder builder);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.OutputCaching.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.OutputCaching.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.OutputCaching
+
+``` diff
+ namespace Microsoft.AspNetCore.OutputCaching {
++    public interface IOutputCacheBufferStore : IOutputCacheStore {
++        ValueTask SetAsync(string key, ReadOnlySequence<byte> value, ReadOnlyMemory<string> tags, TimeSpan validFor, CancellationToken cancellationToken);
++        ValueTask<bool> TryGetAsync(string key, PipeWriter destination, CancellationToken cancellationToken);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Server.HttpSys.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.AspNetCore.Server.HttpSys.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Server.HttpSys
+
+``` diff
+ namespace Microsoft.AspNetCore.Server.HttpSys {
+     public class HttpSysOptions {
++        public bool EnableKernelResponseBuffering { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Caching.Memory.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Caching.Memory.md
@@ -1,0 +1,12 @@
+# Microsoft.Extensions.Caching.Memory
+
+``` diff
+ namespace Microsoft.Extensions.Caching.Memory {
+     public class MemoryCacheOptions : IOptions<MemoryCacheOptions> {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This property is retained only for compatibility.  Remove use and instead call MemoryCache.Compact as needed.", true)]
++        public bool CompactOnMemoryPressure { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Configuration.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Configuration.md
@@ -1,0 +1,10 @@
+# Microsoft.Extensions.Configuration
+
+``` diff
+ namespace Microsoft.Extensions.Configuration {
+-    public sealed class ConfigurationManager : IConfiguration, IConfigurationBuilder, IConfigurationRoot, IDisposable
++    public sealed class ConfigurationManager : IConfiguration, IConfigurationBuilder, IConfigurationManager, IConfigurationRoot, IDisposable
++    public interface IConfigurationManager : IConfiguration, IConfigurationBuilder
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,20 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
+-    public static class IdentityApiEndpointsServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Authentication middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IdentityBuilder AddIdentityApiEndpoints<TUser>(this IServiceCollection services) where TUser : class, new();
+-        [RequiresUnreferencedCodeAttribute("Authentication middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IdentityBuilder AddIdentityApiEndpoints<TUser>(this IServiceCollection services, Action<IdentityOptions> configure) where TUser : class, new();
+-    }
+     public static class IdentityServiceCollectionExtensions {
++        public static IdentityBuilder AddIdentityApiEndpoints<TUser>(this IServiceCollection services) where TUser : class, new();
++        public static IdentityBuilder AddIdentityApiEndpoints<TUser>(this IServiceCollection services, Action<IdentityOptions> configure) where TUser : class, new();
+     }
++    public static class MetricsServiceExtensions {
++        public static IServiceCollection AddMetrics(this IServiceCollection services);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Diagnostics.Metrics.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Diagnostics.Metrics.md
@@ -1,0 +1,14 @@
+# Microsoft.Extensions.Diagnostics.Metrics
+
+``` diff
+ namespace Microsoft.Extensions.Diagnostics.Metrics {
+     public static class MeterFactoryExtensions {
++        public static Meter Create(this IMeterFactory meterFactory, string name, string? version = null, IEnumerable<KeyValuePair<string, object?>>? tags = null);
+-        public static Meter Create(this IMeterFactory meterFactory, string name, string? version = null, IEnumerable<KeyValuePair<string, object?>>? tags = null, object? scope = null);
+     }
+-    public static class MetricsServiceExtensions {
+-        public static IServiceCollection AddMetrics(this IServiceCollection services);
+-    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Hosting.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Hosting.md
@@ -1,0 +1,20 @@
+# Microsoft.Extensions.Hosting
+
+``` diff
+ namespace Microsoft.Extensions.Hosting {
+-    public sealed class HostApplicationBuilder {
++    public sealed class HostApplicationBuilder : IHostApplicationBuilder {
++        IConfigurationManager IHostApplicationBuilder.Configuration { get; }
++        IDictionary<object, object> IHostApplicationBuilder.Properties { get; }
+     }
++    public interface IHostApplicationBuilder {
++        IConfigurationManager Configuration { get; }
++        IHostEnvironment Environment { get; }
++        ILoggingBuilder Logging { get; }
++        IDictionary<object, object> Properties { get; }
++        IServiceCollection Services { get; }
++        void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure = null);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Logging.Console.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Logging.Console.md
@@ -1,0 +1,35 @@
+# Microsoft.Extensions.Logging.Console
+
+``` diff
+ namespace Microsoft.Extensions.Logging.Console {
++    [EditorBrowsableAttribute(1)]
++    [ObsoleteAttribute("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.")]
++    public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings {
++        public ConfigurationConsoleLoggerSettings(IConfiguration configuration);
++        public IChangeToken? ChangeToken { get; }
++        public bool IncludeScopes { get; }
++        public IConsoleLoggerSettings Reload();
++        public bool TryGetSwitch(string name, out LogLevel level);
++    }
++    [EditorBrowsableAttribute(1)]
++    [ObsoleteAttribute("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.", true)]
++    public class ConsoleLoggerSettings : IConsoleLoggerSettings {
++        public ConsoleLoggerSettings();
++        public IChangeToken? ChangeToken { get; set; }
++        public bool DisableColors { get; set; }
++        public bool IncludeScopes { get; set; }
++        public IDictionary<string, LogLevel> Switches { get; set; }
++        public IConsoleLoggerSettings Reload();
++        public bool TryGetSwitch(string name, out LogLevel level);
++    }
++    [EditorBrowsableAttribute(1)]
++    [ObsoleteAttribute("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.", true)]
++    public interface IConsoleLoggerSettings {
++        IChangeToken? ChangeToken { get; }
++        bool IncludeScopes { get; }
++        IConsoleLoggerSettings Reload();
++        bool TryGetSwitch(string name, out LogLevel level);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Logging.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Logging.md
@@ -1,0 +1,81 @@
+# Microsoft.Extensions.Logging
+
+``` diff
+ namespace Microsoft.Extensions.Logging {
+     [UnsupportedOSPlatformAttribute("browser")]
+     public static class ConsoleLoggerExtensions {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConsoleLoggerSettings settings);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel, bool includeScopes);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, bool includeScopes);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, Func<string, LogLevel, bool> filter);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddConsole(this ILoggerFactory factory, Func<string, LogLevel, bool> filter, bool includeScopes);
+     }
+     public static class DebugLoggerFactoryExtensions {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddDebug(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddDebug(this ILoggerFactory factory);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddDebug(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddDebug(this ILoggerFactory factory, LogLevel minLevel);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddDebug(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddDebug(this ILoggerFactory factory, Func<string, LogLevel, bool> filter);
+     }
+     public static class EventLoggerFactoryExtensions {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddEventLog(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddEventLog(this ILoggerFactory factory);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddEventLog(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddEventLog(this ILoggerFactory factory, EventLogSettings settings);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddEventLog(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddEventLog(this ILoggerFactory factory, LogLevel minLevel);
+     }
+     public static class EventSourceLoggerFactoryExtensions {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddEventSourceLogger(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddEventSourceLogger(this ILoggerFactory factory);
+     }
+     [AttributeUsageAttribute(64)]
+     public sealed class LoggerMessageAttribute : Attribute {
++        public LoggerMessageAttribute(LogLevel level);
++        public LoggerMessageAttribute(LogLevel level, string message);
++        public LoggerMessageAttribute(string message);
+     }
+     public static class TraceSourceFactoryExtensions {
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddTraceSource(this ILoggerFactory factory, SourceSwitch sourceSwitch);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddTraceSource(this ILoggerFactory factory, SourceSwitch sourceSwitch, TraceListener listener);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddTraceSource(this ILoggerFactory factory, string switchName);
++        [EditorBrowsableAttribute(1)]
++        [ObsoleteAttribute("This method is retained only for compatibility. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).", true)]
++        public static ILoggerFactory AddTraceSource(this ILoggerFactory factory, string switchName, TraceListener listener);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Options.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Options.md
@@ -1,0 +1,23 @@
+# Microsoft.Extensions.Options
+
+``` diff
+ namespace Microsoft.Extensions.Options {
++    [AttributeUsageAttribute(12)]
++    public sealed class OptionsValidatorAttribute : Attribute {
++        public OptionsValidatorAttribute();
++    }
++    [AttributeUsageAttribute(384)]
++    public sealed class ValidateEnumeratedItemsAttribute : Attribute {
++        public ValidateEnumeratedItemsAttribute();
++        public ValidateEnumeratedItemsAttribute(Type validator);
++        public Type Validator { get; }
++    }
++    [AttributeUsageAttribute(384)]
++    public sealed class ValidateObjectMembersAttribute : Attribute {
++        public ValidateObjectMembersAttribute();
++        public ValidateObjectMembersAttribute(Type validator);
++        public Type Validator { get; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Primitives.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.AspNetCore.App/8.0-preview6_Microsoft.Extensions.Primitives.md
@@ -1,0 +1,18 @@
+# Microsoft.Extensions.Primitives
+
+``` diff
+ namespace Microsoft.Extensions.Primitives {
++    [EditorBrowsableAttribute(1)]
++    [ObsoleteAttribute("This type is retained only for compatibility. The recommended alternative is string.Create<TState> (int length, TState state, System.Buffers.SpanAction<char,TState> action).", true)]
++    public struct InplaceStringBuilder {
++        public InplaceStringBuilder(int capacity);
++        public int Capacity { get; set; }
++        public void Append(StringSegment segment);
++        public void Append(char c);
++        public void Append(string value);
++        public void Append(string value, int offset, int count);
++        public override string ToString();
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6.md
@@ -1,0 +1,26 @@
+# API Difference 8.0-preview5 vs 8.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](8.0-preview6_System.md)
+* [System.Diagnostics.CodeAnalysis](8.0-preview6_System.Diagnostics.CodeAnalysis.md)
+* [System.Diagnostics.Metrics](8.0-preview6_System.Diagnostics.Metrics.md)
+* [System.Diagnostics.Tracing](8.0-preview6_System.Diagnostics.Tracing.md)
+* [System.Formats.Asn1](8.0-preview6_System.Formats.Asn1.md)
+* [System.IO.Compression](8.0-preview6_System.IO.Compression.md)
+* [System.IO.Pipes](8.0-preview6_System.IO.Pipes.md)
+* [System.Net.Http](8.0-preview6_System.Net.Http.md)
+* [System.Net.Mime](8.0-preview6_System.Net.Mime.md)
+* [System.Net.Security](8.0-preview6_System.Net.Security.md)
+* [System.Numerics](8.0-preview6_System.Numerics.md)
+* [System.Runtime.CompilerServices](8.0-preview6_System.Runtime.CompilerServices.md)
+* [System.Runtime.InteropServices.Marshalling](8.0-preview6_System.Runtime.InteropServices.Marshalling.md)
+* [System.Runtime.Intrinsics](8.0-preview6_System.Runtime.Intrinsics.md)
+* [System.Runtime.Intrinsics.Wasm](8.0-preview6_System.Runtime.Intrinsics.Wasm.md)
+* [System.Runtime.Intrinsics.X86](8.0-preview6_System.Runtime.Intrinsics.X86.md)
+* [System.Security.Cryptography](8.0-preview6_System.Security.Cryptography.md)
+* [System.Text.Json](8.0-preview6_System.Text.Json.md)
+* [System.Text.Json.Serialization](8.0-preview6_System.Text.Json.Serialization.md)
+* [System.Threading.Tasks](8.0-preview6_System.Threading.Tasks.md)
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.CodeAnalysis.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.CodeAnalysis.md
@@ -1,0 +1,13 @@
+# System.Diagnostics.CodeAnalysis
+
+``` diff
+ namespace System.Diagnostics.CodeAnalysis {
++    [AttributeUsageAttribute(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Delegate | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, Inherited=false)]
++    public sealed class ExperimentalAttribute : Attribute {
++        public ExperimentalAttribute(string diagnosticId);
++        public string DiagnosticId { get; }
++        public string? UrlFormat { get; set; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.Metrics.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.Metrics.md
@@ -1,0 +1,15 @@
+# System.Diagnostics.Metrics
+
+``` diff
+ namespace System.Diagnostics.Metrics {
+-    public sealed class InstrumentRecorder<T> : IDisposable where T : struct {
+-        public InstrumentRecorder(Instrument instrument);
+-        public InstrumentRecorder(Meter meter, string instrumentName);
+-        public InstrumentRecorder(object? scopeFilter, string meterName, string instrumentName);
+-        public Instrument? Instrument { get; }
+-        public void Dispose();
+-        public IEnumerable<Measurement<T>> GetMeasurements(bool clear = false);
+-    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.Tracing.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Diagnostics.Tracing.md
@@ -1,0 +1,37 @@
+# System.Diagnostics.Tracing
+
+``` diff
+ namespace System.Diagnostics.Tracing {
+     public class EventSource : IDisposable {
++        protected void WriteEvent(int eventId, params EventSource.EventSourcePrimitive[] args);
++        public readonly struct EventSourcePrimitive {
++            public static implicit operator EventSource.EventSourcePrimitive (bool value);
++            public static implicit operator EventSource.EventSourcePrimitive (byte value);
++            public static implicit operator EventSource.EventSourcePrimitive (byte[] value);
++            public static implicit operator EventSource.EventSourcePrimitive (char value);
++            public static implicit operator EventSource.EventSourcePrimitive (DateTime value);
++            public static implicit operator EventSource.EventSourcePrimitive (decimal value);
++            public static implicit operator EventSource.EventSourcePrimitive (double value);
++            public static implicit operator EventSource.EventSourcePrimitive (Enum value);
++            public static implicit operator EventSource.EventSourcePrimitive (Guid value);
++            public static implicit operator EventSource.EventSourcePrimitive (short value);
++            public static implicit operator EventSource.EventSourcePrimitive (int value);
++            public static implicit operator EventSource.EventSourcePrimitive (long value);
++            public static implicit operator EventSource.EventSourcePrimitive (IntPtr value);
++            [CLSCompliantAttribute(false)]
++            public static implicit operator EventSource.EventSourcePrimitive (sbyte value);
++            public static implicit operator EventSource.EventSourcePrimitive (float value);
++            public static implicit operator EventSource.EventSourcePrimitive (string value);
++            [CLSCompliantAttribute(false)]
++            public static implicit operator EventSource.EventSourcePrimitive (ushort value);
++            [CLSCompliantAttribute(false)]
++            public static implicit operator EventSource.EventSourcePrimitive (uint value);
++            [CLSCompliantAttribute(false)]
++            public static implicit operator EventSource.EventSourcePrimitive (ulong value);
++            [CLSCompliantAttribute(false)]
++            public static implicit operator EventSource.EventSourcePrimitive (UIntPtr value);
++        }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Formats.Asn1.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Formats.Asn1.md
@@ -1,0 +1,10 @@
+# System.Formats.Asn1
+
+``` diff
+ namespace System.Formats.Asn1 {
+     public class AsnReader {
++        public AsnReader Clone();
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.IO.Compression.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.IO.Compression.md
@@ -1,0 +1,16 @@
+# System.IO.Compression
+
+``` diff
+ namespace System.IO.Compression {
+     public static class ZipFile {
++        public static void CreateFromDirectory(string sourceDirectoryName, Stream destination);
++        public static void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory);
++        public static void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding);
++        public static void ExtractToDirectory(Stream source, string destinationDirectoryName);
++        public static void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles);
++        public static void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding? entryNameEncoding);
++        public static void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding? entryNameEncoding, bool overwriteFiles);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.IO.Pipes.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.IO.Pipes.md
@@ -1,0 +1,11 @@
+# System.IO.Pipes
+
+``` diff
+ namespace System.IO.Pipes {
+     [FlagsAttribute]
+     public enum PipeOptions {
++        FirstPipeInstance = 524288,
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Http.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Http.md
@@ -1,0 +1,16 @@
+# System.Net.Http
+
+``` diff
+ namespace System.Net.Http {
+-    public sealed class HttpRequestOptions : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>> {
++    public sealed class HttpRequestOptions : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>>, IReadOnlyCollection<KeyValuePair<string, object?>>, IReadOnlyDictionary<string, object?> {
++        int IReadOnlyCollection<KeyValuePair<string, object?>>.Count { get; }
++        object? IReadOnlyDictionary<string, object?>.this[string key] { get; }
++        IEnumerable<string> IReadOnlyDictionary<string, object?>.Keys { get; }
++        IEnumerable<object?> IReadOnlyDictionary<string, object?>.Values { get; }
++        bool IReadOnlyDictionary<string, object?>.ContainsKey(string key);
++        bool IReadOnlyDictionary<string, object?>.TryGetValue(string key, out object value);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Mime.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Mime.md
@@ -1,0 +1,47 @@
+# System.Net.Mime
+
+``` diff
+ namespace System.Net.Mime {
+     public static class MediaTypeNames {
+         public static class Application {
++            public const string FormUrlEncoded = "application/x-www-form-urlencoded";
++            public const string JsonPatch = "application/json-patch+json";
++            public const string JsonSequence = "application/json-seq";
++            public const string Manifest = "application/manifest+json";
++            public const string ProblemJson = "application/problem+json";
++            public const string ProblemXml = "application/problem+xml";
++            public const string Wasm = "application/wasm";
++            public const string XmlDtd = "application/xml-dtd";
++            public const string XmlPatch = "application/xml-patch+xml";
+         }
++        public static class Font {
++            public const string Collection = "font/collection";
++            public const string Otf = "font/otf";
++            public const string Sfnt = "font/sfnt";
++            public const string Ttf = "font/ttf";
++            public const string Woff = "font/woff";
++            public const string Woff2 = "font/woff2";
++        }
+         public static class Image {
++            public const string Avif = "image/avif";
++            public const string Bmp = "image/bmp";
++            public const string Icon = "image/x-icon";
++            public const string Png = "image/png";
++            public const string Svg = "image/svg+xml";
++            public const string Webp = "image/webp";
+         }
++        public static class Multipart {
++            public const string ByteRanges = "multipart/byteranges";
++            public const string FormData = "multipart/form-data";
++        }
+         public static class Text {
++            public const string Css = "text/css";
++            public const string Csv = "text/csv";
++            public const string JavaScript = "text/javascript";
++            public const string Markdown = "text/markdown";
++            public const string Rtf = "text/rtf";
+         }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Security.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Net.Security.md
@@ -1,0 +1,10 @@
+# System.Net.Security
+
+``` diff
+ namespace System.Net.Security {
+-    [UnsupportedOSPlatformAttribute("tvos")]
+-    public class NegotiateStream : AuthenticatedStream
++    public class NegotiateStream : AuthenticatedStream
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Numerics.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Numerics.md
@@ -1,0 +1,159 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+     public static class Vector {
+-        public static Vector<T> Abs<T>(Vector<T> value) where T : struct;
++        public static Vector<T> Abs<T>(Vector<T> value);
+-        public static Vector<T> Add<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Add<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> AndNot<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> AndNot<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<TTo> As<TFrom, TTo>(this Vector<TFrom> vector) where TFrom : struct where TTo : struct;
++        public static Vector<TTo> As<TFrom, TTo>(this Vector<TFrom> vector);
+-        public static Vector<byte> AsVectorByte<T>(Vector<T> value) where T : struct;
++        public static Vector<byte> AsVectorByte<T>(Vector<T> value);
+-        public static Vector<double> AsVectorDouble<T>(Vector<T> value) where T : struct;
++        public static Vector<double> AsVectorDouble<T>(Vector<T> value);
+-        public static Vector<short> AsVectorInt16<T>(Vector<T> value) where T : struct;
++        public static Vector<short> AsVectorInt16<T>(Vector<T> value);
+-        public static Vector<int> AsVectorInt32<T>(Vector<T> value) where T : struct;
++        public static Vector<int> AsVectorInt32<T>(Vector<T> value);
+-        public static Vector<long> AsVectorInt64<T>(Vector<T> value) where T : struct;
++        public static Vector<long> AsVectorInt64<T>(Vector<T> value);
+-        public static Vector<IntPtr> AsVectorNInt<T>(Vector<T> value) where T : struct;
++        public static Vector<IntPtr> AsVectorNInt<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<UIntPtr> AsVectorNUInt<T>(Vector<T> value) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<UIntPtr> AsVectorNUInt<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<sbyte> AsVectorSByte<T>(Vector<T> value) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<sbyte> AsVectorSByte<T>(Vector<T> value);
+-        public static Vector<float> AsVectorSingle<T>(Vector<T> value) where T : struct;
++        public static Vector<float> AsVectorSingle<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<ushort> AsVectorUInt16<T>(Vector<T> value) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<ushort> AsVectorUInt16<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<uint> AsVectorUInt32<T>(Vector<T> value) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<uint> AsVectorUInt32<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<ulong> AsVectorUInt64<T>(Vector<T> value) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<ulong> AsVectorUInt64<T>(Vector<T> value);
+-        public static Vector<T> BitwiseAnd<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> BitwiseAnd<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> BitwiseOr<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> BitwiseOr<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> ConditionalSelect<T>(Vector<T> condition, Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> ConditionalSelect<T>(Vector<T> condition, Vector<T> left, Vector<T> right);
+-        public static Vector<T> Divide<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Divide<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> Divide<T>(Vector<T> left, T right) where T : struct;
++        public static Vector<T> Divide<T>(Vector<T> left, T right);
+-        public static T Dot<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static T Dot<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> Equals<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Equals<T>(Vector<T> left, Vector<T> right);
+-        public static bool EqualsAll<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool EqualsAll<T>(Vector<T> left, Vector<T> right);
+-        public static bool EqualsAny<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool EqualsAny<T>(Vector<T> left, Vector<T> right);
+-        public static T GetElement<T>(this Vector<T> vector, int index) where T : struct;
++        public static T GetElement<T>(this Vector<T> vector, int index);
+-        public static Vector<T> GreaterThan<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> GreaterThan<T>(Vector<T> left, Vector<T> right);
+-        public static bool GreaterThanAll<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool GreaterThanAll<T>(Vector<T> left, Vector<T> right);
+-        public static bool GreaterThanAny<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool GreaterThanAny<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> GreaterThanOrEqual<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> GreaterThanOrEqual<T>(Vector<T> left, Vector<T> right);
+-        public static bool GreaterThanOrEqualAll<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAll<T>(Vector<T> left, Vector<T> right);
+-        public static bool GreaterThanOrEqualAny<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAny<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> LessThan<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> LessThan<T>(Vector<T> left, Vector<T> right);
+-        public static bool LessThanAll<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool LessThanAll<T>(Vector<T> left, Vector<T> right);
+-        public static bool LessThanAny<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool LessThanAny<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> LessThanOrEqual<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> LessThanOrEqual<T>(Vector<T> left, Vector<T> right);
+-        public static bool LessThanOrEqualAll<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool LessThanOrEqualAll<T>(Vector<T> left, Vector<T> right);
+-        public static bool LessThanOrEqualAny<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static bool LessThanOrEqualAny<T>(Vector<T> left, Vector<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector<T> Load<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector<T> Load<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector<T> LoadAligned<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector<T> LoadAligned<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector<T> LoadAlignedNonTemporal<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector<T> LoadAlignedNonTemporal<T>(T* source);
+-        public static Vector<T> LoadUnsafe<T>(ref T source) where T : struct;
++        public static Vector<T> LoadUnsafe<T>(ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
+-        public static Vector<T> Max<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Max<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> Min<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Min<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> Multiply<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Multiply<T>(Vector<T> left, Vector<T> right);
+-        public static Vector<T> Multiply<T>(Vector<T> left, T right) where T : struct;
++        public static Vector<T> Multiply<T>(Vector<T> left, T right);
+-        public static Vector<T> Multiply<T>(T left, Vector<T> right) where T : struct;
++        public static Vector<T> Multiply<T>(T left, Vector<T> right);
+-        public static Vector<T> Negate<T>(Vector<T> value) where T : struct;
++        public static Vector<T> Negate<T>(Vector<T> value);
+-        public static Vector<T> OnesComplement<T>(Vector<T> value) where T : struct;
++        public static Vector<T> OnesComplement<T>(Vector<T> value);
+-        public static Vector<T> SquareRoot<T>(Vector<T> value) where T : struct;
++        public static Vector<T> SquareRoot<T>(Vector<T> value);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Store<T>(this Vector<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Store<T>(this Vector<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAligned<T>(this Vector<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAligned<T>(this Vector<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAlignedNonTemporal<T>(this Vector<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAlignedNonTemporal<T>(this Vector<T> source, T* destination);
+-        public static void StoreUnsafe<T>(this Vector<T> source, ref T destination) where T : struct;
++        public static void StoreUnsafe<T>(this Vector<T> source, ref T destination);
+-        [CLSCompliantAttribute(false)]
+-        public static void StoreUnsafe<T>(this Vector<T> source, ref T destination, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static void StoreUnsafe<T>(this Vector<T> source, ref T destination, UIntPtr elementOffset);
+-        public static Vector<T> Subtract<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Subtract<T>(Vector<T> left, Vector<T> right);
+-        public static T Sum<T>(Vector<T> value) where T : struct;
++        public static T Sum<T>(Vector<T> value);
+-        public static T ToScalar<T>(this Vector<T> vector) where T : struct;
++        public static T ToScalar<T>(this Vector<T> vector);
+-        public static Vector<T> WithElement<T>(this Vector<T> vector, int index, T value) where T : struct;
++        public static Vector<T> WithElement<T>(this Vector<T> vector, int index, T value);
+-        public static Vector<T> Xor<T>(Vector<T> left, Vector<T> right) where T : struct;
++        public static Vector<T> Xor<T>(Vector<T> left, Vector<T> right);
+     }
+-    public readonly struct Vector<T> : IEquatable<Vector<T>>, IFormattable where T : struct
++    public readonly struct Vector<T> : IEquatable<Vector<T>>, IFormattable
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.CompilerServices.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.CompilerServices.md
@@ -1,0 +1,20 @@
+# System.Runtime.CompilerServices
+
+``` diff
+ namespace System.Runtime.CompilerServices {
++    [AttributeUsageAttribute(AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
++    public sealed class UnsafeAccessorAttribute : Attribute {
++        public UnsafeAccessorAttribute(UnsafeAccessorKind kind);
++        public UnsafeAccessorKind Kind { get; }
++        public string Name { get; set; }
++    }
++    public enum UnsafeAccessorKind {
++        Constructor = 0,
++        Field = 3,
++        Method = 1,
++        StaticField = 4,
++        StaticMethod = 2,
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.InteropServices.Marshalling.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.InteropServices.Marshalling.md
@@ -1,0 +1,36 @@
+# System.Runtime.InteropServices.Marshalling
+
+``` diff
+ namespace System.Runtime.InteropServices.Marshalling {
+     [CLSCompliantAttribute(false)]
+     [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder), MarshalMode.Default, typeof(ComInterfaceMarshaller<>))]
+     [UnsupportedOSPlatformAttribute("android")]
+     [UnsupportedOSPlatformAttribute("browser")]
+     [UnsupportedOSPlatformAttribute("ios")]
+     [UnsupportedOSPlatformAttribute("tvos")]
+     public static class ComInterfaceMarshaller<T> {
++        public unsafe static void Free(void* unmanaged);
+     }
++    [FlagsAttribute]
++    public enum ComInterfaceOptions {
++        ComObjectWrapper = 2,
++        ManagedObjectWrapper = 1,
++        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++        None = 0,
++    }
+     [AttributeUsageAttribute(AttributeTargets.Interface)]
+     public class GeneratedComInterfaceAttribute : Attribute {
++        public ComInterfaceOptions Options { get; set; }
+     }
+     [CLSCompliantAttribute(false)]
+     [CustomMarshallerAttribute(typeof(CustomMarshallerAttribute.GenericPlaceholder), MarshalMode.Default, typeof(UniqueComInterfaceMarshaller<>))]
+     [UnsupportedOSPlatformAttribute("android")]
+     [UnsupportedOSPlatformAttribute("browser")]
+     [UnsupportedOSPlatformAttribute("ios")]
+     [UnsupportedOSPlatformAttribute("tvos")]
+     public static class UniqueComInterfaceMarshaller<T> {
++        public unsafe static void Free(void* unmanaged);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.Wasm.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.Wasm.md
@@ -1,0 +1,84 @@
+# System.Runtime.Intrinsics.Wasm
+
+``` diff
+ namespace System.Runtime.Intrinsics.Wasm {
+     [CLSCompliantAttribute(false)]
+     public abstract class PackedSimd {
++        public unsafe static Vector128<byte> LoadScalarAndInsert(byte* address, Vector128<byte> vector, [ConstantExpectedAttribute(Max=(byte)15)] byte index);
++        public unsafe static Vector128<double> LoadScalarAndInsert(double* address, Vector128<double> vector, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static Vector128<short> LoadScalarAndInsert(short* address, Vector128<short> vector, [ConstantExpectedAttribute(Max=(byte)7)] byte index);
++        public unsafe static Vector128<int> LoadScalarAndInsert(int* address, Vector128<int> vector, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static Vector128<long> LoadScalarAndInsert(long* address, Vector128<long> vector, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static Vector128<IntPtr> LoadScalarAndInsert(IntPtr* address, Vector128<IntPtr> vector, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static Vector128<sbyte> LoadScalarAndInsert(sbyte* address, Vector128<sbyte> vector, [ConstantExpectedAttribute(Max=(byte)15)] byte index);
++        public unsafe static Vector128<float> LoadScalarAndInsert(float* address, Vector128<float> vector, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static Vector128<ushort> LoadScalarAndInsert(ushort* address, Vector128<ushort> vector, [ConstantExpectedAttribute(Max=(byte)7)] byte index);
++        public unsafe static Vector128<uint> LoadScalarAndInsert(uint* address, Vector128<uint> vector, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static Vector128<ulong> LoadScalarAndInsert(ulong* address, Vector128<ulong> vector, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static Vector128<UIntPtr> LoadScalarAndInsert(UIntPtr* address, Vector128<UIntPtr> vector, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static Vector128<byte> LoadScalarAndSplatVector128(byte* address);
++        public unsafe static Vector128<double> LoadScalarAndSplatVector128(double* address);
++        public unsafe static Vector128<short> LoadScalarAndSplatVector128(short* address);
++        public unsafe static Vector128<int> LoadScalarAndSplatVector128(int* address);
++        public unsafe static Vector128<long> LoadScalarAndSplatVector128(long* address);
++        public unsafe static Vector128<IntPtr> LoadScalarAndSplatVector128(IntPtr* address);
++        public unsafe static Vector128<sbyte> LoadScalarAndSplatVector128(sbyte* address);
++        public unsafe static Vector128<float> LoadScalarAndSplatVector128(float* address);
++        public unsafe static Vector128<ushort> LoadScalarAndSplatVector128(ushort* address);
++        public unsafe static Vector128<uint> LoadScalarAndSplatVector128(uint* address);
++        public unsafe static Vector128<ulong> LoadScalarAndSplatVector128(ulong* address);
++        public unsafe static Vector128<UIntPtr> LoadScalarAndSplatVector128(UIntPtr* address);
++        public unsafe static Vector128<double> LoadScalarVector128(double* address);
++        public unsafe static Vector128<int> LoadScalarVector128(int* address);
++        public unsafe static Vector128<long> LoadScalarVector128(long* address);
++        public unsafe static Vector128<IntPtr> LoadScalarVector128(IntPtr* address);
++        public unsafe static Vector128<float> LoadScalarVector128(float* address);
++        public unsafe static Vector128<uint> LoadScalarVector128(uint* address);
++        public unsafe static Vector128<ulong> LoadScalarVector128(ulong* address);
++        public unsafe static Vector128<UIntPtr> LoadScalarVector128(UIntPtr* address);
++        public unsafe static Vector128<byte> LoadVector128(byte* address);
++        public unsafe static Vector128<double> LoadVector128(double* address);
++        public unsafe static Vector128<short> LoadVector128(short* address);
++        public unsafe static Vector128<int> LoadVector128(int* address);
++        public unsafe static Vector128<long> LoadVector128(long* address);
++        public unsafe static Vector128<IntPtr> LoadVector128(IntPtr* address);
++        public unsafe static Vector128<sbyte> LoadVector128(sbyte* address);
++        public unsafe static Vector128<float> LoadVector128(float* address);
++        public unsafe static Vector128<ushort> LoadVector128(ushort* address);
++        public unsafe static Vector128<uint> LoadVector128(uint* address);
++        public unsafe static Vector128<ulong> LoadVector128(ulong* address);
++        public unsafe static Vector128<UIntPtr> LoadVector128(UIntPtr* address);
++        public unsafe static Vector128<ushort> LoadWideningVector128(byte* address);
++        public unsafe static Vector128<int> LoadWideningVector128(short* address);
++        public unsafe static Vector128<long> LoadWideningVector128(int* address);
++        public unsafe static Vector128<short> LoadWideningVector128(sbyte* address);
++        public unsafe static Vector128<uint> LoadWideningVector128(ushort* address);
++        public unsafe static Vector128<ulong> LoadWideningVector128(uint* address);
++        public unsafe static void Store(byte* address, Vector128<byte> source);
++        public unsafe static void Store(double* address, Vector128<double> source);
++        public unsafe static void Store(short* address, Vector128<short> source);
++        public unsafe static void Store(int* address, Vector128<int> source);
++        public unsafe static void Store(long* address, Vector128<long> source);
++        public unsafe static void Store(IntPtr* address, Vector128<IntPtr> source);
++        public unsafe static void Store(sbyte* address, Vector128<sbyte> source);
++        public unsafe static void Store(float* address, Vector128<float> source);
++        public unsafe static void Store(ushort* address, Vector128<ushort> source);
++        public unsafe static void Store(uint* address, Vector128<uint> source);
++        public unsafe static void Store(ulong* address, Vector128<ulong> source);
++        public unsafe static void Store(UIntPtr* address, Vector128<UIntPtr> source);
++        public unsafe static void StoreSelectedScalar(byte* address, Vector128<byte> source, [ConstantExpectedAttribute(Max=(byte)15)] byte index);
++        public unsafe static void StoreSelectedScalar(double* address, Vector128<double> source, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static void StoreSelectedScalar(short* address, Vector128<short> source, [ConstantExpectedAttribute(Max=(byte)7)] byte index);
++        public unsafe static void StoreSelectedScalar(int* address, Vector128<int> source, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static void StoreSelectedScalar(long* address, Vector128<long> source, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static void StoreSelectedScalar(IntPtr* address, Vector128<IntPtr> source, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static void StoreSelectedScalar(sbyte* address, Vector128<sbyte> source, [ConstantExpectedAttribute(Max=(byte)15)] byte index);
++        public unsafe static void StoreSelectedScalar(float* address, Vector128<float> source, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static void StoreSelectedScalar(ushort* address, Vector128<ushort> source, [ConstantExpectedAttribute(Max=(byte)7)] byte index);
++        public unsafe static void StoreSelectedScalar(uint* address, Vector128<uint> source, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
++        public unsafe static void StoreSelectedScalar(ulong* address, Vector128<ulong> source, [ConstantExpectedAttribute(Max=(byte)1)] byte index);
++        public unsafe static void StoreSelectedScalar(UIntPtr* address, Vector128<UIntPtr> source, [ConstantExpectedAttribute(Max=(byte)3)] byte index);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.X86.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.X86.md
@@ -1,0 +1,173 @@
+# System.Runtime.Intrinsics.X86
+
+``` diff
+ namespace System.Runtime.Intrinsics.X86 {
+     [CLSCompliantAttribute(false)]
+     public abstract class Avx512BW : Avx512F {
++        public static Vector512<byte> BlendVariable(Vector512<byte> left, Vector512<byte> right, Vector512<byte> mask);
++        public static Vector512<short> BlendVariable(Vector512<short> left, Vector512<short> right, Vector512<short> mask);
++        public static Vector512<sbyte> BlendVariable(Vector512<sbyte> left, Vector512<sbyte> right, Vector512<sbyte> mask);
++        public static Vector512<ushort> BlendVariable(Vector512<ushort> left, Vector512<ushort> right, Vector512<ushort> mask);
++        public static Vector512<byte> CompareEqual(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareEqual(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareEqual(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareEqual(Vector512<ushort> left, Vector512<ushort> right);
++        public static Vector512<byte> CompareGreaterThan(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareGreaterThan(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareGreaterThan(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareGreaterThan(Vector512<ushort> left, Vector512<ushort> right);
++        public static Vector512<byte> CompareGreaterThanOrEqual(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareGreaterThanOrEqual(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareGreaterThanOrEqual(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareGreaterThanOrEqual(Vector512<ushort> left, Vector512<ushort> right);
++        public static Vector512<byte> CompareLessThan(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareLessThan(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareLessThan(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareLessThan(Vector512<ushort> left, Vector512<ushort> right);
++        public static Vector512<byte> CompareLessThanOrEqual(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareLessThanOrEqual(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareLessThanOrEqual(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareLessThanOrEqual(Vector512<ushort> left, Vector512<ushort> right);
++        public static Vector512<byte> CompareNotEqual(Vector512<byte> left, Vector512<byte> right);
++        public static Vector512<short> CompareNotEqual(Vector512<short> left, Vector512<short> right);
++        public static Vector512<sbyte> CompareNotEqual(Vector512<sbyte> left, Vector512<sbyte> right);
++        public static Vector512<ushort> CompareNotEqual(Vector512<ushort> left, Vector512<ushort> right);
+         public new abstract class VL : Avx512F.VL {
++            public static Vector128<byte> CompareGreaterThan(Vector128<byte> left, Vector128<byte> right);
++            public static Vector128<ushort> CompareGreaterThan(Vector128<ushort> left, Vector128<ushort> right);
++            public static Vector256<byte> CompareGreaterThan(Vector256<byte> left, Vector256<byte> right);
++            public static Vector256<ushort> CompareGreaterThan(Vector256<ushort> left, Vector256<ushort> right);
++            public static Vector128<byte> CompareGreaterThanOrEqual(Vector128<byte> left, Vector128<byte> right);
++            public static Vector128<short> CompareGreaterThanOrEqual(Vector128<short> left, Vector128<short> right);
++            public static Vector128<sbyte> CompareGreaterThanOrEqual(Vector128<sbyte> left, Vector128<sbyte> right);
++            public static Vector128<ushort> CompareGreaterThanOrEqual(Vector128<ushort> left, Vector128<ushort> right);
++            public static Vector256<byte> CompareGreaterThanOrEqual(Vector256<byte> left, Vector256<byte> right);
++            public static Vector256<short> CompareGreaterThanOrEqual(Vector256<short> left, Vector256<short> right);
++            public static Vector256<sbyte> CompareGreaterThanOrEqual(Vector256<sbyte> left, Vector256<sbyte> right);
++            public static Vector256<ushort> CompareGreaterThanOrEqual(Vector256<ushort> left, Vector256<ushort> right);
++            public static Vector128<byte> CompareLessThan(Vector128<byte> left, Vector128<byte> right);
++            public static Vector128<short> CompareLessThan(Vector128<short> left, Vector128<short> right);
++            public static Vector128<sbyte> CompareLessThan(Vector128<sbyte> left, Vector128<sbyte> right);
++            public static Vector128<ushort> CompareLessThan(Vector128<ushort> left, Vector128<ushort> right);
++            public static Vector256<byte> CompareLessThan(Vector256<byte> left, Vector256<byte> right);
++            public static Vector256<short> CompareLessThan(Vector256<short> left, Vector256<short> right);
++            public static Vector256<sbyte> CompareLessThan(Vector256<sbyte> left, Vector256<sbyte> right);
++            public static Vector256<ushort> CompareLessThan(Vector256<ushort> left, Vector256<ushort> right);
++            public static Vector128<byte> CompareLessThanOrEqual(Vector128<byte> left, Vector128<byte> right);
++            public static Vector128<short> CompareLessThanOrEqual(Vector128<short> left, Vector128<short> right);
++            public static Vector128<sbyte> CompareLessThanOrEqual(Vector128<sbyte> left, Vector128<sbyte> right);
++            public static Vector128<ushort> CompareLessThanOrEqual(Vector128<ushort> left, Vector128<ushort> right);
++            public static Vector256<byte> CompareLessThanOrEqual(Vector256<byte> left, Vector256<byte> right);
++            public static Vector256<short> CompareLessThanOrEqual(Vector256<short> left, Vector256<short> right);
++            public static Vector256<sbyte> CompareLessThanOrEqual(Vector256<sbyte> left, Vector256<sbyte> right);
++            public static Vector256<ushort> CompareLessThanOrEqual(Vector256<ushort> left, Vector256<ushort> right);
++            public static Vector128<byte> CompareNotEqual(Vector128<byte> left, Vector128<byte> right);
++            public static Vector128<short> CompareNotEqual(Vector128<short> left, Vector128<short> right);
++            public static Vector128<sbyte> CompareNotEqual(Vector128<sbyte> left, Vector128<sbyte> right);
++            public static Vector128<ushort> CompareNotEqual(Vector128<ushort> left, Vector128<ushort> right);
++            public static Vector256<byte> CompareNotEqual(Vector256<byte> left, Vector256<byte> right);
++            public static Vector256<short> CompareNotEqual(Vector256<short> left, Vector256<short> right);
++            public static Vector256<sbyte> CompareNotEqual(Vector256<sbyte> left, Vector256<sbyte> right);
++            public static Vector256<ushort> CompareNotEqual(Vector256<ushort> left, Vector256<ushort> right);
+         }
+     }
+     [CLSCompliantAttribute(false)]
+     public abstract class Avx512F : Avx2 {
++        public static Vector512<double> BlendVariable(Vector512<double> left, Vector512<double> right, Vector512<double> mask);
++        public static Vector512<int> BlendVariable(Vector512<int> left, Vector512<int> right, Vector512<int> mask);
++        public static Vector512<long> BlendVariable(Vector512<long> left, Vector512<long> right, Vector512<long> mask);
++        public static Vector512<float> BlendVariable(Vector512<float> left, Vector512<float> right, Vector512<float> mask);
++        public static Vector512<uint> BlendVariable(Vector512<uint> left, Vector512<uint> right, Vector512<uint> mask);
++        public static Vector512<ulong> BlendVariable(Vector512<ulong> left, Vector512<ulong> right, Vector512<ulong> mask);
++        public static Vector512<double> Compare(Vector512<double> left, Vector512<double> right, [ConstantExpectedAttribute(Max=FloatComparisonMode.UnorderedTrueSignaling)] FloatComparisonMode mode);
++        public static Vector512<float> Compare(Vector512<float> left, Vector512<float> right, [ConstantExpectedAttribute(Max=FloatComparisonMode.UnorderedTrueSignaling)] FloatComparisonMode mode);
++        public static Vector512<double> CompareEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareEqual(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareEqual(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareEqual(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareEqual(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareGreaterThan(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareGreaterThan(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareGreaterThan(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareGreaterThan(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareGreaterThan(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareGreaterThan(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareGreaterThanOrEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareGreaterThanOrEqual(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareGreaterThanOrEqual(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareGreaterThanOrEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareGreaterThanOrEqual(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareGreaterThanOrEqual(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareLessThan(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareLessThan(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareLessThan(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareLessThan(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareLessThan(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareLessThan(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareLessThanOrEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareLessThanOrEqual(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareLessThanOrEqual(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareLessThanOrEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareLessThanOrEqual(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareLessThanOrEqual(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareNotEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<int> CompareNotEqual(Vector512<int> left, Vector512<int> right);
++        public static Vector512<long> CompareNotEqual(Vector512<long> left, Vector512<long> right);
++        public static Vector512<float> CompareNotEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<uint> CompareNotEqual(Vector512<uint> left, Vector512<uint> right);
++        public static Vector512<ulong> CompareNotEqual(Vector512<ulong> left, Vector512<ulong> right);
++        public static Vector512<double> CompareNotGreaterThan(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareNotGreaterThan(Vector512<float> left, Vector512<float> right);
++        public static Vector512<double> CompareNotGreaterThanOrEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareNotGreaterThanOrEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<double> CompareNotLessThan(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareNotLessThan(Vector512<float> left, Vector512<float> right);
++        public static Vector512<double> CompareNotLessThanOrEqual(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareNotLessThanOrEqual(Vector512<float> left, Vector512<float> right);
++        public static Vector512<double> CompareOrdered(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareOrdered(Vector512<float> left, Vector512<float> right);
++        public static Vector512<double> CompareUnordered(Vector512<double> left, Vector512<double> right);
++        public static Vector512<float> CompareUnordered(Vector512<float> left, Vector512<float> right);
+         public abstract class VL {
++            public static Vector128<uint> CompareGreaterThan(Vector128<uint> left, Vector128<uint> right);
++            public static Vector128<ulong> CompareGreaterThan(Vector128<ulong> left, Vector128<ulong> right);
++            public static Vector256<uint> CompareGreaterThan(Vector256<uint> left, Vector256<uint> right);
++            public static Vector256<ulong> CompareGreaterThan(Vector256<ulong> left, Vector256<ulong> right);
++            public static Vector128<int> CompareGreaterThanOrEqual(Vector128<int> left, Vector128<int> right);
++            public static Vector128<long> CompareGreaterThanOrEqual(Vector128<long> left, Vector128<long> right);
++            public static Vector128<uint> CompareGreaterThanOrEqual(Vector128<uint> left, Vector128<uint> right);
++            public static Vector128<ulong> CompareGreaterThanOrEqual(Vector128<ulong> left, Vector128<ulong> right);
++            public static Vector256<int> CompareGreaterThanOrEqual(Vector256<int> left, Vector256<int> right);
++            public static Vector256<long> CompareGreaterThanOrEqual(Vector256<long> left, Vector256<long> right);
++            public static Vector256<uint> CompareGreaterThanOrEqual(Vector256<uint> left, Vector256<uint> right);
++            public static Vector256<ulong> CompareGreaterThanOrEqual(Vector256<ulong> left, Vector256<ulong> right);
++            public static Vector128<int> CompareLessThan(Vector128<int> left, Vector128<int> right);
++            public static Vector128<long> CompareLessThan(Vector128<long> left, Vector128<long> right);
++            public static Vector128<uint> CompareLessThan(Vector128<uint> left, Vector128<uint> right);
++            public static Vector128<ulong> CompareLessThan(Vector128<ulong> left, Vector128<ulong> right);
++            public static Vector256<int> CompareLessThan(Vector256<int> left, Vector256<int> right);
++            public static Vector256<long> CompareLessThan(Vector256<long> left, Vector256<long> right);
++            public static Vector256<uint> CompareLessThan(Vector256<uint> left, Vector256<uint> right);
++            public static Vector256<ulong> CompareLessThan(Vector256<ulong> left, Vector256<ulong> right);
++            public static Vector128<int> CompareLessThanOrEqual(Vector128<int> left, Vector128<int> right);
++            public static Vector128<long> CompareLessThanOrEqual(Vector128<long> left, Vector128<long> right);
++            public static Vector128<uint> CompareLessThanOrEqual(Vector128<uint> left, Vector128<uint> right);
++            public static Vector128<ulong> CompareLessThanOrEqual(Vector128<ulong> left, Vector128<ulong> right);
++            public static Vector256<int> CompareLessThanOrEqual(Vector256<int> left, Vector256<int> right);
++            public static Vector256<long> CompareLessThanOrEqual(Vector256<long> left, Vector256<long> right);
++            public static Vector256<uint> CompareLessThanOrEqual(Vector256<uint> left, Vector256<uint> right);
++            public static Vector256<ulong> CompareLessThanOrEqual(Vector256<ulong> left, Vector256<ulong> right);
++            public static Vector128<int> CompareNotEqual(Vector128<int> left, Vector128<int> right);
++            public static Vector128<long> CompareNotEqual(Vector128<long> left, Vector128<long> right);
++            public static Vector128<uint> CompareNotEqual(Vector128<uint> left, Vector128<uint> right);
++            public static Vector128<ulong> CompareNotEqual(Vector128<ulong> left, Vector128<ulong> right);
++            public static Vector256<int> CompareNotEqual(Vector256<int> left, Vector256<int> right);
++            public static Vector256<long> CompareNotEqual(Vector256<long> left, Vector256<long> right);
++            public static Vector256<uint> CompareNotEqual(Vector256<uint> left, Vector256<uint> right);
++            public static Vector256<ulong> CompareNotEqual(Vector256<ulong> left, Vector256<ulong> right);
+         }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Runtime.Intrinsics.md
@@ -1,0 +1,765 @@
+# System.Runtime.Intrinsics
+
+``` diff
+ namespace System.Runtime.Intrinsics {
+     public static class Vector128 {
+-        public static Vector128<T> Abs<T>(Vector128<T> vector) where T : struct;
++        public static Vector128<T> Abs<T>(Vector128<T> vector);
+-        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<TTo> As<TFrom, TTo>(this Vector128<TFrom> vector) where TFrom : struct where TTo : struct;
++        public static Vector128<TTo> As<TFrom, TTo>(this Vector128<TFrom> vector);
+-        public static Vector128<byte> AsByte<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<byte> AsByte<T>(this Vector128<T> vector);
+-        public static Vector128<double> AsDouble<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<double> AsDouble<T>(this Vector128<T> vector);
+-        public static Vector128<short> AsInt16<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<short> AsInt16<T>(this Vector128<T> vector);
+-        public static Vector128<int> AsInt32<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<int> AsInt32<T>(this Vector128<T> vector);
+-        public static Vector128<long> AsInt64<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<long> AsInt64<T>(this Vector128<T> vector);
+-        public static Vector128<IntPtr> AsNInt<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<IntPtr> AsNInt<T>(this Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<UIntPtr> AsNUInt<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<UIntPtr> AsNUInt<T>(this Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<sbyte> AsSByte<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<sbyte> AsSByte<T>(this Vector128<T> vector);
+-        public static Vector128<float> AsSingle<T>(this Vector128<T> vector) where T : struct;
++        public static Vector128<float> AsSingle<T>(this Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<ushort> AsUInt16<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<ushort> AsUInt16<T>(this Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<uint> AsUInt32<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<uint> AsUInt32<T>(this Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<ulong> AsUInt64<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<ulong> AsUInt64<T>(this Vector128<T> vector);
+-        public static Vector128<T> AsVector128<T>(this Vector<T> value) where T : struct;
++        public static Vector128<T> AsVector128<T>(this Vector<T> value);
+-        public static Vector<T> AsVector<T>(this Vector128<T> value) where T : struct;
++        public static Vector<T> AsVector<T>(this Vector128<T> value);
+-        public static Vector128<T> BitwiseAnd<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> BitwiseAnd<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> BitwiseOr<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> BitwiseOr<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> ConditionalSelect<T>(Vector128<T> condition, Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> ConditionalSelect<T>(Vector128<T> condition, Vector128<T> left, Vector128<T> right);
+-        public static void CopyTo<T>(this Vector128<T> vector, Span<T> destination) where T : struct;
++        public static void CopyTo<T>(this Vector128<T> vector, Span<T> destination);
+-        public static void CopyTo<T>(this Vector128<T> vector, T[] destination) where T : struct;
++        public static void CopyTo<T>(this Vector128<T> vector, T[] destination);
+-        public static void CopyTo<T>(this Vector128<T> vector, T[] destination, int startIndex) where T : struct;
++        public static void CopyTo<T>(this Vector128<T> vector, T[] destination, int startIndex);
+-        public static Vector128<T> Create<T>(ReadOnlySpan<T> values) where T : struct;
++        public static Vector128<T> Create<T>(ReadOnlySpan<T> values);
+-        public static Vector128<T> Create<T>(Vector64<T> lower, Vector64<T> upper) where T : struct;
++        public static Vector128<T> Create<T>(Vector64<T> lower, Vector64<T> upper);
+-        public static Vector128<T> Create<T>(T value) where T : struct;
++        public static Vector128<T> Create<T>(T value);
+-        public static Vector128<T> Create<T>(T[] values) where T : struct;
++        public static Vector128<T> Create<T>(T[] values);
+-        public static Vector128<T> Create<T>(T[] values, int index) where T : struct;
++        public static Vector128<T> Create<T>(T[] values, int index);
+-        public static Vector128<T> CreateScalar<T>(T value) where T : struct;
++        public static Vector128<T> CreateScalar<T>(T value);
+-        public static Vector128<T> CreateScalarUnsafe<T>(T value) where T : struct;
++        public static Vector128<T> CreateScalarUnsafe<T>(T value);
+-        public static Vector128<T> Divide<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Divide<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> Divide<T>(Vector128<T> left, T right) where T : struct;
++        public static Vector128<T> Divide<T>(Vector128<T> left, T right);
+-        public static T Dot<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static T Dot<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> Equals<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Equals<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool EqualsAll<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool EqualsAll<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool EqualsAny<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool EqualsAny<T>(Vector128<T> left, Vector128<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public static uint ExtractMostSignificantBits<T>(this Vector128<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static uint ExtractMostSignificantBits<T>(this Vector128<T> vector);
+-        public static T GetElement<T>(this Vector128<T> vector, int index) where T : struct;
++        public static T GetElement<T>(this Vector128<T> vector, int index);
+-        public static Vector64<T> GetLower<T>(this Vector128<T> vector) where T : struct;
++        public static Vector64<T> GetLower<T>(this Vector128<T> vector);
+-        public static Vector64<T> GetUpper<T>(this Vector128<T> vector) where T : struct;
++        public static Vector64<T> GetUpper<T>(this Vector128<T> vector);
+-        public static Vector128<T> GreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> GreaterThan<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool GreaterThanAll<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool GreaterThanAll<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool GreaterThanAny<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool GreaterThanAny<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> GreaterThanOrEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> GreaterThanOrEqual<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool GreaterThanOrEqualAll<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAll<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool GreaterThanOrEqualAny<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAny<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> LessThan<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> LessThan<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool LessThanAll<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool LessThanAll<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool LessThanAny<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool LessThanAny<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> LessThanOrEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> LessThanOrEqual<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool LessThanOrEqualAll<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool LessThanOrEqualAll<T>(Vector128<T> left, Vector128<T> right);
+-        public static bool LessThanOrEqualAny<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static bool LessThanOrEqualAny<T>(Vector128<T> left, Vector128<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector128<T> Load<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector128<T> Load<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector128<T> LoadAligned<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector128<T> LoadAligned<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector128<T> LoadAlignedNonTemporal<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector128<T> LoadAlignedNonTemporal<T>(T* source);
+-        public static Vector128<T> LoadUnsafe<T>(ref T source) where T : struct;
++        public static Vector128<T> LoadUnsafe<T>(ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector128<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
+-        public static Vector128<T> Max<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Max<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> Min<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Min<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> Multiply<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Multiply<T>(Vector128<T> left, Vector128<T> right);
+-        public static Vector128<T> Multiply<T>(Vector128<T> left, T right) where T : struct;
++        public static Vector128<T> Multiply<T>(Vector128<T> left, T right);
+-        public static Vector128<T> Multiply<T>(T left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Multiply<T>(T left, Vector128<T> right);
+-        public static Vector128<T> Negate<T>(Vector128<T> vector) where T : struct;
++        public static Vector128<T> Negate<T>(Vector128<T> vector);
+-        public static Vector128<T> OnesComplement<T>(Vector128<T> vector) where T : struct;
++        public static Vector128<T> OnesComplement<T>(Vector128<T> vector);
+-        public static Vector128<T> Sqrt<T>(Vector128<T> vector) where T : struct;
++        public static Vector128<T> Sqrt<T>(Vector128<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Store<T>(this Vector128<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Store<T>(this Vector128<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAligned<T>(this Vector128<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAligned<T>(this Vector128<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAlignedNonTemporal<T>(this Vector128<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAlignedNonTemporal<T>(this Vector128<T> source, T* destination);
+-        public static void StoreUnsafe<T>(this Vector128<T> source, ref T destination) where T : struct;
++        public static void StoreUnsafe<T>(this Vector128<T> source, ref T destination);
+-        [CLSCompliantAttribute(false)]
+-        public static void StoreUnsafe<T>(this Vector128<T> source, ref T destination, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static void StoreUnsafe<T>(this Vector128<T> source, ref T destination, UIntPtr elementOffset);
+-        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right);
+-        public static T Sum<T>(Vector128<T> vector) where T : struct;
++        public static T Sum<T>(Vector128<T> vector);
+-        public static T ToScalar<T>(this Vector128<T> vector) where T : struct;
++        public static T ToScalar<T>(this Vector128<T> vector);
+-        public static Vector256<T> ToVector256<T>(this Vector128<T> vector) where T : struct;
++        public static Vector256<T> ToVector256<T>(this Vector128<T> vector);
+-        public static Vector256<T> ToVector256Unsafe<T>(this Vector128<T> vector) where T : struct;
++        public static Vector256<T> ToVector256Unsafe<T>(this Vector128<T> vector);
+-        public static bool TryCopyTo<T>(this Vector128<T> vector, Span<T> destination) where T : struct;
++        public static bool TryCopyTo<T>(this Vector128<T> vector, Span<T> destination);
+-        public static Vector128<T> WithElement<T>(this Vector128<T> vector, int index, T value) where T : struct;
++        public static Vector128<T> WithElement<T>(this Vector128<T> vector, int index, T value);
+-        public static Vector128<T> WithLower<T>(this Vector128<T> vector, Vector64<T> value) where T : struct;
++        public static Vector128<T> WithLower<T>(this Vector128<T> vector, Vector64<T> value);
+-        public static Vector128<T> WithUpper<T>(this Vector128<T> vector, Vector64<T> value) where T : struct;
++        public static Vector128<T> WithUpper<T>(this Vector128<T> vector, Vector64<T> value);
+-        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct;
++        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right);
+     }
+-    public readonly struct Vector128<T> : IEquatable<Vector128<T>> where T : struct
++    public readonly struct Vector128<T> : IEquatable<Vector128<T>>
+     public static class Vector256 {
+-        public static Vector256<T> Abs<T>(Vector256<T> vector) where T : struct;
++        public static Vector256<T> Abs<T>(Vector256<T> vector);
+-        public static Vector256<T> Add<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Add<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> AndNot<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> AndNot<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<TTo> As<TFrom, TTo>(this Vector256<TFrom> vector) where TFrom : struct where TTo : struct;
++        public static Vector256<TTo> As<TFrom, TTo>(this Vector256<TFrom> vector);
+-        public static Vector256<byte> AsByte<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<byte> AsByte<T>(this Vector256<T> vector);
+-        public static Vector256<double> AsDouble<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<double> AsDouble<T>(this Vector256<T> vector);
+-        public static Vector256<short> AsInt16<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<short> AsInt16<T>(this Vector256<T> vector);
+-        public static Vector256<int> AsInt32<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<int> AsInt32<T>(this Vector256<T> vector);
+-        public static Vector256<long> AsInt64<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<long> AsInt64<T>(this Vector256<T> vector);
+-        public static Vector256<IntPtr> AsNInt<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<IntPtr> AsNInt<T>(this Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<UIntPtr> AsNUInt<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<UIntPtr> AsNUInt<T>(this Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<sbyte> AsSByte<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<sbyte> AsSByte<T>(this Vector256<T> vector);
+-        public static Vector256<float> AsSingle<T>(this Vector256<T> vector) where T : struct;
++        public static Vector256<float> AsSingle<T>(this Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<ushort> AsUInt16<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<ushort> AsUInt16<T>(this Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<uint> AsUInt32<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<uint> AsUInt32<T>(this Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<ulong> AsUInt64<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<ulong> AsUInt64<T>(this Vector256<T> vector);
+-        public static Vector256<T> AsVector256<T>(this Vector<T> value) where T : struct;
++        public static Vector256<T> AsVector256<T>(this Vector<T> value);
+-        public static Vector<T> AsVector<T>(this Vector256<T> value) where T : struct;
++        public static Vector<T> AsVector<T>(this Vector256<T> value);
+-        public static Vector256<T> BitwiseAnd<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> BitwiseAnd<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> BitwiseOr<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> BitwiseOr<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> ConditionalSelect<T>(Vector256<T> condition, Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> ConditionalSelect<T>(Vector256<T> condition, Vector256<T> left, Vector256<T> right);
+-        public static void CopyTo<T>(this Vector256<T> vector, Span<T> destination) where T : struct;
++        public static void CopyTo<T>(this Vector256<T> vector, Span<T> destination);
+-        public static void CopyTo<T>(this Vector256<T> vector, T[] destination) where T : struct;
++        public static void CopyTo<T>(this Vector256<T> vector, T[] destination);
+-        public static void CopyTo<T>(this Vector256<T> vector, T[] destination, int startIndex) where T : struct;
++        public static void CopyTo<T>(this Vector256<T> vector, T[] destination, int startIndex);
+-        public static Vector256<T> Create<T>(ReadOnlySpan<T> values) where T : struct;
++        public static Vector256<T> Create<T>(ReadOnlySpan<T> values);
+-        public static Vector256<T> Create<T>(Vector128<T> lower, Vector128<T> upper) where T : struct;
++        public static Vector256<T> Create<T>(Vector128<T> lower, Vector128<T> upper);
+-        public static Vector256<T> Create<T>(T value) where T : struct;
++        public static Vector256<T> Create<T>(T value);
+-        public static Vector256<T> Create<T>(T[] values) where T : struct;
++        public static Vector256<T> Create<T>(T[] values);
+-        public static Vector256<T> Create<T>(T[] values, int index) where T : struct;
++        public static Vector256<T> Create<T>(T[] values, int index);
+-        public static Vector256<T> CreateScalar<T>(T value) where T : struct;
++        public static Vector256<T> CreateScalar<T>(T value);
+-        public static Vector256<T> CreateScalarUnsafe<T>(T value) where T : struct;
++        public static Vector256<T> CreateScalarUnsafe<T>(T value);
+-        public static Vector256<T> Divide<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Divide<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> Divide<T>(Vector256<T> left, T right) where T : struct;
++        public static Vector256<T> Divide<T>(Vector256<T> left, T right);
+-        public static T Dot<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static T Dot<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> Equals<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Equals<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool EqualsAll<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool EqualsAll<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool EqualsAny<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool EqualsAny<T>(Vector256<T> left, Vector256<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public static uint ExtractMostSignificantBits<T>(this Vector256<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static uint ExtractMostSignificantBits<T>(this Vector256<T> vector);
+-        public static T GetElement<T>(this Vector256<T> vector, int index) where T : struct;
++        public static T GetElement<T>(this Vector256<T> vector, int index);
+-        public static Vector128<T> GetLower<T>(this Vector256<T> vector) where T : struct;
++        public static Vector128<T> GetLower<T>(this Vector256<T> vector);
+-        public static Vector128<T> GetUpper<T>(this Vector256<T> vector) where T : struct;
++        public static Vector128<T> GetUpper<T>(this Vector256<T> vector);
+-        public static Vector256<T> GreaterThan<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> GreaterThan<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool GreaterThanAll<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool GreaterThanAll<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool GreaterThanAny<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool GreaterThanAny<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> GreaterThanOrEqual<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> GreaterThanOrEqual<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool GreaterThanOrEqualAll<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAll<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool GreaterThanOrEqualAny<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAny<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> LessThan<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> LessThan<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool LessThanAll<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool LessThanAll<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool LessThanAny<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool LessThanAny<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> LessThanOrEqual<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> LessThanOrEqual<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool LessThanOrEqualAll<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool LessThanOrEqualAll<T>(Vector256<T> left, Vector256<T> right);
+-        public static bool LessThanOrEqualAny<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static bool LessThanOrEqualAny<T>(Vector256<T> left, Vector256<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector256<T> Load<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector256<T> Load<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector256<T> LoadAligned<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector256<T> LoadAligned<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector256<T> LoadAlignedNonTemporal<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector256<T> LoadAlignedNonTemporal<T>(T* source);
+-        public static Vector256<T> LoadUnsafe<T>(ref T source) where T : struct;
++        public static Vector256<T> LoadUnsafe<T>(ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector256<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
+-        public static Vector256<T> Max<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Max<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> Min<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Min<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> Multiply<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Multiply<T>(Vector256<T> left, Vector256<T> right);
+-        public static Vector256<T> Multiply<T>(Vector256<T> left, T right) where T : struct;
++        public static Vector256<T> Multiply<T>(Vector256<T> left, T right);
+-        public static Vector256<T> Multiply<T>(T left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Multiply<T>(T left, Vector256<T> right);
+-        public static Vector256<T> Negate<T>(Vector256<T> vector) where T : struct;
++        public static Vector256<T> Negate<T>(Vector256<T> vector);
+-        public static Vector256<T> OnesComplement<T>(Vector256<T> vector) where T : struct;
++        public static Vector256<T> OnesComplement<T>(Vector256<T> vector);
+-        public static Vector256<T> Sqrt<T>(Vector256<T> vector) where T : struct;
++        public static Vector256<T> Sqrt<T>(Vector256<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Store<T>(this Vector256<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Store<T>(this Vector256<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAligned<T>(this Vector256<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAligned<T>(this Vector256<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAlignedNonTemporal<T>(this Vector256<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAlignedNonTemporal<T>(this Vector256<T> source, T* destination);
+-        public static void StoreUnsafe<T>(this Vector256<T> source, ref T destination) where T : struct;
++        public static void StoreUnsafe<T>(this Vector256<T> source, ref T destination);
+-        [CLSCompliantAttribute(false)]
+-        public static void StoreUnsafe<T>(this Vector256<T> source, ref T destination, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static void StoreUnsafe<T>(this Vector256<T> source, ref T destination, UIntPtr elementOffset);
+-        public static Vector256<T> Subtract<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Subtract<T>(Vector256<T> left, Vector256<T> right);
+-        public static T Sum<T>(Vector256<T> vector) where T : struct;
++        public static T Sum<T>(Vector256<T> vector);
+-        public static T ToScalar<T>(this Vector256<T> vector) where T : struct;
++        public static T ToScalar<T>(this Vector256<T> vector);
+-        public static Vector512<T> ToVector512<T>(this Vector256<T> vector) where T : struct;
++        public static Vector512<T> ToVector512<T>(this Vector256<T> vector);
+-        public static Vector512<T> ToVector512Unsafe<T>(this Vector256<T> vector) where T : struct;
++        public static Vector512<T> ToVector512Unsafe<T>(this Vector256<T> vector);
+-        public static bool TryCopyTo<T>(this Vector256<T> vector, Span<T> destination) where T : struct;
++        public static bool TryCopyTo<T>(this Vector256<T> vector, Span<T> destination);
+-        public static Vector256<T> WithElement<T>(this Vector256<T> vector, int index, T value) where T : struct;
++        public static Vector256<T> WithElement<T>(this Vector256<T> vector, int index, T value);
+-        public static Vector256<T> WithLower<T>(this Vector256<T> vector, Vector128<T> value) where T : struct;
++        public static Vector256<T> WithLower<T>(this Vector256<T> vector, Vector128<T> value);
+-        public static Vector256<T> WithUpper<T>(this Vector256<T> vector, Vector128<T> value) where T : struct;
++        public static Vector256<T> WithUpper<T>(this Vector256<T> vector, Vector128<T> value);
+-        public static Vector256<T> Xor<T>(Vector256<T> left, Vector256<T> right) where T : struct;
++        public static Vector256<T> Xor<T>(Vector256<T> left, Vector256<T> right);
+     }
+-    public readonly struct Vector256<T> : IEquatable<Vector256<T>> where T : struct
++    public readonly struct Vector256<T> : IEquatable<Vector256<T>>
+     public static class Vector512 {
+-        public static Vector512<T> Abs<T>(Vector512<T> vector) where T : struct;
++        public static Vector512<T> Abs<T>(Vector512<T> vector);
+-        public static Vector512<T> Add<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Add<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> AndNot<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> AndNot<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<TTo> As<TFrom, TTo>(this Vector512<TFrom> vector) where TFrom : struct where TTo : struct;
++        public static Vector512<TTo> As<TFrom, TTo>(this Vector512<TFrom> vector);
+-        public static Vector512<byte> AsByte<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<byte> AsByte<T>(this Vector512<T> vector);
+-        public static Vector512<double> AsDouble<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<double> AsDouble<T>(this Vector512<T> vector);
+-        public static Vector512<short> AsInt16<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<short> AsInt16<T>(this Vector512<T> vector);
+-        public static Vector512<int> AsInt32<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<int> AsInt32<T>(this Vector512<T> vector);
+-        public static Vector512<long> AsInt64<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<long> AsInt64<T>(this Vector512<T> vector);
+-        public static Vector512<IntPtr> AsNInt<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<IntPtr> AsNInt<T>(this Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<UIntPtr> AsNUInt<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<UIntPtr> AsNUInt<T>(this Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<sbyte> AsSByte<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<sbyte> AsSByte<T>(this Vector512<T> vector);
+-        public static Vector512<float> AsSingle<T>(this Vector512<T> vector) where T : struct;
++        public static Vector512<float> AsSingle<T>(this Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<ushort> AsUInt16<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<ushort> AsUInt16<T>(this Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<uint> AsUInt32<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<uint> AsUInt32<T>(this Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<ulong> AsUInt64<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<ulong> AsUInt64<T>(this Vector512<T> vector);
+-        public static Vector512<T> AsVector512<T>(this Vector<T> value) where T : struct;
++        public static Vector512<T> AsVector512<T>(this Vector<T> value);
+-        public static Vector<T> AsVector<T>(this Vector512<T> value) where T : struct;
++        public static Vector<T> AsVector<T>(this Vector512<T> value);
+-        public static Vector512<T> BitwiseAnd<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> BitwiseAnd<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> BitwiseOr<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> BitwiseOr<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> ConditionalSelect<T>(Vector512<T> condition, Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> ConditionalSelect<T>(Vector512<T> condition, Vector512<T> left, Vector512<T> right);
+-        public static void CopyTo<T>(this Vector512<T> vector, Span<T> destination) where T : struct;
++        public static void CopyTo<T>(this Vector512<T> vector, Span<T> destination);
+-        public static void CopyTo<T>(this Vector512<T> vector, T[] destination) where T : struct;
++        public static void CopyTo<T>(this Vector512<T> vector, T[] destination);
+-        public static void CopyTo<T>(this Vector512<T> vector, T[] destination, int startIndex) where T : struct;
++        public static void CopyTo<T>(this Vector512<T> vector, T[] destination, int startIndex);
+-        public static Vector512<T> Create<T>(ReadOnlySpan<T> values) where T : struct;
++        public static Vector512<T> Create<T>(ReadOnlySpan<T> values);
+-        public static Vector512<T> Create<T>(Vector256<T> lower, Vector256<T> upper) where T : struct;
++        public static Vector512<T> Create<T>(Vector256<T> lower, Vector256<T> upper);
+-        public static Vector512<T> Create<T>(T value) where T : struct;
++        public static Vector512<T> Create<T>(T value);
+-        public static Vector512<T> Create<T>(T[] values) where T : struct;
++        public static Vector512<T> Create<T>(T[] values);
+-        public static Vector512<T> Create<T>(T[] values, int index) where T : struct;
++        public static Vector512<T> Create<T>(T[] values, int index);
+-        public static Vector512<T> CreateScalar<T>(T value) where T : struct;
++        public static Vector512<T> CreateScalar<T>(T value);
+-        public static Vector512<T> CreateScalarUnsafe<T>(T value) where T : struct;
++        public static Vector512<T> CreateScalarUnsafe<T>(T value);
+-        public static Vector512<T> Divide<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Divide<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> Divide<T>(Vector512<T> left, T right) where T : struct;
++        public static Vector512<T> Divide<T>(Vector512<T> left, T right);
+-        public static T Dot<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static T Dot<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> Equals<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Equals<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool EqualsAll<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool EqualsAll<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool EqualsAny<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool EqualsAny<T>(Vector512<T> left, Vector512<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public static ulong ExtractMostSignificantBits<T>(this Vector512<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static ulong ExtractMostSignificantBits<T>(this Vector512<T> vector);
+-        public static T GetElement<T>(this Vector512<T> vector, int index) where T : struct;
++        public static T GetElement<T>(this Vector512<T> vector, int index);
+-        public static Vector256<T> GetLower<T>(this Vector512<T> vector) where T : struct;
++        public static Vector256<T> GetLower<T>(this Vector512<T> vector);
+-        public static Vector256<T> GetUpper<T>(this Vector512<T> vector) where T : struct;
++        public static Vector256<T> GetUpper<T>(this Vector512<T> vector);
+-        public static Vector512<T> GreaterThan<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> GreaterThan<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool GreaterThanAll<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool GreaterThanAll<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool GreaterThanAny<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool GreaterThanAny<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> GreaterThanOrEqual<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> GreaterThanOrEqual<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool GreaterThanOrEqualAll<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAll<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool GreaterThanOrEqualAny<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAny<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> LessThan<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> LessThan<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool LessThanAll<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool LessThanAll<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool LessThanAny<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool LessThanAny<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> LessThanOrEqual<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> LessThanOrEqual<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool LessThanOrEqualAll<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool LessThanOrEqualAll<T>(Vector512<T> left, Vector512<T> right);
+-        public static bool LessThanOrEqualAny<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static bool LessThanOrEqualAny<T>(Vector512<T> left, Vector512<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector512<T> Load<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector512<T> Load<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector512<T> LoadAligned<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector512<T> LoadAligned<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector512<T> LoadAlignedNonTemporal<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector512<T> LoadAlignedNonTemporal<T>(T* source);
+-        public static Vector512<T> LoadUnsafe<T>(ref T source) where T : struct;
++        public static Vector512<T> LoadUnsafe<T>(ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector512<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
+-        public static Vector512<T> Max<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Max<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> Min<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Min<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> Multiply<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Multiply<T>(Vector512<T> left, Vector512<T> right);
+-        public static Vector512<T> Multiply<T>(Vector512<T> left, T right) where T : struct;
++        public static Vector512<T> Multiply<T>(Vector512<T> left, T right);
+-        public static Vector512<T> Multiply<T>(T left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Multiply<T>(T left, Vector512<T> right);
+-        public static Vector512<T> Negate<T>(Vector512<T> vector) where T : struct;
++        public static Vector512<T> Negate<T>(Vector512<T> vector);
+-        public static Vector512<T> OnesComplement<T>(Vector512<T> vector) where T : struct;
++        public static Vector512<T> OnesComplement<T>(Vector512<T> vector);
+-        public static Vector512<T> Sqrt<T>(Vector512<T> vector) where T : struct;
++        public static Vector512<T> Sqrt<T>(Vector512<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Store<T>(this Vector512<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Store<T>(this Vector512<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAligned<T>(this Vector512<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAligned<T>(this Vector512<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAlignedNonTemporal<T>(this Vector512<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAlignedNonTemporal<T>(this Vector512<T> source, T* destination);
+-        public static void StoreUnsafe<T>(this Vector512<T> source, ref T destination) where T : struct;
++        public static void StoreUnsafe<T>(this Vector512<T> source, ref T destination);
+-        [CLSCompliantAttribute(false)]
+-        public static void StoreUnsafe<T>(this Vector512<T> source, ref T destination, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static void StoreUnsafe<T>(this Vector512<T> source, ref T destination, UIntPtr elementOffset);
+-        public static Vector512<T> Subtract<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Subtract<T>(Vector512<T> left, Vector512<T> right);
+-        public static T Sum<T>(Vector512<T> vector) where T : struct;
++        public static T Sum<T>(Vector512<T> vector);
+-        public static T ToScalar<T>(this Vector512<T> vector) where T : struct;
++        public static T ToScalar<T>(this Vector512<T> vector);
+-        public static bool TryCopyTo<T>(this Vector512<T> vector, Span<T> destination) where T : struct;
++        public static bool TryCopyTo<T>(this Vector512<T> vector, Span<T> destination);
+-        public static Vector512<T> WithElement<T>(this Vector512<T> vector, int index, T value) where T : struct;
++        public static Vector512<T> WithElement<T>(this Vector512<T> vector, int index, T value);
+-        public static Vector512<T> WithLower<T>(this Vector512<T> vector, Vector256<T> value) where T : struct;
++        public static Vector512<T> WithLower<T>(this Vector512<T> vector, Vector256<T> value);
+-        public static Vector512<T> WithUpper<T>(this Vector512<T> vector, Vector256<T> value) where T : struct;
++        public static Vector512<T> WithUpper<T>(this Vector512<T> vector, Vector256<T> value);
+-        public static Vector512<T> Xor<T>(Vector512<T> left, Vector512<T> right) where T : struct;
++        public static Vector512<T> Xor<T>(Vector512<T> left, Vector512<T> right);
+     }
+-    public readonly struct Vector512<T> : IEquatable<Vector512<T>> where T : struct
++    public readonly struct Vector512<T> : IEquatable<Vector512<T>>
+     public static class Vector64 {
+-        public static Vector64<T> Abs<T>(Vector64<T> vector) where T : struct;
++        public static Vector64<T> Abs<T>(Vector64<T> vector);
+-        public static Vector64<T> Add<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Add<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> AndNot<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> AndNot<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<TTo> As<TFrom, TTo>(this Vector64<TFrom> vector) where TFrom : struct where TTo : struct;
++        public static Vector64<TTo> As<TFrom, TTo>(this Vector64<TFrom> vector);
+-        public static Vector64<byte> AsByte<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<byte> AsByte<T>(this Vector64<T> vector);
+-        public static Vector64<double> AsDouble<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<double> AsDouble<T>(this Vector64<T> vector);
+-        public static Vector64<short> AsInt16<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<short> AsInt16<T>(this Vector64<T> vector);
+-        public static Vector64<int> AsInt32<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<int> AsInt32<T>(this Vector64<T> vector);
+-        public static Vector64<long> AsInt64<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<long> AsInt64<T>(this Vector64<T> vector);
+-        public static Vector64<IntPtr> AsNInt<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<IntPtr> AsNInt<T>(this Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<UIntPtr> AsNUInt<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<UIntPtr> AsNUInt<T>(this Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<sbyte> AsSByte<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<sbyte> AsSByte<T>(this Vector64<T> vector);
+-        public static Vector64<float> AsSingle<T>(this Vector64<T> vector) where T : struct;
++        public static Vector64<float> AsSingle<T>(this Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<ushort> AsUInt16<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<ushort> AsUInt16<T>(this Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<ulong> AsUInt64<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<ulong> AsUInt64<T>(this Vector64<T> vector);
+-        public static Vector64<T> BitwiseAnd<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> BitwiseAnd<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> BitwiseOr<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> BitwiseOr<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> ConditionalSelect<T>(Vector64<T> condition, Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> ConditionalSelect<T>(Vector64<T> condition, Vector64<T> left, Vector64<T> right);
+-        public static void CopyTo<T>(this Vector64<T> vector, Span<T> destination) where T : struct;
++        public static void CopyTo<T>(this Vector64<T> vector, Span<T> destination);
+-        public static void CopyTo<T>(this Vector64<T> vector, T[] destination) where T : struct;
++        public static void CopyTo<T>(this Vector64<T> vector, T[] destination);
+-        public static void CopyTo<T>(this Vector64<T> vector, T[] destination, int startIndex) where T : struct;
++        public static void CopyTo<T>(this Vector64<T> vector, T[] destination, int startIndex);
+-        public static Vector64<T> Create<T>(ReadOnlySpan<T> values) where T : struct;
++        public static Vector64<T> Create<T>(ReadOnlySpan<T> values);
+-        public static Vector64<T> Create<T>(T value) where T : struct;
++        public static Vector64<T> Create<T>(T value);
+-        public static Vector64<T> Create<T>(T[] values) where T : struct;
++        public static Vector64<T> Create<T>(T[] values);
+-        public static Vector64<T> Create<T>(T[] values, int index) where T : struct;
++        public static Vector64<T> Create<T>(T[] values, int index);
+-        public static Vector64<T> CreateScalar<T>(T value) where T : struct;
++        public static Vector64<T> CreateScalar<T>(T value);
+-        public static Vector64<T> CreateScalarUnsafe<T>(T value) where T : struct;
++        public static Vector64<T> CreateScalarUnsafe<T>(T value);
+-        public static Vector64<T> Divide<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Divide<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> Divide<T>(Vector64<T> left, T right) where T : struct;
++        public static Vector64<T> Divide<T>(Vector64<T> left, T right);
+-        public static T Dot<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static T Dot<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> Equals<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Equals<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool EqualsAll<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool EqualsAll<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool EqualsAny<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool EqualsAny<T>(Vector64<T> left, Vector64<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public static uint ExtractMostSignificantBits<T>(this Vector64<T> vector) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static uint ExtractMostSignificantBits<T>(this Vector64<T> vector);
+-        public static T GetElement<T>(this Vector64<T> vector, int index) where T : struct;
++        public static T GetElement<T>(this Vector64<T> vector, int index);
+-        public static Vector64<T> GreaterThan<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> GreaterThan<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool GreaterThanAll<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool GreaterThanAll<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool GreaterThanAny<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool GreaterThanAny<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> GreaterThanOrEqual<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> GreaterThanOrEqual<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool GreaterThanOrEqualAll<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAll<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool GreaterThanOrEqualAny<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool GreaterThanOrEqualAny<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> LessThan<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> LessThan<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool LessThanAll<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool LessThanAll<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool LessThanAny<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool LessThanAny<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> LessThanOrEqual<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> LessThanOrEqual<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool LessThanOrEqualAll<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool LessThanOrEqualAll<T>(Vector64<T> left, Vector64<T> right);
+-        public static bool LessThanOrEqualAny<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static bool LessThanOrEqualAny<T>(Vector64<T> left, Vector64<T> right);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector64<T> Load<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector64<T> Load<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector64<T> LoadAligned<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector64<T> LoadAligned<T>(T* source);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static Vector64<T> LoadAlignedNonTemporal<T>(T* source) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static Vector64<T> LoadAlignedNonTemporal<T>(T* source);
+-        public static Vector64<T> LoadUnsafe<T>(ref T source) where T : struct;
++        public static Vector64<T> LoadUnsafe<T>(ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static Vector64<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
+-        public static Vector64<T> Max<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Max<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> Min<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Min<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> Multiply<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Multiply<T>(Vector64<T> left, Vector64<T> right);
+-        public static Vector64<T> Multiply<T>(Vector64<T> left, T right) where T : struct;
++        public static Vector64<T> Multiply<T>(Vector64<T> left, T right);
+-        public static Vector64<T> Multiply<T>(T left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Multiply<T>(T left, Vector64<T> right);
+-        public static Vector64<T> Negate<T>(Vector64<T> vector) where T : struct;
++        public static Vector64<T> Negate<T>(Vector64<T> vector);
+-        public static Vector64<T> OnesComplement<T>(Vector64<T> vector) where T : struct;
++        public static Vector64<T> OnesComplement<T>(Vector64<T> vector);
+-        public static Vector64<T> Sqrt<T>(Vector64<T> vector) where T : struct;
++        public static Vector64<T> Sqrt<T>(Vector64<T> vector);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Store<T>(this Vector64<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Store<T>(this Vector64<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAligned<T>(this Vector64<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAligned<T>(this Vector64<T> source, T* destination);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void StoreAlignedNonTemporal<T>(this Vector64<T> source, T* destination) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public unsafe static void StoreAlignedNonTemporal<T>(this Vector64<T> source, T* destination);
+-        public static void StoreUnsafe<T>(this Vector64<T> source, ref T destination) where T : struct;
++        public static void StoreUnsafe<T>(this Vector64<T> source, ref T destination);
+-        [CLSCompliantAttribute(false)]
+-        public static void StoreUnsafe<T>(this Vector64<T> source, ref T destination, UIntPtr elementOffset) where T : struct;
++        [CLSCompliantAttribute(false)]
++        public static void StoreUnsafe<T>(this Vector64<T> source, ref T destination, UIntPtr elementOffset);
+-        public static Vector64<T> Subtract<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Subtract<T>(Vector64<T> left, Vector64<T> right);
+-        public static T Sum<T>(Vector64<T> vector) where T : struct;
++        public static T Sum<T>(Vector64<T> vector);
+-        public static T ToScalar<T>(this Vector64<T> vector) where T : struct;
++        public static T ToScalar<T>(this Vector64<T> vector);
+-        public static Vector128<T> ToVector128<T>(this Vector64<T> vector) where T : struct;
++        public static Vector128<T> ToVector128<T>(this Vector64<T> vector);
+-        public static Vector128<T> ToVector128Unsafe<T>(this Vector64<T> vector) where T : struct;
++        public static Vector128<T> ToVector128Unsafe<T>(this Vector64<T> vector);
+-        public static bool TryCopyTo<T>(this Vector64<T> vector, Span<T> destination) where T : struct;
++        public static bool TryCopyTo<T>(this Vector64<T> vector, Span<T> destination);
+-        public static Vector64<T> WithElement<T>(this Vector64<T> vector, int index, T value) where T : struct;
++        public static Vector64<T> WithElement<T>(this Vector64<T> vector, int index, T value);
+-        public static Vector64<T> Xor<T>(Vector64<T> left, Vector64<T> right) where T : struct;
++        public static Vector64<T> Xor<T>(Vector64<T> left, Vector64<T> right);
+     }
+-    public readonly struct Vector64<T> : IEquatable<Vector64<T>> where T : struct
++    public readonly struct Vector64<T> : IEquatable<Vector64<T>>
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Security.Cryptography.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Security.Cryptography.md
@@ -1,0 +1,170 @@
+# System.Security.Cryptography
+
+``` diff
+ namespace System.Security.Cryptography {
+     public readonly struct HashAlgorithmName : IEquatable<HashAlgorithmName> {
++        public static HashAlgorithmName SHA3_256 { get; }
++        public static HashAlgorithmName SHA3_384 { get; }
++        public static HashAlgorithmName SHA3_512 { get; }
+     }
++    public class HMACSHA3_256 : HMAC {
++        public const int HashSizeInBits = 256;
++        public const int HashSizeInBytes = 32;
++        public HMACSHA3_256();
++        public HMACSHA3_256(byte[] key);
++        public static bool IsSupported { get; }
++        public override byte[] Key { get; set; }
++        protected override void Dispose(bool disposing);
++        protected override void HashCore(byte[] rgb, int ib, int cb);
++        protected override void HashCore(ReadOnlySpan<byte> source);
++        public static byte[] HashData(byte[] key, byte[] source);
++        public static byte[] HashData(byte[] key, Stream source);
++        public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
++        public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        protected override byte[] HashFinal();
++        public override void Initialize();
++        public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten);
++    }
++    public class HMACSHA3_384 : HMAC {
++        public const int HashSizeInBits = 384;
++        public const int HashSizeInBytes = 48;
++        public HMACSHA3_384();
++        public HMACSHA3_384(byte[] key);
++        public static bool IsSupported { get; }
++        public override byte[] Key { get; set; }
++        protected override void Dispose(bool disposing);
++        protected override void HashCore(byte[] rgb, int ib, int cb);
++        protected override void HashCore(ReadOnlySpan<byte> source);
++        public static byte[] HashData(byte[] key, byte[] source);
++        public static byte[] HashData(byte[] key, Stream source);
++        public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
++        public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        protected override byte[] HashFinal();
++        public override void Initialize();
++        public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten);
++    }
++    public class HMACSHA3_512 : HMAC {
++        public const int HashSizeInBits = 512;
++        public const int HashSizeInBytes = 64;
++        public HMACSHA3_512();
++        public HMACSHA3_512(byte[] key);
++        public static bool IsSupported { get; }
++        public override byte[] Key { get; set; }
++        protected override void Dispose(bool disposing);
++        protected override void HashCore(byte[] rgb, int ib, int cb);
++        protected override void HashCore(ReadOnlySpan<byte> source);
++        public static byte[] HashData(byte[] key, byte[] source);
++        public static byte[] HashData(byte[] key, Stream source);
++        public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
++        public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        protected override byte[] HashFinal();
++        public override void Initialize();
++        public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++        protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten);
++    }
+     public sealed class RSAEncryptionPadding : IEquatable<RSAEncryptionPadding> {
++        public static RSAEncryptionPadding OaepSHA3_256 { get; }
++        public static RSAEncryptionPadding OaepSHA3_384 { get; }
++        public static RSAEncryptionPadding OaepSHA3_512 { get; }
+     }
++    public abstract class SHA3_256 : HashAlgorithm {
++        public const int HashSizeInBits = 256;
++        public const int HashSizeInBytes = 32;
++        protected SHA3_256();
++        public static bool IsSupported { get; }
++        public static new SHA3_256 Create();
++        public static byte[] HashData(byte[] source);
++        public static byte[] HashData(Stream source);
++        public static int HashData(Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++    }
++    public abstract class SHA3_384 : HashAlgorithm {
++        public const int HashSizeInBits = 384;
++        public const int HashSizeInBytes = 48;
++        protected SHA3_384();
++        public static bool IsSupported { get; }
++        public static new SHA3_384 Create();
++        public static byte[] HashData(byte[] source);
++        public static byte[] HashData(Stream source);
++        public static int HashData(Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++    }
++    public abstract class SHA3_512 : HashAlgorithm {
++        public const int HashSizeInBits = 512;
++        public const int HashSizeInBytes = 64;
++        protected SHA3_512();
++        public static bool IsSupported { get; }
++        public static new SHA3_512 Create();
++        public static byte[] HashData(byte[] source);
++        public static byte[] HashData(Stream source);
++        public static int HashData(Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> source);
++        public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default(CancellationToken));
++        public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
++    }
++    public sealed class Shake128 : IDisposable {
++        public Shake128();
++        public static bool IsSupported { get; }
++        public void AppendData(byte[] data);
++        public void AppendData(ReadOnlySpan<byte> data);
++        public void Dispose();
++        public byte[] GetCurrentHash(int outputLength);
++        public void GetCurrentHash(Span<byte> destination);
++        public byte[] GetHashAndReset(int outputLength);
++        public void GetHashAndReset(Span<byte> destination);
++        public static byte[] HashData(byte[] source, int outputLength);
++        public static byte[] HashData(Stream source, int outputLength);
++        public static void HashData(Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
++        public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++    }
++    public sealed class Shake256 : IDisposable {
++        public Shake256();
++        public static bool IsSupported { get; }
++        public void AppendData(byte[] data);
++        public void AppendData(ReadOnlySpan<byte> data);
++        public void Dispose();
++        public byte[] GetCurrentHash(int outputLength);
++        public void GetCurrentHash(Span<byte> destination);
++        public byte[] GetHashAndReset(int outputLength);
++        public void GetHashAndReset(Span<byte> destination);
++        public static byte[] HashData(byte[] source, int outputLength);
++        public static byte[] HashData(Stream source, int outputLength);
++        public static void HashData(Stream source, Span<byte> destination);
++        public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
++        public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
++        public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default(CancellationToken));
++        public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken));
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Text.Json.Serialization.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Text.Json.Serialization.md
@@ -1,0 +1,22 @@
+# System.Text.Json.Serialization
+
+``` diff
+ namespace System.Text.Json.Serialization {
+     public abstract class JsonConverter {
++        public abstract Type Type { get; }
+     }
+     public abstract class JsonConverter<T> : JsonConverter {
++        public sealed override Type Type { get; }
+     }
+     public abstract class JsonConverterFactory : JsonConverter {
++        public sealed override Type Type { get; }
+     }
++    public class JsonStringEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct {
++        public JsonStringEnumConverter();
++        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true);
++        public sealed override bool CanConvert(Type typeToConvert);
++        public sealed override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Text.Json.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Text.Json.md
@@ -1,0 +1,11 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     public sealed class JsonSerializerOptions {
+-        public bool TryGetTypeInfo(Type type, [NotNullWhenAttribute(true)] out JsonTypeInfo typeInfo);
++        public bool TryGetTypeInfo(Type type, [NotNullWhenAttribute(true)] out JsonTypeInfo? typeInfo);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Threading.Tasks.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.Threading.Tasks.md
@@ -1,0 +1,20 @@
+# System.Threading.Tasks
+
+``` diff
+ namespace System.Threading.Tasks {
++    [FlagsAttribute]
++    public enum ConfigureAwaitOptions {
++        ContinueOnCapturedContext = 1,
++        ForceYielding = 4,
++        None = 0,
++        SuppressThrowing = 2,
++    }
+     public class Task : IAsyncResult, IDisposable {
++        public ConfiguredTaskAwaitable ConfigureAwait(ConfigureAwaitOptions options);
+     }
+     public class Task<TResult> : Task {
++        public new ConfiguredTaskAwaitable<TResult> ConfigureAwait(ConfigureAwaitOptions options);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.NETCore.App/8.0-preview6_System.md
@@ -1,0 +1,35 @@
+# System
+
+``` diff
+ namespace System {
+     public readonly struct Double : IAdditionOperators<double, double, double>, IAdditiveIdentity<double, double>, IBinaryFloatingPointIeee754<double>, IBinaryNumber<double>, IBitwiseOperators<double, double, double>, IComparable, IComparable<double>, IComparisonOperators<double, double, bool>, IConvertible, IDecrementOperators<double>, IDivisionOperators<double, double, double>, IEqualityOperators<double, double, bool>, IEquatable<double>, IExponentialFunctions<double>, IFloatingPoint<double>, IFloatingPointConstants<double>, IFloatingPointIeee754<double>, IFormattable, IHyperbolicFunctions<double>, IIncrementOperators<double>, ILogarithmicFunctions<double>, IMinMaxValue<double>, IModulusOperators<double, double, double>, IMultiplicativeIdentity<double, double>, IMultiplyOperators<double, double, double>, INumber<double>, INumberBase<double>, IParsable<double>, IPowerFunctions<double>, IRootFunctions<double>, ISignedNumber<double>, ISpanFormattable, ISpanParsable<double>, ISubtractionOperators<double, double, double>, ITrigonometricFunctions<double>, IUnaryNegationOperators<double, double>, IUnaryPlusOperators<double, double>, IUtf8SpanFormattable {
+-        public const double NegativeZero = 0;
++        public const double NegativeZero = -0;
+     }
+     public static class MemoryExtensions {
++        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this Span<T> span, SearchValues<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>?;
++        public static bool ContainsAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this Span<T> span, SearchValues<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this Span<T> span, T value) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>?;
++        public static bool ContainsAnyExcept<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>?;
++        public static bool ContainsAnyExceptInRange<T>(this ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : IComparable<T>;
++        public static bool ContainsAnyExceptInRange<T>(this Span<T> span, T lowInclusive, T highInclusive) where T : IComparable<T>;
++        public static bool ContainsAnyInRange<T>(this ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : IComparable<T>;
++        public static bool ContainsAnyInRange<T>(this Span<T> span, T lowInclusive, T highInclusive) where T : IComparable<T>;
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6.md
@@ -1,0 +1,8 @@
+# API Difference 8.0-preview5 vs 8.0-preview6
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.ComponentModel.Design](8.0-preview6_System.ComponentModel.Design.md)
+* [System.Windows.Forms](8.0-preview6_System.Windows.Forms.md)
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6_System.ComponentModel.Design.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6_System.ComponentModel.Design.md
@@ -1,0 +1,51 @@
+# System.ComponentModel.Design
+
+``` diff
+ namespace System.ComponentModel.Design {
+     public class DesignSurface : IDisposable, IServiceProvider {
+-        public DesignSurface(IServiceProvider parentProvider);
++        public DesignSurface(IServiceProvider? parentProvider);
+-        public DesignSurface(IServiceProvider parentProvider, Type rootComponentType);
++        public DesignSurface(IServiceProvider? parentProvider, Type rootComponentType);
+-        public event EventHandler Disposed;
++        public event EventHandler? Disposed;
+-        public event EventHandler Flushed;
++        public event EventHandler? Flushed;
+-        public event LoadedEventHandler Loaded;
++        public event LoadedEventHandler? Loaded;
+-        public event EventHandler Loading;
++        public event EventHandler? Loading;
+-        public event EventHandler Unloaded;
++        public event EventHandler? Unloaded;
+-        public event EventHandler Unloading;
++        public event EventHandler? Unloading;
+-        public event EventHandler ViewActivated;
++        public event EventHandler? ViewActivated;
+-        [ObsoleteAttribute("CreateComponent has been replaced by CreateInstance and will be removed after Beta2")]
+-        protected internal virtual IComponent CreateComponent(Type componentType);
++        [ObsoleteAttribute("CreateComponent has been replaced by CreateInstance and will be removed after Beta2")]
++        protected internal virtual IComponent? CreateComponent(Type componentType);
+-        protected internal virtual IDesigner CreateDesigner(IComponent component, bool rootDesigner);
++        protected internal virtual IDesigner? CreateDesigner(IComponent component, bool rootDesigner);
+-        protected internal virtual object CreateInstance(Type type);
++        protected internal virtual object? CreateInstance(Type type);
+-        public INestedContainer CreateNestedContainer(IComponent owningComponent, string containerName);
++        public INestedContainer CreateNestedContainer(IComponent owningComponent, string? containerName);
+-        public object GetService(Type serviceType);
++        public object? GetService(Type serviceType);
+     }
+     public sealed class DesignSurfaceCollection : ICollection, IEnumerable {
+-        int System.Collections.ICollection.Count { get; }
++        int ICollection.Count { get; }
+-        bool System.Collections.ICollection.IsSynchronized { get; }
++        bool ICollection.IsSynchronized { get; }
+-        object System.Collections.ICollection.SyncRoot { get; }
++        object ICollection.SyncRoot { get; }
+     }
+     public class DesignSurfaceManager : IDisposable, IServiceProvider {
+-        public object GetService(Type serviceType);
++        public object? GetService(Type serviceType);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6_System.Windows.Forms.md
+++ b/release-notes/8.0/preview/api-diff/preview6/Microsoft.WindowsDesktop.App/8.0-preview6_System.Windows.Forms.md
@@ -1,0 +1,125 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+     [DefaultEventAttribute("Opening")]
+     [SRDescriptionAttribute("DescriptionContextMenuStrip")]
+     public class ContextMenuStrip : ToolStripDropDownMenu {
++        protected override void OnClosed(ToolStripDropDownClosedEventArgs e);
++        protected override void OnOpened(EventArgs e);
+     }
+     [DefaultPropertyAttribute("Text")]
+     [DesignTimeVisibleAttribute(false)]
+     [ToolboxItemAttribute(false)]
+     [TypeConverterAttribute(typeof(ListViewItemConverter))]
+     public class ListViewItem : ICloneable, IKeyboardToolTip, ISerializable {
+-        public ListViewItem(ListViewItem.ListViewSubItem[] subItems, string imageKey, ListViewGroup group);
++        public ListViewItem(ListViewItem.ListViewSubItem[] subItems, string? imageKey, ListViewGroup? group);
+-        public ListViewItem(string text);
++        public ListViewItem(string? text);
+-        public ListViewItem(string text, int imageIndex);
++        public ListViewItem(string? text, int imageIndex);
+-        public ListViewItem(string text, int imageIndex, ListViewGroup group);
++        public ListViewItem(string? text, int imageIndex, ListViewGroup? group);
+-        public ListViewItem(string text, string imageKey);
++        public ListViewItem(string? text, string? imageKey);
+-        public ListViewItem(string text, string imageKey, ListViewGroup group);
++        public ListViewItem(string? text, string? imageKey, ListViewGroup? group);
+-        public ListViewItem(string text, ListViewGroup group);
++        public ListViewItem(string? text, ListViewGroup? group);
+-        public ListViewItem(string[]? items, int imageIndex, Color foreColor, Color backColor, Font font);
++        public ListViewItem(string[]? items, int imageIndex, Color foreColor, Color backColor, Font? font);
+-        public ListViewItem(string[]? items, int imageIndex, Color foreColor, Color backColor, Font font, ListViewGroup group);
++        public ListViewItem(string[]? items, int imageIndex, Color foreColor, Color backColor, Font? font, ListViewGroup? group);
+-        public ListViewItem(string[]? items, int imageIndex, ListViewGroup group);
++        public ListViewItem(string[]? items, int imageIndex, ListViewGroup? group);
+-        public ListViewItem(string[]? items, string imageKey);
++        public ListViewItem(string[]? items, string? imageKey);
+-        public ListViewItem(string[]? items, string imageKey, Color foreColor, Color backColor, Font font);
++        public ListViewItem(string[]? items, string? imageKey, Color foreColor, Color backColor, Font? font);
+-        public ListViewItem(string[]? items, string imageKey, Color foreColor, Color backColor, Font font, ListViewGroup group);
++        public ListViewItem(string[]? items, string? imageKey, Color foreColor, Color backColor, Font? font, ListViewGroup? group);
+-        public ListViewItem(string[]? items, string imageKey, ListViewGroup group);
++        public ListViewItem(string[]? items, string? imageKey, ListViewGroup? group);
+-        public ListViewItem(string[]? items, ListViewGroup group);
++        public ListViewItem(string[]? items, ListViewGroup? group);
+-        public ListViewItem(ListViewGroup group);
++        public ListViewItem(ListViewGroup? group);
+-        [DefaultValueAttribute(null)]
+-        [LocalizableAttribute(true)]
+-        [SRCategoryAttribute("CatBehavior")]
+-        public ListViewGroup Group { get; set; }
++        [DefaultValueAttribute(null)]
++        [LocalizableAttribute(true)]
++        [SRCategoryAttribute("CatBehavior")]
++        public ListViewGroup? Group { get; set; }
+-        [BrowsableAttribute(false)]
+-        public ImageList ImageList { get; }
++        [BrowsableAttribute(false)]
++        public ImageList? ImageList { get; }
+-        [BrowsableAttribute(false)]
+-        public ListView ListView { get; }
++        [BrowsableAttribute(false)]
++        public ListView? ListView { get; }
+-        [BindableAttribute(true)]
+-        [DefaultValueAttribute(null)]
+-        [LocalizableAttribute(false)]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("ControlTagDescr")]
+-        [TypeConverterAttribute(typeof(StringConverter))]
+-        public object Tag { get; set; }
++        [BindableAttribute(true)]
++        [DefaultValueAttribute(null)]
++        [LocalizableAttribute(false)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("ControlTagDescr")]
++        [TypeConverterAttribute(typeof(StringConverter))]
++        public object? Tag { get; set; }
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [LocalizableAttribute(true)]
+-        [SRCategoryAttribute("CatAppearance")]
+-        public string Text { get; set; }
++        [DesignerSerializationVisibilityAttribute(0)]
++        [LocalizableAttribute(true)]
++        [SRCategoryAttribute("CatAppearance")]
++        [AllowNullAttribute]
++        public string Text { get; set; }
+-        [DefaultValueAttribute("")]
+-        [SRCategoryAttribute("CatAppearance")]
+-        public string ToolTipText { get; set; }
++        [DefaultValueAttribute("")]
++        [SRCategoryAttribute("CatAppearance")]
++        [AllowNullAttribute]
++        public string ToolTipText { get; set; }
+-        public ListViewItem FindNearestItem(SearchDirectionHint searchDirection);
++        public ListViewItem? FindNearestItem(SearchDirectionHint searchDirection);
+-        public ListViewItem.ListViewSubItem GetSubItemAt(int x, int y);
++        public ListViewItem.ListViewSubItem? GetSubItemAt(int x, int y);
+         [DefaultPropertyAttribute("Text")]
+         [DesignTimeVisibleAttribute(false)]
+         [ToolboxItemAttribute(false)]
+         [TypeConverterAttribute(typeof(ListViewSubItemConverter))]
+         public class ListViewSubItem {
+-            public ListViewSubItem(ListViewItem owner, string? text);
++            public ListViewSubItem(ListViewItem owner, string text);
+-            public ListViewSubItem(ListViewItem owner, string? text, Color foreColor, Color backColor, Font font);
++            public ListViewSubItem(ListViewItem owner, string text, Color foreColor, Color backColor, Font font);
+-            [BindableAttribute(true)]
+-            [DefaultValueAttribute(null)]
+-            [LocalizableAttribute(false)]
+-            [SRCategoryAttribute("CatData")]
+-            [SRDescriptionAttribute("ControlTagDescr")]
+-            [TypeConverterAttribute(typeof(StringConverter))]
+-            public object? Tag { get; set; }
++            [BindableAttribute(true)]
++            [DefaultValueAttribute(null)]
++            [LocalizableAttribute(false)]
++            [SRCategoryAttribute("CatData")]
++            [SRDescriptionAttribute("ControlTagDescr")]
++            [TypeConverterAttribute(typeof(StringConverter))]
++            public object Tag { get; set; }
+         }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/preview6/README.md
+++ b/release-notes/8.0/preview/api-diff/preview6/README.md
@@ -1,0 +1,7 @@
+# .NET 8.0 Preview 6 API Changes
+
+The following API changes were made in .NET 8.0 Preview 6:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/8.0-preview6.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/8.0-preview6.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/8.0-preview6.md)


### PR DESCRIPTION
**Known issues**:
- The AsmDiff tool sometimes skips adding `{` or `{}`. Please add a GitHub suggestion to correct it. [arcade#10981](https://github.com/dotnet/arcade/issues/10981)
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect. I have an issue to track this: [arcade#13814](https://github.com/dotnet/arcade/issues/13814) 
  
Repos area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @dreddy-work @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @jeffhandley @karelz @ericstj @stephentoub

Libraries area owners:
 
- System @dotnet/area-system-runtime 
- System.Diagnostics.CodeAnalysis no area label, tagging most recent modifiers: @RussKie @stephentoub 
- System.Diagnostics.Metrics @tommcdon @noahfalk 
- System.Diagnostics.Tracing @tommcdon @noahfalk @tarekgh 
- System.Formats.Asn1 @dotnet/area-system-formats-asn1 
- System.IO.Compression @dotnet/area-system-io-compression 
- System.IO.Pipes No area label, tagging most recent modifiers: @MihaZupan 
- System.Net @dotnet/ncl 
- System.Numerics @dotnet/area-system-numerics 
- System.Runtime.CompilerServices: @dotnet/area-system-runtime-compilerservices 
- System.Runtime.InteropServices @dotnet/interop-contrib 
- System.Runtime.Intrinsics @dotnet/area-system-runtime-intrinsics 
- System.Security @dotnet/area-system-security 
- System.Text.Json @dotnet/area-system-text-json 
- System.Threading.Tasks @dotnet/area-system-threading-tasks 

- Microsoft.Extensions.Caching @dotnet/area-extensions-caching 
- Microsoft.Extensions.DependencyInjection @dotnet/area-extensions-dependencyinjection 
- Microsoft.Extensions.Diagnostics.Metrics @tommcdon @noahfalk 
- Microsoft.Extensions.Hosting @dotnet/area-extensions-hosting 
- Microsoft.Extensions.Logging @dotnet/area-extensions-logging 
- Microsoft.Extensions.Options @dotnet/area-extensions-options 
- Microsoft.Extensions.Primitives @dotnet/area-extensions-primitives 