### PR TITLE
Rel index patch

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -22,6 +22,7 @@
             "latest-sdk": "8.0.302",
             "product": ".NET",
             "support-phase": "active",
+            "eol-date": "2026-11-10",
             "release-type": "lts",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json"
         },
@@ -34,6 +35,7 @@
             "latest-sdk": "7.0.410",
             "product": ".NET",
             "support-phase": "eol",
+            "eol-date": "2024-05-14",
             "release-type": "sts",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json"
         },
@@ -46,6 +48,7 @@
             "latest-sdk": "6.0.423",
             "product": ".NET",
             "support-phase": "active",
+            "eol-date": "2024-11-12",
             "release-type": "lts",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
         },

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -9,8 +9,9 @@
             "latest-runtime": "9.0.0-preview.5.24306.7",
             "latest-sdk": "9.0.100-preview.5.24307.3",
             "product": ".NET",
-            "release-type" : "sts",
             "support-phase": "preview",
+            "eol-date": "2026-05-11",
+            "release-type" : "sts",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/releases.json"
         },
         {


### PR DESCRIPTION
Some eol-date fields were wrongly removed in the May updates. Adding them back. 