### PR TITLE
Remove .NET 7 from main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The following [.NET releases](./releases.md) are currently supported:
 | :-- | :-- | :-- | :-- | :-- |
 | [.NET 9](release-notes/9.0/README.md) | November 12, 2024 | [STS][policies] | [9.0.0-preview.3][9.0.0-preview.3] |  |
 | [.NET 8](release-notes/8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | [8.0.4][8.0.4] | November 10, 2026 |
-| [.NET 7](release-notes/7.0/README.md) | [November 8, 2022](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/) | [STS][policies] | [7.0.18][7.0.18] | May 14, 2024 |
 | [.NET 6](release-notes/6.0/README.md) | [November 8, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.29][6.0.29]  | November 12, 2024 |
 
 
@@ -28,7 +27,6 @@ You can find release notes for all releases, including out-of-support releases, 
 
 [9.0.0-preview.3]: release-notes/9.0/preview/preview3/9.0.0-preview.3.md
 [8.0.4]: release-notes/8.0/8.0.4/8.0.4.md
-[7.0.18]: release-notes/7.0/7.0.18/7.0.18.md
 [6.0.29]: release-notes/6.0/6.0.29/6.0.29.md
 
 ## Release Information


### PR DESCRIPTION
.NET 7 is out of date, removing