### PR TITLE
Fix releases.json vs-support vs vs-version confusion in 9.0-preview.4

### DIFF
--- a/release-notes/9.0/releases.json
+++ b/release-notes/9.0/releases.json
@@ -17,7 +17,7 @@
       "runtime": {
         "version": "9.0.0-preview.4.24266.19",
         "version-display": "9.0.0-preview.4",
-        "vs-version": "Visual Studio 2022 (v17.11 Preview 1)",
+        "vs-support": "Visual Studio 2022 (v17.11 Preview 1)",
         "vs-mac-version": "",
         "files": [
           {


### PR DESCRIPTION
Use vs-support over vs-version in 9.0-preview.4 runtime releases.json. As it is strictly not a version string, keeping this in line with the other previews which use vs-support in this place.

Also: it has been a while I had to open a PR like this, GitHub just put up a notice that was in Jan 2023. My compliments on keeping a consistent structure! Thanks!