### PR TITLE
API diff between .NET 8 RC 1 and .NET 8 RC 2

### DIFF
--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2.md
@@ -1,0 +1,27 @@
+# API Difference 8.0-rc1 vs 8.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Authentication.BearerToken](8.0-rc2_Microsoft.AspNetCore.Authentication.BearerToken.md)
+* [Microsoft.AspNetCore.Builder](8.0-rc2_Microsoft.AspNetCore.Builder.md)
+* [Microsoft.AspNetCore.Components](8.0-rc2_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Endpoints](8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.md)
+* [Microsoft.AspNetCore.Components.Endpoints.Infrastructure](8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md)
+* [Microsoft.AspNetCore.Components.Forms](8.0-rc2_Microsoft.AspNetCore.Components.Forms.md)
+* [Microsoft.AspNetCore.Components.Forms.Mapping](8.0-rc2_Microsoft.AspNetCore.Components.Forms.Mapping.md)
+* [Microsoft.AspNetCore.Components.Infrastructure](8.0-rc2_Microsoft.AspNetCore.Components.Infrastructure.md)
+* [Microsoft.AspNetCore.Components.Rendering](8.0-rc2_Microsoft.AspNetCore.Components.Rendering.md)
+* [Microsoft.AspNetCore.Components.RenderTree](8.0-rc2_Microsoft.AspNetCore.Components.RenderTree.md)
+* [Microsoft.AspNetCore.Components.Routing](8.0-rc2_Microsoft.AspNetCore.Components.Routing.md)
+* [Microsoft.AspNetCore.Components.Web](8.0-rc2_Microsoft.AspNetCore.Components.Web.md)
+* [Microsoft.AspNetCore.Components.Web.HtmlRendering](8.0-rc2_Microsoft.AspNetCore.Components.Web.HtmlRendering.md)
+* [Microsoft.AspNetCore.Http.HttpResults](8.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md)
+* [Microsoft.AspNetCore.HttpLogging](8.0-rc2_Microsoft.AspNetCore.HttpLogging.md)
+* [Microsoft.AspNetCore.Identity](8.0-rc2_Microsoft.AspNetCore.Identity.md)
+* [Microsoft.AspNetCore.Identity.Data](8.0-rc2_Microsoft.AspNetCore.Identity.Data.md)
+* [Microsoft.AspNetCore.Mvc.Razor.Internal](8.0-rc2_Microsoft.AspNetCore.Mvc.Razor.Internal.md)
+* [Microsoft.AspNetCore.Routing.Template](8.0-rc2_Microsoft.AspNetCore.Routing.Template.md)
+* [Microsoft.AspNetCore.Server.IIS](8.0-rc2_Microsoft.AspNetCore.Server.IIS.md)
+* [Microsoft.Extensions.DependencyInjection](8.0-rc2_Microsoft.Extensions.DependencyInjection.md)
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Authentication.BearerToken.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Authentication.BearerToken.md
@@ -1,0 +1,14 @@
+# Microsoft.AspNetCore.Authentication.BearerToken
+
+``` diff
+ namespace Microsoft.AspNetCore.Authentication.BearerToken {
++    public sealed class AccessTokenResponse {
++        public AccessTokenResponse();
++        public required string AccessToken { get; set; }
++        public required long ExpiresIn { get; set; }
++        public required string RefreshToken { get; set; }
++        public string TokenType { get; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Builder.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Builder.md
@@ -1,0 +1,20 @@
+# Microsoft.AspNetCore.Builder
+
+``` diff
+ namespace Microsoft.AspNetCore.Builder {
+     public static class ExceptionHandlerExtensions {
++        public static IApplicationBuilder UseExceptionHandler(this IApplicationBuilder app, string errorHandlingPath, bool createScopeForErrors);
+     }
+     public class ExceptionHandlerOptions {
++        public bool CreateScopeForErrors { get; set; }
+     }
+     public sealed class RazorComponentsEndpointConventionBuilder : IEndpointConventionBuilder {
+-        public void AddRenderMode(IComponentRenderMode renderMode);
+-        public RazorComponentsEndpointConventionBuilder AddServerRenderMode();
+     }
++    public static class ServerRazorComponentsEndpointConventionBuilderExtensions {
++        public static RazorComponentsEndpointConventionBuilder AddInteractiveServerRenderMode(this RazorComponentsEndpointConventionBuilder builder);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.Infrastructure.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Endpoints.Infrastructure
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Endpoints.Infrastructure {
++    public static class ComponentEndpointConventionBuilderHelper {
++        public static void AddRenderMode(RazorComponentsEndpointConventionBuilder builder, IComponentRenderMode renderMode);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Endpoints.md
@@ -1,0 +1,44 @@
+# Microsoft.AspNetCore.Components.Endpoints
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Endpoints {
+-    public class RazorComponentResult : IResult {
+-        public RazorComponentResult(Type componentType);
+-        public RazorComponentResult(Type componentType, IReadOnlyDictionary<string, object?>? parameters);
+-        public RazorComponentResult(Type componentType, object? parameters);
+-        public Type ComponentType { get; }
+-        public string? ContentType { get; set; }
+-        public IReadOnlyDictionary<string, object?> Parameters { get; }
+-        public bool PreventStreamingRendering { get; set; }
+-        public int? StatusCode { get; set; }
+-        public Task ExecuteAsync(HttpContext httpContext);
+-    }
+-    public class RazorComponentResult<TComponent> : RazorComponentResult where TComponent : IComponent {
+-        public RazorComponentResult();
+-        public RazorComponentResult(IReadOnlyDictionary<string, object?> parameters);
+-        public RazorComponentResult(object parameters);
+-    }
+-    public class RazorComponentResultExecutor {
+-        public static readonly string DefaultContentType;
+-        public RazorComponentResultExecutor();
+-        public virtual Task ExecuteAsync(HttpContext httpContext, RazorComponentResult result);
+-    }
+-    public sealed class RazorComponentsOptions {
+-        public RazorComponentsOptions();
+-        public int MaxFormMappingCollectionSize { get; set; }
+-        public int MaxFormMappingErrorCount { get; set; }
+-        public int MaxFormMappingKeySize { get; set; }
+-        public int MaxFormMappingRecursionDepth { get; set; }
+-    }
++    public sealed class RazorComponentsServiceOptions {
++        public RazorComponentsServiceOptions();
++        public bool DetailedErrors { get; set; }
++        public int MaxFormMappingCollectionSize { get; set; }
++        public int MaxFormMappingErrorCount { get; set; }
++        public int MaxFormMappingKeySize { get; set; }
++        public int MaxFormMappingRecursionDepth { get; set; }
++        public TimeSpan TemporaryRedirectionUrlValidityDuration { get; set; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Forms.Mapping.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Forms.Mapping.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components.Forms.Mapping
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Forms.Mapping {
+-    public class FormMappingError
++    public sealed class FormMappingError
+-    public class FormValueMappingContext {
++    public sealed class FormValueMappingContext {
+-        public FormValueMappingContext(string acceptMappingScopeName, string? acceptFormName, Type valueType, string parameterName);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Forms.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Forms.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.Forms
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Forms {
+     public class EditForm : ComponentBase {
++        [ParameterAttribute]
++        public bool Enhance { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Infrastructure.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Infrastructure.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Infrastructure
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Infrastructure {
+     public class ComponentStatePersistenceManager {
+-        public Task PersistStateAsync(IPersistentComponentStateStore store, Dispatcher dispatcher);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.RenderTree.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.RenderTree.md
@@ -1,0 +1,14 @@
+# Microsoft.AspNetCore.Components.RenderTree
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.RenderTree {
+     public abstract class Renderer : IAsyncDisposable, IDisposable {
++        protected internal virtual IComponentRenderMode? GetComponentRenderMode(IComponent component);
++        protected internal ComponentState GetComponentState(IComponent component);
+     }
+     public abstract class WebRenderer : Renderer {
+-        protected virtual void UpdateRootComponents(string operationsJson);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Rendering.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Rendering.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Components.Rendering
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Rendering {
+     public sealed class RenderTreeBuilder : IDisposable {
++        public void AddComponentRenderMode(IComponentRenderMode renderMode);
+-        public void AddComponentRenderMode(int sequence, IComponentRenderMode renderMode);
+-        public void AddNamedEvent(int sequence, string eventType, string assignedName);
++        public void AddNamedEvent(string eventType, string assignedName);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Routing.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Routing.md
@@ -1,0 +1,14 @@
+# Microsoft.AspNetCore.Components.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Routing {
+     public class Router : IComponent, IDisposable, IHandleAfterRender {
+-        [ParameterAttribute]
+-        public bool PreferExactMatches { get; set; }
++        [ObsoleteAttribute("This property is obsolete and configuring it has not effect.")]
++        [ParameterAttribute]
++        public bool PreferExactMatches { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Web.HtmlRendering.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Web.HtmlRendering.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Web.HtmlRendering
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Web.HtmlRendering {
+     public readonly struct HtmlRootComponent {
+-        public int ComponentId { get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Web.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.Web.md
@@ -1,0 +1,267 @@
+# Microsoft.AspNetCore.Components.Web
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Web {
+-    public class AutoRenderMode : IComponentRenderMode {
+-        public AutoRenderMode();
+-        public AutoRenderMode(bool prerender);
+-        public bool Prerender { get; }
+-    }
+-    [EventHandlerAttribute("onabort", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("onactivate", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onbeforeactivate", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onbeforecopy", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onbeforecut", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onbeforedeactivate", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onbeforepaste", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onblur", typeof(FocusEventArgs), true, true)]
+-    [EventHandlerAttribute("oncanplay", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("oncanplaythrough", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onchange", typeof(ChangeEventArgs), true, true)]
+-    [EventHandlerAttribute("onclick", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("oncontextmenu", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("oncopy", typeof(ClipboardEventArgs), true, true)]
+-    [EventHandlerAttribute("oncuechange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("oncut", typeof(ClipboardEventArgs), true, true)]
+-    [EventHandlerAttribute("ondblclick", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("ondeactivate", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("ondrag", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondragend", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondragenter", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondragleave", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondragover", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondragstart", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondrop", typeof(DragEventArgs), true, true)]
+-    [EventHandlerAttribute("ondurationchange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onemptied", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onended", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onerror", typeof(ErrorEventArgs), true, true)]
+-    [EventHandlerAttribute("onfocus", typeof(FocusEventArgs), true, true)]
+-    [EventHandlerAttribute("onfocusin", typeof(FocusEventArgs), true, true)]
+-    [EventHandlerAttribute("onfocusout", typeof(FocusEventArgs), true, true)]
+-    [EventHandlerAttribute("onfullscreenchange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onfullscreenerror", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("ongotpointercapture", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("oninput", typeof(ChangeEventArgs), true, true)]
+-    [EventHandlerAttribute("oninvalid", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onkeydown", typeof(KeyboardEventArgs), true, true)]
+-    [EventHandlerAttribute("onkeypress", typeof(KeyboardEventArgs), true, true)]
+-    [EventHandlerAttribute("onkeyup", typeof(KeyboardEventArgs), true, true)]
+-    [EventHandlerAttribute("onload", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("onloadeddata", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onloadedmetadata", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onloadend", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("onloadstart", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("onlostpointercapture", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onmousedown", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmouseenter", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmouseleave", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmousemove", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmouseout", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmouseover", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmouseup", typeof(MouseEventArgs), true, true)]
+-    [EventHandlerAttribute("onmousewheel", typeof(WheelEventArgs), true, true)]
+-    [EventHandlerAttribute("onpaste", typeof(ClipboardEventArgs), true, true)]
+-    [EventHandlerAttribute("onpause", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onplay", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onplaying", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onpointercancel", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerdown", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerenter", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerleave", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerlockchange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerlockerror", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onpointermove", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerout", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerover", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onpointerup", typeof(PointerEventArgs), true, true)]
+-    [EventHandlerAttribute("onprogress", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("onratechange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onreadystatechange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onreset", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onscroll", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onseeked", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onseeking", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onselect", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onselectionchange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onselectstart", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onstalled", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onstop", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onsubmit", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onsuspend", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("ontimeout", typeof(ProgressEventArgs), true, true)]
+-    [EventHandlerAttribute("ontimeupdate", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("ontoggle", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchcancel", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchend", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchenter", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchleave", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchmove", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("ontouchstart", typeof(TouchEventArgs), true, true)]
+-    [EventHandlerAttribute("onvolumechange", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onwaiting", typeof(EventArgs), true, true)]
+-    [EventHandlerAttribute("onwheel", typeof(WheelEventArgs), true, true)]
+-    public static class EventHandlers
++    [EventHandlerAttribute("onabort", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("onactivate", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onbeforeactivate", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onbeforecopy", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onbeforecut", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onbeforedeactivate", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onbeforepaste", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onblur", typeof(FocusEventArgs), true, true)]
++    [EventHandlerAttribute("oncancel", typeof(EventArgs), false, true)]
++    [EventHandlerAttribute("oncanplay", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("oncanplaythrough", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onchange", typeof(ChangeEventArgs), true, true)]
++    [EventHandlerAttribute("onclick", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onclose", typeof(EventArgs), false, true)]
++    [EventHandlerAttribute("oncontextmenu", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("oncopy", typeof(ClipboardEventArgs), true, true)]
++    [EventHandlerAttribute("oncuechange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("oncut", typeof(ClipboardEventArgs), true, true)]
++    [EventHandlerAttribute("ondblclick", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("ondeactivate", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("ondrag", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondragend", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondragenter", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondragleave", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondragover", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondragstart", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondrop", typeof(DragEventArgs), true, true)]
++    [EventHandlerAttribute("ondurationchange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onemptied", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onended", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onerror", typeof(ErrorEventArgs), true, true)]
++    [EventHandlerAttribute("onfocus", typeof(FocusEventArgs), true, true)]
++    [EventHandlerAttribute("onfocusin", typeof(FocusEventArgs), true, true)]
++    [EventHandlerAttribute("onfocusout", typeof(FocusEventArgs), true, true)]
++    [EventHandlerAttribute("onfullscreenchange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onfullscreenerror", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("ongotpointercapture", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("oninput", typeof(ChangeEventArgs), true, true)]
++    [EventHandlerAttribute("oninvalid", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onkeydown", typeof(KeyboardEventArgs), true, true)]
++    [EventHandlerAttribute("onkeypress", typeof(KeyboardEventArgs), true, true)]
++    [EventHandlerAttribute("onkeyup", typeof(KeyboardEventArgs), true, true)]
++    [EventHandlerAttribute("onload", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("onloadeddata", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onloadedmetadata", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onloadend", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("onloadstart", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("onlostpointercapture", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onmousedown", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmouseenter", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmouseleave", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmousemove", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmouseout", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmouseover", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmouseup", typeof(MouseEventArgs), true, true)]
++    [EventHandlerAttribute("onmousewheel", typeof(WheelEventArgs), true, true)]
++    [EventHandlerAttribute("onpaste", typeof(ClipboardEventArgs), true, true)]
++    [EventHandlerAttribute("onpause", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onplay", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onplaying", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onpointercancel", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerdown", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerenter", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerleave", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerlockchange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onpointerlockerror", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onpointermove", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerout", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerover", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onpointerup", typeof(PointerEventArgs), true, true)]
++    [EventHandlerAttribute("onprogress", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("onratechange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onreadystatechange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onreset", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onscroll", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onseeked", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onseeking", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onselect", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onselectionchange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onselectstart", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onstalled", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onstop", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onsubmit", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onsuspend", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("ontimeout", typeof(ProgressEventArgs), true, true)]
++    [EventHandlerAttribute("ontimeupdate", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("ontoggle", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("ontouchcancel", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("ontouchend", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("ontouchenter", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("ontouchleave", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("ontouchmove", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("ontouchstart", typeof(TouchEventArgs), true, true)]
++    [EventHandlerAttribute("onvolumechange", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onwaiting", typeof(EventArgs), true, true)]
++    [EventHandlerAttribute("onwheel", typeof(WheelEventArgs), true, true)]
++    public static class EventHandlers
++    public class InteractiveAutoRenderMode : IComponentRenderMode {
++        public InteractiveAutoRenderMode();
++        public InteractiveAutoRenderMode(bool prerender);
++        public bool Prerender { get; }
++    }
++    public class InteractiveServerRenderMode : IComponentRenderMode {
++        public InteractiveServerRenderMode();
++        public InteractiveServerRenderMode(bool prerender);
++        public bool Prerender { get; }
++    }
++    public class InteractiveWebAssemblyRenderMode : IComponentRenderMode {
++        public InteractiveWebAssemblyRenderMode();
++        public InteractiveWebAssemblyRenderMode(bool prerender);
++        public bool Prerender { get; }
++    }
+     public static class RenderMode {
+-        public static AutoRenderMode Auto { get; }
++        public static InteractiveAutoRenderMode InteractiveAuto { get; }
++        public static InteractiveServerRenderMode InteractiveServer { get; }
++        public static InteractiveWebAssemblyRenderMode InteractiveWebAssembly { get; }
+-        public static ServerRenderMode Server { get; }
+-        public static WebAssemblyRenderMode WebAssembly { get; }
+     }
+-    public class RenderModeAutoAttribute : RenderModeAttribute {
+-        public RenderModeAutoAttribute();
+-        public RenderModeAutoAttribute(bool prerender);
+-        public override IComponentRenderMode Mode { get; }
+-    }
++    public class RenderModeInteractiveAutoAttribute : RenderModeAttribute {
++        public RenderModeInteractiveAutoAttribute();
++        public RenderModeInteractiveAutoAttribute(bool prerender);
++        public override IComponentRenderMode Mode { get; }
++    }
++    public class RenderModeInteractiveServerAttribute : RenderModeAttribute {
++        public RenderModeInteractiveServerAttribute();
++        public RenderModeInteractiveServerAttribute(bool prerender);
++        public override IComponentRenderMode Mode { get; }
++    }
++    public class RenderModeInteractiveWebAssemblyAttribute : RenderModeAttribute {
++        public RenderModeInteractiveWebAssemblyAttribute();
++        public RenderModeInteractiveWebAssemblyAttribute(bool prerender);
++        public override IComponentRenderMode Mode { get; }
++    }
+-    public class RenderModeServerAttribute : RenderModeAttribute {
+-        public RenderModeServerAttribute();
+-        public RenderModeServerAttribute(bool prerender);
+-        public override IComponentRenderMode Mode { get; }
+-    }
+-    public class RenderModeWebAssemblyAttribute : RenderModeAttribute {
+-        public RenderModeWebAssemblyAttribute();
+-        public RenderModeWebAssemblyAttribute(bool prerender);
+-        public override IComponentRenderMode Mode { get; }
+-    }
+-    public class ServerRenderMode : IComponentRenderMode {
+-        public ServerRenderMode();
+-        public ServerRenderMode(bool prerender);
+-        public bool Prerender { get; }
+-    }
+-    public class WebAssemblyRenderMode : IComponentRenderMode {
+-        public WebAssemblyRenderMode();
+-        public WebAssemblyRenderMode(bool prerender);
+-        public bool Prerender { get; }
+-    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,52 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
+     [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+     public sealed class CascadingParameterAttribute : CascadingParameterAttributeBase {
+-        public override string Name { get; set; }
++        public string Name { get; set; }
+     }
+     public abstract class CascadingParameterAttributeBase : Attribute {
+-        public abstract string Name { get; set; }
+     }
+     public class CascadingValueSource<TValue> : ICascadingValueSupplier {
+-        public CascadingValueSource(Func<TValue> valueFactory, bool isFixed);
++        public CascadingValueSource(Func<TValue> initialValueFactory, bool isFixed);
+-        public CascadingValueSource(string name, Func<TValue> valueFactory, bool isFixed);
++        public CascadingValueSource(string name, Func<TValue> initialValueFactory, bool isFixed);
+     }
+     [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+     public sealed class InjectAttribute : Attribute {
++        public object Key { get; set; }
+     }
+     public interface IPersistentComponentStateStore {
++        bool SupportsRenderMode(IComponentRenderMode renderMode);
+     }
+     public class PersistentComponentState {
++        public PersistingComponentStateSubscription RegisterOnPersisting(Func<Task> callback, IComponentRenderMode? renderMode);
+     }
+-    [AttributeUsageAttribute(4)]
+-    public abstract class RenderModeAttribute : Attribute
++    [AttributeUsageAttribute(4, AllowMultiple=false, Inherited=true)]
++    public abstract class RenderModeAttribute : Attribute
+     [AttributeUsageAttribute(4, AllowMultiple=false)]
+     public class StreamRenderingAttribute : Attribute {
+-        public StreamRenderingAttribute(bool enabled);
++        public StreamRenderingAttribute(bool enabled = true);
+     }
+     [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+     public sealed class SupplyParameterFromFormAttribute : CascadingParameterAttributeBase {
++        public string FormName { get; set; }
+-        public string Handler { get; set; }
+-        public override string Name { get; set; }
++        public string Name { get; set; }
+     }
+     [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+     public sealed class SupplyParameterFromQueryAttribute : CascadingParameterAttributeBase {
+-        public override string Name { get; set; }
++        public string Name { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Http.HttpResults.md
@@ -1,0 +1,23 @@
+# Microsoft.AspNetCore.Http.HttpResults
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.HttpResults {
++    public class RazorComponentResult : IContentTypeHttpResult, IResult, IStatusCodeHttpResult {
++        public RazorComponentResult(Type componentType);
++        public RazorComponentResult(Type componentType, IReadOnlyDictionary<string, object?> parameters);
++        public RazorComponentResult(Type componentType, object parameters);
++        public Type ComponentType { get; }
++        public string? ContentType { get; set; }
++        public IReadOnlyDictionary<string, object?> Parameters { get; }
++        public bool PreventStreamingRendering { get; set; }
++        public int? StatusCode { get; set; }
++        public Task ExecuteAsync(HttpContext httpContext);
++    }
++    public class RazorComponentResult<TComponent> : RazorComponentResult where TComponent : IComponent {
++        public RazorComponentResult();
++        public RazorComponentResult(IReadOnlyDictionary<string, object?> parameters);
++        public RazorComponentResult(object parameters);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.HttpLogging.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.HttpLogging.md
@@ -1,0 +1,33 @@
+# Microsoft.AspNetCore.HttpLogging
+
+``` diff
+ namespace Microsoft.AspNetCore.HttpLogging {
+     [FlagsAttribute]
+     public enum HttpLoggingFields : long {
+-        All = (long)3325,
++        All = (long)7421,
++        Duration = (long)4096,
+     }
++    public sealed class HttpLoggingInterceptorContext {
++        public HttpLoggingInterceptorContext();
++        public HttpContext HttpContext { get; set; }
++        public HttpLoggingFields LoggingFields { get; set; }
++        public IList<KeyValuePair<string, object?>> Parameters { get; }
++        public int RequestBodyLogLimit { get; set; }
++        public int ResponseBodyLogLimit { get; set; }
++        public void AddParameter(string key, object? value);
++        public void Disable(HttpLoggingFields fields);
++        public void Enable(HttpLoggingFields fields);
++        public bool IsAnyEnabled(HttpLoggingFields fields);
++        public bool TryDisable(HttpLoggingFields fields);
++    }
+     public sealed class HttpLoggingOptions {
++        public bool CombineLogs { get; set; }
+     }
++    public interface IHttpLoggingInterceptor {
++        ValueTask OnRequestAsync(HttpLoggingInterceptorContext logContext);
++        ValueTask OnResponseAsync(HttpLoggingInterceptorContext logContext);
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Identity.Data.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Identity.Data.md
@@ -1,0 +1,65 @@
+# Microsoft.AspNetCore.Identity.Data
+
+``` diff
++namespace Microsoft.AspNetCore.Identity.Data {
++    public sealed class ForgotPasswordRequest {
++        public ForgotPasswordRequest();
++        public required string Email { get; set; }
++    }
++    public sealed class InfoRequest {
++        public InfoRequest();
++        public string NewEmail { get; set; }
++        public string NewPassword { get; set; }
++        public string OldPassword { get; set; }
++    }
++    public sealed class InfoResponse {
++        public InfoResponse();
++        public required IDictionary<string, string> Claims { get; set; }
++        public required string Email { get; set; }
++        public required bool IsEmailConfirmed { get; set; }
++    }
++    public sealed class LoginRequest {
++        public LoginRequest();
++        public required string Email { get; set; }
++        public required string Password { get; set; }
++        public string? TwoFactorCode { get; set; }
++        public string? TwoFactorRecoveryCode { get; set; }
++    }
++    public sealed class RefreshRequest {
++        public RefreshRequest();
++        public required string RefreshToken { get; set; }
++    }
++    public sealed class RegisterRequest {
++        public RegisterRequest();
++        public required string Email { get; set; }
++        public required string Password { get; set; }
++    }
++    public sealed class ResendConfirmationEmailRequest {
++        public ResendConfirmationEmailRequest();
++        public required string Email { get; set; }
++    }
++    public sealed class ResetPasswordRequest {
++        public ResetPasswordRequest();
++        public required string Email { get; set; }
++        public required string NewPassword { get; set; }
++        public required string ResetCode { get; set; }
++    }
++    public sealed class TwoFactorRequest {
++        public TwoFactorRequest();
++        public bool? Enable { get; set; }
++        public bool ForgetMachine { get; set; }
++        public bool ResetRecoveryCodes { get; set; }
++        public bool ResetSharedKey { get; set; }
++        public string TwoFactorCode { get; set; }
++    }
++    public sealed class TwoFactorResponse {
++        public TwoFactorResponse();
++        public required bool IsMachineRemembered { get; set; }
++        public required bool IsTwoFactorEnabled { get; set; }
++        public string[]? RecoveryCodes { get; set; }
++        public required int RecoveryCodesLeft { get; set; }
++        public required string SharedKey { get; set; }
++    }
++}
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Identity.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Identity.md
@@ -1,0 +1,16 @@
+# Microsoft.AspNetCore.Identity
+
+``` diff
+ namespace Microsoft.AspNetCore.Identity {
++    public interface IEmailSender<TUser> where TUser : class {
++        Task SendConfirmationLinkAsync(TUser user, string email, string confirmationLink);
++        Task SendPasswordResetCodeAsync(TUser user, string email, string resetCode);
++        Task SendPasswordResetLinkAsync(TUser user, string email, string resetLink);
++    }
+     public class SignInManager<TUser> where TUser : class {
++        public string AuthenticationScheme { get; set; }
+-        public string PrimaryAuthenticationScheme { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Mvc.Razor.Internal.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Mvc.Razor.Internal.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Mvc.Razor.Internal
+
+``` diff
+ namespace Microsoft.AspNetCore.Mvc.Razor.Internal {
+     [AttributeUsageAttribute(128, AllowMultiple=false, Inherited=true)]
+     public class RazorInjectAttribute : Attribute {
++        public object Key { get; set; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Routing.Template.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Routing.Template.md
@@ -1,0 +1,13 @@
+# Microsoft.AspNetCore.Routing.Template
+
+``` diff
+ namespace Microsoft.AspNetCore.Routing.Template {
+     [DebuggerDisplayAttribute("{DebuggerToString()}")]
+     public class TemplatePart {
+-        public bool IsLiteral { get; }
++        [MemberNotNullWhenAttribute(true, "Text")]
++        public bool IsLiteral { [MemberNotNullWhenAttribute(true, "Text")] get; }
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Server.IIS.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.AspNetCore.Server.IIS.md
@@ -1,0 +1,18 @@
+# Microsoft.AspNetCore.Server.IIS
+
+``` diff
+ namespace Microsoft.AspNetCore.Server.IIS {
++    public interface IIISEnvironmentFeature {
++        string AppConfigPath { get; }
++        string ApplicationId { get; }
++        string ApplicationPhysicalPath { get; }
++        string ApplicationVirtualPath { get; }
++        string AppPoolConfigFile { get; }
++        string AppPoolId { get; }
++        Version IISVersion { get; }
++        uint SiteId { get; }
++        string SiteName { get; }
++    }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.Extensions.DependencyInjection.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.AspNetCore.App/8.0-rc2_Microsoft.Extensions.DependencyInjection.md
@@ -1,0 +1,35 @@
+# Microsoft.Extensions.DependencyInjection
+
+``` diff
+ namespace Microsoft.Extensions.DependencyInjection {
+     public static class CascadingValueServiceCollectionExtensions {
+-        public static IServiceCollection AddCascadingValue<TValue>(this IServiceCollection serviceCollection, Func<IServiceProvider, TValue> valueFactory);
++        public static IServiceCollection AddCascadingValue<TValue>(this IServiceCollection serviceCollection, Func<IServiceProvider, TValue> initialValueFactory);
+-        public static IServiceCollection AddCascadingValue<TValue>(this IServiceCollection serviceCollection, string name, Func<IServiceProvider, TValue> valueFactory);
++        public static IServiceCollection AddCascadingValue<TValue>(this IServiceCollection serviceCollection, string name, Func<IServiceProvider, TValue> initialValueFactory);
++        public static void TryAddCascadingValue<TValue>(this IServiceCollection serviceCollection, Func<IServiceProvider, CascadingValueSource<TValue>> sourceFactory);
++        public static void TryAddCascadingValue<TValue>(this IServiceCollection serviceCollection, Func<IServiceProvider, TValue> valueFactory);
++        public static void TryAddCascadingValue<TValue>(this IServiceCollection serviceCollection, string name, Func<IServiceProvider, TValue> valueFactory);
+     }
+     public static class HttpClientFactoryServiceCollectionExtensions {
+-        public static IServiceCollection ConfigureHttpClientDefaults(IServiceCollection services, Action<IHttpClientBuilder> configure);
++        public static IServiceCollection ConfigureHttpClientDefaults(this IServiceCollection services, Action<IHttpClientBuilder> configure);
+     }
+     public static class HttpLoggingServicesExtensions {
++        public static IServiceCollection AddHttpLoggingInterceptor<T>(this IServiceCollection services) where T : class, IHttpLoggingInterceptor;
+     }
+     public static class RazorComponentsServiceCollectionExtensions {
+-        [RequiresUnreferencedCodeAttribute("Razor Components does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IRazorComponentsBuilder AddRazorComponents(this IServiceCollection services, Action<RazorComponentsOptions>? configure = null);
++        [RequiresUnreferencedCodeAttribute("Razor Components does not currently support trimming or native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
++        public static IRazorComponentsBuilder AddRazorComponents(this IServiceCollection services, Action<RazorComponentsServiceOptions>? configure = null);
+     }
+     public static class ServerRazorComponentsBuilderExtensions {
++        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
++        public static IServerSideBlazorBuilder AddInteractiveServerComponents(this IRazorComponentsBuilder builder, Action<CircuitOptions>? configure = null);
+-        [RequiresUnreferencedCodeAttribute("Server-side Blazor does not currently support native AOT.", Url="https://aka.ms/aspnet/nativeaot")]
+-        public static IServerSideBlazorBuilder AddServerComponents(this IRazorComponentsBuilder builder, Action<CircuitOptions>? configure = null);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2.md
@@ -1,0 +1,9 @@
+# API Difference 8.0-rc1 vs 8.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](8.0-rc2_System.md)
+* [System.ComponentModel.DataAnnotations](8.0-rc2_System.ComponentModel.DataAnnotations.md)
+* [System.Runtime.InteropServices](8.0-rc2_System.Runtime.InteropServices.md)
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.ComponentModel.DataAnnotations.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.ComponentModel.DataAnnotations.md
@@ -1,0 +1,13 @@
+# System.ComponentModel.DataAnnotations
+
+``` diff
+ namespace System.ComponentModel.DataAnnotations {
+     public static class Validator {
+-        public static bool TryValidateValue(object value, ValidationContext validationContext, ICollection<ValidationResult>? validationResults, IEnumerable<ValidationAttribute> validationAttributes);
++        public static bool TryValidateValue(object? value, ValidationContext validationContext, ICollection<ValidationResult>? validationResults, IEnumerable<ValidationAttribute> validationAttributes);
+-        public static void ValidateValue(object value, ValidationContext validationContext, IEnumerable<ValidationAttribute> validationAttributes);
++        public static void ValidateValue(object? value, ValidationContext validationContext, IEnumerable<ValidationAttribute> validationAttributes);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.Runtime.InteropServices.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.Runtime.InteropServices.md
@@ -1,0 +1,11 @@
+# System.Runtime.InteropServices
+
+``` diff
+ namespace System.Runtime.InteropServices {
+     public static class Marshal {
+-        public static int QueryInterface(IntPtr pUnk, in Guid iid, out IntPtr ppv);
++        public static int QueryInterface(IntPtr pUnk, [RequiresLocationAttribute] ref Guid iid, out IntPtr ppv);
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.NETCore.App/8.0-rc2_System.md
@@ -1,0 +1,12 @@
+# System
+
+``` diff
+ namespace System {
+     public static class GC {
+-        [RequiresPreviewFeaturesAttribute("RefreshMemoryLimit is in preview.")]
+-        public static void RefreshMemoryLimit();
++        public static void RefreshMemoryLimit();
+     }
+ }
+```
+

--- a/release-notes/8.0/preview/api-diff/rc2/Microsoft.WindowsDesktop.App/8.0-rc2.md
+++ b/release-notes/8.0/preview/api-diff/rc2/Microsoft.WindowsDesktop.App/8.0-rc2.md
@@ -1,0 +1,6 @@
+# API Difference 8.0-rc1 vs 8.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+

--- a/release-notes/8.0/preview/api-diff/rc2/README.md
+++ b/release-notes/8.0/preview/api-diff/rc2/README.md
@@ -1,0 +1,7 @@
+# .NET 8.0 RC 2 API Changes
+
+The following API changes were made in .NET 8.0 RC 2:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/8.0-rc2.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/8.0-rc2.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/8.0-rc2.md)


### PR DESCRIPTION
**Known tooling issues**:
- The AsmDiff tool sometimes skips adding `{` or `{}`. Please provide a GitHub suggestion in this PR so I can correct it. [arcade#10981](https://github.com/dotnet/arcade/issues/10981)
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect. I have an issue to track this: [arcade#13814](https://github.com/dotnet/arcade/issues/13814) 
  
Repos area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @dreddy-work @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffhandley @karelz @ericstj @stephentoub

Libraries area owners:
 
- System @dotnet/area-system-runtime 
- System.ComponentModel.DataAnnotations @dotnet/area-system-componentmodel-dataannotations 
- System.Runtime.InteropServices @dotnet/interop-contrib 