### PR TITLE
API diff between .NET 9 Preview2 and .NET 9 Preview3

### DIFF
--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3.md
@@ -1,0 +1,9 @@
+# API Difference 9.0-preview2 vs 9.0-preview3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components.Web](9.0-preview3_Microsoft.AspNetCore.Components.Web.md)
+* [Microsoft.AspNetCore.Http](9.0-preview3_Microsoft.AspNetCore.Http.md)
+* [Microsoft.AspNetCore.Http.HttpResults](9.0-preview3_Microsoft.AspNetCore.Http.HttpResults.md)
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Components.Web.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Components.Web.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Web
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Web {
+     public class KeyboardEventArgs : EventArgs {
++        public bool IsComposing { get; set; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Http.HttpResults.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Http.HttpResults.md
@@ -1,0 +1,21 @@
+# Microsoft.AspNetCore.Http.HttpResults
+
+``` diff
+ namespace Microsoft.AspNetCore.Http.HttpResults {
++    public sealed class InternalServerError : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        public int StatusCode { get; }
++        public Task ExecuteAsync(HttpContext httpContext);
++        static void Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
++    }
++    public sealed class InternalServerError<TValue> : IEndpointMetadataProvider, IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue> {
++        int? Microsoft.AspNetCore.Http.IStatusCodeHttpResult.StatusCode { get; }
++        object? Microsoft.AspNetCore.Http.IValueHttpResult.Value { get; }
++        public int StatusCode { get; }
++        public TValue? Value { get; }
++        public Task ExecuteAsync(HttpContext httpContext);
++        static void Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder);
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Http.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/9.0-preview3_Microsoft.AspNetCore.Http.md
@@ -1,0 +1,21 @@
+# Microsoft.AspNetCore.Http
+
+``` diff
+ namespace Microsoft.AspNetCore.Http {
+     public readonly struct HostString : IEquatable<HostString> {
+-        public HostString(string value);
++        public HostString(string? value);
+-        public string Value { get; }
++        public string? Value { get; }
+     }
+     public static class Results {
++        public static IResult InternalServerError();
++        public static IResult InternalServerError<TValue>(TValue error);
+     }
+     public static class TypedResults {
++        public static InternalServerError InternalServerError();
++        public static InternalServerError<TValue> InternalServerError<TValue>(TValue error);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3.md
@@ -1,0 +1,12 @@
+# API Difference 9.0-preview2 vs 9.0-preview3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](9.0-preview3_System.md)
+* [System.Diagnostics.CodeAnalysis](9.0-preview3_System.Diagnostics.CodeAnalysis.md)
+* [System.Reflection](9.0-preview3_System.Reflection.md)
+* [System.Reflection.Emit](9.0-preview3_System.Reflection.Emit.md)
+* [System.Runtime.CompilerServices](9.0-preview3_System.Runtime.CompilerServices.md)
+* [System.Runtime.Intrinsics.Arm](9.0-preview3_System.Runtime.Intrinsics.Arm.md)
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Diagnostics.CodeAnalysis.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Diagnostics.CodeAnalysis.md
@@ -1,0 +1,15 @@
+# System.Diagnostics.CodeAnalysis
+
+``` diff
+ namespace System.Diagnostics.CodeAnalysis {
++    public sealed class FeatureGuardAttribute : Attribute {
++        public FeatureGuardAttribute(Type featureType);
++        public Type FeatureType { get; }
++    }
++    public sealed class FeatureSwitchDefinitionAttribute : Attribute {
++        public FeatureSwitchDefinitionAttribute(string switchName);
++        public string SwitchName { get; }
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Reflection.Emit.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Reflection.Emit.md
@@ -1,0 +1,30 @@
+# System.Reflection.Emit
+
+``` diff
+ namespace System.Reflection.Emit {
+     public abstract class AssemblyBuilder : Assembly {
+-        public static AssemblyBuilder DefinePersistedAssembly(AssemblyName name, Assembly coreAssembly, IEnumerable<CustomAttributeBuilder>? assemblyAttributes = null);
+
+-        public void Save(Stream stream);
+
+-        public void Save(string assemblyFileName);
+
+-        protected virtual void SaveCore(Stream stream);
+
+     }
++    public sealed class PersistedAssemblyBuilder : AssemblyBuilder {
++        public PersistedAssemblyBuilder(AssemblyName name, Assembly coreAssembly, IEnumerable<CustomAttributeBuilder>? assemblyAttributes = null);
++        public override string? FullName { get; }
++        public override bool IsDynamic { get; }
++        public override Module ManifestModule { get; }
++        protected override ModuleBuilder DefineDynamicModuleCore(string name);
++        public MetadataBuilder GenerateMetadata(out BlobBuilder ilStream, out BlobBuilder mappedFieldData);
++        protected override ModuleBuilder? GetDynamicModuleCore(string name);
++        public override AssemblyName GetName(bool copiedName);
++        public void Save(Stream stream);
++        public void Save(string assemblyFileName);
++        protected override void SetCustomAttributeCore(ConstructorInfo con, ReadOnlySpan<byte> binaryAttribute);
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Reflection.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Reflection.md
@@ -1,0 +1,10 @@
+# System.Reflection
+
+``` diff
+ namespace System.Reflection {
+     public enum GenericParameterAttributes {
++        AllowByRefLike = 32,
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Runtime.CompilerServices.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Runtime.CompilerServices.md
@@ -1,0 +1,13 @@
+# System.Runtime.CompilerServices
+
+``` diff
+ namespace System.Runtime.CompilerServices {
++    public sealed class ParamCollectionAttribute : Attribute {
++        public ParamCollectionAttribute();
++    }
+     public static class RuntimeFeature {
++        public const string ByRefLikeGenerics = "ByRefLikeGenerics";
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Runtime.Intrinsics.Arm.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.Runtime.Intrinsics.Arm.md
@@ -1,0 +1,48 @@
+# System.Runtime.Intrinsics.Arm
+
+``` diff
+ namespace System.Runtime.Intrinsics.Arm {
+     public abstract class Sve : AdvSimd {
++        public static Vector<byte> CreateTrueMaskByte(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<double> CreateTrueMaskDouble(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<short> CreateTrueMaskInt16(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<int> CreateTrueMaskInt32(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<long> CreateTrueMaskInt64(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<sbyte> CreateTrueMaskSByte(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<float> CreateTrueMaskSingle(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<ushort> CreateTrueMaskUInt16(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<uint> CreateTrueMaskUInt32(SveMaskPattern pattern = SveMaskPattern.All);
++        public static Vector<ulong> CreateTrueMaskUInt64(SveMaskPattern pattern = SveMaskPattern.All);
++        public unsafe static Vector<byte> LoadVector(Vector<byte> mask, byte* address);
++        public unsafe static Vector<double> LoadVector(Vector<double> mask, double* address);
++        public unsafe static Vector<short> LoadVector(Vector<short> mask, short* address);
++        public unsafe static Vector<int> LoadVector(Vector<int> mask, int* address);
++        public unsafe static Vector<long> LoadVector(Vector<long> mask, long* address);
++        public unsafe static Vector<sbyte> LoadVector(Vector<sbyte> mask, sbyte* address);
++        public unsafe static Vector<float> LoadVector(Vector<float> mask, float* address);
++        public unsafe static Vector<ushort> LoadVector(Vector<ushort> mask, ushort* address);
++        public unsafe static Vector<uint> LoadVector(Vector<uint> mask, uint* address);
++        public unsafe static Vector<ulong> LoadVector(Vector<ulong> mask, ulong* address);
+     }
++    public enum SveMaskPattern : byte {
++        All = (byte)31,
++        LargestMultipleOf3 = (byte)30,
++        LargestMultipleOf4 = (byte)29,
++        LargestPowerOf2 = (byte)0,
++        VectorCount1 = (byte)1,
++        VectorCount128 = (byte)12,
++        VectorCount16 = (byte)9,
++        VectorCount2 = (byte)2,
++        VectorCount256 = (byte)13,
++        VectorCount3 = (byte)3,
++        VectorCount32 = (byte)10,
++        VectorCount4 = (byte)4,
++        VectorCount5 = (byte)5,
++        VectorCount6 = (byte)6,
++        VectorCount64 = (byte)11,
++        VectorCount7 = (byte)7,
++        VectorCount8 = (byte)8,
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.NETCore.App/9.0-preview3_System.md
@@ -1,0 +1,19 @@
+# System
+
+``` diff
+ namespace System {
+     public readonly struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, IParsable<TimeSpan>, ISpanFormattable, ISpanParsable<TimeSpan>, IUtf8SpanFormattable {
++        public static TimeSpan FromDays(int days);
++        public static TimeSpan FromDays(int days, int hours = 0, long minutes = (long)0, long seconds = (long)0, long milliseconds = (long)0, long microseconds = (long)0);
++        public static TimeSpan FromHours(int hours);
++        public static TimeSpan FromHours(int hours, long minutes = (long)0, long seconds = (long)0, long milliseconds = (long)0, long microseconds = (long)0);
++        public static TimeSpan FromMicroseconds(long microseconds);
++        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = (long)0);
++        public static TimeSpan FromMinutes(long minutes);
++        public static TimeSpan FromMinutes(long minutes, long seconds = (long)0, long milliseconds = (long)0, long microseconds = (long)0);
++        public static TimeSpan FromSeconds(long seconds);
++        public static TimeSpan FromSeconds(long seconds, long milliseconds = (long)0, long microseconds = (long)0);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/9.0-preview3.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/9.0-preview3.md
@@ -1,0 +1,7 @@
+# API Difference 9.0-preview2 vs 9.0-preview3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Windows.Forms](9.0-preview3_System.Windows.Forms.md)
+

--- a/release-notes/9.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/9.0-preview3_System.Windows.Forms.md
+++ b/release-notes/9.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/9.0-preview3_System.Windows.Forms.md
@@ -1,0 +1,11 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+     public interface IBindableComponent : IComponent, IDisposable {
+-        BindingContext BindingContext { get; set; }
++        BindingContext? BindingContext { get; set; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview3/api-diff/README.md
+++ b/release-notes/9.0/preview/preview3/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 9.0 Preview 3 API Changes
+
+The following API changes were made in .NET 9.0 Preview 3:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/9.0-preview3.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/9.0-preview3.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/9.0-preview3.md)


### PR DESCRIPTION
Repos area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @dreddy-work @JeremyKuhne
- Libraries - @artl93 @jeffhandley @karelz @ericstj @stephentoub

Libraries area owners:
- System/System.Private.CoreLib: @dotnet/area-system-runtime 
- @dotnet/area-system-diagnostics 
- @dotnet/area-system-reflection 
- @dotnet/area-system-reflection-emit 
- @dotnet/area-system-runtime-compilerservices 
- @dotnet/area-system-runtime-intrinsics 

**Known api-diff tool issues**:
- The AsmDiff tool sometimes skips adding `{` or `{}`. Please provide a GitHub suggestion in this PR so we can correct it manually: [arcade#10981](https://github.com/dotnet/arcade/issues/10981)
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect: [arcade#13814](https://github.com/dotnet/arcade/issues/13814) 
  
