### PR TITLE
Update links to point to 'stable' versions of BuildCheck documents

### DIFF
--- a/release-notes/9.0/preview/preview6/sdk.md
+++ b/release-notes/9.0/preview/preview6/sdk.md
@@ -2,9 +2,10 @@
 
 Here's a summary of what's new in the .NET SDK in this preview release:
 
-- [NuGetAudit now raises warnings for vulnerabilities in transitive dependencies](#nugetaudit-now-raises-warnings-for-vulnerabilities-in-transitive-dependencies)
-- Addition of [`dotnet nuget why`](#dotnet-nuget-why) to find out why a transitive package is being used in your project
-- [MSBuild BuildChecks](#msbuild-buildchecks) to help users enforce rules and invariants during their builds
+- [SDK updates in .NET 9 Preview 6](#sdk-updates-in-net-9-preview-6)
+  - [NuGetAudit now raises warnings for vulnerabilities in transitive dependencies](#nugetaudit-now-raises-warnings-for-vulnerabilities-in-transitive-dependencies)
+  - [`dotnet nuget why`](#dotnet-nuget-why)
+  - [MSBuild BuildChecks](#msbuild-buildchecks)
 
 SDK updates in .NET 9 Preview 6:
 
@@ -52,12 +53,12 @@ MSBuild has introduced a new tool called BuildChecks to help users enforce rules
 Like Roslyn Analyzers, the goal of this feature is to not only detect problems, but ensure that problems don't re-introduce themselves into the build once fixed.
 
 In this release, we have added two BuildCheck rules
-- [BC0101 - Shared Output Path](https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck/Codes.md#bc0101---shared-output-path)
-- [BC0102 - Double Write detection](https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck/Codes.md#bc0102---double-writes)
+- [BC0101 - Shared Output Path](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0101---shared-output-path)
+- [BC0102 - Double Write detection](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0102---double-writes)
 
 BuildCheck analysis can be used by adding the `/analyze` flag to any MSBuild-invoking call, both for `dotnet` and for `msbuild.exe`.
 For example, `dotnet build myapp.sln /analyze` would build the `myapp` solution and run all configured BuildChecks.
 
 When a BuildCheck detects a problem, you should see a diagnostic just like any other MSBuild diagnostic for the project that triggered the problem.
 
-You can read more about the BuildCheck system in our [design documentation](https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck.md).
+You can read more about the BuildCheck system in our [design documentation](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/BuildCheck.md).


### PR DESCRIPTION
We stabilized these documents and so need to update these links.