### PR TITLE
[WIP] Enable markdown linting

### DIFF
--- a/.github/linters/.markdownlintignore
+++ b/.github/linters/.markdownlintignore
@@ -1,0 +1,11 @@
+# Ignore errors from before linting was enabled to allow incremental fixes
+/*.md
+9.0/preview1/**
+9.0/preview2/**
+9.0/preview3/**
+9.0/preview4/**
+9.0/preview5/**
+9.0/preview6/**
+9.0/preview7/**
+9.0/README.md
+Aspire/announcing-preview-3.md

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
-          VALIDATE_MARKDOWN: false
+          VALIDATE_MARKDOWN: true
           VALIDATE_NATURAL_LANGUAGE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
-          VALIDATE_MARKDOWN: true
           VALIDATE_NATURAL_LANGUAGE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Evaluating markdown linting option in super linter. 

This is different from some other dotnet repos that are using markdown-cli with a markdownlint-problem-matcher.json to create pull request suggestions. Super Linter includes a default problem matcher which should hopefully work for pull request suggestions.