### PR TITLE
Update Linux support statements

### DIFF
--- a/linux.md
+++ b/linux.md
@@ -1,8 +1,8 @@
-# .NET Support and Compatibility for Linux Distributions
+# Linux Distribution Support and Compatibility
 
 .NET can be [installed](https://learn.microsoft.com/dotnet/core/install/linux) and run on almost any Linux distribution. Packages that are available in a given distribution are compatible with that distribution. Packages and binaries from Microsoft are compatible with a broad set of distributions.
 
-The community provides best effort support for .NET across all Linux distributions. [Commercial support](support.md) is provided for some popular distributions.
+The .NET community provides [best effort support](./os-lifecycle-policy.md) across all Linux distributions. [Commercial support](support.md) is provided for some popular distributions.
 
 ## Containers
 
@@ -78,16 +78,6 @@ ldd (Ubuntu GLIBC 2.23-0ubuntu11.3) 2.23
 Portable builds support both OpenSSL 1.x and 3.x and can be run on distributions with either version of OpenSSL. For example, Ubuntu 22.04 only includes OpenSSL 3 in its official package archive.
 
 The highest OpenSSL version is loaded by default, but it can be [configured to use a specific version](https://github.com/dotnet/runtime/issues/79153#issuecomment-1335476471).
-
-## Red Hat Enterprise Linux support
-
-RHEL-compatible distributions are supported, including: AlmaLinux, CentOS Stream, Oracle Linux, and Rocky Linux.
-
-New .NET versions will typically only be supported on Red Hat Enterprise Linux (RHEL) versions in active support.
-
-- RHEL 7 is considered in maintenance.
-- RHEL 8 is considered in active support.
-- RHEL 9 is considered in active support.
 
 ## Building .NET from source
 

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -170,8 +170,7 @@
                         "9"
                     ],
                     "unsupported-versions": [
-                        "8",
-                        "7"
+                        "8"
                     ]
                 },
                 {
@@ -249,7 +248,7 @@
                         "7"
                     ],
                     "notes": [
-                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
+                        "RHEL-compatible derivatives are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -249,7 +249,7 @@
                         "7"
                     ],
                     "notes": [
-                        "Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md)."
+                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "6.0",
-    "last-updated": "2024-07-01",
+    "last-updated": "2024-07-11",
     "families": [
         {
             "name": "Android",

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -43,7 +43,7 @@ Notes:
 OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     | [None](#out-of-support-os-versions) | x64                | [Lifecycle][9]     |
+[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
 [CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
 [Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
 [Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
@@ -55,7 +55,7 @@ OS                              | Versions                     | Architectures  
 Notes:
 
 * CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
-* Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
+* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
@@ -147,8 +147,8 @@ macOS                           | 10.15                        | [2022-09-12](ht
 Nano Server                     | 20H2                         | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring) |
 Nano Server                     | 2004                         | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing) |
 openSUSE Leap                   | 15.4                         | 2023-12-07         |
-openSUSE Leap                   | 15.3                         | 2022-12-31         |
-openSUSE Leap                   | 15.2                         | 2022-01-04         |
+openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
+openSUSE Leap                   | 15.2                         | [2022-01-04](https://web.archive.org/web/20230529015218/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.2/) |
 SUSE Enterprise Linux           | 15.4                         | 2023-12-31         |
 SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
 SUSE Enterprise Linux           | 15.2                         | 2021-12-31         |
@@ -176,3 +176,5 @@ Windows Server                  | 2004                         | [2021-12-14](ht
 Windows Server Core             | 20H2                         | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring) |
 Windows Server Core             | 1607                         | [2022-01-11](https://learn.microsoft.com/virtualization/windowscontainers/deploy-containers/base-image-lifecycle) |
 Windows Server Core             | 2004                         | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing) |
+
+[OOS]: #out-of-support-os-versions

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -1,5 +1,7 @@
 # .NET 6 - Supported OS versions
 
+Last updated: 2024-07-11
+
 [.NET 6](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
 This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -55,7 +55,7 @@ OS                              | Versions                     | Architectures  
 Notes:
 
 * CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
-* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
+* Red Hat Enterprise Linux: RHEL-compatible derivatives are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
@@ -132,7 +132,6 @@ Android                         | 9                            | [2022-01-01](ht
 CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
 CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
 CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
-CentOS Stream                   | 7                            | -                  |
 Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
 Fedora                          | 38                           | 2024-05-21         |
 Fedora                          | 37                           | 2023-12-05         |

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "7.0",
-    "last-updated": "2024-07-01",
+    "last-updated": "2024-07-11",
     "families": [
         {
             "name": "Android",

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -165,8 +165,7 @@
                         "9"
                     ],
                     "unsupported-versions": [
-                        "8",
-                        "7"
+                        "8"
                     ]
                 },
                 {
@@ -241,7 +240,7 @@
                         "7"
                     ],
                     "notes": [
-                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
+                        "RHEL-compatible derivatives are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -241,7 +241,7 @@
                         "7"
                     ],
                     "notes": [
-                        "Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md)."
+                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -55,7 +55,7 @@ OS                              | Versions                     | Architectures  
 Notes:
 
 * CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
-* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
+* Red Hat Enterprise Linux: RHEL-compatible derivatives are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
@@ -129,7 +129,6 @@ Android                         | 10                           | 2023-03-06     
 CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
 CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
 CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
-CentOS Stream                   | 7                            | -                  |
 Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
 Fedora                          | 38                           | 2024-05-21         |
 Fedora                          | 37                           | 2023-12-05         |

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -1,5 +1,7 @@
 # .NET 7 - Supported OS versions
 
+Last updated: 2024-07-11
+
 [.NET 7](README.md) is a [Standard Term Support (STS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
 This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -24,7 +24,7 @@ OS                              | Versions                     | Architectures  
 [iOS][2]                        | 17, 16, 15                   | Arm64              |
 [iPadOS][3]                     | 17, 16, 15                   | Arm64              |
 [macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | [None](#out-of-support-os-versions) | Arm64              |
+[tvOS][5]                       | [None][OOS]                  | Arm64              |
 
 Notes:
 
@@ -43,7 +43,7 @@ Notes:
 OS                              | Versions                     | Architectures      | Lifecycle          |
 --------------------------------|------------------------------|--------------------|--------------------|
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     | [None](#out-of-support-os-versions) | x64                | [Lifecycle][9]     |
+[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
 [CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
 [Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
 [Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
@@ -55,7 +55,7 @@ OS                              | Versions                     | Architectures  
 Notes:
 
 * CentOS: The CentOS project has moved to [supporting CentOS Stream as its future](https://blog.centos.org/2020/12/future-is-centos-stream/). Users can consider [migrating to Red Hat Enterprise Linux](https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol) or another distro.
-* Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
+* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/
@@ -140,7 +140,7 @@ iPadOS                          | 12                           | -              
 macOS                           | 11                           | [2023-09-26](https://support.apple.com/HT211896) |
 macOS                           | 10.15                        | [2022-09-12](https://support.apple.com/HT210642) |
 openSUSE Leap                   | 15.4                         | 2023-12-07         |
-openSUSE Leap                   | 15.3                         | 2022-12-31         |
+openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
 SUSE Enterprise Linux           | 12.5                         | 2024-10-31         |
 SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
 SUSE Enterprise Linux           | 12.4                         | 2020-06-30         |
@@ -162,3 +162,5 @@ Windows                         | 10 21H1                      | [2022-12-13](ht
 Windows                         | 7 SP1                        | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7) |
 Windows Server                  | 2012-R2                      | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2) |
 Windows Server                  | 2012                         | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012) |
+
+[OOS]: #out-of-support-os-versions

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "8.0",
-    "last-updated": "2024-07-01",
+    "last-updated": "2024-07-11",
     "families": [
         {
             "name": "Android",

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -202,7 +202,7 @@
                         "8"
                     ],
                     "notes": [
-                        "Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md)."
+                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -202,7 +202,7 @@
                         "8"
                     ],
                     "notes": [
-                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
+                        "RHEL-compatible derivatives are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -1,5 +1,7 @@
 # .NET 8 - Supported OS versions
 
+Last updated: 2024-07-11
+
 [.NET 8](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
 This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -53,7 +53,7 @@ OS                              | Versions                     | Architectures  
 
 Notes:
 
-* Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
+* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -53,7 +53,7 @@ OS                              | Versions                     | Architectures  
 
 Notes:
 
-* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
+* Red Hat Enterprise Linux: RHEL-compatible derivatives are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -187,7 +187,7 @@
                         "8"
                     ],
                     "notes": [
-                        "Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md)."
+                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -187,7 +187,7 @@
                         "8"
                     ],
                     "notes": [
-                        "RHEL-compatible distributions are supported per [.NET Support](../../support.md)."
+                        "RHEL-compatible derivatives are supported per [.NET Support](../../support.md)."
                     ]
                 },
                 {

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "9.0",
-    "last-updated": "2024-07-01",
+    "last-updated": "2024-07-11",
     "families": [
         {
             "name": "Android",

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -53,7 +53,7 @@ OS                              | Versions                     | Architectures  
 
 Notes:
 
-* Red Hat Enterprise Linux: Red Hat family distributions are supported per [Linux compatibility and support](../../linux-support.md).
+* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -53,7 +53,7 @@ OS                              | Versions                     | Architectures  
 
 Notes:
 
-* Red Hat Enterprise Linux: RHEL-compatible distributions are supported per [.NET Support](../../support.md).
+* Red Hat Enterprise Linux: RHEL-compatible derivatives are supported per [.NET Support](../../support.md).
 
 [6]: https://alpinelinux.org/
 [7]: https://alpinelinux.org/releases/

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -1,5 +1,7 @@
 # .NET 9 - Supported OS versions
 
+Last updated: 2024-07-11
+
 [.NET 9](README.md) is a [Standard Term Support (STS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
 This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).

--- a/support.md
+++ b/support.md
@@ -12,9 +12,18 @@
 
 ## Community support
 
-Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core).
+Community support is available on GitHub, such as at [dotnet/core](https://github.com/dotnet/core) and [.NET repos](./Documentation/core-repos.md).
 
 Community builds are available for [FreeBSD](https://wiki.freebsd.org/.NET), [Linux](linux.md), and [macOS](https://formulae.brew.sh/cask/dotnet-sdk)
+
+### Downstream derivative support
+
+There are many [Linux distributions](https://en.wikipedia.org/wiki/List_of_Linux_distributions). In general, a downstream distribution of a [supported distribution](./os-lifecycle-policy.md) will also be supported.
+
+Supported derivatives:
+
+* RHEL-family: AlmaLinux, CentOS Stream, Oracle Linux, and Rocky Linux.
+* Ubuntu family: Linux Mint
 
 ## Commercial support
 

--- a/support.md
+++ b/support.md
@@ -16,9 +16,9 @@ Community support is available on GitHub, such as at [dotnet/core](https://githu
 
 Community builds are available for [FreeBSD](https://wiki.freebsd.org/.NET), [Linux](linux.md), and [macOS](https://formulae.brew.sh/cask/dotnet-sdk)
 
-### Downstream derivative support
+### Compatible derivatives
 
-There are many [Linux distributions](https://en.wikipedia.org/wiki/List_of_Linux_distributions). In general, a downstream distribution of a [supported distribution](./os-lifecycle-policy.md) will also be supported.
+There are many [Linux distributions](https://en.wikipedia.org/wiki/List_of_Linux_distributions). Compatible derivatives of a [supported distribution](./os-lifecycle-policy.md) will typically be supported at the same level.
 
 The following derivatives are supported, for example:
 

--- a/support.md
+++ b/support.md
@@ -20,7 +20,7 @@ Community builds are available for [FreeBSD](https://wiki.freebsd.org/.NET), [Li
 
 There are many [Linux distributions](https://en.wikipedia.org/wiki/List_of_Linux_distributions). In general, a downstream distribution of a [supported distribution](./os-lifecycle-policy.md) will also be supported.
 
-Supported derivatives:
+The following derivatives are supported, for example:
 
 * RHEL-family: AlmaLinux, CentOS Stream, Oracle Linux, and Rocky Linux.
 * Ubuntu family: Linux Mint


### PR DESCRIPTION
No change in support is intended.

- Simplifying language
- Broadening derivative support to include more than RHEL
- Fix broken links
- Remove CentOS Stream 7. I think Stream started with v8.
- Update the last-updated date
- Include last-updated date in the markdown
- Re-run generator (new lifecycle links came in)

@Falco20019 @omajid @leecow @MichaelSimons @jkotas