### PR TITLE
Add february updates to CVE documentation

### DIFF
--- a/release-notes/6.0/cve.md
+++ b/release-notes/6.0/cve.md
@@ -8,6 +8,9 @@ Your app needs to be on the latest .NET 6 patch version to be secure. The longer
 
 Your app may be vulnerable to the following published security [CVEs](https://www.cve.org/) if you are using an older .NET 6 patch version.
 
+- 6.0.27 (February 2024)
+  - [CVE-2024-21386 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/295)
+  - [CVE-2024-21404 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/296)
 - 6.0.26 (January 2024)
   - [CVE-2024-0056](https://github.com/dotnet/announcements/issues/292) | .NET Information Disclosure Vulnerability
   - [CVE-2024-0057 | .NET Security Feature Bypass Vulnerability](https://github.com/dotnet/announcements/issues/291)

--- a/release-notes/6.0/cve.md
+++ b/release-notes/6.0/cve.md
@@ -12,7 +12,7 @@ Your app may be vulnerable to the following published security [CVEs](https://ww
   - [CVE-2024-21386 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/295)
   - [CVE-2024-21404 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/296)
 - 6.0.26 (January 2024)
-  - [CVE-2024-0056](https://github.com/dotnet/announcements/issues/292) | .NET Information Disclosure Vulnerability
+  - [CVE-2024-0056 | .NET Information Disclosure Vulnerability](https://github.com/dotnet/announcements/issues/292)
   - [CVE-2024-0057 | .NET Security Feature Bypass Vulnerability](https://github.com/dotnet/announcements/issues/291)
   - [CVE-2024-21319 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/290)
 - 6.0.25 (November 2023)

--- a/release-notes/7.0/cve.md
+++ b/release-notes/7.0/cve.md
@@ -8,6 +8,9 @@ Your app needs to be on the latest .NET 7 patch version to be secure. The longer
 
 Your app may be vulnerable to the following published security [CVEs](https://www.cve.org/) if you are using the given version or older.
 
+- 7.0.16 (February 2024)
+  - [CVE-2024-21386 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/295)
+  - [CVE-2024-21404 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/296)
 - 7.0.15 (January 2024)
   - [CVE-2024-0056 | .NET Information Disclosure Vulnerability](https://github.com/dotnet/announcements/issues/292)
   - [CVE-2024-0057 | .NET Security Feature Bypass Vulnerability](https://github.com/dotnet/announcements/issues/291)

--- a/release-notes/8.0/cve.md
+++ b/release-notes/8.0/cve.md
@@ -7,6 +7,9 @@ Your app needs to be on the latest .NET 8 patch version to be secure. The longer
 ## Which CVEs apply to my app?
 
 Your app may be vulnerable to the following published security [CVEs](https://www.cve.org/) if you are using the given version or older.
+- 8.0.2 (February 2024)
+  - [CVE-2024-21386 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/295)
+  - [CVE-2024-21404 | .NET Denial of Service Vulnerability](https://github.com/dotnet/announcements/issues/296)
 - 8.0.1 (January 2024)
   - [CVE-2024-0056 | .NET Information Disclosure Vulnerability](https://github.com/dotnet/announcements/issues/292)
   - [CVE-2024-0057 | .NET Security Feature Bypass Vulnerability](https://github.com/dotnet/announcements/issues/291)


### PR DESCRIPTION
While working on https://github.com/dotnet/core/pull/9210/ I just saw that the `cve.md` files are not updated yet.

/CC @richlander @rbhanda 