### PR TITLE
Remove outdated comment about Powershell 7.3 RC1 from release notes

### DIFF
--- a/release-notes/7.0/7.0.4/7.0.4.md
+++ b/release-notes/7.0/7.0.4/7.0.4.md
@@ -41,8 +41,6 @@ The following repos have been updated.
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
-**_Note: The .NET 7.0 SDK container images contain version 7.3 RC 1 of PowerShell. It is expected that the 7.3 GA release of PowerShell will be included in these images as part of the December servicing release._**
-
 ## Notable Changes
 
 ### Additional fixes in this release

--- a/release-notes/8.0/8.0.0/8.0.0.md
+++ b/release-notes/8.0/8.0.0/8.0.0.md
@@ -54,8 +54,6 @@ The following repos have been updated.
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
-**_Note: The .NET 8.0 SDK container images contain version 7.3 RC 1 of PowerShell. It is expected that the 7.3 GA release of PowerShell will be included in these images as part of the December servicing release._**
-
 ## Notable Changes
 
  [.NET 8.0 Blog][dotnet-blog]

--- a/release-notes/8.0/8.0.1/8.0.1.md
+++ b/release-notes/8.0/8.0.1/8.0.1.md
@@ -39,8 +39,6 @@ The following repos have been updated.
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
-**_Note: The .NET 8.0 SDK container images contain version 7.3 RC 1 of PowerShell. It is expected that the 7.3 GA release of PowerShell will be included in these images as part of the December servicing release._**
-
 ## Notable Changes
 
  [.NET 8.0 Blog][dotnet-blog]
@@ -657,4 +655,3 @@ Microsoft.TemplateEngine.TemplateLocalizer.Core | 8.0.101
 [dotnet-sdk-win-x64.zip]: https://download.visualstudio.microsoft.com/download/pr/6902745c-34bd-4d66-8e84-d5b61a17dfb7/e61732b00f7e144e162d7e6914291f16/dotnet-sdk-8.0.101-win-x64.zip
 [dotnet-sdk-win-x86.exe]: https://download.visualstudio.microsoft.com/download/pr/88238db3-d71e-4431-bba5-1f6d16f7a415/d1e7b4c6302c51f1e968d07391cac7e1/dotnet-sdk-8.0.101-win-x86.exe
 [dotnet-sdk-win-x86.zip]: https://download.visualstudio.microsoft.com/download/pr/059613f3-d3e9-4585-b8a9-3814e675b6d0/01150dbaaa7f392f103137bd325786b6/dotnet-sdk-8.0.101-win-x86.zip
-

--- a/release-notes/8.0/8.0.2/8.0.2.md
+++ b/release-notes/8.0/8.0.2/8.0.2.md
@@ -39,8 +39,6 @@ The following repos have been updated.
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
-**_Note: The .NET 8.0 SDK container images contain version 7.3 RC 1 of PowerShell. It is expected that the 7.3 GA release of PowerShell will be included in these images as part of the December servicing release._**
-
 ## Notable Changes
 
  [.NET 8.0 Blog][dotnet-blog]

--- a/release-notes/8.0/8.0.3/8.0.3.md
+++ b/release-notes/8.0/8.0.3/8.0.3.md
@@ -39,8 +39,6 @@ The following repos have been updated.
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
 
-**_Note: The .NET 8.0 SDK container images contain version 7.3 RC 1 of PowerShell. It is expected that the 7.3 GA release of PowerShell will be included in these images as part of the December servicing release._**
-
 ## Notable Changes
 
  [.NET 8.0 Blog][dotnet-blog]


### PR DESCRIPTION
The release notes for various releases have been containing a copied note about Powershell 7.3 RC1 being part of the Docker images, which was only the case for the first released Docker image in the 7.0 series and no longer true ever since. However, this message has been repeated once after and been part of all the 8.0 release notes.

This PR removes this wrong and outdated information for these cases.

See also https://github.com/dotnet/dotnet-docker/pull/4200.