### PR TITLE
Update support statements

### DIFF
--- a/linux-support.md
+++ b/linux-support.md
@@ -1,22 +1,25 @@
 # .NET Support and Compatibility for Linux Distributions
 
-.NET is [supported by Microsoft](os-lifecycle-policy.md) and by [various commercial vendors and the community](linux.md) on multiple Linux distributions.
+.NET is supported by multiple [commercial and community organizations](support.md) on [multiple Linux distributions](linux.md).
 
-.NET can typically be run on any Linux distribution, via:
+.NET can be run on any Linux distribution, via:
 
-- The Microsoft build, which is built to be broadly compatible.
+- Portable builds, which are built to be broadly compatible with most Linux distributions.
 - Distribution-specific builds, which are built specifically for a given distribution version (like Red Hat Enterprise Linux 9 or Ubuntu 22.04).
+
+Microsoft builds are portable builds.
 
 ## General dependencies
 
-Microsoft builds have multiple dependencies that must be installed:
+.NET has multiple dependencies that must be installed:
 
 - [.NET 6 dependencies](./release-notes/6.0/linux-packages.md)
 - [.NET 7 dependencies](./release-notes/7.0/linux-packages.md)
+- [.NET 8 dependencies](./release-notes/8.0/linux-packages.md)
 
 ## libc compatibility
 
-Microsoft builds supports both [glibc](https://www.gnu.org/software/libc/)-based and [musl libc](https://musl.libc.org/)-based Linux distributions, per the following minimum version information.
+Portable builds supports both [glibc](https://www.gnu.org/software/libc/)-based and [musl libc](https://musl.libc.org/)-based Linux distributions, per the following minimum version information.
 
 - [.NET 6 minimum libc](release-notes/6.0/supported-os.md#libc-compatibility)
 - [.NET 7 minimum libc](release-notes/7.0/supported-os.md#libc-compatibility)
@@ -24,7 +27,7 @@ Microsoft builds supports both [glibc](https://www.gnu.org/software/libc/)-based
 
 You can use the following pattern to determine the libc version provided for your distribution.
 
-On Alpine 3.16:
+On Alpine:
 
 ```bash
 # ldd --version
@@ -32,7 +35,7 @@ musl libc (aarch64)
 Version 1.2.3
 ```
 
-On Ubuntu 22.04:
+On Ubuntu:
 
 ```bash
 # ldd --version
@@ -41,30 +44,16 @@ ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
 
 ## OpenSSL compatibility
 
-Microsoft builds support both OpenSSL 1.x and 3.x and can be run on distributions with either version of this package. For example, Ubuntu 22.04 only includes OpenSSL 3 in its official package archive.
+Portable builds support both OpenSSL 1.x and 3.x and can be run on distributions with either version of OpenSSL. For example, Ubuntu 22.04 only includes OpenSSL 3 in its official package archive.
 
-Microsoft builds will generally load the highest OpenSSL version it finds, but can be configured to use a specific version.
+The highest OpenSSL version is loaded by default, but can be [configured to use a specific version](https://github.com/dotnet/runtime/issues/79153#issuecomment-1335476471).
 
 ## Red Hat Enterprise Linux Family support
 
-Microsoft builds support multiple Red Hat versions. New .NET versions will typically only be supported on RHEL era distributions in active support.
+New .NET versions will typically only be supported on RHEL era distributions in active support.
 
 - RHEL 7 era distributions are considered in maintenance.
 - RHEL 8 era distributions are considered in active support.
 - RHEL 9 era distributions are considered in active support.
 
 Red Hat family distributions include: AlmaLinux, CentOS, Oracle Linux, Red Hat Enterprise Linux, and Rocky Linux.
-
-## Red Hat Commercial Support
-
-Red Hat supports .NET via [Red Hat Enterprise Linux](http://redhatloves.net/), per the following.
-
-- .NET 6 is supported in RHEL 7+.
-- .NET 7 is supported in RHEL 8+.
-
-## Ubuntu Commercial Support
-
-Canonical supports .NET on Ubuntu via APT archives, per the following.
-
-- .NET 6 is supported in Ubuntu 22.04+.
-- .NET 7 is supported in Ubuntu 22.10+.

--- a/linux-support.md
+++ b/linux-support.md
@@ -11,7 +11,7 @@ Microsoft builds are portable builds.
 
 ## General dependencies
 
-.NET has multiple dependencies that must be installed:
+Portable builds have multiple dependencies that must be installed:
 
 - [.NET 6 dependencies](./release-notes/6.0/linux-packages.md)
 - [.NET 7 dependencies](./release-notes/7.0/linux-packages.md)

--- a/linux.md
+++ b/linux.md
@@ -4,9 +4,9 @@
 
 .NET is supported on Linux per [.NET Support and Compatibility for Linux Distributions](linux-support.md).
 
-## Distribution archives
+## Package archives
 
-.NET is included in the [archives](https://pkgs.org/download/dotnet) of the following distributions:
+.NET is included in the [package archives](https://pkgs.org/download/dotnet) of the following distributions:
 
 - [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=dotnet*)
 - [Arch Linux](https://archlinux.org/packages/?q=dotnet)
@@ -22,9 +22,9 @@ In general, you can install the .NET SDK via a versioned package, like `dotnet7`
 sudo apt update && sudo apt install -y dotnet-sdk-7.0
 ```
 
-## Microsoft archives
+## Microsoft packages
 
-Microsoft offers alternate feeds at [packages.microsoft.com](http://packages.microsoft.com/) that include the Microsoft binary build of .NET. They are document at [Install .NET on Linux](https://learn.microsoft.com/dotnet/core/install/linux).
+Microsoft offers alternate package feeds at [packages.microsoft.com](http://packages.microsoft.com/) that include the Microsoft binary build of .NET. They are document at [Install .NET on Linux](https://learn.microsoft.com/dotnet/core/install/linux).
 
 You can move back-and-forth between distribution and Microsoft archives using a variety of [package manager patterns](https://learn.microsoft.com/dotnet/core/install/linux-package-mixup) and [previous challenges](https://github.com/dotnet/core/issues/7699) to guide you.
 
@@ -40,6 +40,6 @@ Microsoft publishes container images per [.NET container publishing policy](http
 
 ## Building .NET from source
 
-.NET can be built from source via [dotnet/source-build](https://github.com/dotnet/source-build). This capability is expanding with [dotnet/dotnet](https://github.com/dotnet/dotnet) (which also uses source-build).
+.NET can be built from source via [dotnet/dotnet](https://github.com/dotnet/dotnet).
 
 For distributions publishing packages, please follow [.NET Packaging Guidelines](https://learn.microsoft.com/dotnet/core/distribution-packaging#recommended-packages).

--- a/microsoft-support.md
+++ b/microsoft-support.md
@@ -1,21 +1,3 @@
 # Microsoft support for .NET
 
-[Microsoft supports .NET](https://dotnet.microsoft.com/platform/support/policy) on multiple operating systems, per the [Microsoft Modern Lifecycle](https://support.microsoft.com/help/30881/modern-lifecycle-policy).
-
-Support is provided for: .NET SDK, .NET Runtimes, ASP.NET Core, and EF Core.
-
-Support has two key benefits:
-
-* Patches are provided (for free) as required for functional or security issues, typically monthly.
-* You can [contact Microsoft support to request help](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding) (potentially at a cost).
-
-You can also request [community support on GitHub](https://github.com/dotnet/core) (for free), but there is no guarantee on a quick reply.
-
-Support is conditional on using the latest .NET patch update and a supported operating system, as defined by:
-
-* [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy)
-* [.NET releases](releases.md)
-* [.NET release policies](release-policies.md)
-* [.NET supported operating system lifecycle](os-lifecycle-policy.md).
-
-Knowing key dates for a product lifecycle helps you make informed decisions about when to upgrade or make other changes to your software and computing environment.
+This content has been moved to [.NET support](support.md).

--- a/os-lifecycle-policy.md
+++ b/os-lifecycle-policy.md
@@ -1,8 +1,6 @@
 # .NET Supported OS Policy
 
-.NET is [supported by Microsoft](microsoft-support.md) on multiple operating systems.
-
-A more restrictive policy is used for [.NET container images](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md).
+.NET is [supported](support.md) on multiple operating systems.
 
 ## Supported .NET versions
 

--- a/support.md
+++ b/support.md
@@ -14,26 +14,26 @@ Knowing key dates and policies can help you make informed decisions about when t
 
 ## Community Support
 
-Community builds are available for [Linux](linux.md) and macOS ([cask](https://formulae.brew.sh/cask/dotnet-sdk) and [formulae](https://formulae.brew.sh/formula/dotnet)).
+Community builds are available for [Linux](linux.md) and [macOS](https://formulae.brew.sh/cask/dotnet-sdk).
 
 Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core), but there is no guarantee of a quick reply.
 
-## Microsoft Commercial Support
-
-Microsoft provides [stable builds](https://dotnet.microsoft.com/download) and [commercial support](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding) for .NET on Linux, macOS, and Windows, per [.NET support policy](https://dotnet.microsoft.com/platform/support/policy).
-
-A more restrictive policy is used for [.NET container images](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md).
-
-## Red Hat Commercial Support
-
-[Red Hat supports .NET](http://redhatloves.net/) on Red Hat Enterprise Linux, per the following.
-
-- .NET 6 is supported in RHEL 7+.
-- .NET 7 is supported in RHEL 8+.
-
-## Ubuntu Commercial Support
+## Canonical support
 
 Canonical supports .NET on Ubuntu via APT archives, per the following.
 
 - .NET 6 is supported in Ubuntu 22.04+.
 - .NET 7 is supported in Ubuntu 22.04+.
+
+## Microsoft support
+
+Microsoft provides [stable builds](https://dotnet.microsoft.com/download) and [commercial support](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding) for .NET on Linux, macOS, and Windows, per [.NET support policy](https://dotnet.microsoft.com/platform/support/policy).
+
+A more restrictive policy is used for [.NET container images](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md).
+
+## Red Hat support
+
+[Red Hat supports .NET](http://redhatloves.net/) on Red Hat Enterprise Linux, per the following.
+
+- .NET 6 is supported in RHEL 7+.
+- .NET 7 is supported in RHEL 8+.

--- a/support.md
+++ b/support.md
@@ -1,0 +1,39 @@
+# .NET Support and Distributions
+
+.NET is available (as a binary distribution) in many package managers and official download sites. These builds of .NET are provided and supported by  organizations that participate in the .NET community, [build .NET from source](https://github.com/dotnet/dotnet), and offer stable binaries to their users. These organizations work together to enable developers to be productive and safe on Linux, macOS, and Windows.
+
+Patches are provided for functional or security issues, typically monthly on [Patch Tuesday](https://en.wikipedia.org/wiki/Patch_Tuesday).
+
+.NET is supported per the following policies:
+
+* [.NET releases](releases.md)
+* [.NET release policies](release-policies.md)
+* [.NET supported operating system lifecycle](os-lifecycle-policy.md).
+
+Knowing key dates and policies can help you make informed decisions about when to upgrade or make other changes to your software and computing environment.
+
+## Community Support
+
+Community builds are available for [Linux](linux.md) and macOS ([cask](https://formulae.brew.sh/cask/dotnet-sdk) and [formulae](https://formulae.brew.sh/formula/dotnet)).
+
+Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core), but there is no guarantee of a quick reply.
+
+## Microsoft Commercial Support
+
+Microsoft provides [stable builds](https://dotnet.microsoft.com/download) and [commercial support](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding) for .NET on Linux, macOS, and Windows, per [.NET support policy](https://dotnet.microsoft.com/platform/support/policy).
+
+A more restrictive policy is used for [.NET container images](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md).
+
+## Red Hat Commercial Support
+
+[Red Hat supports .NET](http://redhatloves.net/) on Red Hat Enterprise Linux, per the following.
+
+- .NET 6 is supported in RHEL 7+.
+- .NET 7 is supported in RHEL 8+.
+
+## Ubuntu Commercial Support
+
+Canonical supports .NET on Ubuntu via APT archives, per the following.
+
+- .NET 6 is supported in Ubuntu 22.04+.
+- .NET 7 is supported in Ubuntu 22.04+.

--- a/support.md
+++ b/support.md
@@ -10,28 +10,25 @@ Patches are provided for functional or security issues, typically monthly on [Pa
 * [.NET release policies](release-policies.md)
 * [.NET supported operating system lifecycle](os-lifecycle-policy.md).
 
-Knowing key dates and policies can help you make informed decisions about when to upgrade or make other changes to your software and computing environment.
 
-## Community Support
+Community builds are available for [Linux](linux.md) and [macOS](https://formulae.brew.sh/cask/dotnet-sdk). Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core).
 
-Community builds are available for [Linux](linux.md) and [macOS](https://formulae.brew.sh/cask/dotnet-sdk).
+Official builds and commercial support is available from the following companies.
 
-Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core), but there is no guarantee of a quick reply.
+## Canonical
 
-## Canonical support
-
-Canonical supports .NET on Ubuntu via APT archives, per the following.
+Canonical supports .NET on Ubuntu, per the following.
 
 - .NET 6 is supported in Ubuntu 22.04+.
 - .NET 7 is supported in Ubuntu 22.04+.
 
-## Microsoft support
+## Microsoft
 
 Microsoft provides [stable builds](https://dotnet.microsoft.com/download) and [commercial support](https://support.serviceshub.microsoft.com/supportforbusiness/onboarding) for .NET on Linux, macOS, and Windows, per [.NET support policy](https://dotnet.microsoft.com/platform/support/policy).
 
 A more restrictive policy is used for [.NET container images](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md).
 
-## Red Hat support
+## Red Hat
 
 [Red Hat supports .NET](http://redhatloves.net/) on Red Hat Enterprise Linux, per the following.
 


### PR DESCRIPTION
The goal here is to make Microsoft more of a peer to other companies working in the .NET ecosystem. The docs are unnecessarily Microsoft-specific. This is based on customer feedback for a company seeking to better understand the Red Hat support story. That's great to see.