### PR TITLE
API diff  between .NET 9 Preview 3 and .NET 9 Preview 4

### DIFF
--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4.md
@@ -1,0 +1,9 @@
+# API Difference 9.0-preview3 vs 9.0-preview4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components](9.0-preview4_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Routing](9.0-preview4_Microsoft.AspNetCore.Components.Routing.md)
+* [Microsoft.AspNetCore.Components.Web.Internal](9.0-preview4_Microsoft.AspNetCore.Components.Web.Internal.md)
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.Routing.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.Routing.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Routing
+
+``` diff
+ namespace Microsoft.AspNetCore.Components.Routing {
++    public static class RazorComponentsEndpointHttpContextExtensions {
++        public static bool AcceptsInteractiveRouting(this HttpContext context);
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.Web.Internal.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.Web.Internal.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components.Web.Internal
+
+``` diff
++namespace Microsoft.AspNetCore.Components.Web.Internal {
++    public interface IInternalWebJSInProcessRuntime {
++        string InvokeJS(string identifier, string? argsJson, JSCallResultType resultType, long targetInstanceId);
++    }
++}
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/9.0-preview4_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,10 @@
+# Microsoft.AspNetCore.Components
+
+``` diff
+ namespace Microsoft.AspNetCore.Components {
++    public sealed class ExcludeFromInteractiveRoutingAttribute : Attribute {
++        public ExcludeFromInteractiveRoutingAttribute();
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4.md
@@ -1,0 +1,25 @@
+# API Difference 9.0-preview3 vs 9.0-preview4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](9.0-preview4_System.md)
+* [System.CodeDom.Compiler](9.0-preview4_System.CodeDom.Compiler.md)
+* [System.Formats.Asn1](9.0-preview4_System.Formats.Asn1.md)
+* [System.IO](9.0-preview4_System.IO.md)
+* [System.IO.Pipes](9.0-preview4_System.IO.Pipes.md)
+* [System.Numerics](9.0-preview4_System.Numerics.md)
+* [System.Reflection.Emit](9.0-preview4_System.Reflection.Emit.md)
+* [System.Runtime.CompilerServices](9.0-preview4_System.Runtime.CompilerServices.md)
+* [System.Runtime.InteropServices](9.0-preview4_System.Runtime.InteropServices.md)
+* [System.Runtime.Intrinsics](9.0-preview4_System.Runtime.Intrinsics.md)
+* [System.Security.Cryptography](9.0-preview4_System.Security.Cryptography.md)
+* [System.Text](9.0-preview4_System.Text.md)
+* [System.Text.Json](9.0-preview4_System.Text.Json.md)
+* [System.Text.Json.Nodes](9.0-preview4_System.Text.Json.Nodes.md)
+* [System.Text.Json.Serialization](9.0-preview4_System.Text.Json.Serialization.md)
+* [System.Text.Json.Serialization.Metadata](9.0-preview4_System.Text.Json.Serialization.Metadata.md)
+* [System.Threading](9.0-preview4_System.Threading.md)
+* [System.Threading.Channels](9.0-preview4_System.Threading.Channels.md)
+* [System.Threading.Tasks](9.0-preview4_System.Threading.Tasks.md)
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.CodeDom.Compiler.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.CodeDom.Compiler.md
@@ -1,0 +1,11 @@
+# System.CodeDom.Compiler
+
+``` diff
+ namespace System.CodeDom.Compiler {
+     public class IndentedTextWriter : TextWriter {
++        public override void Write(string format, ReadOnlySpan<object?> arg);
++        public override void WriteLine(string format, ReadOnlySpan<object?> arg);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Formats.Asn1.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Formats.Asn1.md
@@ -1,0 +1,11 @@
+# System.Formats.Asn1
+
+``` diff
+ namespace System.Formats.Asn1 {
+     public static class AsnDecoder {
++        public static int? DecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed);
++        public static bool TryDecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int? decodedLength, out int bytesConsumed);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.IO.Pipes.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.IO.Pipes.md
@@ -1,0 +1,10 @@
+# System.IO.Pipes
+
+``` diff
+ namespace System.IO.Pipes {
+     public sealed class NamedPipeClientStream : PipeStream {
++        public NamedPipeClientStream(string serverName, string pipeName, PipeAccessRights desiredAccessRights, PipeOptions options, TokenImpersonationLevel impersonationLevel, HandleInheritability inheritability);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.IO.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.IO.md
@@ -1,0 +1,19 @@
+# System.IO
+
+``` diff
+ namespace System.IO {
+     public static class Path {
++        public static string Combine(ReadOnlySpan<string> paths);
++        public static string Join(ReadOnlySpan<string?> paths);
+     }
+     public class StreamWriter : TextWriter {
++        public override void Write(string format, ReadOnlySpan<object?> arg);
++        public override void WriteLine(string format, ReadOnlySpan<object?> arg);
+     }
+     public abstract class TextWriter : MarshalByRefObject, IAsyncDisposable, IDisposable {
++        public virtual void Write(string format, ReadOnlySpan<object?> arg);
++        public virtual void WriteLine(string format, ReadOnlySpan<object?> arg);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Numerics.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Numerics.md
@@ -1,0 +1,17 @@
+# System.Numerics
+
+``` diff
+ namespace System.Numerics {
+     public interface IFloatingPoint<TSelf> : IAdditionOperators<TSelf, TSelf, TSelf>, IAdditiveIdentity<TSelf, TSelf>, IComparable, IComparable<TSelf>, IComparisonOperators<TSelf, TSelf, bool>, IDecrementOperators<TSelf>, IDivisionOperators<TSelf, TSelf, TSelf>, IEqualityOperators<TSelf, TSelf, bool>, IEquatable<TSelf>, IFloatingPointConstants<TSelf>, IFormattable, IIncrementOperators<TSelf>, IModulusOperators<TSelf, TSelf, TSelf>, IMultiplicativeIdentity<TSelf, TSelf>, IMultiplyOperators<TSelf, TSelf, TSelf>, INumber<TSelf>, INumberBase<TSelf>, IParsable<TSelf>, ISignedNumber<TSelf>, ISpanFormattable, ISpanParsable<TSelf>, ISubtractionOperators<TSelf, TSelf, TSelf>, IUnaryNegationOperators<TSelf, TSelf>, IUnaryPlusOperators<TSelf, TSelf>, IUtf8SpanFormattable, IUtf8SpanParsable<TSelf> where TSelf : IFloatingPoint<TSelf>? {
++        TInteger ConvertToInteger<TInteger>(TSelf value);
++        TInteger ConvertToIntegerNative<TInteger>(TSelf value);
+     }
+     public static class Vector {
++        public static Vector<Int32> ConvertToInt32Native(Vector<Single> value);
++        public static Vector<Int64> ConvertToInt64Native(Vector<Double> value);
++        public static Vector<UInt32> ConvertToUInt32Native(Vector<Single> value);
++        public static Vector<UInt64> ConvertToUInt64Native(Vector<Double> value);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Reflection.Emit.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Reflection.Emit.md
@@ -1,0 +1,23 @@
+# System.Reflection.Emit
+
+``` diff
+ namespace System.Reflection.Emit {
+     public abstract class ILGenerator {
++        public void MarkSequencePoint(ISymbolDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn);
++        protected virtual void MarkSequencePointCore(ISymbolDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn);
+     }
+     public abstract class LocalBuilder : LocalVariableInfo {
++        public void SetLocalSymInfo(string name);
++        protected virtual void SetLocalSymInfoCore(string name);
+     }
+     public abstract class ModuleBuilder : Module {
++        public ISymbolDocumentWriter DefineDocument(string url, Guid language = default(Guid));
++        public ISymbolDocumentWriter DefineDocument(string url, Guid language, Guid languageVendor, Guid documentType);
++        protected virtual ISymbolDocumentWriter DefineDocumentCore(string url, Guid language = default(Guid));
+     }
+     public sealed class PersistedAssemblyBuilder : AssemblyBuilder {
++        public MetadataBuilder GenerateMetadata(out BlobBuilder ilStream, out BlobBuilder mappedFieldData, out MetadataBuilder pdbBuilder);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.CompilerServices.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.CompilerServices.md
@@ -1,0 +1,15 @@
+# System.Runtime.CompilerServices
+
+``` diff
+ namespace System.Runtime.CompilerServices {
+     public static class RuntimeHelpers {
++        public static object? Box(ref byte target, RuntimeTypeHandle type);
++        public static int SizeOf(RuntimeTypeHandle type);
+     }
+     public static class Unsafe {
+-        public static TTo BitCast<TFrom, TTo>(TFrom source) where TFrom : struct where TTo : struct;
++        public static TTo BitCast<TFrom, TTo>(TFrom source);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.InteropServices.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.InteropServices.md
@@ -1,0 +1,11 @@
+# System.Runtime.InteropServices
+
+``` diff
+ namespace System.Runtime.InteropServices {
+     public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat, bool>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat, bool>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointConstants<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat>, IUtf8SpanFormattable, IUtf8SpanParsable<NFloat> {
++        static TInteger ConvertToInteger<TInteger>(NFloat value);
++        static TInteger ConvertToIntegerNative<TInteger>(NFloat value);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.InteropServices.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.InteropServices.md
@@ -3,8 +3,8 @@
 ``` diff
  namespace System.Runtime.InteropServices {
      public readonly struct NFloat : IAdditionOperators<NFloat, NFloat, NFloat>, IAdditiveIdentity<NFloat, NFloat>, IBinaryFloatingPointIeee754<NFloat>, IBinaryNumber<NFloat>, IBitwiseOperators<NFloat, NFloat, NFloat>, IComparable, IComparable<NFloat>, IComparisonOperators<NFloat, NFloat, bool>, IDecrementOperators<NFloat>, IDivisionOperators<NFloat, NFloat, NFloat>, IEqualityOperators<NFloat, NFloat, bool>, IEquatable<NFloat>, IExponentialFunctions<NFloat>, IFloatingPoint<NFloat>, IFloatingPointConstants<NFloat>, IFloatingPointIeee754<NFloat>, IFormattable, IHyperbolicFunctions<NFloat>, IIncrementOperators<NFloat>, ILogarithmicFunctions<NFloat>, IMinMaxValue<NFloat>, IModulusOperators<NFloat, NFloat, NFloat>, IMultiplicativeIdentity<NFloat, NFloat>, IMultiplyOperators<NFloat, NFloat, NFloat>, INumber<NFloat>, INumberBase<NFloat>, IParsable<NFloat>, IPowerFunctions<NFloat>, IRootFunctions<NFloat>, ISignedNumber<NFloat>, ISpanFormattable, ISpanParsable<NFloat>, ISubtractionOperators<NFloat, NFloat, NFloat>, ITrigonometricFunctions<NFloat>, IUnaryNegationOperators<NFloat, NFloat>, IUnaryPlusOperators<NFloat, NFloat>, IUtf8SpanFormattable, IUtf8SpanParsable<NFloat> {
-+        static TInteger ConvertToInteger<TInteger>(NFloat value);
-+        static TInteger ConvertToIntegerNative<TInteger>(NFloat value);
++        static virtual TInteger ConvertToInteger<TInteger>(NFloat value);
++        static virtual TInteger ConvertToIntegerNative<TInteger>(NFloat value);
      }
  }
 ```

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.Intrinsics.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Runtime.Intrinsics.md
@@ -1,0 +1,31 @@
+# System.Runtime.Intrinsics
+
+``` diff
+ namespace System.Runtime.Intrinsics {
+     public static class Vector128 {
++        public static Vector128<Int32> ConvertToInt32Native(Vector128<Single> vector);
++        public static Vector128<Int64> ConvertToInt64Native(Vector128<Double> vector);
++        public static Vector128<UInt32> ConvertToUInt32Native(Vector128<Single> vector);
++        public static Vector128<UInt64> ConvertToUInt64Native(Vector128<Double> vector);
+     }
+     public static class Vector256 {
++        public static Vector256<Int32> ConvertToInt32Native(Vector256<Single> vector);
++        public static Vector256<Int64> ConvertToInt64Native(Vector256<Double> vector);
++        public static Vector256<UInt32> ConvertToUInt32Native(Vector256<Single> vector);
++        public static Vector256<UInt64> ConvertToUInt64Native(Vector256<Double> vector);
+     }
+     public static class Vector512 {
++        public static Vector512<Int32> ConvertToInt32Native(Vector512<Single> vector);
++        public static Vector512<Int64> ConvertToInt64Native(Vector512<Double> vector);
++        public static Vector512<UInt32> ConvertToUInt32Native(Vector512<Single> vector);
++        public static Vector512<UInt64> ConvertToUInt64Native(Vector512<Double> vector);
+     }
+     public static class Vector64 {
++        public static Vector64<Int32> ConvertToInt32Native(Vector64<Single> vector);
++        public static Vector64<Int64> ConvertToInt64Native(Vector64<Double> vector);
++        public static Vector64<UInt32> ConvertToUInt32Native(Vector64<Single> vector);
++        public static Vector64<UInt64> ConvertToUInt64Native(Vector64<Double> vector);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Security.Cryptography.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Security.Cryptography.md
@@ -1,0 +1,19 @@
+# System.Security.Cryptography
+
+``` diff
+ namespace System.Security.Cryptography {
+     public sealed class Shake128 : IDisposable {
++        public Shake128 Clone();
++        public byte[] Read(int outputLength);
++        public void Read(Span<byte> destination);
++        public void Reset();
+     }
+     public sealed class Shake256 : IDisposable {
++        public Shake256 Clone();
++        public byte[] Read(int outputLength);
++        public void Read(Span<byte> destination);
++        public void Reset();
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Nodes.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Nodes.md
@@ -1,0 +1,11 @@
+# System.Text.Json.Nodes
+
+``` diff
+ namespace System.Text.Json.Nodes {
+     public sealed class JsonArray : JsonNode, ICollection<JsonNode?>, IEnumerable, IEnumerable<JsonNode?>, IList<JsonNode?> {
++        public JsonArray(ReadOnlySpan<JsonNode?> items);
++        public JsonArray(JsonNodeOptions options, ReadOnlySpan<JsonNode?> items);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Serialization.Metadata.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Serialization.Metadata.md
@@ -1,0 +1,10 @@
+# System.Text.Json.Serialization.Metadata
+
+``` diff
+ namespace System.Text.Json.Serialization.Metadata {
+     public static class JsonTypeInfoResolver {
++        public static IJsonTypeInfoResolver Combine(ReadOnlySpan<IJsonTypeInfoResolver?> resolvers);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Serialization.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.Serialization.md
@@ -1,0 +1,10 @@
+# System.Text.Json.Serialization
+
+``` diff
+ namespace System.Text.Json.Serialization {
+     public sealed class JsonSourceGenerationOptionsAttribute : JsonAttribute {
++        public string NewLine { get; set; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.Json.md
@@ -1,0 +1,25 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     public sealed class JsonSerializerOptions {
+-        public JsonNamingPolicy DictionaryKeyPolicy { get; set; }
++        public JsonNamingPolicy? DictionaryKeyPolicy { get; set; }
+-        public JavaScriptEncoder Encoder { get; set; }
++        public JavaScriptEncoder? Encoder { get; set; }
++        public string NewLine { get; set; }
+-        public JsonNamingPolicy PropertyNamingPolicy { get; set; }
++        public JsonNamingPolicy? PropertyNamingPolicy { get; set; }
+-        public ReferenceHandler ReferenceHandler { get; set; }
++        public ReferenceHandler? ReferenceHandler { get; set; }
+-        public IJsonTypeInfoResolver TypeInfoResolver { get; set; }
++        public IJsonTypeInfoResolver? TypeInfoResolver { get; set; }
+     }
+     public struct JsonWriterOptions {
+-        public JavaScriptEncoder Encoder { get; set; }
++        public JavaScriptEncoder? Encoder { get; set; }
++        public string NewLine { get; set; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Text.md
@@ -1,0 +1,15 @@
+# System.Text
+
+``` diff
+ namespace System.Text {
+     public sealed class StringBuilder : ISerializable {
++        public StringBuilder AppendFormat(IFormatProvider? provider, string format, ReadOnlySpan<object?> args);
++        public StringBuilder AppendFormat(string format, ReadOnlySpan<object?> args);
++        public StringBuilder AppendJoin(char separator, ReadOnlySpan<object?> values);
++        public StringBuilder AppendJoin(char separator, ReadOnlySpan<string?> values);
++        public StringBuilder AppendJoin(string? separator, ReadOnlySpan<object?> values);
++        public StringBuilder AppendJoin(string? separator, ReadOnlySpan<string?> values);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.Channels.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.Channels.md
@@ -1,0 +1,15 @@
+# System.Threading.Channels
+
+``` diff
+ namespace System.Threading.Channels {
+     public static class Channel {
++        public static Channel<T> CreateUnboundedPrioritized<T>();
++        public static Channel<T> CreateUnboundedPrioritized<T>(UnboundedPrioritizedChannelOptions<T> options);
+     }
++    public sealed class UnboundedPrioritizedChannelOptions<T> : ChannelOptions {
++        public UnboundedPrioritizedChannelOptions();
++        public IComparer<T>? Comparer { get; set; }
++    }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.Tasks.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.Tasks.md
@@ -1,0 +1,21 @@
+# System.Threading.Tasks
+
+``` diff
+ namespace System.Threading.Tasks {
+     public class Task : IAsyncResult, IDisposable {
++        public static void WaitAll(IEnumerable<Task> tasks, CancellationToken cancellationToken = default(CancellationToken));
++        public static void WaitAll(ReadOnlySpan<Task> tasks);
++        public static Task WhenAll(ReadOnlySpan<Task> tasks);
++        public static Task<TResult[]> WhenAll<TResult>(ReadOnlySpan<Task<TResult>> tasks);
++        public static Task<Task> WhenAny(ReadOnlySpan<Task> tasks);
++        public static Task<Task<TResult>> WhenAny<TResult>(ReadOnlySpan<Task<TResult>> tasks);
++        public static IAsyncEnumerable<Task> WhenEach(IEnumerable<Task> tasks);
++        public static IAsyncEnumerable<Task> WhenEach(ReadOnlySpan<Task> tasks);
++        public static IAsyncEnumerable<Task> WhenEach(params Task[] tasks);
++        public static IAsyncEnumerable<Task<TResult>> WhenEach<TResult>(IEnumerable<Task<TResult>> tasks);
++        public static IAsyncEnumerable<Task<TResult>> WhenEach<TResult>(ReadOnlySpan<Task<TResult>> tasks);
++        public static IAsyncEnumerable<Task<TResult>> WhenEach<TResult>(params Task<TResult>[] tasks);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.Threading.md
@@ -1,0 +1,10 @@
+# System.Threading
+
+``` diff
+ namespace System.Threading {
+     public class CancellationTokenSource : IDisposable {
++        public static CancellationTokenSource CreateLinkedTokenSource(ReadOnlySpan<CancellationToken> tokens);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.NETCore.App/9.0-preview4_System.md
@@ -1,0 +1,44 @@
+# System
+
+``` diff
+ namespace System {
+     public static class Console {
++        public static void Write(string format, ReadOnlySpan<object?> arg);
++        public static void WriteLine(string format, ReadOnlySpan<object?> arg);
+     }
+     public readonly struct Decimal : IAdditionOperators<decimal, decimal, decimal>, IAdditiveIdentity<decimal, decimal>, IComparable, IComparable<decimal>, IComparisonOperators<decimal, decimal, bool>, IConvertible, IDecrementOperators<decimal>, IDeserializationCallback, IDivisionOperators<decimal, decimal, decimal>, IEqualityOperators<decimal, decimal, bool>, IEquatable<decimal>, IFloatingPoint<decimal>, IFloatingPointConstants<decimal>, IFormattable, IIncrementOperators<decimal>, IMinMaxValue<decimal>, IModulusOperators<decimal, decimal, decimal>, IMultiplicativeIdentity<decimal, decimal>, IMultiplyOperators<decimal, decimal, decimal>, INumber<decimal>, INumberBase<decimal>, IParsable<decimal>, ISerializable, ISignedNumber<decimal>, ISpanFormattable, ISpanParsable<decimal>, ISubtractionOperators<decimal, decimal, decimal>, IUnaryNegationOperators<decimal, decimal>, IUnaryPlusOperators<decimal, decimal>, IUtf8SpanFormattable, IUtf8SpanParsable<decimal> {
++        static TInteger ConvertToInteger<TInteger>(Decimal value);
++        static TInteger ConvertToIntegerNative<TInteger>(Decimal value);
+     }
+     public abstract class Delegate : ICloneable, ISerializable {
++        public static Delegate? Combine(ReadOnlySpan<Delegate?> delegates);
+     }
+     public readonly struct Double : IAdditionOperators<double, double, double>, IAdditiveIdentity<double, double>, IBinaryFloatingPointIeee754<double>, IBinaryNumber<double>, IBitwiseOperators<double, double, double>, IComparable, IComparable<double>, IComparisonOperators<double, double, bool>, IConvertible, IDecrementOperators<double>, IDivisionOperators<double, double, double>, IEqualityOperators<double, double, bool>, IEquatable<double>, IExponentialFunctions<double>, IFloatingPoint<double>, IFloatingPointConstants<double>, IFloatingPointIeee754<double>, IFormattable, IHyperbolicFunctions<double>, IIncrementOperators<double>, ILogarithmicFunctions<double>, IMinMaxValue<double>, IModulusOperators<double, double, double>, IMultiplicativeIdentity<double, double>, IMultiplyOperators<double, double, double>, INumber<double>, INumberBase<double>, IParsable<double>, IPowerFunctions<double>, IRootFunctions<double>, ISignedNumber<double>, ISpanFormattable, ISpanParsable<double>, ISubtractionOperators<double, double, double>, ITrigonometricFunctions<double>, IUnaryNegationOperators<double, double>, IUnaryPlusOperators<double, double>, IUtf8SpanFormattable, IUtf8SpanParsable<double> {
++        static TInteger ConvertToInteger<TInteger>(Double value);
++        static TInteger ConvertToIntegerNative<TInteger>(Double value);
+     }
+     public readonly struct Half : IAdditionOperators<Half, Half, Half>, IAdditiveIdentity<Half, Half>, IBinaryFloatingPointIeee754<Half>, IBinaryNumber<Half>, IBitwiseOperators<Half, Half, Half>, IComparable, IComparable<Half>, IComparisonOperators<Half, Half, bool>, IDecrementOperators<Half>, IDivisionOperators<Half, Half, Half>, IEqualityOperators<Half, Half, bool>, IEquatable<Half>, IExponentialFunctions<Half>, IFloatingPoint<Half>, IFloatingPointConstants<Half>, IFloatingPointIeee754<Half>, IFormattable, IHyperbolicFunctions<Half>, IIncrementOperators<Half>, ILogarithmicFunctions<Half>, IMinMaxValue<Half>, IModulusOperators<Half, Half, Half>, IMultiplicativeIdentity<Half, Half>, IMultiplyOperators<Half, Half, Half>, INumber<Half>, INumberBase<Half>, IParsable<Half>, IPowerFunctions<Half>, IRootFunctions<Half>, ISignedNumber<Half>, ISpanFormattable, ISpanParsable<Half>, ISubtractionOperators<Half, Half, Half>, ITrigonometricFunctions<Half>, IUnaryNegationOperators<Half, Half>, IUnaryPlusOperators<Half, Half>, IUtf8SpanFormattable, IUtf8SpanParsable<Half> {
++        static TInteger ConvertToInteger<TInteger>(Half value);
++        static TInteger ConvertToIntegerNative<TInteger>(Half value);
+     }
+     public readonly struct Single : IAdditionOperators<float, float, float>, IAdditiveIdentity<float, float>, IBinaryFloatingPointIeee754<float>, IBinaryNumber<float>, IBitwiseOperators<float, float, float>, IComparable, IComparable<float>, IComparisonOperators<float, float, bool>, IConvertible, IDecrementOperators<float>, IDivisionOperators<float, float, float>, IEqualityOperators<float, float, bool>, IEquatable<float>, IExponentialFunctions<float>, IFloatingPoint<float>, IFloatingPointConstants<float>, IFloatingPointIeee754<float>, IFormattable, IHyperbolicFunctions<float>, IIncrementOperators<float>, ILogarithmicFunctions<float>, IMinMaxValue<float>, IModulusOperators<float, float, float>, IMultiplicativeIdentity<float, float>, IMultiplyOperators<float, float, float>, INumber<float>, INumberBase<float>, IParsable<float>, IPowerFunctions<float>, IRootFunctions<float>, ISignedNumber<float>, ISpanFormattable, ISpanParsable<float>, ISubtractionOperators<float, float, float>, ITrigonometricFunctions<float>, IUnaryNegationOperators<float, float>, IUnaryPlusOperators<float, float>, IUtf8SpanFormattable, IUtf8SpanParsable<float> {
++        static TInteger ConvertToInteger<TInteger>(Single value);
++        static TInteger ConvertToIntegerNative<TInteger>(Single value);
+     }
+     public sealed class String : ICloneable, IComparable, IComparable<string?>, IConvertible, IEnumerable, IEnumerable<char>, IEquatable<string?>, IParsable<string>, ISpanParsable<string> {
++        public static String Concat(ReadOnlySpan<object?> args);
++        public static String Concat(ReadOnlySpan<string?> values);
++        public static String Format(IFormatProvider? provider, String format, ReadOnlySpan<object?> args);
++        public static String Format(String format, ReadOnlySpan<object?> args);
++        public static String Join(char separator, ReadOnlySpan<object?> values);
++        public static String Join(char separator, ReadOnlySpan<string?> value);
++        public static String Join(String? separator, ReadOnlySpan<object?> values);
++        public static String Join(String? separator, ReadOnlySpan<string?> value);
++        public string[] Split(ReadOnlySpan<char> separator);
++        public String Trim(ReadOnlySpan<char> trimChars);
++        public String TrimEnd(ReadOnlySpan<char> trimChars);
++        public String TrimStart(ReadOnlySpan<char> trimChars);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4.md
@@ -1,0 +1,9 @@
+# API Difference 9.0-preview3 vs 9.0-preview4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Drawing.Imaging](9.0-preview4_System.Drawing.Imaging.md)
+* [System.Windows.Forms](9.0-preview4_System.Windows.Forms.md)
+* [System.Windows.Forms.Design](9.0-preview4_System.Windows.Forms.Design.md)
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Drawing.Imaging.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Drawing.Imaging.md
@@ -1,0 +1,20 @@
+# System.Drawing.Imaging
+
+``` diff
+ namespace System.Drawing.Imaging {
+     public sealed class ColorPalette {
+-        public ColorPalette(params Color[] entries);
++        public ColorPalette(params Color[] customColors);
+-        public ColorPalette(PaletteType paletteType);
++        public ColorPalette(PaletteType fixedPaletteType);
+-        public static ColorPalette CreateOptimalPalette(int colorCount, bool useTransparentColor, Bitmap bitmap);
++        public static ColorPalette CreateOptimalPalette(int colors, bool useTransparentColor, Bitmap bitmap);
+     }
+     public enum PaletteType {
++        FixedBlackAndWhite = 2,
+-        FixedBW = 2,
+
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Windows.Forms.Design.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Windows.Forms.Design.md
@@ -1,0 +1,19 @@
+# System.Windows.Forms.Design
+
+``` diff
+ namespace System.Windows.Forms.Design {
+     public class ControlDesigner : ComponentDesigner {
+-        protected AccessibleObject accessibilityObj;
++        protected AccessibleObject? accessibilityObj;
+-        protected BehaviorService BehaviorService { get; }
++        protected BehaviorService? BehaviorService { get; }
+-        protected override InheritanceAttribute InheritanceAttribute { get; }
++        protected override InheritanceAttribute? InheritanceAttribute { get; }
+-        protected override IComponent ParentComponent { get; }
++        protected override IComponent? ParentComponent { get; }
+-        public virtual ControlDesigner InternalControlDesigner(int internalControlIndex);
++        public virtual ControlDesigner? InternalControlDesigner(int internalControlIndex);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Windows.Forms.md
+++ b/release-notes/9.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/9.0-preview4_System.Windows.Forms.md
@@ -1,0 +1,43 @@
+# System.Windows.Forms
+
+``` diff
+ namespace System.Windows.Forms {
+     public class Control : Component, IArrangedElement, IBindableComponent, IComponent, IDisposable, IDropTarget, IHandle<HWND>, IKeyboardToolTip, IOleControl.Interface, IOleInPlaceActiveObject.Interface, IOleInPlaceObject.Interface, IOleObject.Interface, IOleWindow.Interface, IPersist.Interface, IPersistPropertyBag.Interface, IPersistStorage.Interface, IPersistStreamInit.Interface, IQuickActivate.Interface, ISupportOleDropSource, ISynchronizeInvoke, IViewObject.Interface, IViewObject2.Interface, IWin32Window {
+-        protected virtual void OnEnter(EventArgs e);
++        protected internal virtual void OnEnter(EventArgs e);
+-        protected virtual void OnLeave(EventArgs e);
++        protected internal virtual void OnLeave(EventArgs e);
+     }
+     public class DataGridView : Control, ISupportInitialize {
+-        protected override void OnEnter(EventArgs e);
++        protected internal override void OnEnter(EventArgs e);
+-        protected override void OnLeave(EventArgs e);
++        protected internal override void OnLeave(EventArgs e);
+     }
+     public class Form : ContainerControl {
+-        protected override void OnEnter(EventArgs e);
++        protected internal override void OnEnter(EventArgs e);
+     }
+     public class RadioButton : ButtonBase {
+-        protected override void OnEnter(EventArgs e);
++        protected internal override void OnEnter(EventArgs e);
+     }
+     public class TabControl : Control {
+-        protected override void OnEnter(EventArgs e);
++        protected internal override void OnEnter(EventArgs e);
+-        protected override void OnLeave(EventArgs e);
++        protected internal override void OnLeave(EventArgs e);
+     }
+     public class TabPage : Panel {
+-        protected override void OnEnter(EventArgs e);
++        protected internal override void OnEnter(EventArgs e);
+-        protected override void OnLeave(EventArgs e);
++        protected internal override void OnLeave(EventArgs e);
+     }
+     public class ToolStrip : ScrollableControl, IArrangedElement, IComponent, IDisposable, ISupportToolStripPanel {
+-        protected override void OnLeave(EventArgs e);
++        protected internal override void OnLeave(EventArgs e);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/preview4/api-diff/README.md
+++ b/release-notes/9.0/preview/preview4/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 9.0 Preview 4 API Changes
+
+The following API changes were made in .NET 9.0 Preview 4:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/9.0-preview4.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/9.0-preview4.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/9.0-preview4.md)


### PR DESCRIPTION
Repo area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @dreddy-work @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffschwMSFT @jeffhandley @karelz @ericstj @stephentoub

Libraries area owners:
- @dotnet/area-system-codedom 
- @dotnet/area-system-formats-asn1 
- @dotnet/area-system-io 
- System.IO.Pipes @dotnet/aspnet-api-review 
- @dotnet/area-system-numerics 
- @dotnet/area-system-reflection-emit 
- @dotnet/area-system-runtime-compilerservices 
- System.Runtime.InteropServices @dotnet/interop-contrib 
- @dotnet/area-system-runtime-intrinsics 
- @dotnet/area-system-security 
- @dotnet/area-system-text-encoding 
- @dotnet/area-system-text-json 
- System.Threading @kouvel @mangod9 
- @dotnet/area-system-threading-channels 
- @dotnet/area-system-threading-tasks 

**Known api-diff tool issues**:

If yo usee any of these, please provide a GitHub suggestion in this PR to correct it: 

- The AsmDiff tool sometimes skips adding `{` or `{}` [arcade#10981](https://github.com/dotnet/arcade/issues/10981)(https://github.com/dotnet/arcade/issues/13814) 
- RequiresPreviewAttribute not getting auto added [arcade#14498](https://github.com/dotnet/arcade/issues/14498)
- Changes to `protected internal` visibility should stop showing. https://github.com/dotnet/arcade/issues/14579
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect: [arcade#13814]
