### PR TITLE
Update CentOS support information

### DIFF
--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -157,6 +157,21 @@
                     ]
                 },
                 {
+                    "id": "centos-stream",
+                    "name": "CentOS Stream",
+                    "link": "https://centos.org/",
+                    "architectures": [
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9"
+                    ],
+                    "unsupported-versions": [
+                        "8",
+                        "7"
+                    ]
+                },
+                {
                     "id": "debian",
                     "name": "Debian",
                     "link": "https://www.debian.org/",

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -139,6 +139,21 @@
                     ]
                 },
                 {
+                    "id": "centos",
+                    "name": "CentOS",
+                    "link": "https://centos.org/",
+                    "lifecycle": "https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/",
+                    "architectures": [
+                        "x64"
+                    ],
+                    "supported-versions": [
+                    ],
+                    "unsupported-versions": [
+                        "8",
+                        "7"
+                    ]
+                },
+                {
                     "id": "debian",
                     "name": "Debian",
                     "link": "https://www.debian.org/",

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -161,7 +161,7 @@
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
                     "architectures": [
-                        "Arm32",
+                        "Arm64",
                         "s390x",
                         "x64"
                     ],

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -161,6 +161,8 @@
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
                     "architectures": [
+                        "Arm32",
+                        "s390x",
                         "x64"
                     ],
                     "supported-versions": [

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -151,6 +151,9 @@
                     "unsupported-versions": [
                         "8",
                         "7"
+                    ],
+                    "notes": [
+                        "The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro."
                     ]
                 },
                 {

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -160,6 +160,7 @@
                     "id": "centos-stream",
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
+                    "lifecycle": "https://www.centos.org/cl-vs-cs/",
                     "architectures": [
                         "Arm64",
                         "s390x",

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -6,7 +6,7 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
 
@@ -19,7 +19,7 @@ Notes:
 
 ## Apple
 
-OS                              | Version                      | Architectures      |
+OS                              | Versions                     | Architectures      |
 --------------------------------|------------------------------|--------------------|
 [iOS][2]                        | 17, 16, 15                   | Arm64              |
 [iPadOS][3]                     | 17, 16, 15                   | Arm64              |
@@ -40,17 +40,17 @@ Notes:
 
 ## Linux
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     |                              | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  |
-[Debian][11]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
-[Fedora][13]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][14]    |
-[openSUSE Leap][15]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][16]    |
-[Red Hat Enterprise Linux][17]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][18]    |
-[SUSE Enterprise Linux][19]     | 15.5, 12.5                   | Arm64, x64         | [Lifecycle][20]    |
-[Ubuntu][21]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][22]    |
+[CentOS][8]                     | [None](#out-of-support-os-versions) | x64                | [Lifecycle][9]     |
+[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
+[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
+[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
+[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
+[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
+[SUSE Enterprise Linux][20]     | 15.5, 12.5                   | Arm64, x64         | [Lifecycle][21]    |
+[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
 
 Notes:
 
@@ -62,41 +62,42 @@ Notes:
 [8]: https://centos.org/
 [9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
 [10]: https://centos.org/
-[11]: https://www.debian.org/
-[12]: https://wiki.debian.org/DebianReleases
-[13]: https://fedoraproject.org/
-[14]: https://fedoraproject.org/wiki/End_of_life
-[15]: https://www.opensuse.org/
-[16]: https://en.opensuse.org/Lifetime
-[17]: https://access.redhat.com/
-[18]: https://access.redhat.com/support/policy/updates/errata/
-[19]: https://www.suse.com/
-[20]: https://www.suse.com/lifecycle/
-[21]: https://ubuntu.com/
-[22]: https://wiki.ubuntu.com/Releases
+[11]: https://www.centos.org/cl-vs-cs/
+[12]: https://www.debian.org/
+[13]: https://wiki.debian.org/DebianReleases
+[14]: https://fedoraproject.org/
+[15]: https://fedoraproject.org/wiki/End_of_life
+[16]: https://www.opensuse.org/
+[17]: https://en.opensuse.org/Lifetime
+[18]: https://access.redhat.com/
+[19]: https://access.redhat.com/support/policy/updates/errata/
+[20]: https://www.suse.com/
+[21]: https://www.suse.com/lifecycle/
+[22]: https://ubuntu.com/
+[23]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][23]               | 2022, 2019                   | x64                | [Lifecycle][24]    |
-[Windows][25]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 20H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][26]    |
-[Windows Server][27]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][28]    |
-[Windows Server Core][29]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][30]    |
+[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
+[Windows][26]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 20H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
+[Windows Server][28]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][29]    |
+[Windows Server Core][30]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][31]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[25]: https://www.microsoft.com/windows/
-[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[27]: https://www.microsoft.com/windows-server
-[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[29]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[30]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[26]: https://www.microsoft.com/windows/
+[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[28]: https://www.microsoft.com/windows-server
+[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -43,54 +43,60 @@ Notes:
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[Debian][8]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][9]     |
-[Fedora][10]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[openSUSE Leap][12]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][13]    |
-[Red Hat Enterprise Linux][14]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][15]    |
-[SUSE Enterprise Linux][16]     | 15.5, 12.5                   | Arm64, x64         | [Lifecycle][17]    |
-[Ubuntu][18]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][19]    |
+[CentOS][8]                     |                              | x64                | [Lifecycle][9]     |
+[CentOS Stream][10]             | 9                            | x64                |
+[Debian][11]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
+[Fedora][13]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][14]    |
+[openSUSE Leap][15]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][16]    |
+[Red Hat Enterprise Linux][17]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][18]    |
+[SUSE Enterprise Linux][19]     | 15.5, 12.5                   | Arm64, x64         | [Lifecycle][20]    |
+[Ubuntu][21]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][22]    |
 
 Notes:
 
+* CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
 * Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
-[8]: https://www.debian.org/
-[9]: https://wiki.debian.org/DebianReleases
-[10]: https://fedoraproject.org/
-[11]: https://fedoraproject.org/wiki/End_of_life
-[12]: https://www.opensuse.org/
-[13]: https://en.opensuse.org/Lifetime
-[14]: https://access.redhat.com/
-[15]: https://access.redhat.com/support/policy/updates/errata/
-[16]: https://www.suse.com/
-[17]: https://www.suse.com/lifecycle/
-[18]: https://ubuntu.com/
-[19]: https://wiki.ubuntu.com/Releases
+[8]: https://centos.org/
+[9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
+[10]: https://centos.org/
+[11]: https://www.debian.org/
+[12]: https://wiki.debian.org/DebianReleases
+[13]: https://fedoraproject.org/
+[14]: https://fedoraproject.org/wiki/End_of_life
+[15]: https://www.opensuse.org/
+[16]: https://en.opensuse.org/Lifetime
+[17]: https://access.redhat.com/
+[18]: https://access.redhat.com/support/policy/updates/errata/
+[19]: https://www.suse.com/
+[20]: https://www.suse.com/lifecycle/
+[21]: https://ubuntu.com/
+[22]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][20]               | 2022, 2019                   | x64                | [Lifecycle][21]    |
-[Windows][22]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 20H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][23]    |
-[Windows Server][24]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][25]    |
-[Windows Server Core][26]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][27]    |
+[Nano Server][23]               | 2022, 2019                   | x64                | [Lifecycle][24]    |
+[Windows][25]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 20H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][26]    |
+[Windows Server][27]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][28]    |
+[Windows Server Core][29]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][30]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[20]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[21]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[22]: https://www.microsoft.com/windows/
-[23]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[24]: https://www.microsoft.com/windows-server
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[25]: https://www.microsoft.com/windows/
+[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[27]: https://www.microsoft.com/windows-server
+[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[29]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[30]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 
@@ -122,6 +128,10 @@ Alpine                          | 3.12                         | [2022-05-01](ht
 Android                         | 11                           | 2024-02-05         |
 Android                         | 10                           | 2023-03-06         |
 Android                         | 9                            | [2022-01-01](https://developer.android.com/about/versions/pie) |
+CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
+CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
+CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
+CentOS Stream                   | 7                            | -                  |
 Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
 Fedora                          | 38                           | 2024-05-21         |
 Fedora                          | 37                           | 2023-12-05         |

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -44,7 +44,7 @@ OS                              | Version                      | Architectures  
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
 [CentOS][8]                     |                              | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | x64                |
+[CentOS Stream][10]             | 9                            | Arm32, s390x, x64  |
 [Debian][11]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
 [Fedora][13]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][14]    |
 [openSUSE Leap][15]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][16]    |

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -44,7 +44,7 @@ OS                              | Version                      | Architectures  
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
 [CentOS][8]                     |                              | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | Arm32, s390x, x64  |
+[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  |
 [Debian][11]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
 [Fedora][13]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][14]    |
 [openSUSE Leap][15]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][16]    |

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -134,6 +134,42 @@
                     ]
                 },
                 {
+                    "id": "centos",
+                    "name": "CentOS",
+                    "link": "https://centos.org/",
+                    "lifecycle": "https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/",
+                    "architectures": [
+                        "x64"
+                    ],
+                    "supported-versions": [
+                    ],
+                    "unsupported-versions": [
+                        "8",
+                        "7"
+                    ],
+                    "notes": [
+                        "The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro."
+                    ]
+                },
+                {
+                    "id": "centos-stream",
+                    "name": "CentOS Stream",
+                    "link": "https://centos.org/",
+                    "lifecycle": "https://www.centos.org/cl-vs-cs/",
+                    "architectures": [
+                        "Arm64",
+                        "s390x",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9"
+                    ],
+                    "unsupported-versions": [
+                        "8",
+                        "7"
+                    ]
+                },
+                {
                     "id": "debian",
                     "name": "Debian",
                     "link": "https://www.debian.org/",

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -6,7 +6,7 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
 
@@ -19,12 +19,12 @@ Notes:
 
 ## Apple
 
-OS                              | Version                      | Architectures      |
+OS                              | Versions                     | Architectures      |
 --------------------------------|------------------------------|--------------------|
 [iOS][2]                        | 17, 16, 15                   | Arm64              |
 [iPadOS][3]                     | 17, 16, 15                   | Arm64              |
 [macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       |                              | Arm64              |
+[tvOS][5]                       | [None](#out-of-support-os-versions) | Arm64              |
 
 Notes:
 
@@ -40,57 +40,64 @@ Notes:
 
 ## Linux
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[Debian][8]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][9]     |
-[Fedora][10]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[openSUSE Leap][12]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][13]    |
-[Red Hat Enterprise Linux][14]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][15]    |
-[SUSE Enterprise Linux][16]     | 15.5, 15.4                   | Arm64, x64         | [Lifecycle][17]    |
-[Ubuntu][18]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][19]    |
+[CentOS][8]                     | [None](#out-of-support-os-versions) | x64                | [Lifecycle][9]     |
+[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
+[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
+[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
+[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
+[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
+[SUSE Enterprise Linux][20]     | 15.5, 15.4                   | Arm64, x64         | [Lifecycle][21]    |
+[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
 
 Notes:
 
+* CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
 * Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
-[8]: https://www.debian.org/
-[9]: https://wiki.debian.org/DebianReleases
-[10]: https://fedoraproject.org/
-[11]: https://fedoraproject.org/wiki/End_of_life
-[12]: https://www.opensuse.org/
-[13]: https://en.opensuse.org/Lifetime
-[14]: https://access.redhat.com/
-[15]: https://access.redhat.com/support/policy/updates/errata/
-[16]: https://www.suse.com/
-[17]: https://www.suse.com/lifecycle/
-[18]: https://ubuntu.com/
-[19]: https://wiki.ubuntu.com/Releases
+[8]: https://centos.org/
+[9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
+[10]: https://centos.org/
+[11]: https://www.centos.org/cl-vs-cs/
+[12]: https://www.debian.org/
+[13]: https://wiki.debian.org/DebianReleases
+[14]: https://fedoraproject.org/
+[15]: https://fedoraproject.org/wiki/End_of_life
+[16]: https://www.opensuse.org/
+[17]: https://en.opensuse.org/Lifetime
+[18]: https://access.redhat.com/
+[19]: https://access.redhat.com/support/policy/updates/errata/
+[20]: https://www.suse.com/
+[21]: https://www.suse.com/lifecycle/
+[22]: https://ubuntu.com/
+[23]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][20]               | 2022, 2019                   | x64                | [Lifecycle][21]    |
-[Windows][22]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][23]    |
-[Windows Server][24]            | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][25]    |
-[Windows Server Core][26]       | 2022, 2019, 2016             | x64, x86           | [Lifecycle][27]    |
+[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
+[Windows][26]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
+[Windows Server][28]            | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
+[Windows Server Core][30]       | 2022, 2019, 2016             | x64, x86           | [Lifecycle][31]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[20]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[21]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[22]: https://www.microsoft.com/windows/
-[23]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[24]: https://www.microsoft.com/windows-server
+[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
 [25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[26]: https://www.microsoft.com/windows/
+[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[28]: https://www.microsoft.com/windows-server
+[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 
@@ -119,6 +126,10 @@ Alpine                          | 3.16                         | [2024-05-23](ht
 Alpine                          | 3.15                         | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html) |
 Android                         | 11                           | 2024-02-05         |
 Android                         | 10                           | 2023-03-06         |
+CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
+CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
+CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
+CentOS Stream                   | 7                            | -                  |
 Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
 Fedora                          | 38                           | 2024-05-21         |
 Fedora                          | 37                           | 2023-12-05         |

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -127,7 +127,7 @@
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
                     "architectures": [
-                        "Arm32",
+                        "Arm64",
                         "s390x",
                         "x64"
                     ],

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -126,9 +126,12 @@
                     "id": "centos-stream",
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
+                    "lifecycle": "https://www.centos.org/cl-vs-cs/",
                     "architectures": [
                         "Arm64",
+                        "ppc64le",
                         "s390x",
+                        
                         "x64"
                     ],
                     "supported-versions": [

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -123,6 +123,19 @@
                     ]
                 },
                 {
+                    "id": "centos-stream",
+                    "name": "CentOS Stream",
+                    "link": "https://centos.org/",
+                    "architectures": [
+                        "Arm32",
+                        "s390x",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9"
+                    ]
+                },
+                {
                     "id": "debian",
                     "name": "Debian",
                     "link": "https://www.debian.org/",

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -43,12 +43,13 @@ Notes:
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[Debian][8]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][9]     |
-[Fedora][10]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[openSUSE Leap][12]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][13]    |
-[Red Hat Enterprise Linux][14]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][15]    |
-[SUSE Enterprise Linux][16]     | 15.5                         | Arm64, x64         | [Lifecycle][17]    |
-[Ubuntu][18]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][19]    |
+[CentOS Stream][8]              | 9                            | Arm32, s390x, x64  |
+[Debian][9]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][10]    |
+[Fedora][11]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
+[openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |
+[Red Hat Enterprise Linux][15]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][16]    |
+[SUSE Enterprise Linux][17]     | 15.5                         | Arm64, x64         | [Lifecycle][18]    |
+[Ubuntu][19]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][20]    |
 
 Notes:
 
@@ -56,41 +57,42 @@ Notes:
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
-[8]: https://www.debian.org/
-[9]: https://wiki.debian.org/DebianReleases
-[10]: https://fedoraproject.org/
-[11]: https://fedoraproject.org/wiki/End_of_life
-[12]: https://www.opensuse.org/
-[13]: https://en.opensuse.org/Lifetime
-[14]: https://access.redhat.com/
-[15]: https://access.redhat.com/support/policy/updates/errata/
-[16]: https://www.suse.com/
-[17]: https://www.suse.com/lifecycle/
-[18]: https://ubuntu.com/
-[19]: https://wiki.ubuntu.com/Releases
+[8]: https://centos.org/
+[9]: https://www.debian.org/
+[10]: https://wiki.debian.org/DebianReleases
+[11]: https://fedoraproject.org/
+[12]: https://fedoraproject.org/wiki/End_of_life
+[13]: https://www.opensuse.org/
+[14]: https://en.opensuse.org/Lifetime
+[15]: https://access.redhat.com/
+[16]: https://access.redhat.com/support/policy/updates/errata/
+[17]: https://www.suse.com/
+[18]: https://www.suse.com/lifecycle/
+[19]: https://ubuntu.com/
+[20]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][20]               | 2022, 2019                   | x64                | [Lifecycle][21]    |
-[Windows][22]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][23]    |
-[Windows Server][24]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][25]    |
-[Windows Server Core][26]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][27]    |
+[Nano Server][21]               | 2022, 2019                   | x64                | [Lifecycle][22]    |
+[Windows][23]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][24]    |
+[Windows Server][25]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][26]    |
+[Windows Server Core][27]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][28]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[20]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[21]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[22]: https://www.microsoft.com/windows/
-[23]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[24]: https://www.microsoft.com/windows-server
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[21]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[22]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://www.microsoft.com/windows/
+[24]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[25]: https://www.microsoft.com/windows-server
+[26]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[27]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -6,7 +6,7 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
 
@@ -19,7 +19,7 @@ Notes:
 
 ## Apple
 
-OS                              | Version                      | Architectures      |
+OS                              | Versions                     | Architectures      |
 --------------------------------|------------------------------|--------------------|
 [iOS][2]                        | 17, 16, 15                   | Arm64              |
 [iPadOS][3]                     | 17, 16, 15                   | Arm64              |
@@ -40,16 +40,16 @@ Notes:
 
 ## Linux
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm64, s390x, x64  |
-[Debian][9]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][10]    |
-[Fedora][11]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
-[openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |
-[Red Hat Enterprise Linux][15]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][16]    |
-[SUSE Enterprise Linux][17]     | 15.5                         | Arm64, x64         | [Lifecycle][18]    |
-[Ubuntu][19]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][20]    |
+[CentOS Stream][8]              | 9                            | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]     |
+[Debian][10]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][11]    |
+[Fedora][12]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
+[openSUSE Leap][14]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][15]    |
+[Red Hat Enterprise Linux][16]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]    |
+[SUSE Enterprise Linux][18]     | 15.5                         | Arm64, x64         | [Lifecycle][19]    |
+[Ubuntu][20]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][21]    |
 
 Notes:
 
@@ -58,41 +58,42 @@ Notes:
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
-[9]: https://www.debian.org/
-[10]: https://wiki.debian.org/DebianReleases
-[11]: https://fedoraproject.org/
-[12]: https://fedoraproject.org/wiki/End_of_life
-[13]: https://www.opensuse.org/
-[14]: https://en.opensuse.org/Lifetime
-[15]: https://access.redhat.com/
-[16]: https://access.redhat.com/support/policy/updates/errata/
-[17]: https://www.suse.com/
-[18]: https://www.suse.com/lifecycle/
-[19]: https://ubuntu.com/
-[20]: https://wiki.ubuntu.com/Releases
+[9]: https://www.centos.org/cl-vs-cs/
+[10]: https://www.debian.org/
+[11]: https://wiki.debian.org/DebianReleases
+[12]: https://fedoraproject.org/
+[13]: https://fedoraproject.org/wiki/End_of_life
+[14]: https://www.opensuse.org/
+[15]: https://en.opensuse.org/Lifetime
+[16]: https://access.redhat.com/
+[17]: https://access.redhat.com/support/policy/updates/errata/
+[18]: https://www.suse.com/
+[19]: https://www.suse.com/lifecycle/
+[20]: https://ubuntu.com/
+[21]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][21]               | 2022, 2019                   | x64                | [Lifecycle][22]    |
-[Windows][23]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][24]    |
-[Windows Server][25]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][26]    |
-[Windows Server Core][27]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][28]    |
+[Nano Server][22]               | 2022, 2019                   | x64                | [Lifecycle][23]    |
+[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][25]    |
+[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][27]    |
+[Windows Server Core][28]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][29]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[21]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[22]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[23]: https://www.microsoft.com/windows/
-[24]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[25]: https://www.microsoft.com/windows-server
-[26]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[27]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[22]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[23]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[24]: https://www.microsoft.com/windows/
+[25]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[26]: https://www.microsoft.com/windows-server
+[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[28]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -43,7 +43,7 @@ Notes:
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm32, s390x, x64  |
+[CentOS Stream][8]              | 9                            | Arm64, s390x, x64  |
 [Debian][9]                     | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][10]    |
 [Fedora][11]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][12]    |
 [openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -115,6 +115,19 @@
                     ]
                 },
                 {
+                    "id": "centos-stream",
+                    "name": "CentOS Stream",
+                    "link": "https://centos.org/",
+                    "architectures": [
+                        "Arm32",
+                        "s390x",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9"
+                    ]
+                },
+                {
                     "id": "debian",
                     "name": "Debian",
                     "link": "https://www.debian.org/",

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -118,8 +118,10 @@
                     "id": "centos-stream",
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
+                    "lifecycle": "https://www.centos.org/cl-vs-cs/",
                     "architectures": [
                         "Arm64",
+                        "ppc64le",
                         "s390x",
                         "x64"
                     ],

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -119,7 +119,7 @@
                     "name": "CentOS Stream",
                     "link": "https://centos.org/",
                     "architectures": [
-                        "Arm32",
+                        "Arm64",
                         "s390x",
                         "x64"
                     ],

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -43,7 +43,7 @@ Notes:
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19                   | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm32, s390x, x64  |
+[CentOS Stream][8]              | 9                            | Arm64, s390x, x64  |
 [Debian][9]                     | 12                           | Arm32, Arm64, x64  | [Lifecycle][10]    |
 [Fedora][11]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][12]    |
 [openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -43,12 +43,13 @@ Notes:
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19                   | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[Debian][8]                     | 12                           | Arm32, Arm64, x64  | [Lifecycle][9]     |
-[Fedora][10]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[openSUSE Leap][12]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][13]    |
-[Red Hat Enterprise Linux][14]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][15]    |
-[SUSE Enterprise Linux][16]     | 15.5                         | Arm64, x64         | [Lifecycle][17]    |
-[Ubuntu][18]                    | 24.04, 22.04, 20.04          | Arm32, Arm64, x64  | [Lifecycle][19]    |
+[CentOS Stream][8]              | 9                            | Arm32, s390x, x64  |
+[Debian][9]                     | 12                           | Arm32, Arm64, x64  | [Lifecycle][10]    |
+[Fedora][11]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][12]    |
+[openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |
+[Red Hat Enterprise Linux][15]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][16]    |
+[SUSE Enterprise Linux][17]     | 15.5                         | Arm64, x64         | [Lifecycle][18]    |
+[Ubuntu][19]                    | 24.04, 22.04, 20.04          | Arm32, Arm64, x64  | [Lifecycle][20]    |
 
 Notes:
 
@@ -56,41 +57,42 @@ Notes:
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
-[8]: https://www.debian.org/
-[9]: https://wiki.debian.org/DebianReleases
-[10]: https://fedoraproject.org/
-[11]: https://fedoraproject.org/wiki/End_of_life
-[12]: https://www.opensuse.org/
-[13]: https://en.opensuse.org/Lifetime
-[14]: https://access.redhat.com/
-[15]: https://access.redhat.com/support/policy/updates/errata/
-[16]: https://www.suse.com/
-[17]: https://www.suse.com/lifecycle/
-[18]: https://ubuntu.com/
-[19]: https://wiki.ubuntu.com/Releases
+[8]: https://centos.org/
+[9]: https://www.debian.org/
+[10]: https://wiki.debian.org/DebianReleases
+[11]: https://fedoraproject.org/
+[12]: https://fedoraproject.org/wiki/End_of_life
+[13]: https://www.opensuse.org/
+[14]: https://en.opensuse.org/Lifetime
+[15]: https://access.redhat.com/
+[16]: https://access.redhat.com/support/policy/updates/errata/
+[17]: https://www.suse.com/
+[18]: https://www.suse.com/lifecycle/
+[19]: https://ubuntu.com/
+[20]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
 OS                              | Version                      | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][20]               | 2022, 2019                   | x64                | [Lifecycle][21]    |
-[Windows][22]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][23]    |
-[Windows Server][24]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][25]    |
-[Windows Server Core][26]       | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][27]    |
+[Nano Server][21]               | 2022, 2019                   | x64                | [Lifecycle][22]    |
+[Windows][23]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][24]    |
+[Windows Server][25]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][26]    |
+[Windows Server Core][27]       | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][28]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[20]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[21]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[22]: https://www.microsoft.com/windows/
-[23]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[24]: https://www.microsoft.com/windows-server
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[21]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[22]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://www.microsoft.com/windows/
+[24]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[25]: https://www.microsoft.com/windows-server
+[26]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[27]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -6,7 +6,7 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
 
@@ -19,7 +19,7 @@ Notes:
 
 ## Apple
 
-OS                              | Version                      | Architectures      |
+OS                              | Versions                     | Architectures      |
 --------------------------------|------------------------------|--------------------|
 [iOS][2]                        | 17, 16, 15                   | Arm64              |
 [iPadOS][3]                     | 17, 16, 15                   | Arm64              |
@@ -40,16 +40,16 @@ Notes:
 
 ## Linux
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19                   | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm64, s390x, x64  |
-[Debian][9]                     | 12                           | Arm32, Arm64, x64  | [Lifecycle][10]    |
-[Fedora][11]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][12]    |
-[openSUSE Leap][13]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][14]    |
-[Red Hat Enterprise Linux][15]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][16]    |
-[SUSE Enterprise Linux][17]     | 15.5                         | Arm64, x64         | [Lifecycle][18]    |
-[Ubuntu][19]                    | 24.04, 22.04, 20.04          | Arm32, Arm64, x64  | [Lifecycle][20]    |
+[CentOS Stream][8]              | 9                            | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]     |
+[Debian][10]                    | 12                           | Arm32, Arm64, x64  | [Lifecycle][11]    |
+[Fedora][12]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][13]    |
+[openSUSE Leap][14]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][15]    |
+[Red Hat Enterprise Linux][16]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]    |
+[SUSE Enterprise Linux][18]     | 15.5                         | Arm64, x64         | [Lifecycle][19]    |
+[Ubuntu][20]                    | 24.04, 22.04, 20.04          | Arm32, Arm64, x64  | [Lifecycle][21]    |
 
 Notes:
 
@@ -58,41 +58,42 @@ Notes:
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
-[9]: https://www.debian.org/
-[10]: https://wiki.debian.org/DebianReleases
-[11]: https://fedoraproject.org/
-[12]: https://fedoraproject.org/wiki/End_of_life
-[13]: https://www.opensuse.org/
-[14]: https://en.opensuse.org/Lifetime
-[15]: https://access.redhat.com/
-[16]: https://access.redhat.com/support/policy/updates/errata/
-[17]: https://www.suse.com/
-[18]: https://www.suse.com/lifecycle/
-[19]: https://ubuntu.com/
-[20]: https://wiki.ubuntu.com/Releases
+[9]: https://www.centos.org/cl-vs-cs/
+[10]: https://www.debian.org/
+[11]: https://wiki.debian.org/DebianReleases
+[12]: https://fedoraproject.org/
+[13]: https://fedoraproject.org/wiki/End_of_life
+[14]: https://www.opensuse.org/
+[15]: https://en.opensuse.org/Lifetime
+[16]: https://access.redhat.com/
+[17]: https://access.redhat.com/support/policy/updates/errata/
+[18]: https://www.suse.com/
+[19]: https://www.suse.com/lifecycle/
+[20]: https://ubuntu.com/
+[21]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Version                      | Architectures      | Lifecycle          |
+OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][21]               | 2022, 2019                   | x64                | [Lifecycle][22]    |
-[Windows][23]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][24]    |
-[Windows Server][25]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][26]    |
-[Windows Server Core][27]       | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][28]    |
+[Nano Server][22]               | 2022, 2019                   | x64                | [Lifecycle][23]    |
+[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][25]    |
+[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][27]    |
+[Windows Server Core][28]       | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[21]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[22]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[23]: https://www.microsoft.com/windows/
-[24]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[25]: https://www.microsoft.com/windows-server
-[26]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[27]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[28]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[22]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[23]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[24]: https://www.microsoft.com/windows/
+[25]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[26]: https://www.microsoft.com/windows-server
+[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[28]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 


### PR DESCRIPTION
I added sections for CentOS and CentOS Stream to clarify our support position.

The intent for .NET 8+ was to rely on our [RHEL compatibility statement](https://github.com/dotnet/core/blob/main/linux.md#red-hat-enterprise-linux-support) to take care of the RHEL-compatible distros. 

Doing that for .NET 6 doesn't make sense, for two reasons:

- CentOS isn't listed in the RHEL compatibility statement, only CentOS Stream.
- .NET 6 was released in the era where there was significant confusion between CentOS and CentOS Stream.

All in all, it makes good sense to clarify our position on CentOS given that CentOS 7 recently went EOL.

We'll publish a separate announcement on CentOS 7 support to provide better visibility than just this PR.

Related: https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol

@Falco20019 @omajid @rbhanda 