### PR TITLE
Update README.md to reflect correct release date for .net 7

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -5,7 +5,7 @@ The following [.NET releases](../releases.md) are currently supported:
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
 | [.NET 8](8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-rc-1/) | [LTS][policies] | [8.0.0-rc.2][8.0.0-rc.2] | November 10, 2026 |
-| [.NET 7](7.0/README.md) | [November 8, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS][policies] | [7.0.13][7.0.13] | May 14, 2024 |
+| [.NET 7](7.0/README.md) | [November 8, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS][policies] | [7.0.13][7.0.13] | May 14, 2024 |
 | [.NET 6](6.0/README.md) | [November 8, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.24][6.0.24]  | November 12, 2024 |
 
 You can find release notes for all releases, including out-of-support releases, in the [release-notes](.) directory.


### PR DESCRIPTION
The release date (year) was wrong for .net 7.  Not critical, but likely important?