### PR TITLE
Fix F#/C# versions for .NET 6/7

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -136,7 +136,7 @@
         "vs-mac-version": "",
         "vs-support": "",
         "vs-mac-support": "",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -247,7 +247,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -357,7 +357,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.2)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -467,7 +467,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -851,7 +851,7 @@
         "vs-mac-version": "",
         "vs-support": "",
         "vs-mac-support": "",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -962,7 +962,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1072,7 +1072,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.2)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1182,7 +1182,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1546,7 +1546,7 @@
         "vs-mac-version": "",
         "vs-support": "",
         "vs-mac-support": "",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -1657,7 +1657,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1767,7 +1767,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.2)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -1877,7 +1877,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2256,7 +2256,7 @@
         "vs-mac-version": "",
         "vs-support": "",
         "vs-mac-support": "",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "6.0",
         "vb-version": "16.9",
         "files": [
@@ -2367,7 +2367,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2477,7 +2477,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.2)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [
@@ -2587,7 +2587,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "6.0",
           "vb-version": "16.9",
           "files": [

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -1893,8 +1893,8 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "10.0-preview",
-          "fsharp-version": "6.0-preview",
+          "csharp-version": "12.0",
+          "fsharp-version": "7.0",
           "vb-version": "15.5",
           "files": [
             {

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -137,7 +137,7 @@
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
         "csharp-version": "12.0",
-        "fsharp-version": "6.0",
+        "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
           {
@@ -248,7 +248,7 @@
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -358,7 +358,7 @@
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -468,7 +468,7 @@
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -860,7 +860,7 @@
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
         "csharp-version": "12.0",
-        "fsharp-version": "6.0",
+        "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
           {
@@ -971,7 +971,7 @@
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -1081,7 +1081,7 @@
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -1191,7 +1191,7 @@
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -1563,7 +1563,7 @@
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
         "csharp-version": "12.0",
-        "fsharp-version": "6.0",
+        "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
           {
@@ -1674,7 +1674,7 @@
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -1784,7 +1784,7 @@
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -2274,7 +2274,7 @@
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
         "csharp-version": "12.0",
-        "fsharp-version": "6.0",
+        "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
           {
@@ -2385,7 +2385,7 @@
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {
@@ -2495,7 +2495,7 @@
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
           "csharp-version": "12.0",
-          "fsharp-version": "6.0",
+          "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
             {

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -136,7 +136,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -247,7 +247,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -357,7 +357,7 @@
           "vs-mac-version": "17.6.10",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -467,7 +467,7 @@
           "vs-mac-version": "17.4.14",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -859,7 +859,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -970,7 +970,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1080,7 +1080,7 @@
           "vs-mac-version": "17.6.9",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1190,7 +1190,7 @@
           "vs-mac-version": "17.4.13",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1562,7 +1562,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -1673,7 +1673,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1783,7 +1783,7 @@
           "vs-mac-version": "17.6.8",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1893,7 +1893,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "15.5",
           "files": [
@@ -2273,7 +2273,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "12.0",
+        "csharp-version": "10.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -2384,7 +2384,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -2494,7 +2494,7 @@
           "vs-mac-version": "17.6.7",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -2604,7 +2604,7 @@
           "vs-mac-version": "17.4.11",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "12.0",
+          "csharp-version": "10.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -136,7 +136,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -247,7 +247,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -357,7 +357,7 @@
           "vs-mac-version": "17.6.10",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -467,7 +467,7 @@
           "vs-mac-version": "17.4.14",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -859,7 +859,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -970,7 +970,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1080,7 +1080,7 @@
           "vs-mac-version": "17.6.9",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1190,7 +1190,7 @@
           "vs-mac-version": "17.4.13",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1562,7 +1562,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -1673,7 +1673,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1783,7 +1783,7 @@
           "vs-mac-version": "17.6.8",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -1893,7 +1893,7 @@
           "vs-mac-version": "",
           "vs-support": "",
           "vs-mac-support": "",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "15.5",
           "files": [
@@ -2273,7 +2273,7 @@
         "vs-mac-version": "17.6",
         "vs-support": "Visual Studio 2022 (v17.7)",
         "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-        "csharp-version": "10.0",
+        "csharp-version": "11.0",
         "fsharp-version": "7.0",
         "vb-version": "16.9",
         "files": [
@@ -2384,7 +2384,7 @@
           "vs-mac-version": "17.6",
           "vs-support": "Visual Studio 2022 (v17.7)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -2494,7 +2494,7 @@
           "vs-mac-version": "17.6.7",
           "vs-support": "Visual Studio 2022 (v17.6)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.6)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [
@@ -2604,7 +2604,7 @@
           "vs-mac-version": "17.4.11",
           "vs-support": "Visual Studio 2022 (v17.4)",
           "vs-mac-support": "Visual Studio 2022 for Mac (v17.4)",
-          "csharp-version": "10.0",
+          "csharp-version": "11.0",
           "fsharp-version": "7.0",
           "vb-version": "16.9",
           "files": [

--- a/release-notes/7.0/releases.json
+++ b/release-notes/7.0/releases.json
@@ -1895,7 +1895,7 @@
           "vs-mac-support": "",
           "csharp-version": "11.0",
           "fsharp-version": "7.0",
-          "vb-version": "15.5",
+          "vb-version": "16.9",
           "files": [
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",


### PR DESCRIPTION
We got a customer feedback for the site complaining about .NET 7 needing to support F# 7

It seems we decreased the version starting with 7.0.11

Fixes https://github.com/dotnet/website/issues/5834