### PR TITLE
Add missing ASP.NET Core contributors

### DIFF
--- a/release-notes/9.0/preview/preview2/aspnetcore.md
+++ b/release-notes/9.0/preview/preview2/aspnetcore.md
@@ -123,3 +123,4 @@ Thank you contributors! ❤️
 - [satma0745](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview2+author%3Asatma0745)
 - [Kahbazi](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview2+author%3AKahbazi)
 - [evgenykotkov](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview2+author%3Aevgenykotkov)
+- [tmds](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview2+author%3Atmds)

--- a/release-notes/9.0/preview/preview3/aspnetcore.md
+++ b/release-notes/9.0/preview/preview3/aspnetcore.md
@@ -61,3 +61,6 @@ Thank you contributors! ❤️
 - [johatuni](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3Ajohatuni)
 - [andrewjsaid](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3Aandrewjsaid)
 - [Kahbazi](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3AKahbazi)
+- [hakenr](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3Ahakenr)
+- [WeihanLi](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3AWeihanLi)
+- [StevenTCramer](https://github.com/dotnet/aspnetcore/pulls?q=is%3Apr+is%3Amerged+milestone%3A9.0-preview3+author%3AStevenTCramer)


### PR DESCRIPTION
A few contributors to ASP.NET Core in .NET 9 were missed due to some infrastructure issues with how we label PRs with the correct milestone. Adding the missing contributors.