### PR TITLE
doc - Fixed servicing releases table not rendering

### DIFF
--- a/daily-builds.md
+++ b/daily-builds.md
@@ -19,7 +19,7 @@ Preview branches are for new versions of .NET that have not yet been released an
 Servicing branches are for new patch versions of .NET that have not yet been released and are not yet supported.
 
 |Component|*.NET 7.0*|*.NET 6.0*|*.NET Core 3.1*|
-|:------:|:------:|:------:|:------:|:------:|
+|:------:|:------:|:------:|:------:|
 |SDK|[.NET SDK 7.0.xxx](https://github.com/dotnet/installer/blob/main/README.md#installers-and-binaries)|[.NET SDK 6.0.xxx](https://github.com/dotnet/installer/blob/main/README.md#installers-and-binaries)|[.NET Core SDK 3.1.xxx](https://github.com/dotnet/core-sdk/blob/main/README.md#installers-and-binaries)|
 |ASP.NET Core|[ASP.NET Core 7.0](https://github.com/dotnet/aspnetcore/blob/main/docs/DailyBuilds.md)|[ASP.NET Core 6.0](https://github.com/dotnet/aspnetcore/blob/main/docs/DailyBuilds.md)|[ASP.NET Core 3.1](https://github.com/dotnet/aspnetcore/blob/main/docs/DailyBuilds.md)|
 |Runtime|[.NET Runtime 7.0](https://github.com/dotnet/installer/blob/master/README.md#daily-builds)|[.NET Core Runtime 6.0](https://github.com/dotnet/installer/blob/master/README.md#daily-builds)|[.NET Core Runtime 3.1](https://github.com/dotnet/core-setup/blob/master/README.md#daily-builds)|


### PR DESCRIPTION
Hello,

The table didn't render because there was an extra column indicator ("|:------:|") after the header. There were five indicators, when it should have been four according to the header. This is fixed by removing the extra column indicator.

Thanks!