### PR TITLE
API diff between .NET 8 Preview 7 and .NET 8 RC 1

### DIFF
--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1.md
@@ -1,0 +1,37 @@
+# API Difference 8.0-preview7 vs 8.0-rc1
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Builder](8.0-rc1_Microsoft.AspNetCore.Builder.md)
+* [Microsoft.AspNetCore.Components](8.0-rc1_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Discovery](8.0-rc1_Microsoft.AspNetCore.Components.Discovery.md)
+* [Microsoft.AspNetCore.Components.Endpoints](8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.md)
+* [Microsoft.AspNetCore.Components.Endpoints.Infrastructure](8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md)
+* [Microsoft.AspNetCore.Components.Forms](8.0-rc1_Microsoft.AspNetCore.Components.Forms.md)
+* [Microsoft.AspNetCore.Components.Infrastructure](8.0-rc1_Microsoft.AspNetCore.Components.Infrastructure.md)
+* [Microsoft.AspNetCore.Components.Routing](8.0-rc1_Microsoft.AspNetCore.Components.Routing.md)
+* [Microsoft.AspNetCore.Connections.Abstractions](8.0-rc1_Microsoft.AspNetCore.Connections.Abstractions.md)
+* [Microsoft.AspNetCore.Http](8.0-rc1_Microsoft.AspNetCore.Http.md)
+* [Microsoft.AspNetCore.Http.Connections](8.0-rc1_Microsoft.AspNetCore.Http.Connections.md)
+* [Microsoft.AspNetCore.Http.Metadata](8.0-rc1_Microsoft.AspNetCore.Http.Metadata.md)
+* [Microsoft.AspNetCore.HttpOverrides](8.0-rc1_Microsoft.AspNetCore.HttpOverrides.md)
+* [Microsoft.AspNetCore.Mvc](8.0-rc1_Microsoft.AspNetCore.Mvc.md)
+* [Microsoft.AspNetCore.Mvc.ApplicationModels](8.0-rc1_Microsoft.AspNetCore.Mvc.ApplicationModels.md)
+* [Microsoft.AspNetCore.Mvc.Controllers](8.0-rc1_Microsoft.AspNetCore.Mvc.Controllers.md)
+* [Microsoft.AspNetCore.Mvc.Filters](8.0-rc1_Microsoft.AspNetCore.Mvc.Filters.md)
+* [Microsoft.AspNetCore.Mvc.ModelBinding](8.0-rc1_Microsoft.AspNetCore.Mvc.ModelBinding.md)
+* [Microsoft.AspNetCore.Mvc.Razor](8.0-rc1_Microsoft.AspNetCore.Mvc.Razor.md)
+* [Microsoft.AspNetCore.Mvc.RazorPages](8.0-rc1_Microsoft.AspNetCore.Mvc.RazorPages.md)
+* [Microsoft.AspNetCore.Mvc.Rendering](8.0-rc1_Microsoft.AspNetCore.Mvc.Rendering.md)
+* [Microsoft.AspNetCore.Mvc.TagHelpers](8.0-rc1_Microsoft.AspNetCore.Mvc.TagHelpers.md)
+* [Microsoft.AspNetCore.Mvc.ViewFeatures](8.0-rc1_Microsoft.AspNetCore.Mvc.ViewFeatures.md)
+* [Microsoft.AspNetCore.Routing](8.0-rc1_Microsoft.AspNetCore.Routing.md)
+* [Microsoft.AspNetCore.Server.Kestrel.Core](8.0-rc1_Microsoft.AspNetCore.Server.Kestrel.Core.md)
+* [Microsoft.AspNetCore.SignalR](8.0-rc1_Microsoft.AspNetCore.SignalR.md)
+* [Microsoft.Extensions.DependencyInjection](8.0-rc1_Microsoft.Extensions.DependencyInjection.md)
+* [Microsoft.Extensions.Diagnostics.HealthChecks](8.0-rc1_Microsoft.Extensions.Diagnostics.HealthChecks.md)
+* [Microsoft.Extensions.Diagnostics.Metrics](8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.md)
+* [Microsoft.Extensions.Diagnostics.Metrics.Configuration](8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.Configuration.md)
+* [Microsoft.Extensions.Hosting](8.0-rc1_Microsoft.Extensions.Hosting.md)
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Builder.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Builder.md
@@ -1,0 +1,39 @@
+# Microsoft.AspNetCore.Builder
+
+``` diff
+ namespace Microsoft.AspNetCore.Builder {
+     public class ForwardedHeadersOptions {
++        public string ForwardedPrefixHeaderName { get; set; }
++        public string OriginalPrefixHeaderName { get; set; }
+     }
+-    public class RazorComponentEndpointConventionBuilder : IEndpointConventionBuilder {
+-        public ComponentApplicationBuilder ApplicationBuilder { get; }
+-        public void Add(Action<EndpointBuilder> convention);
+-        public RazorComponentEndpointConventionBuilder AddServerRenderMode();
+-        public RazorComponentEndpointConventionBuilder AddWebAssemblyRenderMode();
+-        public void Finally(Action<EndpointBuilder> finallyConvention);
+-    }
++    public sealed class RazorComponentsEndpointConventionBuilder : IEndpointConventionBuilder {
++        public void Add(Action<EndpointBuilder> convention);
++        public void AddRenderMode(IComponentRenderMode renderMode);
++        public RazorComponentsEndpointConventionBuilder AddServerRenderMode();
++        public void Finally(Action<EndpointBuilder> finallyConvention);
++    }
++    public static class RazorComponentsEndpointConventionBuilderExtensions {
++        public static RazorComponentsEndpointConventionBuilder AddAdditionalAssemblies(this RazorComponentsEndpointConventionBuilder builder, params Assembly[] assemblies);
++    }
+     public static class RazorComponentsEndpointRouteBuilderExtensions {
+-        public static RazorComponentEndpointConventionBuilder MapRazorComponents<TRootComponent>(this IEndpointRouteBuilder endpoints);
++        public static RazorComponentsEndpointConventionBuilder MapRazorComponents<TRootComponent>(this IEndpointRouteBuilder endpoints);
+     }
+     public static class RoutingEndpointConventionBuilderExtensions {
++        public static TBuilder WithFormMappingOptions<TBuilder>(this TBuilder builder, int? maxCollectionSize = default(int?), int? maxRecursionDepth = default(int?), int? maxKeySize = default(int?)) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder WithFormOptions<TBuilder>(this TBuilder builder, bool? bufferBody = default(bool?), int? memoryBufferThreshold = default(int?), long? bufferBodyLengthLimit = default(long?), int? valueCountLimit = default(int?), int? keyLengthLimit = default(int?), int? valueLengthLimit = default(int?), int? multipartBoundaryLengthLimit = default(int?), int? multipartHeadersCountLimit = default(int?), int? multipartHeadersLengthLimit = default(int?), long? multipartBodyLengthLimit = default(long?)) where TBuilder : IEndpointConventionBuilder;
++        public static TBuilder WithOrder<TBuilder>(this TBuilder builder, int order) where TBuilder : IEndpointConventionBuilder;
+     }
+     public sealed class WebApplicationBuilder : IHostApplicationBuilder {
++        public IMetricsBuilder Metrics { get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Discovery.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Discovery.md
@@ -1,0 +1,43 @@
+# Microsoft.AspNetCore.Components.Discovery
+
+``` diff
+-namespace Microsoft.AspNetCore.Components.Discovery {
+-    [DebuggerDisplayAttribute("{GetDebuggerDisplay(),nq}")]
+-    public class AssemblyComponentLibraryDescriptor {
+-        public AssemblyComponentLibraryDescriptor(string name, IReadOnlyList<PageComponentBuilder> pages, IReadOnlyList<ComponentBuilder> components);
+-        public string AssemblyName { get; }
+-        public IReadOnlyList<ComponentBuilder> Components { get; }
+-        public IReadOnlyList<PageComponentBuilder> Pages { get; }
+-    }
+-    public class ComponentApplicationBuilder {
+-        public ComponentApplicationBuilder();
+-        public void AddLibrary(AssemblyComponentLibraryDescriptor libraryBuilder);
+-        public void Combine(ComponentApplicationBuilder other);
+-        public void Exclude(ComponentApplicationBuilder builder);
+-        public static ComponentApplicationBuilder? GetBuilder<TComponent>();
+-        public bool HasLibrary(string assemblyName);
+-        public void RemoveLibrary(string assembly);
+-    }
+-    public class ComponentBuilder : IEquatable<ComponentBuilder?> {
+-        public ComponentBuilder();
+-        public required string AssemblyName { get; set; }
+-        public required Type ComponentType { get; set; }
+-        public RenderModeAttribute? RenderMode { get; set; }
+-        public bool Equals(ComponentBuilder? other);
+-        public override bool Equals(object? obj);
+-        public override int GetHashCode();
+-    }
+-    [DebuggerDisplayAttribute("{GetDebuggerDisplay(),nq}")]
+-    public class PageComponentBuilder : IEquatable<PageComponentBuilder?> {
+-        public PageComponentBuilder();
+-        public required string AssemblyName { get; set; }
+-        public required Type PageType { get; set; }
+-        public required IReadOnlyList<string> RouteTemplates { get; set; }
+-        public bool Equals(PageComponentBuilder? other);
+-        public override bool Equals(object? obj);
+-        public override int GetHashCode();
+-        public bool HasSource(string source);
+-    }
+-}
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md
@@ -1,0 +1,12 @@
+# Microsoft.AspNetCore.Components.Endpoints.Infrastructure
+
+``` diff
++namespace Microsoft.AspNetCore.Components.Endpoints.Infrastructure {
++    public abstract class RenderModeEndpointProvider {
++        protected RenderModeEndpointProvider();
++        public abstract IEnumerable<RouteEndpointBuilder> GetEndpointBuilders(IComponentRenderMode renderMode, IApplicationBuilder applicationBuilder);
++        public abstract bool Supports(IComponentRenderMode renderMode);
++    }
++}
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Endpoints.md
@@ -1,0 +1,37 @@
+# Microsoft.AspNetCore.Components.Endpoints
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Endpoints {
+-    public class ComponentTypeMetadata
++    public sealed class ComponentTypeMetadata
++    public interface IRazorComponentEndpointInvoker {
++        Task Render(HttpContext context);
++    }
+-    public interface IRazorComponentsBuilder {
+-        IServiceCollection Services { get; }
+-    }
+-    public class RazorComponentDataSourceOptions {
+-        public RazorComponentDataSourceOptions();
+-        public bool UseDeclaredRenderModes { get; set; }
+-    }
++    public sealed class RazorComponentsOptions {
++        public RazorComponentsOptions();
++        public int MaxFormMappingCollectionSize { get; set; }
++        public int MaxFormMappingErrorCount { get; set; }
++        public int MaxFormMappingKeySize { get; set; }
++        public int MaxFormMappingRecursionDepth { get; set; }
++    }
+-    public abstract class RenderModeEndpointProvider {
+-        protected RenderModeEndpointProvider();
+-        public abstract IEnumerable<RouteEndpointBuilder> GetEndpointBuilders(IComponentRenderMode renderMode, IApplicationBuilder applicationBuilder);
+-        public abstract bool Supports(IComponentRenderMode renderMode);
+-    }
+-    public class RootComponentMetadata
++    public sealed class RootComponentMetadata
+-    public sealed class WebAssemblyComponentsEndpointOptions {
+-        public WebAssemblyComponentsEndpointOptions();
+-        public PathString PathPrefix { get; set; }
+-    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Forms.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Forms.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.Forms
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Forms {
+     public sealed class EditContext {
++        public bool IsValid(in FieldIdentifier fieldIdentifier);
++        public bool IsValid(Expression<Func<object>> accessor);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Infrastructure.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Infrastructure.md
@@ -1,0 +1,12 @@
+# Microsoft.AspNetCore.Components.Infrastructure
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Infrastructure {
+-    [AttributeUsageAttribute(1, AllowMultiple=false)]
+-    public abstract class RazorComponentApplicationAttribute : Attribute, IRazorComponentApplication {
+-        protected RazorComponentApplicationAttribute();
+-        public abstract ComponentApplicationBuilder GetBuilder();
+-    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Routing.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.Routing.md
@@ -1,0 +1,14 @@
+# Microsoft.AspNetCore.Components.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Routing {
+     public class Router : IComponent, IDisposable, IHandleAfterRender {
+-        [EditorRequiredAttribute]
+-        [ParameterAttribute]
+-        public RenderFragment NotFound { get; set; }
++        [ParameterAttribute]
++        public RenderFragment NotFound { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
+     public abstract class NavigationManager {
++        public virtual void Refresh(bool forceReload = false);
+     }
+     public sealed class RouteData {
++        public string? Template { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Connections.Abstractions.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Connections.Abstractions.md
@@ -1,0 +1,15 @@
+# Microsoft.AspNetCore.Connections.Abstractions
+
+``` diff
+ namespace Microsoft.AspNetCore.Connections.Abstractions {
+-    public interface IReconnectFeature {
+-        Action NotifyOnReconnect { get; set; }
+-    }
++    [RequiresPreviewFeaturesAttribute("IStatefulReconnectFeature is a preview interface")]
++    public interface IStatefulReconnectFeature {
++        void DisableReconnect();
++        void OnReconnected(Func<PipeWriter, Task> notifyOnReconnect);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.Connections.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.Connections.md
@@ -1,0 +1,15 @@
+# Microsoft.AspNetCore.Http.Connections
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Connections {
+     public class HttpConnectionDispatcherOptions {
+-        public bool AllowAcks { get; set; }
++        public bool AllowStatefulReconnects { get; set; }
+     }
+     public class NegotiationResponse {
+-        public bool UseAcking { get; set; }
++        public bool UseStatefulReconnect { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.Metadata.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.Metadata.md
@@ -1,0 +1,25 @@
+# Microsoft.AspNetCore.Http.Metadata
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.Metadata {
++    public class FormMappingOptionsMetadata {
++        public FormMappingOptionsMetadata(int? maxCollectionSize = default(int?), int? maxRecursionDepth = default(int?), int? maxKeySize = default(int?));
++        public int? MaxCollectionSize { get; }
++        public int? MaxKeySize { get; }
++        public int? MaxRecursionDepth { get; }
++    }
++    public interface IFormOptionsMetadata {
++        bool? BufferBody { get; }
++        long? BufferBodyLengthLimit { get; }
++        int? KeyLengthLimit { get; }
++        int? MemoryBufferThreshold { get; }
++        long? MultipartBodyLengthLimit { get; }
++        int? MultipartBoundaryLengthLimit { get; }
++        int? MultipartHeadersCountLimit { get; }
++        int? MultipartHeadersLengthLimit { get; }
++        int? ValueCountLimit { get; }
++        int? ValueLengthLimit { get; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Http.md
@@ -1,0 +1,16 @@
+# Microsoft.AspNetCore.Http
+
+``` diff
+ namespace Microsoft.AspNetCore.Http {
+-    [DebuggerDisplayAttribute("Count = {Count}")]
+-    [DebuggerTypeProxyAttribute(typeof(HeaderDictionary.HeaderDictionaryDebugView))]
+-    public class HeaderDictionary : ICollection<KeyValuePair<string, StringValues>>, IDictionary<string, StringValues>, IEnumerable, IEnumerable<KeyValuePair<string, StringValues>>, IHeaderDictionary
++    [DebuggerDisplayAttribute("{DebuggerToString(),nq}")]
++    [DebuggerTypeProxyAttribute(typeof(HeaderDictionary.HeaderDictionaryDebugView))]
++    public class HeaderDictionary : ICollection<KeyValuePair<string, StringValues>>, IDictionary<string, StringValues>, IEnumerable, IEnumerable<KeyValuePair<string, StringValues>>, IHeaderDictionary
+-    public class HttpContextAccessor : IHttpContextAccessor
++    [DebuggerDisplayAttribute("HttpContext = {HttpContext}")]
++    public class HttpContextAccessor : IHttpContextAccessor
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.HttpOverrides.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.HttpOverrides.md
@@ -1,0 +1,17 @@
+# Microsoft.AspNetCore.HttpOverrides
+
+``` diff
+ namespace Microsoft.AspNetCore.HttpOverrides {
+     [FlagsAttribute]
+     public enum ForwardedHeaders {
+-        All = 7,
++        All = 15,
++        XForwardedPrefix = 8,
+     }
+     public static class ForwardedHeadersDefaults {
++        public static string XForwardedPrefixHeaderName { get; }
++        public static string XOriginalPrefixHeaderName { get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ApplicationModels.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ApplicationModels.md
@@ -1,0 +1,31 @@
+# Microsoft.AspNetCore.Mvc.ApplicationModels
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.ApplicationModels {
+-    [DebuggerDisplayAttribute("ApplicationModel: Controllers: {Controllers.Count}, Filters: {Filters.Count}")]
+-    public class ApplicationModel : IApiExplorerModel, IFilterModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Controllers = {Controllers.Count}, Filters = {Filters.Count}")]
++    public class ApplicationModel : IApiExplorerModel, IFilterModel, IPropertyModel
+-    [DebuggerDisplayAttribute("PageHandlerModel: Name={Name}")]
+-    public class PageHandlerModel : ICommonModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Name = {Name}")]
++    public class PageHandlerModel : ICommonModel, IPropertyModel
+-    [DebuggerDisplayAttribute("PageParameterModel: Name={ParameterName}")]
+-    public class PageParameterModel : ParameterModelBase, IBindingModel, ICommonModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Name = {ParameterName}")]
++    public class PageParameterModel : ParameterModelBase, IBindingModel, ICommonModel, IPropertyModel
+-    [DebuggerDisplayAttribute("PagePropertyModel: Name={PropertyName}")]
+-    public class PagePropertyModel : ParameterModelBase, ICommonModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Name = {PropertyName}")]
++    public class PagePropertyModel : ParameterModelBase, ICommonModel, IPropertyModel
+-    [DebuggerDisplayAttribute("ParameterModel: Name={ParameterName}")]
+-    public class ParameterModel : ParameterModelBase, ICommonModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Name = {ParameterName}")]
++    public class ParameterModel : ParameterModelBase, ICommonModel, IPropertyModel
+-    [DebuggerDisplayAttribute("PropertyModel: Name={PropertyName}")]
+-    public class PropertyModel : ParameterModelBase, IBindingModel, ICommonModel, IPropertyModel
++    [DebuggerDisplayAttribute("Type = {GetType().Name}, Name = {PropertyName}")]
++    public class PropertyModel : ParameterModelBase, IBindingModel, ICommonModel, IPropertyModel
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Controllers.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Controllers.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Mvc.Controllers
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Controllers {
+-    [DebuggerDisplayAttribute("{DisplayName}")]
+-    public class ControllerActionDescriptor : ActionDescriptor
++    [DebuggerDisplayAttribute("{DisplayName,nq}")]
++    public class ControllerActionDescriptor : ActionDescriptor
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Filters.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Filters.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Mvc.Filters
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Filters {
+-    [DebuggerDisplayAttribute("FilterItem: {Filter}")]
+-    public class FilterItem
++    [DebuggerDisplayAttribute("Filter = {Filter}")]
++    public class FilterItem
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ModelBinding.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ModelBinding.md
@@ -1,0 +1,18 @@
+# Microsoft.AspNetCore.Mvc.ModelBinding
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.ModelBinding {
+     public class BindingInfo {
++        public object ServiceKey { get; set; }
+     }
+-    [DebuggerDisplayAttribute("Source: {DisplayName}")]
+-    public class BindingSource : IEquatable<BindingSource?>
++    [DebuggerDisplayAttribute("Source = {DisplayName}")]
++    public class BindingSource : IEquatable<BindingSource?>
+-    public class ModelStateDictionary : IEnumerable, IEnumerable<KeyValuePair<string, ModelStateEntry?>>, IReadOnlyCollection<KeyValuePair<string, ModelStateEntry?>>, IReadOnlyDictionary<string, ModelStateEntry?>
++    [DebuggerDisplayAttribute("Entries = {Count}, IsValid = {IsValid}")]
++    [DebuggerTypeProxyAttribute(typeof(ModelStateDictionary.ModelStateDictionaryDebugView))]
++    public class ModelStateDictionary : IEnumerable, IEnumerable<KeyValuePair<string, ModelStateEntry?>>, IReadOnlyCollection<KeyValuePair<string, ModelStateEntry?>>, IReadOnlyDictionary<string, ModelStateEntry?>
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Razor.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Razor.md
@@ -1,0 +1,37 @@
+# Microsoft.AspNetCore.Mvc.Razor
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Razor {
+     public abstract class RazorPageBase : IRazorPage {
+-        public IHtmlContent? BodyContent { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IHtmlContent? BodyContent { get; set; }
+-        [RazorInjectAttribute]
+-        public DiagnosticSource DiagnosticSource { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        [RazorInjectAttribute]
++        public DiagnosticSource DiagnosticSource { get; set; }
+-        [RazorInjectAttribute]
+-        public HtmlEncoder HtmlEncoder { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        [RazorInjectAttribute]
++        public HtmlEncoder HtmlEncoder { get; set; }
+-        public bool IsLayoutBeingRendered { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public bool IsLayoutBeingRendered { get; set; }
+-        public virtual TextWriter Output { get; }
++        [DebuggerBrowsableAttribute(0)]
++        public virtual TextWriter Output { get; }
+-        public IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; }
+-        public IDictionary<string, RenderAsyncDelegate> SectionWriters { get; }
++        [DebuggerBrowsableAttribute(0)]
++        public IDictionary<string, RenderAsyncDelegate> SectionWriters { get; }
+     }
+-    public class RazorView : IView
++    [DebuggerDisplayAttribute("{Path,nq}")]
++    public class RazorView : IView
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.RazorPages.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.RazorPages.md
@@ -1,0 +1,15 @@
+# Microsoft.AspNetCore.Mvc.RazorPages
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.RazorPages {
+     public abstract class PageBase : RazorPageBase {
+-        public IModelMetadataProvider MetadataProvider { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IModelMetadataProvider MetadataProvider { get; set; }
+     }
+-    public class PageContext : ActionContext
++    [DebuggerDisplayAttribute("{DebuggerToString(),nq}")]
++    public class PageContext : ActionContext
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Rendering.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.Rendering.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Mvc.Rendering
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Rendering {
+-    public class ViewContext : ActionContext
++    [DebuggerDisplayAttribute("{DebuggerToString(),nq}")]
++    public class ViewContext : ActionContext
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.TagHelpers.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.TagHelpers.md
@@ -1,0 +1,12 @@
+# Microsoft.AspNetCore.Mvc.TagHelpers
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.TagHelpers {
+     [HtmlTargetElementAttribute("input", Attributes="asp-for", TagStructure=TagStructure.WithoutEndTag)]
+     public class InputTagHelper : TagHelper {
++        [HtmlAttributeNameAttribute("form")]
++        public string FormName { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ViewFeatures.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.ViewFeatures.md
@@ -1,0 +1,22 @@
+# Microsoft.AspNetCore.Mvc.ViewFeatures
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.ViewFeatures {
+-    public class FormContext
++    [DebuggerDisplayAttribute("FormData = {FormData.Count}")]
++    public class FormContext
+-    [DebuggerDisplayAttribute("DeclaredType={Metadata.ModelType.Name} PropertyName={Metadata.PropertyName}")]
+-    public class ModelExplorer
++    [DebuggerDisplayAttribute("DeclaredType = {Metadata.ModelType.Name}, PropertyName = {Metadata.PropertyName}")]
++    public class ModelExplorer
+-    public class TempDataDictionary : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>>, ITempDataDictionary
++    [DebuggerDisplayAttribute("Count = {Count}")]
++    [DebuggerTypeProxyAttribute(typeof(TempDataDictionary.TempDataDictionaryDebugView))]
++    public class TempDataDictionary : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>>, ITempDataDictionary
+-    public class ViewDataDictionary : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>>
++    [DebuggerDisplayAttribute("Count = {Count}")]
++    [DebuggerTypeProxyAttribute(typeof(ViewDataDictionary.ViewDataDictionaryDebugView))]
++    public class ViewDataDictionary : ICollection<KeyValuePair<string, object?>>, IDictionary<string, object?>, IEnumerable, IEnumerable<KeyValuePair<string, object?>>
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Mvc.md
@@ -1,0 +1,59 @@
+# Microsoft.AspNetCore.Mvc
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc {
+     [ControllerAttribute]
+     public abstract class ControllerBase {
+-        public IModelMetadataProvider MetadataProvider { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IModelMetadataProvider MetadataProvider { get; set; }
+-        public IModelBinderFactory ModelBinderFactory { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IModelBinderFactory ModelBinderFactory { get; set; }
+-        public IObjectModelValidator ObjectValidator { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IObjectModelValidator ObjectValidator { get; set; }
+-        public ProblemDetailsFactory ProblemDetailsFactory { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public ProblemDetailsFactory ProblemDetailsFactory { get; set; }
+-        public IUrlHelper Url { get; set; }
++        [DebuggerBrowsableAttribute(0)]
++        public IUrlHelper Url { get; set; }
+     }
+-    public class ControllerContext : ActionContext
++    [DebuggerDisplayAttribute("{DebuggerToString(),nq}")]
++    public class ControllerContext : ActionContext
+-    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
+-    public class RequestFormLimitsAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter {
++    [AttributeUsageAttribute(68, AllowMultiple=false, Inherited=true)]
++    public class RequestFormLimitsAttribute : Attribute, IFilterFactory, IFilterMetadata, IFormOptionsMetadata, IOrderedFilter {
++        bool? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.BufferBody { get; }
++        long? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.BufferBodyLengthLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.KeyLengthLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.MemoryBufferThreshold { get; }
++        long? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.MultipartBodyLengthLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.MultipartBoundaryLengthLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.MultipartHeadersCountLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.MultipartHeadersLengthLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.ValueCountLimit { get; }
++        int? Microsoft.AspNetCore.Http.Metadata.IFormOptionsMetadata.ValueLengthLimit { get; }
+     }
+-    [AttributeUsageAttribute(68, AllowMultiple=true, Inherited=true)]
+-    [DebuggerDisplayAttribute("ServiceFilter: Type={ServiceType} Order={Order}")]
+-    public class ServiceFilterAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter
++    [AttributeUsageAttribute(68, AllowMultiple=true, Inherited=true)]
++    [DebuggerDisplayAttribute("Type = {ServiceType}, Order = {Order}")]
++    public class ServiceFilterAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter
+-    [DebuggerDisplayAttribute("ServiceFilter: Type={ServiceType} Order={Order}")]
+-    public class ServiceFilterAttribute<TFilter> : ServiceFilterAttribute where TFilter : IFilterMetadata
++    [DebuggerDisplayAttribute("Type = {ServiceType}, Order = {Order}")]
++    public class ServiceFilterAttribute<TFilter> : ServiceFilterAttribute where TFilter : IFilterMetadata
+-    [AttributeUsageAttribute(68, AllowMultiple=true, Inherited=true)]
+-    [DebuggerDisplayAttribute("TypeFilter: Type={ImplementationType} Order={Order}")]
+-    public class TypeFilterAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter
++    [AttributeUsageAttribute(68, AllowMultiple=true, Inherited=true)]
++    [DebuggerDisplayAttribute("Type = {ImplementationType}, Order = {Order}")]
++    public class TypeFilterAttribute : Attribute, IFilterFactory, IFilterMetadata, IOrderedFilter
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Routing.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Routing.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing {
+-    public class RouteData
++    [DebuggerDisplayAttribute("Count = {Values.Count}")]
++    [DebuggerTypeProxyAttribute(typeof(RouteData.RouteDataDebugView))]
++    public class RouteData
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Server.Kestrel.Core.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.Server.Kestrel.Core.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Server.Kestrel.Core
+
+``` diff
+ namespace Microsoft.AspNetCore.Server.Kestrel.Core {
+     public class KestrelServerOptions {
++        public bool AllowHostHeaderOverride { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.SignalR.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.AspNetCore.SignalR.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.SignalR
+
+``` diff
+ namespace Microsoft.AspNetCore.SignalR {
+     public class HubOptions {
++        public long StatefulReconnectBufferSize { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,122 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
+     public static class ComponentServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IServerSideBlazorBuilder AddServerSideBlazor(this IServiceCollection services, Action<CircuitOptions>? configure = null);
++        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IServerSideBlazorBuilder AddServerSideBlazor(this IServiceCollection services, Action<CircuitOptions>? configure = null);
+     }
+     public static class IdentityServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Identity middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IdentityBuilder AddIdentity<TUser, TRole>(this IServiceCollection services) where TUser : class where TRole : class;
++        [RequiresUnreferencedCodeAttribute("Identity middleware does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IdentityBuilder AddIdentity<TUser, TRole>(this IServiceCollection services) where TUser : class where TRole : class;
+-        [RequiresUnreferencedCodeAttribute("Identity middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IdentityBuilder AddIdentity<TUser, TRole>(this IServiceCollection services, Action<IdentityOptions> setupAction) where TUser : class where TRole : class;
++        [RequiresUnreferencedCodeAttribute("Identity middleware does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IdentityBuilder AddIdentity<TUser, TRole>(this IServiceCollection services, Action<IdentityOptions> setupAction) where TUser : class where TRole : class;
+     }
++    public interface IRazorComponentsBuilder {
++        IServiceCollection Services { get; }
++    }
+-    public interface IServerSideBlazorBuilder {
++    public interface IServerSideBlazorBuilder : IRazorComponentsBuilder {
++        IServiceCollection IRazorComponentsBuilder.Services { get; }
+-        IServiceCollection Services { get; }
++        new IServiceCollection Services { get; }
+     }
+     public static class MetricsServiceExtensions {
++        public static IServiceCollection AddMetrics(this IServiceCollection services, Action<IMetricsBuilder> configure);
+     }
+     public static class MvcRazorPagesMvcCoreBuilderExtensions {
+-        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcCoreBuilder AddRazorPages(this IMvcCoreBuilder builder);
++        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcCoreBuilder AddRazorPages(this IMvcCoreBuilder builder);
+     }
+     public static class MvcServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddControllers(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddControllers(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddControllers(this IServiceCollection services, Action<MvcOptions>? configure);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddControllers(this IServiceCollection services, Action<MvcOptions>? configure);
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddControllersWithViews(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddControllersWithViews(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddControllersWithViews(this IServiceCollection services, Action<MvcOptions>? configure);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddControllersWithViews(this IServiceCollection services, Action<MvcOptions>? configure);
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddMvc(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddMvc(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("MVC does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddMvc(this IServiceCollection services, Action<MvcOptions> setupAction);
++        [RequiresUnreferencedCodeAttribute("MVC does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddMvc(this IServiceCollection services, Action<MvcOptions> setupAction);
+-        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddRazorPages(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddRazorPages(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IMvcBuilder AddRazorPages(this IServiceCollection services, Action<RazorPagesOptions>? configure);
++        [RequiresUnreferencedCodeAttribute("Razor Pages does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IMvcBuilder AddRazorPages(this IServiceCollection services, Action<RazorPagesOptions>? configure);
+     }
+     public static class OptionsServiceCollectionExtensions {
++        public static OptionsBuilder<TOptions> AddOptionsWithValidateOnStart<TOptions, TValidateOptions>(this IServiceCollection services, string? name = null) where TOptions : class where TValidateOptions : class, IValidateOptions<TOptions>;
++        public static OptionsBuilder<TOptions> AddOptionsWithValidateOnStart<TOptions>(this IServiceCollection services, string? name = null) where TOptions : class;
+     }
+-    public class RazorComponentOptions {
+-        public RazorComponentOptions();
+-        public bool FormMappingUseCurrentCulture { get; set; }
+-        public int MaxFormMappingCollectionSize { get; set; }
+-        public int MaxFormMappingErrorCount { get; set; }
+-        public int MaxFormMappingKeySize { get; set; }
+-        public int MaxFormMappingRecursionDepth { get; set; }
+-    }
+-    public static class RazorComponentsBuilderExtensions {
+-        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IRazorComponentsBuilder AddServerComponents(this IRazorComponentsBuilder builder, Action<CircuitOptions>? configure = null);
+-    }
+     public static class RazorComponentsServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Razor Components does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IRazorComponentsBuilder AddRazorComponents(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("Razor Components does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
++        public static IRazorComponentsBuilder AddRazorComponents(this IServiceCollection services, Action<RazorComponentsOptions>? configure = null);
+-        public static IRazorComponentsBuilder AddRazorComponents(this IServiceCollection services, Action<RazorComponentOptions> setupAction);
+     }
++    public static class ServerRazorComponentsBuilderExtensions {
++        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
++        public static IServerSideBlazorBuilder AddServerComponents(this IRazorComponentsBuilder builder, Action<CircuitOptions>? configure = null);
++    }
+     public static class SessionServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Session State middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IServiceCollection AddSession(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("Session State middleware does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IServiceCollection AddSession(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("Session State middleware does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IServiceCollection AddSession(this IServiceCollection services, Action<SessionOptions> configure);
++        [RequiresUnreferencedCodeAttribute("Session State middleware does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static IServiceCollection AddSession(this IServiceCollection services, Action<SessionOptions> configure);
+     }
+     public static class SignalRDependencyInjectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("SignalR does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static ISignalRServerBuilder AddSignalR(this IServiceCollection services);
++        [RequiresUnreferencedCodeAttribute("SignalR does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static ISignalRServerBuilder AddSignalR(this IServiceCollection services);
+-        [RequiresUnreferencedCodeAttribute("SignalR does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static ISignalRServerBuilder AddSignalR(this IServiceCollection services, Action<HubOptions> configure);
++        [RequiresUnreferencedCodeAttribute("SignalR does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/trimming")]
++        public static ISignalRServerBuilder AddSignalR(this IServiceCollection services, Action<HubOptions> configure);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.HealthChecks.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.HealthChecks.md
@@ -1,0 +1,11 @@
+# Microsoft.Extensions.Diagnostics.HealthChecks
+
+``` diff
+ namespace Microsoft.Extensions.Diagnostics.HealthChecks {
+     public sealed class HealthCheckRegistration {
++        public TimeSpan? Delay { get; set; }
++        public TimeSpan? Period { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.Configuration.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.Configuration.md
@@ -1,0 +1,10 @@
+# Microsoft.Extensions.Diagnostics.Metrics.Configuration
+
+``` diff
++namespace Microsoft.Extensions.Diagnostics.Metrics.Configuration {
++    public interface IMetricListenerConfigurationFactory {
++        IConfiguration GetConfiguration(string listenerName);
++    }
++}
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Diagnostics.Metrics.md
@@ -1,0 +1,70 @@
+# Microsoft.Extensions.Diagnostics.Metrics
+
+``` diff
++namespace Microsoft.Extensions.Diagnostics.Metrics {
++    public static class ConsoleMetrics {
++        public static string DebugListenerName { get; }
++    }
++    public interface IMetricsBuilder {
++        IServiceCollection Services { get; }
++    }
++    public interface IMetricsListener {
++        string Name { get; }
++        MeasurementHandlers GetMeasurementHandlers();
++        void Initialize(IObservableInstrumentsSource source);
++        bool InstrumentPublished(Instrument instrument, out object? userState);
++        void MeasurementsCompleted(Instrument instrument, object? userState);
++    }
++    public class InstrumentRule {
++        public InstrumentRule(string meterName, string instrumentName, string listenerName, MeterScope scopes, bool enable);
++        public bool Enable { get; }
++        public string InstrumentName { get; }
++        public string ListenerName { get; }
++        public string MeterName { get; }
++        public MeterScope Scopes { get; }
++    }
++    public interface IObservableInstrumentsSource {
++        void RecordObservableInstruments();
++    }
++    public class MeasurementHandlers {
++        public MeasurementHandlers();
++        public MeasurementCallback<byte> ByteHandler { get; set; }
++        public MeasurementCallback<decimal> DecimalHandler { get; set; }
++        public MeasurementCallback<double> DoubleHandler { get; set; }
++        public MeasurementCallback<float> FloatHandler { get; set; }
++        public MeasurementCallback<int> IntHandler { get; set; }
++        public MeasurementCallback<long> LongHandler { get; set; }
++        public MeasurementCallback<short> ShortHandler { get; set; }
++    }
++    [FlagsAttribute]
++    public enum MeterScope {
++        Global = 1,
++        Local = 2,
++        None = 0,
++    }
++    public static class MetricsBuilderConfigurationExtensions {
++        public static IMetricsBuilder AddConfiguration(this IMetricsBuilder builder, IConfiguration configuration);
++    }
++    public static class MetricsBuilderConsoleExtensions {
++        public static IMetricsBuilder AddDebugConsole(this IMetricsBuilder builder);
++    }
++    public static class MetricsBuilderExtensions {
++        public static IMetricsBuilder AddListener(this IMetricsBuilder builder, IMetricsListener listener);
++        public static IMetricsBuilder AddListener<T>(this IMetricsBuilder builder) where T : class, IMetricsListener;
++        public static IMetricsBuilder ClearListeners(this IMetricsBuilder builder);
++        public static IMetricsBuilder DisableMetrics(this IMetricsBuilder builder, string? meterName);
++        public static IMetricsBuilder DisableMetrics(this IMetricsBuilder builder, string? meterName, string? instrumentName = null, string? listenerName = null, MeterScope scopes = MeterScope.Global | MeterScope.Local);
++        public static MetricsOptions DisableMetrics(this MetricsOptions options, string? meterName);
++        public static MetricsOptions DisableMetrics(this MetricsOptions options, string? meterName, string? instrumentName = null, string? listenerName = null, MeterScope scopes = MeterScope.Global | MeterScope.Local);
++        public static IMetricsBuilder EnableMetrics(this IMetricsBuilder builder, string? meterName);
++        public static IMetricsBuilder EnableMetrics(this IMetricsBuilder builder, string? meterName, string? instrumentName = null, string? listenerName = null, MeterScope scopes = MeterScope.Global | MeterScope.Local);
++        public static MetricsOptions EnableMetrics(this MetricsOptions options, string? meterName);
++        public static MetricsOptions EnableMetrics(this MetricsOptions options, string? meterName, string? instrumentName = null, string? listenerName = null, MeterScope scopes = MeterScope.Global | MeterScope.Local);
++    }
++    public class MetricsOptions {
++        public MetricsOptions();
++        public IList<InstrumentRule> Rules { get; }
++    }
++}
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Hosting.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.AspNetCore.App/8.0-rc1_Microsoft.Extensions.Hosting.md
@@ -1,0 +1,17 @@
+# Microsoft.Extensions.Hosting
+
+``` diff
+ namespace Microsoft.Extensions.Hosting {
+     public sealed class HostApplicationBuilder : IHostApplicationBuilder {
++        public IMetricsBuilder Metrics { get; }
+     }
+     public static class HostingHostBuilderExtensions {
++        public static IHostBuilder ConfigureMetrics(this IHostBuilder hostBuilder, Action<IMetricsBuilder> configureMetrics);
++        public static IHostBuilder ConfigureMetrics(this IHostBuilder hostBuilder, Action<HostBuilderContext, IMetricsBuilder> configureMetrics);
+     }
+     public interface IHostApplicationBuilder {
++        IMetricsBuilder Metrics { get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1.md
@@ -1,0 +1,24 @@
+# API Difference 8.0-preview7 vs 8.0-rc1
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](8.0-rc1_System.md)
+* [System.Buffers](8.0-rc1_System.Buffers.md)
+* [System.Collections.Immutable](8.0-rc1_System.Collections.Immutable.md)
+* [System.Data.Common](8.0-rc1_System.Data.Common.md)
+* [System.IO](8.0-rc1_System.IO.md)
+* [System.Net](8.0-rc1_System.Net.md)
+* [System.Net.Http](8.0-rc1_System.Net.Http.md)
+* [System.Net.Http.Json](8.0-rc1_System.Net.Http.Json.md)
+* [System.Net.Sockets](8.0-rc1_System.Net.Sockets.md)
+* [System.Numerics](8.0-rc1_System.Numerics.md)
+* [System.Reflection](8.0-rc1_System.Reflection.md)
+* [System.Runtime.CompilerServices](8.0-rc1_System.Runtime.CompilerServices.md)
+* [System.Runtime.InteropServices](8.0-rc1_System.Runtime.InteropServices.md)
+* [System.Runtime.Intrinsics](8.0-rc1_System.Runtime.Intrinsics.md)
+* [System.Runtime.Intrinsics.Wasm](8.0-rc1_System.Runtime.Intrinsics.Wasm.md)
+* [System.Text.Json](8.0-rc1_System.Text.Json.md)
+* [System.Text.Json.Nodes](8.0-rc1_System.Text.Json.Nodes.md)
+* [System.Threading](8.0-rc1_System.Threading.md)
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Buffers.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Buffers.md
@@ -1,0 +1,10 @@
+# System.Buffers
+
+``` diff
+ namespace System.Buffers {
+     public sealed class ArrayBufferWriter<T> : IBufferWriter<T> {
++        public void ResetWrittenCount();
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Collections.Immutable.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Collections.Immutable.md
@@ -1,0 +1,19 @@
+# System.Collections.Immutable
+
+``` diff
+ namespace System.Collections.Immutable {
+-    public interface IImmutableList<T> : IEnumerable, IEnumerable<T>, IReadOnlyCollection<T>, IReadOnlyList<T>
++    [CollectionBuilderAttribute(typeof(ImmutableList), "Create")]
++    public interface IImmutableList<T> : IEnumerable, IEnumerable<T>, IReadOnlyCollection<T>, IReadOnlyList<T>
+-    public interface IImmutableQueue<T> : IEnumerable, IEnumerable<T>
++    [CollectionBuilderAttribute(typeof(ImmutableQueue), "Create")]
++    public interface IImmutableQueue<T> : IEnumerable, IEnumerable<T>
+-    public interface IImmutableSet<T> : IEnumerable, IEnumerable<T>, IReadOnlyCollection<T>
++    [CollectionBuilderAttribute(typeof(ImmutableHashSet), "Create")]
++    public interface IImmutableSet<T> : IEnumerable, IEnumerable<T>, IReadOnlyCollection<T>
+-    public interface IImmutableStack<T> : IEnumerable, IEnumerable<T>
++    [CollectionBuilderAttribute(typeof(ImmutableStack), "Create")]
++    public interface IImmutableStack<T> : IEnumerable, IEnumerable<T>
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Data.Common.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Data.Common.md
@@ -1,0 +1,11 @@
+# System.Data.Common
+
+``` diff
+ namespace System.Data.Common {
+     public abstract class DbBatchCommand {
++        public virtual bool CanCreateParameter { get; }
++        public virtual DbParameter CreateParameter();
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.IO.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.IO.md
@@ -1,0 +1,14 @@
+# System.IO
+
+``` diff
+ namespace System.IO {
+     [FlagsAttribute]
+     public enum FileAttributes {
++        None = 0,
+     }
+     public static class RandomAccess {
++        public static void FlushToDisk(SafeFileHandle handle);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Http.Json.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Http.Json.md
@@ -1,0 +1,30 @@
+# System.Net.Http.Json
+
+``` diff
+ namespace System.Net.Http.Json {
+     public static class HttpClientJsonExtensions {
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default(CancellationToken));
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, [StringSyntaxAttribute("Uri")] string? requestUri, CancellationToken cancellationToken = default(CancellationToken));
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default(CancellationToken));
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> GetFromJsonAsAsyncEnumerable<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default(CancellationToken));
+     }
+     public static class HttpContentJsonExtensions {
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> ReadFromJsonAsAsyncEnumerable<TValue>(this HttpContent content, JsonSerializerOptions? options, CancellationToken cancellationToken = default(CancellationToken));
++        public static IAsyncEnumerable<TValue?> ReadFromJsonAsAsyncEnumerable<TValue>(this HttpContent content, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default(CancellationToken));
++        [RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
++        public static IAsyncEnumerable<TValue?> ReadFromJsonAsAsyncEnumerable<TValue>(this HttpContent content, CancellationToken cancellationToken = default(CancellationToken));
+     }
+     public sealed class JsonContent : HttpContent {
++        public static JsonContent Create(object? inputValue, JsonTypeInfo jsonTypeInfo, MediaTypeHeaderValue? mediaType = null);
++        public static JsonContent Create<T>(T? inputValue, JsonTypeInfo<T> jsonTypeInfo, MediaTypeHeaderValue? mediaType = null);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Http.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Http.md
@@ -1,0 +1,10 @@
+# System.Net.Http
+
+``` diff
+ namespace System.Net.Http {
+     public class HttpMethod : IEquatable<HttpMethod> {
++        public static HttpMethod Parse(ReadOnlySpan<char> method);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Sockets.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.Sockets.md
@@ -1,0 +1,21 @@
+# System.Net.Sockets
+
+``` diff
+ namespace System.Net.Sockets {
+     public class LingerOption {
++        public override bool Equals(object? comparand);
++        public override int GetHashCode();
+     }
+     public class Socket : IDisposable {
++        public int ReceiveFrom(Span<byte> buffer, SocketFlags socketFlags, SocketAddress receivedAddress);
++        public ValueTask<int> ReceiveFromAsync(Memory<byte> buffer, SocketFlags socketFlags, SocketAddress receivedAddress, CancellationToken cancellationToken = default(CancellationToken));
++        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress);
++        public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress, CancellationToken cancellationToken = default(CancellationToken));
+     }
+     public sealed class UnixDomainSocketEndPoint : EndPoint {
++        public override bool Equals([NotNullWhenAttribute(true)] object? obj);
++        public override int GetHashCode();
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Net.md
@@ -1,0 +1,15 @@
+# System.Net
+
+``` diff
+ namespace System.Net {
+-    public class SocketAddress {
++    public class SocketAddress : IEquatable<SocketAddress> {
++        public Memory<byte> Buffer { get; }
+-        public int Size { get; }
++        public int Size { get; set; }
++        public bool Equals(SocketAddress? comparand);
++        public static int GetMaximumAddressSize(AddressFamily addressFamily);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Numerics.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Numerics.md
@@ -4,11 +4,11 @@
  namespace System.Numerics {
      public static class Vector {
 -        public static Vector<T> LoadUnsafe<T>(ref T source);
-+        public static Vector<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
++        public static Vector<T> LoadUnsafe<T>(ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static Vector<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
 +        [CLSCompliantAttribute(false)]
-+        public static Vector<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
++        public static Vector<T> LoadUnsafe<T>(ref readonly T source, UIntPtr elementOffset);
      }
  }
 ```

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Numerics.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Numerics.md
@@ -1,0 +1,15 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+     public static class Vector {
+-        public static Vector<T> LoadUnsafe<T>(ref T source);
++        public static Vector<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
++        [CLSCompliantAttribute(false)]
++        public static Vector<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Reflection.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Reflection.md
@@ -1,0 +1,24 @@
+# System.Reflection
+
+``` diff
+ namespace System.Reflection {
+     public sealed class ConstructorInvoker {
+-        public object Invoke(object arg1);
++        public object Invoke(object? arg1);
+-        public object Invoke(object arg1, object arg2);
++        public object Invoke(object? arg1, object? arg2);
+-        public object Invoke(object arg1, object arg2, object arg3);
++        public object Invoke(object? arg1, object? arg2, object? arg3);
+-        public object Invoke(object arg1, object arg2, object arg3, object arg4);
++        public object Invoke(object? arg1, object? arg2, object? arg3, object? arg4);
+     }
+-    public static class IntrospectionExtensions {
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    public static class IntrospectionExtensions {
+-        public static TypeInfo GetTypeInfo(this Type type);
++        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++        public static TypeInfo GetTypeInfo(this Type type);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.CompilerServices.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.CompilerServices.md
@@ -1,0 +1,40 @@
+# System.Runtime.CompilerServices
+
+``` diff
+ namespace System.Runtime.CompilerServices {
++    [AttributeUsageAttribute(AttributeTargets.Parameter, Inherited=false)]
++    [EditorBrowsableAttribute(EditorBrowsableState.Never)]
++    public sealed class RequiresLocationAttribute : Attribute {
++        public RequiresLocationAttribute();
++    }
+     public static class Unsafe {
+-        public static bool AreSame<T>([AllowNullAttribute] ref T left, [AllowNullAttribute] ref T right);
++        public static bool AreSame<T>([AllowNullAttribute, RequiresLocationAttribute] ref T left, [AllowNullAttribute, RequiresLocationAttribute] ref T right);
+-        public static ref T AsRef<T>([ScopedRefAttribute] in T source);
++        public static ref T AsRef<T>([RequiresLocationAttribute, ScopedRefAttribute] ref T source);
+-        public static IntPtr ByteOffset<T>([AllowNullAttribute] ref T origin, [AllowNullAttribute] ref T target);
++        public static IntPtr ByteOffset<T>([AllowNullAttribute, RequiresLocationAttribute] ref T origin, [AllowNullAttribute, RequiresLocationAttribute] ref T target);
+-        [CLSCompliantAttribute(false)]
+-        public unsafe static void Copy<T>(void* destination, ref T source);
++        [CLSCompliantAttribute(false)]
++        public unsafe static void Copy<T>(void* destination, [RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount);
++        [CLSCompliantAttribute(false)]
++        public static void CopyBlock(ref byte destination, [RequiresLocationAttribute] ref byte source, uint byteCount);
+-        [CLSCompliantAttribute(false)]
+-        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount);
++        [CLSCompliantAttribute(false)]
++        public static void CopyBlockUnaligned(ref byte destination, [RequiresLocationAttribute] ref byte source, uint byteCount);
+-        public static bool IsAddressGreaterThan<T>([AllowNullAttribute] ref T left, [AllowNullAttribute] ref T right);
++        public static bool IsAddressGreaterThan<T>([AllowNullAttribute, RequiresLocationAttribute] ref T left, [AllowNullAttribute, RequiresLocationAttribute] ref T right);
+-        public static bool IsAddressLessThan<T>([AllowNullAttribute] ref T left, [AllowNullAttribute] ref T right);
++        public static bool IsAddressLessThan<T>([AllowNullAttribute, RequiresLocationAttribute] ref T left, [AllowNullAttribute, RequiresLocationAttribute] ref T right);
+-        public static bool IsNullRef<T>(ref T source);
++        public static bool IsNullRef<T>([RequiresLocationAttribute] ref T source);
+-        public static T ReadUnaligned<T>(ref byte source);
++        public static T ReadUnaligned<T>([RequiresLocationAttribute] ref byte source);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.CompilerServices.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.CompilerServices.md
@@ -17,23 +17,23 @@
 -        [CLSCompliantAttribute(false)]
 -        public unsafe static void Copy<T>(void* destination, ref T source);
 +        [CLSCompliantAttribute(false)]
-+        public unsafe static void Copy<T>(void* destination, [RequiresLocationAttribute] ref T source);
++        public unsafe static void Copy<T>(void* destination, ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount);
 +        [CLSCompliantAttribute(false)]
-+        public static void CopyBlock(ref byte destination, [RequiresLocationAttribute] ref byte source, uint byteCount);
++        public static void CopyBlock(ref byte destination, ref readonly byte source, uint byteCount);
 -        [CLSCompliantAttribute(false)]
 -        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount);
 +        [CLSCompliantAttribute(false)]
-+        public static void CopyBlockUnaligned(ref byte destination, [RequiresLocationAttribute] ref byte source, uint byteCount);
++        public static void CopyBlockUnaligned(ref byte destination, ref readonly byte source, uint byteCount);
 -        public static bool IsAddressGreaterThan<T>([AllowNullAttribute] ref T left, [AllowNullAttribute] ref T right);
 +        public static bool IsAddressGreaterThan<T>([AllowNullAttribute, RequiresLocationAttribute] ref T left, [AllowNullAttribute, RequiresLocationAttribute] ref T right);
 -        public static bool IsAddressLessThan<T>([AllowNullAttribute] ref T left, [AllowNullAttribute] ref T right);
 +        public static bool IsAddressLessThan<T>([AllowNullAttribute, RequiresLocationAttribute] ref T left, [AllowNullAttribute, RequiresLocationAttribute] ref T right);
 -        public static bool IsNullRef<T>(ref T source);
-+        public static bool IsNullRef<T>([RequiresLocationAttribute] ref T source);
++        public static bool IsNullRef<T>(ref readonly T source);
 -        public static T ReadUnaligned<T>(ref byte source);
-+        public static T ReadUnaligned<T>([RequiresLocationAttribute] ref byte source);
++        public static T ReadUnaligned<T>(ref readonly byte source);
      }
  }
 ```

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.InteropServices.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.InteropServices.md
@@ -1,0 +1,19 @@
+# System.Runtime.InteropServices
+
+``` diff
+ namespace System.Runtime.InteropServices {
+     public static class Marshal {
+-        public static int QueryInterface(IntPtr pUnk, ref Guid iid, out IntPtr ppv);
++        public static int QueryInterface(IntPtr pUnk, in Guid iid, out IntPtr ppv);
+     }
+     public static class MemoryMarshal {
+-        public static ReadOnlySpan<T> CreateReadOnlySpan<T>([ScopedRefAttribute] ref T reference, int length);
++        public static ReadOnlySpan<T> CreateReadOnlySpan<T>([RequiresLocationAttribute, ScopedRefAttribute] ref T reference, int length);
+-        public static bool TryWrite<T>(Span<byte> destination, ref T value) where T : struct;
++        public static bool TryWrite<T>(Span<byte> destination, in T value) where T : struct;
+-        public static void Write<T>(Span<byte> destination, ref T value) where T : struct;
++        public static void Write<T>(Span<byte> destination, in T value) where T : struct;
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.Wasm.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.Wasm.md
@@ -1,0 +1,12 @@
+# System.Runtime.Intrinsics.Wasm
+
+``` diff
+ namespace System.Runtime.Intrinsics.Wasm {
+     [CLSCompliantAttribute(false)]
+     public abstract class PackedSimd {
+-        public static Vector128<byte> Shuffle(Vector128<byte> lower, Vector128<byte> upper, Vector128<byte> indices);
+-        public static Vector128<sbyte> Shuffle(Vector128<sbyte> lower, Vector128<sbyte> upper, Vector128<sbyte> indices);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.md
@@ -4,35 +4,35 @@
  namespace System.Runtime.Intrinsics {
      public static class Vector128 {
 -        public static Vector128<T> LoadUnsafe<T>(ref T source);
-+        public static Vector128<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
++        public static Vector128<T> LoadUnsafe<T>(ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static Vector128<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
 +        [CLSCompliantAttribute(false)]
-+        public static Vector128<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
++        public static Vector128<T> LoadUnsafe<T>(ref readonly T source, UIntPtr elementOffset);
      }
      public static class Vector256 {
 -        public static Vector256<T> LoadUnsafe<T>(ref T source);
-+        public static Vector256<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
++        public static Vector256<T> LoadUnsafe<T>(ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static Vector256<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
 +        [CLSCompliantAttribute(false)]
-+        public static Vector256<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
++        public static Vector256<T> LoadUnsafe<T>(ref readonly T source, UIntPtr elementOffset);
      }
      public static class Vector512 {
 -        public static Vector512<T> LoadUnsafe<T>(ref T source);
-+        public static Vector512<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
++        public static Vector512<T> LoadUnsafe<T>(ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static Vector512<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
 +        [CLSCompliantAttribute(false)]
-+        public static Vector512<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
++        public static Vector512<T> LoadUnsafe<T>(ref readonly T source, UIntPtr elementOffset);
      }
      public static class Vector64 {
 -        public static Vector64<T> LoadUnsafe<T>(ref T source);
-+        public static Vector64<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
++        public static Vector64<T> LoadUnsafe<T>(ref readonly T source);
 -        [CLSCompliantAttribute(false)]
 -        public static Vector64<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
 +        [CLSCompliantAttribute(false)]
-+        public static Vector64<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
++        public static Vector64<T> LoadUnsafe<T>(ref readonly T source, UIntPtr elementOffset);
      }
  }
 ```

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Runtime.Intrinsics.md
@@ -1,0 +1,39 @@
+# System.Runtime.Intrinsics
+
+``` diff
+ namespace System.Runtime.Intrinsics {
+     public static class Vector128 {
+-        public static Vector128<T> LoadUnsafe<T>(ref T source);
++        public static Vector128<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector128<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
++        [CLSCompliantAttribute(false)]
++        public static Vector128<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
+     }
+     public static class Vector256 {
+-        public static Vector256<T> LoadUnsafe<T>(ref T source);
++        public static Vector256<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector256<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
++        [CLSCompliantAttribute(false)]
++        public static Vector256<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
+     }
+     public static class Vector512 {
+-        public static Vector512<T> LoadUnsafe<T>(ref T source);
++        public static Vector512<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector512<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
++        [CLSCompliantAttribute(false)]
++        public static Vector512<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
+     }
+     public static class Vector64 {
+-        public static Vector64<T> LoadUnsafe<T>(ref T source);
++        public static Vector64<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source);
+-        [CLSCompliantAttribute(false)]
+-        public static Vector64<T> LoadUnsafe<T>(ref T source, UIntPtr elementOffset);
++        [CLSCompliantAttribute(false)]
++        public static Vector64<T> LoadUnsafe<T>([RequiresLocationAttribute] ref T source, UIntPtr elementOffset);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Text.Json.Nodes.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Text.Json.Nodes.md
@@ -1,0 +1,10 @@
+# System.Text.Json.Nodes
+
+``` diff
+ namespace System.Text.Json.Nodes {
+     public abstract class JsonNode {
++        public static Task<JsonNode?> ParseAsync(Stream utf8Json, JsonNodeOptions? nodeOptions = default(JsonNodeOptions?), JsonDocumentOptions documentOptions = default(JsonDocumentOptions), CancellationToken cancellationToken = default(CancellationToken));
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Text.Json.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Text.Json.md
@@ -1,0 +1,11 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     public sealed class JsonSerializerOptions {
++        [RequiresUnreferencedCodeAttribute("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires unreferenced code.")]
++        public void MakeReadOnly(bool populateMissingResolver);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Threading.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Threading.md
@@ -4,49 +4,49 @@
  namespace System.Threading {
      public static class Interlocked {
 -        public static long Read(ref long location);
-+        public static long Read([RequiresLocationAttribute] ref long location);
++        public static long Read(ref readonly long location);
 -        [CLSCompliantAttribute(false)]
 -        public static ulong Read(ref ulong location);
 +        [CLSCompliantAttribute(false)]
-+        public static ulong Read([RequiresLocationAttribute] ref ulong location);
++        public static ulong Read(ref readonly ulong location);
      }
      public static class Volatile {
 -        public static bool Read(ref bool location);
-+        public static bool Read([RequiresLocationAttribute] ref bool location);
++        public static bool Read(ref readonly bool location);
 -        public static byte Read(ref byte location);
-+        public static byte Read([RequiresLocationAttribute] ref byte location);
++        public static byte Read(ref readonly byte location);
 -        public static double Read(ref double location);
-+        public static double Read([RequiresLocationAttribute] ref double location);
++        public static double Read(ref readonly double location);
 -        public static short Read(ref short location);
-+        public static short Read([RequiresLocationAttribute] ref short location);
++        public static short Read(ref readonly short location);
 -        public static int Read(ref int location);
-+        public static int Read([RequiresLocationAttribute] ref int location);
++        public static int Read(ref readonly int location);
 -        public static long Read(ref long location);
-+        public static long Read([RequiresLocationAttribute] ref long location);
++        public static long Read(ref readonly long location);
 -        public static IntPtr Read(ref IntPtr location);
-+        public static IntPtr Read([RequiresLocationAttribute] ref IntPtr location);
++        public static IntPtr Read(ref readonly IntPtr location);
 -        [CLSCompliantAttribute(false)]
 -        public static sbyte Read(ref sbyte location);
 +        [CLSCompliantAttribute(false)]
-+        public static sbyte Read([RequiresLocationAttribute] ref sbyte location);
++        public static sbyte Read(ref readonly sbyte location);
 -        public static float Read(ref float location);
-+        public static float Read([RequiresLocationAttribute] ref float location);
++        public static float Read(ref readonly float location);
 -        [CLSCompliantAttribute(false)]
 -        public static ushort Read(ref ushort location);
 +        [CLSCompliantAttribute(false)]
-+        public static ushort Read([RequiresLocationAttribute] ref ushort location);
++        public static ushort Read(ref readonly ushort location);
 -        [CLSCompliantAttribute(false)]
 -        public static uint Read(ref uint location);
 +        [CLSCompliantAttribute(false)]
-+        public static uint Read([RequiresLocationAttribute] ref uint location);
++        public static uint Read(ref readonly uint location);
 -        [CLSCompliantAttribute(false)]
 -        public static ulong Read(ref ulong location);
 +        [CLSCompliantAttribute(false)]
-+        public static ulong Read([RequiresLocationAttribute] ref ulong location);
++        public static ulong Read(ref readonly ulong location);
 -        [CLSCompliantAttribute(false)]
 -        public static UIntPtr Read(ref UIntPtr location);
 +        [CLSCompliantAttribute(false)]
-+        public static UIntPtr Read([RequiresLocationAttribute] ref UIntPtr location);
++        public static UIntPtr Read(ref readonly UIntPtr location);
 -        [return: NotNullIfNotNullAttribute("location")]
 -        public static T Read<T>([NotNullIfNotNullAttribute("location")] ref T location) where T : class?;
 +        [return: NotNullIfNotNullAttribute("location")]

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Threading.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.Threading.md
@@ -1,0 +1,57 @@
+# System.Threading
+
+``` diff
+ namespace System.Threading {
+     public static class Interlocked {
+-        public static long Read(ref long location);
++        public static long Read([RequiresLocationAttribute] ref long location);
+-        [CLSCompliantAttribute(false)]
+-        public static ulong Read(ref ulong location);
++        [CLSCompliantAttribute(false)]
++        public static ulong Read([RequiresLocationAttribute] ref ulong location);
+     }
+     public static class Volatile {
+-        public static bool Read(ref bool location);
++        public static bool Read([RequiresLocationAttribute] ref bool location);
+-        public static byte Read(ref byte location);
++        public static byte Read([RequiresLocationAttribute] ref byte location);
+-        public static double Read(ref double location);
++        public static double Read([RequiresLocationAttribute] ref double location);
+-        public static short Read(ref short location);
++        public static short Read([RequiresLocationAttribute] ref short location);
+-        public static int Read(ref int location);
++        public static int Read([RequiresLocationAttribute] ref int location);
+-        public static long Read(ref long location);
++        public static long Read([RequiresLocationAttribute] ref long location);
+-        public static IntPtr Read(ref IntPtr location);
++        public static IntPtr Read([RequiresLocationAttribute] ref IntPtr location);
+-        [CLSCompliantAttribute(false)]
+-        public static sbyte Read(ref sbyte location);
++        [CLSCompliantAttribute(false)]
++        public static sbyte Read([RequiresLocationAttribute] ref sbyte location);
+-        public static float Read(ref float location);
++        public static float Read([RequiresLocationAttribute] ref float location);
+-        [CLSCompliantAttribute(false)]
+-        public static ushort Read(ref ushort location);
++        [CLSCompliantAttribute(false)]
++        public static ushort Read([RequiresLocationAttribute] ref ushort location);
+-        [CLSCompliantAttribute(false)]
+-        public static uint Read(ref uint location);
++        [CLSCompliantAttribute(false)]
++        public static uint Read([RequiresLocationAttribute] ref uint location);
+-        [CLSCompliantAttribute(false)]
+-        public static ulong Read(ref ulong location);
++        [CLSCompliantAttribute(false)]
++        public static ulong Read([RequiresLocationAttribute] ref ulong location);
+-        [CLSCompliantAttribute(false)]
+-        public static UIntPtr Read(ref UIntPtr location);
++        [CLSCompliantAttribute(false)]
++        public static UIntPtr Read([RequiresLocationAttribute] ref UIntPtr location);
+-        [return: NotNullIfNotNullAttribute("location")]
+-        public static T Read<T>([NotNullIfNotNullAttribute("location")] ref T location) where T : class?;
++        [return: NotNullIfNotNullAttribute("location")]
++        public static T Read<T>([NotNullIfNotNullAttribute("location"), RequiresLocationAttribute] ref T location) where T : class?;
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.md
@@ -1,0 +1,19 @@
+# System
+
+``` diff
+ namespace System {
+     public static class Nullable {
+-        public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable) where T : struct;
++        public static ref readonly T GetValueRefOrDefaultRef<T>([RequiresLocationAttribute] ref T? nullable) where T : struct;
+     }
+     [NativeMarshallingAttribute(typeof(ReadOnlySpanMarshaller<,>))]
+     public readonly ref struct ReadOnlySpan<T> {
+-        public ReadOnlySpan(in T reference);
++        public ReadOnlySpan([RequiresLocationAttribute] ref T reference);
+     }
+     public sealed class TimeZoneInfo : IDeserializationCallback, IEquatable<TimeZoneInfo?>, ISerializable {
++        public static ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones(bool skipSorting);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.NETCore.App/8.0-rc1_System.md
@@ -4,12 +4,12 @@
  namespace System {
      public static class Nullable {
 -        public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable) where T : struct;
-+        public static ref readonly T GetValueRefOrDefaultRef<T>([RequiresLocationAttribute] ref T? nullable) where T : struct;
++        public static ref readonly T GetValueRefOrDefaultRef<T>(ref readonly T? nullable) where T : struct;
      }
      [NativeMarshallingAttribute(typeof(ReadOnlySpanMarshaller<,>))]
      public readonly ref struct ReadOnlySpan<T> {
 -        public ReadOnlySpan(in T reference);
-+        public ReadOnlySpan([RequiresLocationAttribute] ref T reference);
++        public ReadOnlySpan(ref readonly T reference);
      }
      public sealed class TimeZoneInfo : IDeserializationCallback, IEquatable<TimeZoneInfo?>, ISerializable {
 +        public static ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones(bool skipSorting);

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1.md
@@ -1,0 +1,13 @@
+# API Difference 8.0-preview7 vs 8.0-rc1
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.ComponentModel.Design](8.0-rc1_System.ComponentModel.Design.md)
+* [System.ComponentModel.Design.Serialization](8.0-rc1_System.ComponentModel.Design.Serialization.md)
+* [System.Drawing.Design](8.0-rc1_System.Drawing.Design.md)
+* [System.Resources](8.0-rc1_System.Resources.md)
+* [System.Resources.Extensions](8.0-rc1_System.Resources.Extensions.md)
+* [System.Windows.Forms](8.0-rc1_System.Windows.Forms.md)
+* [System.Windows.Forms.Design](8.0-rc1_System.Windows.Forms.Design.md)
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.ComponentModel.Design.Serialization.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.ComponentModel.Design.Serialization.md
@@ -1,0 +1,30 @@
+# System.ComponentModel.Design.Serialization
+
+``` diff
+ namespace System.ComponentModel.Design.Serialization {
+     [DefaultSerializationProviderAttribute(typeof(CodeDomSerializationProvider))]
+     public class CodeDomSerializer : CodeDomSerializerBase {
+-        public virtual object Deserialize(IDesignerSerializationManager manager, object codeObject);
++        public virtual object? Deserialize(IDesignerSerializationManager manager, object codeObject);
+-        protected object DeserializeStatementToInstance(IDesignerSerializationManager manager, CodeStatement statement);
++        protected object? DeserializeStatementToInstance(IDesignerSerializationManager manager, CodeStatement statement);
+-        public virtual string GetTargetComponentName(CodeStatement statement, CodeExpression expression, Type targetType);
++        public virtual string? GetTargetComponentName(CodeStatement? statement, CodeExpression? expression, Type? targetType);
+-        public virtual object Serialize(IDesignerSerializationManager manager, object value);
++        public virtual object? Serialize(IDesignerSerializationManager manager, object value);
+-        public virtual object SerializeAbsolute(IDesignerSerializationManager manager, object value);
++        public virtual object? SerializeAbsolute(IDesignerSerializationManager manager, object value);
+-        [ObsoleteAttribute("This method has been deprecated. Use SerializeToExpression or GetExpression instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+-        protected CodeExpression SerializeToReferenceExpression(IDesignerSerializationManager manager, object value);
++        [ObsoleteAttribute("This method has been deprecated. Use SerializeToExpression or GetExpression instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
++        protected CodeExpression? SerializeToReferenceExpression(IDesignerSerializationManager manager, object value);
+     }
+     public class CodeDomSerializerException : SystemException {
+-        public CodeDomSerializerException(Exception ex, IDesignerSerializationManager manager);
++        public CodeDomSerializerException(Exception? ex, IDesignerSerializationManager manager);
+-        public CodeDomSerializerException(string message, IDesignerSerializationManager manager);
++        public CodeDomSerializerException(string? message, IDesignerSerializationManager manager);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.ComponentModel.Design.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.ComponentModel.Design.md
@@ -1,0 +1,53 @@
+# System.ComponentModel.Design
+
+``` diff
+ namespace System.ComponentModel.Design {
+     public class InheritanceService : IDisposable, IInheritanceService {
+-        protected virtual void AddInheritedComponents(Type type, IComponent component, IContainer container);
++        protected virtual void AddInheritedComponents(Type? type, IComponent component, IContainer container);
+-        protected virtual bool IgnoreInheritedMember(MemberInfo member, IComponent component);
++        protected virtual bool IgnoreInheritedMember(MemberInfo member, IComponent? component);
+     }
+     public sealed class LoadedEventArgs : EventArgs {
+-        public LoadedEventArgs(bool succeeded, ICollection errors);
++        public LoadedEventArgs(bool succeeded, ICollection? errors);
+     }
+     public abstract class ObjectSelectorEditor : UITypeEditor {
+-        protected virtual void FillTreeWithData(ObjectSelectorEditor.Selector selector, ITypeDescriptorContext context, IServiceProvider provider);
++        protected virtual void FillTreeWithData(ObjectSelectorEditor.Selector selector, ITypeDescriptorContext? context, IServiceProvider provider);
+         public class Selector : TreeView {
+-            public ObjectSelectorEditor.SelectorNode AddNode(string label, object value, ObjectSelectorEditor.SelectorNode parent);
++            public ObjectSelectorEditor.SelectorNode AddNode(string? label, object? value, ObjectSelectorEditor.SelectorNode? parent);
+-            protected void OnAfterSelect(object sender, TreeViewEventArgs e);
++            protected void OnAfterSelect(object? sender, TreeViewEventArgs e);
+-            public bool SetSelection(object value, TreeNodeCollection nodes);
++            public bool SetSelection(object? value, TreeNodeCollection? nodes);
+-            public void Start(IWindowsFormsEditorService edSvc, object value);
++            public void Start(IWindowsFormsEditorService edSvc, object? value);
+         }
+         public class SelectorNode : TreeNode {
+-            public object? value;
++            public object value;
+-            public SelectorNode(string label, object? value);
++            public SelectorNode(string label, object value);
+         }
+     }
+     public abstract class UndoEngine : IDisposable {
+-        public event EventHandler Undoing;
++        public event EventHandler? Undoing;
+-        public event EventHandler Undone;
++        public event EventHandler? Undone;
+-        protected virtual UndoEngine.UndoUnit CreateUndoUnit(string name, bool primary);
++        protected virtual UndoEngine.UndoUnit CreateUndoUnit(string? name, bool primary);
+-        protected object GetService(Type serviceType);
++        protected object? GetService(Type serviceType);
+         protected class UndoUnit {
+-            public UndoUnit(UndoEngine engine, string name);
++            public UndoUnit(UndoEngine engine, string? name);
+-            protected object GetService(Type serviceType);
++            protected object? GetService(Type serviceType);
+         }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Drawing.Design.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Drawing.Design.md
@@ -1,0 +1,11 @@
+# System.Drawing.Design
+
+``` diff
+ namespace System.Drawing.Design {
+     public class FontNameEditor : UITypeEditor {
+-        public override bool GetPaintValueSupported(ITypeDescriptorContext context);
++        public override bool GetPaintValueSupported(ITypeDescriptorContext? context);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Resources.Extensions.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Resources.Extensions.md
@@ -1,0 +1,12 @@
+# System.Resources.Extensions
+
+``` diff
+ namespace System.Resources.Extensions {
+     public sealed class PreserializedResourceWriter : IDisposable, IResourceWriter {
+-        public void AddBinaryFormattedResource(string name, byte[] value, string? typeName = null);
++        [ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId="SYSLIB0011", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
++        public void AddBinaryFormattedResource(string name, byte[] value, string? typeName = null);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Resources.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Resources.md
@@ -1,0 +1,13 @@
+# System.Resources
+
+``` diff
+ namespace System.Resources {
+     public sealed class ResXDataNode : ISerializable {
+-        public object? GetValue(AssemblyName[] names);
++        public object GetValue(AssemblyName[]? names);
+-        public string? GetValueTypeName(AssemblyName[] names);
++        public string GetValueTypeName(AssemblyName[]? names);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Windows.Forms.Design.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Windows.Forms.Design.md
@@ -1,0 +1,31 @@
+# System.Windows.Forms.Design
+
+``` diff
+ namespace System.Windows.Forms.Design {
+     public sealed class EventHandlerService : IEventHandlerService {
+-        public object GetHandler(Type handlerType);
++        public object? GetHandler(Type handlerType);
+     }
+     [CLSCompliantAttribute(false)]
+     public class FolderNameEditor : UITypeEditor {
+-        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value);
++        public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value);
+-        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context);
++        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context);
+         protected sealed class FolderBrowser : Component {
+-            public string Description { get; set; }
++            [AllowNullAttribute]
++            public string Description { get; set; }
+-            public DialogResult ShowDialog(IWin32Window owner);
++            public DialogResult ShowDialog(IWin32Window? owner);
+         }
+     }
+     public class ImageListCodeDomSerializer : CodeDomSerializer {
+-        public override object Deserialize(IDesignerSerializationManager manager, object codeObject);
++        public override object? Deserialize(IDesignerSerializationManager manager, object codeObject);
+-        public override object Serialize(IDesignerSerializationManager manager, object value);
++        public override object? Serialize(IDesignerSerializationManager manager, object value);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Windows.Forms.md
+++ b/release-notes/8.0/preview/api-diff/rc1/Microsoft.WindowsDesktop.App/8.0-rc1_System.Windows.Forms.md
@@ -1,0 +1,282 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+-    [RequiresPreviewFeaturesAttribute]
+-    public abstract class BindableComponent : Component, IBindableComponent, IComponent, IDisposable
++    public abstract class BindableComponent : Component, IBindableComponent, IComponent, IDisposable
+-    public struct BindingMemberInfo : IEquatable<BindingMemberInfo>
++    public readonly struct BindingMemberInfo : IEquatable<BindingMemberInfo>
+     [DesignerAttribute("System.Windows.Forms.Design.ButtonBaseDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     public abstract class ButtonBase : Control, ICommandBindingTargetProvider {
+-        [BindableAttribute(true)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandComponentCommandDescr")]
+-        public ICommand? Command { get; set; }
++        [BindableAttribute(true)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandComponentCommandDescr")]
++        public ICommand? Command { get; set; }
+-        [BindableAttribute(true)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandComponentCommandParameterDescr")]
+-        public object? CommandParameter { [RequiresPreviewFeaturesAttribute] get; [RequiresPreviewFeaturesAttribute] set; }
++        [BindableAttribute(true)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandComponentCommandParameterDescr")]
++        public object? CommandParameter { get; set; }
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandCanExecuteChangedEventDescr")]
+-        public event EventHandler? CommandCanExecuteChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandCanExecuteChangedEventDescr")]
++        public event EventHandler? CommandCanExecuteChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandChangedEventDescr")]
+-        public event EventHandler? CommandChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandChangedEventDescr")]
++        public event EventHandler? CommandChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandParameterChangedEventDescr")]
+-        public event EventHandler? CommandParameterChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandParameterChangedEventDescr")]
++        public event EventHandler? CommandParameterChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandCanExecuteChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandCanExecuteChanged(EventArgs e);
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandChanged(EventArgs e);
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandParameterChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandParameterChanged(EventArgs e);
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnRequestCommandExecute(EventArgs e);
++        protected virtual void OnRequestCommandExecute(EventArgs e);
+     }
+     [LookupBindingPropertiesAttribute]
+     [SRDescriptionAttribute("DescriptionCheckedListBox")]
+     public class CheckedListBox : ListBox {
+-        [DesignerSerializationVisibilityAttribute(2)]
+-        [EditorAttribute("System.Windows.Forms.Design.ListControlStringCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
+-        [LocalizableAttribute(true)]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("ListBoxItemsDescr")]
+-        public new CheckedListBox.ObjectCollection Items { get; }
++        [DesignerSerializationVisibilityAttribute(2)]
++        [EditorAttribute("System.Windows.Forms.Design.ListControlStringCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
++        [LocalizableAttribute(true)]
++        [MergablePropertyAttribute(false)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("ListBoxItemsDescr")]
++        public new CheckedListBox.ObjectCollection Items { get; }
+     }
+     public class DataGridViewButtonCell : DataGridViewCell {
+-        public override Type EditType { get; }
++        public override Type? EditType { get; }
+-        protected override object GetValue(int rowIndex);
++        protected override object? GetValue(int rowIndex);
+-        protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates elementState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts);
++        protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates elementState, object? value, object? formattedValue, string? errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts);
+     }
+     public class DataGridViewComboBoxEditingControl : ComboBox, IDataGridViewEditingControl {
+-        public virtual DataGridView EditingControlDataGridView { get; set; }
++        public virtual DataGridView? EditingControlDataGridView { get; set; }
+     }
+     [ListBindableAttribute(false)]
+     public class DataGridViewSelectedCellCollection : BaseCollection, ICollection, IEnumerable, IList {
+-        int System.Collections.ICollection.Count { get; }
++        int ICollection.Count { get; }
+-        bool System.Collections.ICollection.IsSynchronized { get; }
++        bool ICollection.IsSynchronized { get; }
+-        object System.Collections.ICollection.SyncRoot { get; }
++        object ICollection.SyncRoot { get; }
+-        bool System.Collections.IList.IsFixedSize { get; }
++        bool IList.IsFixedSize { get; }
+-        bool System.Collections.IList.IsReadOnly { get; }
++        bool IList.IsReadOnly { get; }
+-        object System.Collections.IList.this[int index] { get; set; }
++        object? IList.this[int index] { get; set; }
+-        int IList.Add(object value);
++        int IList.Add(object? value);
+-        bool IList.Contains(object value);
++        bool IList.Contains(object? value);
+-        int IList.IndexOf(object value);
++        int IList.IndexOf(object? value);
+-        void IList.Insert(int index, object value);
++        void IList.Insert(int index, object? value);
+-        void IList.Remove(object value);
++        void IList.Remove(object? value);
+     }
+-    public struct ImeModeConversion
++    public readonly struct ImeModeConversion
+     [DefaultPropertyAttribute("Document")]
+     [SRDescriptionAttribute("DescriptionPrintPreviewControl")]
+     public class PrintPreviewControl : Control {
+-        protected override CreateParams CreateParams { get; }
+-        [DefaultValueAttribute(null)]
+-        [SRCategoryAttribute("CatBehavior")]
+-        [SRDescriptionAttribute("PrintPreviewDocumentDescr")]
+-        public PrintDocument Document { get; set; }
++        [DefaultValueAttribute(null)]
++        [SRCategoryAttribute("CatBehavior")]
++        [SRDescriptionAttribute("PrintPreviewDocumentDescr")]
++        public PrintDocument? Document { get; set; }
+-        [BrowsableAttribute(false)]
+-        [DefaultValueAttribute(false)]
+-        [DispIdAttribute(-516)]
+-        [EditorBrowsableAttribute(1)]
+-        public new bool TabStop { get; set; }
++        [DefaultValueAttribute(false)]
++        [DispIdAttribute(-516)]
++        public new bool TabStop { get; set; }
+-        [SRCategoryAttribute("CatPropertyChanged")]
+-        [SRDescriptionAttribute("RadioButtonOnStartPageChangedDescr")]
+-        public event EventHandler StartPageChanged;
++        [SRCategoryAttribute("CatPropertyChanged")]
++        [SRDescriptionAttribute("RadioButtonOnStartPageChangedDescr")]
++        public event EventHandler? StartPageChanged;
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public new event EventHandler TabStopChanged;
+-        [BrowsableAttribute(false)]
+-        [EditorBrowsableAttribute(1)]
+-        public new event EventHandler TextChanged;
++        [BrowsableAttribute(false)]
++        [EditorBrowsableAttribute(1)]
++        public new event EventHandler? TextChanged;
++        protected override void OnGotFocus(EventArgs e);
++        protected override void OnLostFocus(EventArgs e);
++        protected override void OnMouseDown(MouseEventArgs e);
++        protected override void OnPaintBackground(PaintEventArgs e);
+     }
+     [DefaultEventAttribute("Click")]
+     [DefaultPropertyAttribute("Text")]
+     [DesignTimeVisibleAttribute(false)]
+     [DesignerAttribute("System.Windows.Forms.Design.ToolStripItemDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+     [ToolboxItemAttribute(false)]
+     public abstract class ToolStripItem : BindableComponent, IArrangedElement, ICommandBindingTargetProvider, IComponent, IDisposable, IDropTarget, IKeyboardToolTip, ISupportOleDropSource {
+-        [BindableAttribute(true)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandComponentCommandDescr")]
+-        public ICommand Command { get; set; }
++        [BindableAttribute(true)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandComponentCommandDescr")]
++        public ICommand Command { get; set; }
+-        [BindableAttribute(true)]
+-        [BrowsableAttribute(false)]
+-        [DesignerSerializationVisibilityAttribute(0)]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandComponentCommandParameterDescr")]
+-        public object CommandParameter { [RequiresPreviewFeaturesAttribute] get; [RequiresPreviewFeaturesAttribute] set; }
++        [BindableAttribute(true)]
++        [BrowsableAttribute(false)]
++        [DesignerSerializationVisibilityAttribute(0)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandComponentCommandParameterDescr")]
++        public object CommandParameter { get; set; }
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandCanExecuteChangedEventDescr")]
+-        public event EventHandler CommandCanExecuteChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandCanExecuteChangedEventDescr")]
++        public event EventHandler CommandCanExecuteChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandChangedEventDescr")]
+-        public event EventHandler CommandChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandChangedEventDescr")]
++        public event EventHandler CommandChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        [SRCategoryAttribute("CatData")]
+-        [SRDescriptionAttribute("CommandParameterChangedEventDescr")]
+-        public event EventHandler CommandParameterChanged;
++        [EditorBrowsableAttribute(2)]
++        [SRCategoryAttribute("CatData")]
++        [SRDescriptionAttribute("CommandParameterChangedEventDescr")]
++        public event EventHandler CommandParameterChanged;
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandCanExecuteChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandCanExecuteChanged(EventArgs e);
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandChanged(EventArgs e);
+-        [EditorBrowsableAttribute(2)]
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnCommandParameterChanged(EventArgs e);
++        [EditorBrowsableAttribute(2)]
++        protected virtual void OnCommandParameterChanged(EventArgs e);
+-        [RequiresPreviewFeaturesAttribute]
+-        protected virtual void OnRequestCommandExecute(EventArgs e);
++        protected virtual void OnRequestCommandExecute(EventArgs e);
+     }
+     public static class ToolStripManager {
+-        public static ToolStripRenderer Renderer { get; set; }
++        [AllowNullAttribute]
++        public static ToolStripRenderer Renderer { get; set; }
+-        public static event EventHandler RendererChanged;
++        public static event EventHandler? RendererChanged;
+-        public static ToolStrip FindToolStrip(string toolStripName);
++        public static ToolStrip? FindToolStrip(string toolStripName);
+     }
+     [EditorAttribute("System.Windows.Forms.Design.TreeNodeCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
+     public class TreeNodeCollection : ICollection, IEnumerable, IList {
+-        bool System.Collections.ICollection.IsSynchronized { get; }
++        bool ICollection.IsSynchronized { get; }
+-        object System.Collections.ICollection.SyncRoot { get; }
++        object ICollection.SyncRoot { get; }
+-        bool System.Collections.IList.IsFixedSize { get; }
++        bool IList.IsFixedSize { get; }
+-        object System.Collections.IList.this[int index] { get; set; }
++        object IList.this[int index] { get; set; }
+-        public virtual TreeNode Add(string text);
++        public virtual TreeNode Add(string? text);
+-        public virtual TreeNode Insert(int index, string text);
++        public virtual TreeNode Insert(int index, string? text);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc1/README.md
+++ b/release-notes/8.0/preview/api-diff/rc1/README.md
@@ -1,0 +1,7 @@
+# .NET 8.0 RC 1 API Changes
+
+The following API changes were made in .NET 8.0 RC 1:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/8.0-rc1.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/8.0-rc1.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/8.0-rc1.md)


### PR DESCRIPTION
**Known tooling issues**:
- The AsmDiff tool sometimes skips adding `{` or `{}`. Please provide a GitHub suggestion in this PR so I can correct it. [arcade#10981](https://github.com/dotnet/arcade/issues/10981)
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect. I have an issue to track this: [arcade#13814](https://github.com/dotnet/arcade/issues/13814) 
  
Repos area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @dreddy-work @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffhandley @karelz @ericstj @stephentoub

Libraries area owners:
 
- System @dotnet/area-system-runtime 
- @dotnet/area-system-buffers 
- @dotnet/area-system-collections 
- System.Data @ajcvickers @DavoudEshtehari @David-Engel @roji 
- @dotnet/area-system-io 
- System.Net @dotnet/ncl 
- @dotnet/area-system-numerics 
- @dotnet/area-system-reflection 
- @dotnet/area-system-runtime-compilerservices 
- System.Runtime.InteropServices @dotnet/interop-contrib 
- @dotnet/area-system-runtime-intrinsics
- System.Runtime.Intrinsics.Wasm @lewing @BrzVlad 
- @dotnet/area-system-text-json
- System.Threading @mangod @kouvel 