### PR TITLE
Fix iOS/MacCatalyst versions in 9.0

### DIFF
--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -98,10 +98,10 @@ OS                            | Version                 | Architectures     |
 
 OS                            | Version                 | Architectures     |
 ------------------------------|-------------------------|-------------------|
-[iOS][iOS]                    | 12.1+                   | Arm64             |
-[iOS Simulator][iOS]          | 12.1+                   | x64, Arm64        |
-[tvOS][tvOS]                  | 12.1+                   | Arm64             |
-[tvOS Simulator][tvOS]        | 12.1+                   | x64, Arm64        |
+[iOS][iOS]                    | 12.2+                   | Arm64             |
+[iOS Simulator][iOS]          | 12.2+                   | x64, Arm64        |
+[tvOS][tvOS]                  | 12.2+                   | Arm64             |
+[tvOS Simulator][tvOS]        | 12.2+                   | x64, Arm64        |
 [MacCatalyst][macOS]          | 15.0+ (macOS 12.0+)     | x64, Arm64        |
 
 [iOS]: https://support.apple.com/ios

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -98,11 +98,11 @@ OS                            | Version                 | Architectures     |
 
 OS                            | Version                 | Architectures     |
 ------------------------------|-------------------------|-------------------|
-[iOS][iOS]                    | 12.0+                   | Arm64             |
-[iOS Simulator][iOS]          | 12.0+                   | x64, Arm64        |
-[tvOS][tvOS]                  | 12.0+                   | Arm64             |
-[tvOS Simulator][tvOS]        | 12.0+                   | x64, Arm64        |
-[MacCatalyst][macOS]          | 12.0+                   | x64, Arm64        |
+[iOS][iOS]                    | 12.1+                   | Arm64             |
+[iOS Simulator][iOS]          | 12.1+                   | x64, Arm64        |
+[tvOS][tvOS]                  | 12.1+                   | Arm64             |
+[tvOS Simulator][tvOS]        | 12.1+                   | x64, Arm64        |
+[MacCatalyst][macOS]          | 15.0+ (macOS 12.0+)     | x64, Arm64        |
 
 [iOS]: https://support.apple.com/ios
 [tvOS]: https://support.apple.com/apple-tv

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -102,10 +102,11 @@ OS                            | Version                 | Architectures     |
 [iOS Simulator][iOS]          | 12.2+                   | x64, Arm64        |
 [tvOS][tvOS]                  | 12.2+                   | Arm64             |
 [tvOS Simulator][tvOS]        | 12.2+                   | x64, Arm64        |
-[MacCatalyst][macOS]          | 15.0+ (macOS 12.0+)     | x64, Arm64        |
+[MacCatalyst][MacCatalyst]    | 15.0+ (macOS 12.0+)     | x64, Arm64        |
 
 [iOS]: https://support.apple.com/ios
 [tvOS]: https://support.apple.com/apple-tv
+[MacCatalyst]: https://developer.apple.com/documentation/uikit/mac_catalyst
 
 ## QEMU
 


### PR DESCRIPTION
We'll bump to 12.2 in dotnet 9: https://github.com/dotnet/runtime/issues/91736

The MacCatalyst version has two aspects: one side is the iOS version it maps to, the other is the first macOS it shipped with.
Given we only support macOS 12.0 with dotnet9 the lowest MacCatalyst version we can support is 15.0.