### PR TITLE
Clarify Windows license information

### DIFF
--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -8,8 +8,8 @@ apply to your use. By using any or all of these files you agree to their associa
 The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
 
-* api-ms-\*.\* (used by .NET runtime)
-* ucrtbase.dll (used by .NET runtime)
+* api-ms-\*.\* (used by .NET runtime before .NET 7.0)
+* ucrtbase.dll (used by .NET runtime before .NET 7.0)
 * D3DCompiler_47_cor3.dll (used by WPF)
 
 The following binaries are licensed with the
@@ -23,7 +23,7 @@ The following binaries are licensed with the
 (not as a "trial"):
 
 * vcruntime140_cor3.dll (used by WPF)
-* Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET SDK)
+* Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
 
 All other binaries and files are licensed with the
 [MIT license](https://github.com/dotnet/core/blob/main/LICENSE.TXT)

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -1,15 +1,14 @@
 # License information for .NET on Windows
 
-The Windows distribution of .NET 5.0 and later releases contains files that are provided under
-multiple licenses.
+The Windows distribution of .NET contains files that are provided under multiple licenses.
 This information is provided to help you understand the license terms that
 apply to your use. By using any or all of these files you agree to their associated license terms.
 
 The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
 
-* api-ms-\*.\* (used by .NET runtime,  .NET 6 and earlier)
-* ucrtbase.dll (used by .NET runtime,  .NET 6 and earlier)
+* api-ms-\*.\* (used by .NET runtime, .NET 6 and earlier)
+* ucrtbase.dll (used by .NET runtime, .NET 6 and earlier)
 * D3DCompiler_47_cor3.dll (used by WPF)
 
 The following binaries are licensed with the

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -8,8 +8,8 @@ apply to your use. By using any or all of these files you agree to their associa
 The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
 
-* api-ms-\*.\* (used by .NET runtime before .NET 7.0)
-* ucrtbase.dll (used by .NET runtime before .NET 7.0)
+* api-ms-\*.\* (used by .NET runtime,  .NET 6 and earlier)
+* ucrtbase.dll (used by .NET runtime,  .NET 6 and earlier)
 * D3DCompiler_47_cor3.dll (used by WPF)
 
 The following binaries are licensed with the


### PR DESCRIPTION
- DiaSymReader is used by both runtime and SDK
- ucrtbase is no longer included in .NET 7+