### PR TITLE
RunApiDiff.ps1: Fix bug setting wrong filenames and foldernames when comparing preview1 and previous version

### DIFF
--- a/release-notes/RunApiDiff.ps1
+++ b/release-notes/RunApiDiff.ps1
@@ -325,7 +325,7 @@ Function GetPreviewFolderPath
     }
 
     $previewOrRCFolderName = GetPreviewOrRCFolderName $dotNetVersion $previewOrRC $previewNumberVersion
-    Return [IO.Path]::Combine($prefixFolder, "preview", $apiDiffFolderName, $previewOrRCFolderName)
+    Return [IO.Path]::Combine($prefixFolder, "preview", $previewOrRCFolderName, $apiDiffFolderName)
 }
 
 Function RunAsmDiff

--- a/release-notes/RunApiDiff.ps1
+++ b/release-notes/RunApiDiff.ps1
@@ -313,12 +313,12 @@ Function GetPreviewFolderPath
     ,
         [Parameter(Mandatory=$true)]
         [bool]
-        $areVersionsEqual
+        $IsComparingReleases # True when comparing 8.0 GA with 9.0 GA
     )
 
     $prefixFolder = [IO.Path]::Combine($rootFolder, "release-notes", $dotNetVersion)
     $apiDiffFolderName = "api-diff"
-    If ($areVersionsEqual)
+    If (-Not $IsComparingReleases)
     {
         $previewOrRCFolderName = GetPreviewOrRCFolderName $dotNetVersion $previewOrRC $previewNumberVersion
         Return [IO.Path]::Combine($prefixFolder, "preview", $apiDiffFolderName, $previewOrRCFolderName)
@@ -616,7 +616,10 @@ ReBuildIfExeNotFound $asmDiffExe $asmDiffProjectPath $asmDiffArtifactsPath
 
 ## Recreate api-diff folder in core repo folder
 
-$previewFolderPath = GetPreviewFolderPath $CoreRepo $CurrentDotNetVersion $CurrentPreviewOrRC $CurrentPreviewNumberVersion $areVersionsEqual
+# True when comparing 8.0 GA with 9.0 GA
+$IsComparingReleases = (-Not $areVersionsEqual) -And ($PreviousPreviewOrRC -eq "ga") -And ($CurrentPreviewOrRC -eq "ga")
+
+$previewFolderPath = GetPreviewFolderPath $CoreRepo $CurrentDotNetVersion $CurrentPreviewOrRC $CurrentPreviewNumberVersion $IsComparingReleases
 Write-Color cyan "Checking existing diff folder: $previewFolderPath"
 RecreateFolder $previewFolderPath
 


### PR DESCRIPTION
Bug fixed to generate this PR: https://github.com/dotnet/core/pull/9176

The *.md files were being incorrectly named as `9.0.1_Assembly.Name.md`, when it should be `9.0-preview1_Assembly.Name.md`.

Similar problem with the parent folder name, it was showing up as `9.0.1` instead of `preview1`.

Also, invert the folders so that api-diff is the last one.