### PR TITLE
Add patch-release JSON files

### DIFF
--- a/release-notes/8.0/8.0.0/release.json
+++ b/release-notes/8.0/8.0.0/release.json
@@ -1,0 +1,520 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2023-11-14",
+  "release-version": "8.0.0",
+  "security": true,
+  "release": {
+    "release-date": "2023-11-14",
+    "release-version": "8.0.0",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2023-36049",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-36049"
+      },
+      {
+        "cve-id": "CVE-2023-36558",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-36558"
+      },
+      {
+        "cve-id": "CVE-2023-36038",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-36038"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.0/8.0.0.md",
+    "runtime": {
+      "version": "8.0.0",
+      "version-display": "8.0.0",
+      "vs-version": "17.8",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ee0a9245-5b87-4217-a9a5-dc589187612e/f3631cfe19cb713296314a6028a9e856/dotnet-runtime-8.0.0-linux-arm.tar.gz",
+          "hash": "2dd820ae2341b00844430bdfa3d45631b080d69aa2e55c89ab034a46e8712c542428267e10a5077bca607aa0c58e1efd42422cba4d76c2eaabf2ead87874ce24"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c879318f-48f3-4cc4-8dcc-a6b77cfdfc38/7890f8a96ea335f5265cd1aa80cac8ce/dotnet-runtime-8.0.0-linux-arm64.tar.gz",
+          "hash": "bb39fed4cff3a1a0a4e5084a517feeacb571700b8114b83b0b040f63f279d32eb9195d9b94cd60f8aa969b84adaad51694a2e26255177a30f40f50f634d29c21"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/81cc059e-5697-45b2-bf61-a5f4834ae487/85e37684156ca9501d852a27749ec3cd/dotnet-runtime-8.0.0-linux-musl-arm.tar.gz",
+          "hash": "3947064cdcf0c3417e9809f7595707bdc537c6280de82e0df170b15abc6be6705cb180b243c23dc373a76698e9e9f434a89975ae1734abad7f39607ef83e772c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/73ecf1eb-9823-4b32-bc5f-823e4d9ff871/51b31972bc51ac971430a01119bd6b19/dotnet-runtime-8.0.0-linux-musl-arm64.tar.gz",
+          "hash": "a8bb01b3e3dce7cd5a5ddcb8af13f3bc9b3be1cd3d60ee728b845c88cb12005e5e8c5d54a51391fc27de4023080ce9b231c1c48e858b3f1b551a9e1936d59f27"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/731765c8-5774-414d-8157-bf184806bca9/7a3c7add7562e1be15954a2739fefe30/dotnet-runtime-8.0.0-linux-musl-x64.tar.gz",
+          "hash": "bc9278786a728bcc404dd014f7823334312c0db6d949df104bb31e775f53b5684bba00611abb58873b8894d20489d5145fb351903b68dece92a7dbad14c3b9f2"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fc4b4447-45f2-4fd2-899a-77eb1aed7792/6fd52c0c61f064ddc7fe7684e841f491/dotnet-runtime-8.0.0-linux-x64.tar.gz",
+          "hash": "16a93af328bcf61775875f4007c23081e2cb7aa8e2fba724aea6a61bc7ecf7466cc368121b08b58ac3b72f68cb67801c68c6505591eb35f18461db856bb08b37"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/afde1c3f-4e87-402f-8e38-44ea71a6f5f5/cfd54a005105ca0ea48fbc189155cbe4/dotnet-runtime-8.0.0-osx-arm64.pkg",
+          "hash": "1703343cab87195e77161620bed0c9a595944809eadbd16cca48cc369957437510d7a62638fe541cbe13d0e8eadc026b13e9b1b0e148e098e841e078abd84a34"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/65665fae-8f24-4214-89b5-980dbad7be30/1b70f4b76e076b4b656879426e861fbd/dotnet-runtime-8.0.0-osx-arm64.tar.gz",
+          "hash": "5464e6ca9afa89680b71042e200e99c43855a216cfef64ed2cc0b44efe547f7f69e57559ecdc47404e2a8c1c2b0f7d00ebcfc8b949750f0af168eb575e7dc092"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a409864-2f8c-4801-9fa2-6913c487218d/919476e4f52ee910b7c1bb9cfdefa746/dotnet-runtime-8.0.0-osx-x64.pkg",
+          "hash": "d3a33632906428975cc155a8be4029c365d695a61f8eee3633ba231d1d91be4538fc77a5604a0a21c6bb641b6f2ee271fe8b60e5f27620e7102138676287a451"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/65e0ad28-b73d-46ab-b3ae-2d2ae4460b78/50ee103e816a255f9a5331bc2975a6ef/dotnet-runtime-8.0.0-osx-x64.tar.gz",
+          "hash": "a469d4fcbd756861045a2f639f42e7f7296fea3c5cb5bfbe75a9deefae2c5fa1fd658b35fe378e2a4afefcc37d8d874908833728481cc4b18fbd9f6f204d684d"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/42c6a125-439e-4ccf-94a9-f6ace91a0179/b085b6e91c1d1602260d95169c4d9141/dotnet-runtime-8.0.0-win-arm64.exe",
+          "hash": "0db66495e3d84ee3e731de88c5e725cc421fc199022d0909ce88b1763f334db3eb4f593e1c0c16be41651ea7879c79f982b3e3cce6018a4c5f367e384668f7b5"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/394f6191-d02c-4b8f-bcd1-a704676537d8/7cf828ed977dbedcaeb4d5f6a6d5c93c/dotnet-runtime-8.0.0-win-arm64.zip",
+          "hash": "ec731685410b6c66fc7d493f74607ca0eb51444299934b9e21eefef43b5b46263a6cf05f7b9c499451202134e9f2ccbee6d5b54d2b884b3ea9b8fa31c8b816af"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7f4d5cbc-4449-4ea5-9578-c467821f251f/b9b19f89d0642bf78f4b612c6a741637/dotnet-runtime-8.0.0-win-x64.exe",
+          "hash": "3a88fd2da5d2aee4a28e6ae8269560768c5ec53d77657e64ca95ebe2bdae4b2ad55cfd61e1ff17cbcebc6a6bdce95db3197655d69d66a45c207cf9c674244ced"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/924f2e25-ba50-4b90-a35c-6ef73d1149a3/b9a57fa45dad7cca93a0aa937a8ba03d/dotnet-runtime-8.0.0-win-x64.zip",
+          "hash": "b786869739c87ea286ee494fbf72cc92cf0cd91c1f22ede0133a523aa150740dd89cdca6a1530bd1f39d24db4f34939e17e2b0dce3d7efd06e4eced30b530643"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/593685c9-7e98-455a-8e34-4b8ad1be9489/6ccf85c6fc244428d61f74ca3aee0645/dotnet-runtime-8.0.0-win-x86.exe",
+          "hash": "9b75af3897299c712da59dff0b6bee80399362513e81cc509e9e2fe708a348786f7d56112878e1ebf4cca52d2ba152a484f4697a76b1e525512abce2e1c5278e"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fc9946c3-b21d-4a32-a084-e3bc56bb9063/e28a035fb3f8f97dc40323d5da4bb42c/dotnet-runtime-8.0.0-win-x86.zip",
+          "hash": "d32872db44dad127341e6adefb3e24ff879d0e598168c010cb6341bd5daef49f60aecfe4d50371be9cb40978cc54a75b1924dbd6ff3879810877908964c31e65"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.100",
+      "version-display": "8.0.100",
+      "runtime-version": "8.0.0",
+      "vs-version": "17.8.0",
+      "vs-support": "Visual Studio 2022 (v17.8)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ec1a911-afeb-47fa-a1d0-fa22cd980b32/157c20841cbf1811dd2a7a51bf4aaf88/dotnet-sdk-8.0.100-linux-arm.tar.gz",
+          "hash": "bcc741518c7ee442e74ee4160f02f35c06e65b6d53265b2b0cfb6502d07e08fc397b7c3f4aecfc59dd173b875f7ceb6dc105fd3d1715c31216fabee068162d5e"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/43e09d57-d0f5-4c92-a75a-b16cfd1983a4/cba02bd4f7c92fb59e22a25573d5a550/dotnet-sdk-8.0.100-linux-arm64.tar.gz",
+          "hash": "3296d2bc15cc433a0ca13c3da83b93a4e1ba00d4f9f626f5addc60e7e398a7acefa7d3df65273f3d0825df9786e029c89457aea1485507b98a4df2a1193cd765"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4bc8c698-47bd-4217-8ac8-4c82217d47ab/76b0bbe4aa7050a7e5e54814308ab949/dotnet-sdk-8.0.100-linux-musl-arm.tar.gz",
+          "hash": "a8c08c4eaaa1ade3a1521750c62af92ab8fe91bfdd0f4767f8c0469ebfef091f3a68a443d4566bbfe53c49866d72a104c7aea309cabb36148f9aef9cb950ea64"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/88a7d8f6-e27b-4a43-91a4-233cd40daed5/350c9d253971d0ac527f016e145323dd/dotnet-sdk-8.0.100-linux-musl-arm64.tar.gz",
+          "hash": "1d8e54ab8d2b7b83972c1ecd7a23073bf83d39c258e993e54ab91a383ad2aa44276dfc28938f7b162cf79010187005e42a665933dff021ffa5e5d9cfadb5e2b6"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/40a3227f-0d20-4c23-b1a5-ecd659e3faef/fa59541ab3a35a50172ea5f81070e075/dotnet-sdk-8.0.100-linux-musl-x64.tar.gz",
+          "hash": "a904491cf1fe27603cfc21aa234b2f4da7517929fa9dad0eaa2233d010ef1e890339ca4b8e3c4c0d463f3015d7020a0c37ece97319b061cd92a5fc51cd8a7f4c"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5226a5fa-8c0b-474f-b79a-8984ad7c5beb/3113ccbf789c9fd29972835f0f334b7a/dotnet-sdk-8.0.100-linux-x64.tar.gz",
+          "hash": "13905ea20191e70baeba50b0e9bbe5f752a7c34587878ee104744f9fb453bfe439994d38969722bdae7f60ee047d75dda8636f3ab62659450e9cd4024f38b2a5"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cf196f2f-f1e2-4f9a-a7ac-546242c431e2/8c386932f4a2f96c3e95c433e4899ec2/dotnet-sdk-8.0.100-osx-arm64.pkg",
+          "hash": "e19c4e309e62d267d68cbd1de4135e9a3664e6b9c2851943250de68b5fa6142c9a7e154b274de781b570dace97052e0015e91cb0104ede65ad62090fcaf92425"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a79b5ad-82a7-4615-a73b-91bf24028471/0e6a5c6d7f8b792a421e3796a93ef0a1/dotnet-sdk-8.0.100-osx-arm64.tar.gz",
+          "hash": "11a307ec17fa11fd8f133d697cd414c12b1d613ef9ec05db813630b10a00cb2ee0f703580688bc59b60c911e97a27eef8ae0d89fc2298c535e0bb15b5b997bc5"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/27a7ece8-f6cd-4cab-89cf-987e85ae6805/2c9ab2cb294143b0533f005640c393da/dotnet-sdk-8.0.100-osx-x64.pkg",
+          "hash": "5b63eb59e1a90777fcf80a6c0963d0fc82586138a2fcb902cc5129517e6f6a94f9cf4ed68bb247d05f5fa92f5c143505f6547665ebd26f084860d672dc6dd1ce"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e59acfc2-5987-43f9-bd03-0cbe446679e1/7db7313c1c99104279a69ccd47d160a1/dotnet-sdk-8.0.100-osx-x64.tar.gz",
+          "hash": "8ab6a1408e630a7f689414ad062191558c363f8fb8a98b6571ed99d386c07951655c6a499f8b8a4b128d4f566b7a67b6e8be26cda751d9286851b603096d0da2"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/987b30a7-09b2-4f0f-b425-c4f3b8a55a29/ded7b41eaeea7adf1075a51e31925792/dotnet-sdk-8.0.100-win-arm64.exe",
+          "hash": "d1231fe14a0ed93a62f3465397c191fa3f49382a5657ca3b5f5a2f592087495eb1d03a962e36b47a4641c596f40f7371d3e530fd3ab94e9dfa705cabbbd288c6"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7a580d00-03da-4eb0-96ef-4c7bc57bd6cb/58c0a9814ecafc5e06ad7d014f65a984/dotnet-sdk-8.0.100-win-arm64.zip",
+          "hash": "c888b046b71027dbdce116d85e3e2624df4f4073071d73032bafbed5afcf15843f9112518f360a11c0491c5802cf93a62cf217858ae3cce84d797e89eb75d1cd"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/93961dfb-d1e0-49c8-9230-abcba1ebab5a/811ed1eb63d7652325727720edda26a8/dotnet-sdk-8.0.100-win-x64.exe",
+          "hash": "248acec95b381e5302255310fb9396267fd74a4a2dc2c3a5989031969cb31f8270cbd14bda1bc0352ac90f8138bddad1a58e4af1e56cc4a1613b1cf2854b518e"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2b2d6133-c4f9-46dd-9ab6-86443a7f5783/340054e2ac7de2bff9eea73ec9d4995a/dotnet-sdk-8.0.100-win-x64.zip",
+          "hash": "69ee73c56c78c94c186c0fd1b06ce1a7325979f7680857dc1a05d516feb9f0ffe990c2c0441caed1de98a0d0ae3923cc3e04525f91d96306d611e481a24f9fb4"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5645f9cc-4f4f-4eac-bd04-96b422ae3406/069e0632b2232401f4b9d123f2173977/dotnet-sdk-8.0.100-win-x86.exe",
+          "hash": "6ba1d4b2223f4d81055218d1b31fbb3839daf95ac5a063618073cf55badfd7614f1a672552cdf82c1d5aaadd27b0e68497d8e6317ec925daabe20aa68776c9d8"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/210579cb-610d-4040-9052-e024a42bcd9c/e260700ae965a0f7d3bf38e8d8f0778c/dotnet-sdk-8.0.100-win-x86.zip",
+          "hash": "06ec86cdd68a6320bff9a22b2d2ece2f1f33a99f2c521d239451261d56b39071471dda2cccdf91ed5e96a935c7210da55db5e4c76e863cb1b744138bf7378f52"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.100",
+        "version-display": "8.0.100",
+        "runtime-version": "8.0.0",
+        "vs-version": "17.8.0",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ec1a911-afeb-47fa-a1d0-fa22cd980b32/157c20841cbf1811dd2a7a51bf4aaf88/dotnet-sdk-8.0.100-linux-arm.tar.gz",
+            "hash": "bcc741518c7ee442e74ee4160f02f35c06e65b6d53265b2b0cfb6502d07e08fc397b7c3f4aecfc59dd173b875f7ceb6dc105fd3d1715c31216fabee068162d5e"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/43e09d57-d0f5-4c92-a75a-b16cfd1983a4/cba02bd4f7c92fb59e22a25573d5a550/dotnet-sdk-8.0.100-linux-arm64.tar.gz",
+            "hash": "3296d2bc15cc433a0ca13c3da83b93a4e1ba00d4f9f626f5addc60e7e398a7acefa7d3df65273f3d0825df9786e029c89457aea1485507b98a4df2a1193cd765"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4bc8c698-47bd-4217-8ac8-4c82217d47ab/76b0bbe4aa7050a7e5e54814308ab949/dotnet-sdk-8.0.100-linux-musl-arm.tar.gz",
+            "hash": "a8c08c4eaaa1ade3a1521750c62af92ab8fe91bfdd0f4767f8c0469ebfef091f3a68a443d4566bbfe53c49866d72a104c7aea309cabb36148f9aef9cb950ea64"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/88a7d8f6-e27b-4a43-91a4-233cd40daed5/350c9d253971d0ac527f016e145323dd/dotnet-sdk-8.0.100-linux-musl-arm64.tar.gz",
+            "hash": "1d8e54ab8d2b7b83972c1ecd7a23073bf83d39c258e993e54ab91a383ad2aa44276dfc28938f7b162cf79010187005e42a665933dff021ffa5e5d9cfadb5e2b6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/40a3227f-0d20-4c23-b1a5-ecd659e3faef/fa59541ab3a35a50172ea5f81070e075/dotnet-sdk-8.0.100-linux-musl-x64.tar.gz",
+            "hash": "a904491cf1fe27603cfc21aa234b2f4da7517929fa9dad0eaa2233d010ef1e890339ca4b8e3c4c0d463f3015d7020a0c37ece97319b061cd92a5fc51cd8a7f4c"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5226a5fa-8c0b-474f-b79a-8984ad7c5beb/3113ccbf789c9fd29972835f0f334b7a/dotnet-sdk-8.0.100-linux-x64.tar.gz",
+            "hash": "13905ea20191e70baeba50b0e9bbe5f752a7c34587878ee104744f9fb453bfe439994d38969722bdae7f60ee047d75dda8636f3ab62659450e9cd4024f38b2a5"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cf196f2f-f1e2-4f9a-a7ac-546242c431e2/8c386932f4a2f96c3e95c433e4899ec2/dotnet-sdk-8.0.100-osx-arm64.pkg",
+            "hash": "e19c4e309e62d267d68cbd1de4135e9a3664e6b9c2851943250de68b5fa6142c9a7e154b274de781b570dace97052e0015e91cb0104ede65ad62090fcaf92425"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a79b5ad-82a7-4615-a73b-91bf24028471/0e6a5c6d7f8b792a421e3796a93ef0a1/dotnet-sdk-8.0.100-osx-arm64.tar.gz",
+            "hash": "11a307ec17fa11fd8f133d697cd414c12b1d613ef9ec05db813630b10a00cb2ee0f703580688bc59b60c911e97a27eef8ae0d89fc2298c535e0bb15b5b997bc5"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/27a7ece8-f6cd-4cab-89cf-987e85ae6805/2c9ab2cb294143b0533f005640c393da/dotnet-sdk-8.0.100-osx-x64.pkg",
+            "hash": "5b63eb59e1a90777fcf80a6c0963d0fc82586138a2fcb902cc5129517e6f6a94f9cf4ed68bb247d05f5fa92f5c143505f6547665ebd26f084860d672dc6dd1ce"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e59acfc2-5987-43f9-bd03-0cbe446679e1/7db7313c1c99104279a69ccd47d160a1/dotnet-sdk-8.0.100-osx-x64.tar.gz",
+            "hash": "8ab6a1408e630a7f689414ad062191558c363f8fb8a98b6571ed99d386c07951655c6a499f8b8a4b128d4f566b7a67b6e8be26cda751d9286851b603096d0da2"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/987b30a7-09b2-4f0f-b425-c4f3b8a55a29/ded7b41eaeea7adf1075a51e31925792/dotnet-sdk-8.0.100-win-arm64.exe",
+            "hash": "d1231fe14a0ed93a62f3465397c191fa3f49382a5657ca3b5f5a2f592087495eb1d03a962e36b47a4641c596f40f7371d3e530fd3ab94e9dfa705cabbbd288c6"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a580d00-03da-4eb0-96ef-4c7bc57bd6cb/58c0a9814ecafc5e06ad7d014f65a984/dotnet-sdk-8.0.100-win-arm64.zip",
+            "hash": "c888b046b71027dbdce116d85e3e2624df4f4073071d73032bafbed5afcf15843f9112518f360a11c0491c5802cf93a62cf217858ae3cce84d797e89eb75d1cd"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93961dfb-d1e0-49c8-9230-abcba1ebab5a/811ed1eb63d7652325727720edda26a8/dotnet-sdk-8.0.100-win-x64.exe",
+            "hash": "248acec95b381e5302255310fb9396267fd74a4a2dc2c3a5989031969cb31f8270cbd14bda1bc0352ac90f8138bddad1a58e4af1e56cc4a1613b1cf2854b518e"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b2d6133-c4f9-46dd-9ab6-86443a7f5783/340054e2ac7de2bff9eea73ec9d4995a/dotnet-sdk-8.0.100-win-x64.zip",
+            "hash": "69ee73c56c78c94c186c0fd1b06ce1a7325979f7680857dc1a05d516feb9f0ffe990c2c0441caed1de98a0d0ae3923cc3e04525f91d96306d611e481a24f9fb4"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5645f9cc-4f4f-4eac-bd04-96b422ae3406/069e0632b2232401f4b9d123f2173977/dotnet-sdk-8.0.100-win-x86.exe",
+            "hash": "6ba1d4b2223f4d81055218d1b31fbb3839daf95ac5a063618073cf55badfd7614f1a672552cdf82c1d5aaadd27b0e68497d8e6317ec925daabe20aa68776c9d8"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/210579cb-610d-4040-9052-e024a42bcd9c/e260700ae965a0f7d3bf38e8d8f0778c/dotnet-sdk-8.0.100-win-x86.zip",
+            "hash": "06ec86cdd68a6320bff9a22b2d2ece2f1f33a99f2c521d239451261d56b39071471dda2cccdf91ed5e96a935c7210da55db5e4c76e863cb1b744138bf7378f52"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.0",
+      "version-display": "8.0.0",
+      "version-aspnetcoremodule": [
+        "18.0.23305.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6d3049cc-4dcf-4dfb-9444-009997fbe620/fa9da42c88a2d74aef7e99f56269e36d/aspnetcore-runtime-8.0.0-linux-arm.tar.gz",
+          "hash": "5fd4f650217c8531bf5fba9b851462e52f3a04a71c4c1d7b48be6e22970cb06981d1b4fbbfdf2c8aa3662c9921a3c3d91d61ab19debcb5df046e87df1849abd6"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/91223e4e-2300-4e8e-9364-09ea1c317294/47fb26a2df5eeee08f77a4d1b720a34a/aspnetcore-runtime-8.0.0-linux-arm64.tar.gz",
+          "hash": "f9e1ae263dd944c70ea1818a3a44bb62aa5bfb65dafa463dc9f9a33bc8ad1c60b4e7a364a7414cc00a01ff707b5e88fc52c520edf0eb357ed1ddf4a8fcd8eae9"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/639a31d4-e000-40da-aebd-2b97f31a49e7/f3f9bc2b800cac9d7f6d4d5c804c1a4f/aspnetcore-runtime-8.0.0-linux-musl-arm.tar.gz",
+          "hash": "16254138c90ceb74becd25b0a4bc000838ee5e480c987b68300244d2916a97fb2adb4c715935f9a8547efd30bbf499ab68dfdcb79cfbeab77c46f1b575cca2e9"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3bf3103-efdb-42e0-af55-bbf861a4215b/dc22eda8877933b8c6569e3823f18d21/aspnetcore-runtime-8.0.0-linux-musl-arm64.tar.gz",
+          "hash": "9ac1b612e126c7c4a9eb2b3343c93875268f3a4d78cf4c6ece9e718b76b60f13e96efb9488e7d83cfb128ae766d8bf05e764d6a11c3a315ea1820a011afd585f"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7aa33fc7-07fe-48c2-8e44-a4bfb4928535/3b96ec50970eee414895ef3a5b188bcd/aspnetcore-runtime-8.0.0-linux-musl-x64.tar.gz",
+          "hash": "12723b685b86d3d2f69692781f731fe2c56bfc4d34489b9c901775e78f8f96edb78b97b9234b44b14aa2f578c1a054e425ebe8ced42f59e82c39c90c341fc1d9"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/257bdcc7-cbfd-4680-964a-cbe8e9160bca/ac0cbf19d897ba51ae004b4146940a0a/aspnetcore-runtime-8.0.0-linux-x64.tar.gz",
+          "hash": "c0aa3a926d6c2bc0d4cc14f5d7677a4592111bf3ebefa65c5273c4b979a6e2b5d58305a5aaf4ac78f593b46605ec02f40b610dcbff070b1d8cf8ddc656cac7dc"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0d05d563-f3ce-4d40-8cd8-f28247510533/48ed8322af7e47c2f68fc0afbd65e37b/aspnetcore-runtime-8.0.0-osx-arm64.tar.gz",
+          "hash": "0edb1bd0655d7898d9a02f7127e9a93af7e92e3ea324a7d77e9634b5dfa0851184d784f2573612b18bc37cb0510f93d1b0eaa2ae56b6ca99a16f1edafe6cf8fe"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6ef899a5-571a-4fd3-b294-65665d9cc76f/d21cc874f3832a5e0ad583d948d1f228/aspnetcore-runtime-8.0.0-osx-x64.tar.gz",
+          "hash": "1b19d90b631ebd74f6e1f4343ecf54f6f04bc8a2aceebbca66de57d41d440a66c7f56565043c1aaeb77b586dc349914d7d30b8c066197840430d543c24c87539"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/44a28172-e3d3-47f6-8c61-d08b216b1a9d/8efb764492d6356654e156dc6bba45ad/aspnetcore-runtime-8.0.0-win-arm64.zip",
+          "hash": "3899e2148fd8b58059e7f18433038d09f8c35978595f536919e2473134c73d77d08ea62b3727dd11aaa0c807dc7393f40c723d5f6dafa26b87a0243818c57e50"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/89d3660b-d344-47c5-a1cd-d8343a3f3779/9f55af82923dab7e3dce912f5c5b9d60/aspnetcore-runtime-8.0.0-win-x64.exe",
+          "hash": "8bae0bc5cb46486348c45d3df3a9caaf8b5413ae324483f5a90d0482d70ea4224222abee124524523ff7bb44c4c0629b9242dbf24a21736ce275ec0c2549d957"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6df1ec69-9cff-4836-b02a-cf5b09baffaa/9cff973dda0520aa1ed216d67433e37a/aspnetcore-runtime-8.0.0-win-x64.zip",
+          "hash": "ca3f5d578fecf51e2cee30ceb9a88ca1c07ac476d742ef466ba5858b63e0d05cb840d6d22b83d916c49f9fe51c91b68ea385b7a8d53b292d0c9e78e7d671ae91"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/66ae7d00-596a-4e36-be73-2ebc0c332329/e2f6e37933e204fef5687e338a95b749/aspnetcore-runtime-8.0.0-win-x86.exe",
+          "hash": "9cf9f98a7737438c382c90092f25d706927b8ebd0079900c6d420282e6a2ea353a9856d427ef9a2ec675fffcc2b84f21bd02491c7c6b40f6101a58a491e1b478"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5cde0bff-74de-43ca-8ec5-e0a170245e5a/b7941851acdab0dca00c69c0212583ac/aspnetcore-runtime-8.0.0-win-x86.zip",
+          "hash": "c1fb064e0bf6c689a5aca5c944ab500232730fe7549ca9cca88f616fad9f5604c5a4e67424c5e11bb31fa42c00fc3524c4ebc324d5a287d0c605e9e06d6c07e2"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ed839f31-aa31-4360-ac80-e3b6c30c09bf/5b260246e22a9bd8de442b1690c34429/aspnetcore-runtime-composite-8.0.0-linux-arm.tar.gz",
+          "hash": "1bc58d92bcac8e383daa59436677890e061be4c450f30d1744e2f2b161de04ed4d09a54adbe9f22f820ce09773a525b575730d96334043bd17559a462d407063"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/30405043-c6ed-4017-8835-ec073190cf23/342685692dc5beedbb49ad72bf413e83/aspnetcore-runtime-composite-8.0.0-linux-arm64.tar.gz",
+          "hash": "8e3d2fbb491a97b31510d5c69890f4b37520e2141fbef1b9bd8ab0617f08d506246c8c411c05369b1a747e56440027953aae7eb015ae41183fa092e7d87a366a"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/102004e7-1106-4888-b3a1-c4c78194f53d/45806e9d6f996a9841473edede1d5f4c/aspnetcore-runtime-composite-8.0.0-linux-musl-arm.tar.gz",
+          "hash": "9cac51a4529bae44245890cfa20efae2a38be8dbbf01e8df8dd1aa409d4f44ec1329a0ecda6142fe1f306c8e31be05e252c603a96add778899f936de651fdf20"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dc2c8e28-39b3-42b9-be31-ec47e014b945/f394c3d2d91b70486469244323b34282/aspnetcore-runtime-composite-8.0.0-linux-musl-arm64.tar.gz",
+          "hash": "aa87583671636b6cca1cee7d48966d247f7dbfad75757c6ded611e6acd3ef440c30e691fd388aa96e920b9af07a5f9b6b702a0b2b528cd29913a84ac79b55d58"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4c8e070-6794-41ec-a336-27c396edefb5/b7322715c983bafc99970016d88e536f/aspnetcore-runtime-composite-8.0.0-linux-musl-x64.tar.gz",
+          "hash": "5caf1e043d9624e036bf645b0449ac8d87a1861a246c5597ea4485432d2962ea8799d98d73bb5e5c3d1d3b19acb2817502af5a8593a7632d75cc6bfb19f623df"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6c37b740-be2b-4560-9caa-5f45b0f2cb80/6ba5f7ab4e5f815ddeb0644d5f8360a4/aspnetcore-runtime-composite-8.0.0-linux-x64.tar.gz",
+          "hash": "b7f2cf8cf6496a438b03e6e945d776a763c388127b98b7cc20bb86c0e9570c40890e0397f55dea6d8f9aabfbec88dae3800eb2b87462a765a54ecdd7d68c75a3"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a7ae819-fbc4-4611-a1ba-f3b072d4ea25/32f3b931550f7b315d9827d564202eeb/dotnet-hosting-8.0.0-win.exe",
+          "hash": "664bac19fdbd32eeb4adf4513034bb8066b9e7ee2c8c5dd8c21a54ab2e6bf99f86c52f5709299c675cc8ed9ef13cd0a0e188c8094f94a4b4e7b4e5cd368c0e9e",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.0",
+      "version-display": "8.0.0",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/96b09d32-59a7-465c-bfa0-9a49493317f0/a4942158510a267137f161e77906cec0/windowsdesktop-runtime-8.0.0-win-arm64.exe",
+          "hash": "f9b91928493dee45883b0cc6e13494a91b3a22dfbd57223236db0139584fc81fdf843249888efa9de157f158616bccb0de6081121f1787d3bf7ec80852c61d9d"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fca1d1a8-e947-4fab-8e00-0fada425dd0d/f6f3a9e344d9834246d97f178e0d30a0/windowsdesktop-runtime-8.0.0-win-arm64.zip",
+          "hash": "bdcb6b86338c17052f21a25c3b5152beef96c0d09b6a7252c184c79a5e5c49c6e005510882193b5d42a06dae81270ec6c1d432e687887275396b9c365344dbc5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b280d97f-25a9-4ab7-8a12-8291aa3af117/a37ed0e68f51fcd973e9f6cb4f40b1a7/windowsdesktop-runtime-8.0.0-win-x64.exe",
+          "hash": "d2e92f8bdb2b840c3fee170f2ca3baa3237a6a56c7b86589f7e4d7a0d51d2605bafe045adbd14a0c43e946a8a895a621748418d1a2cb9c44370eafd1d1a8ffa9"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/382f253f-0118-481d-acec-d64921fe75c7/3c4ae5e0305780a2a762505953b9b711/windowsdesktop-runtime-8.0.0-win-x64.zip",
+          "hash": "6464817e61bf04e88e535537afeca377cf78a46f0a2acce4accc701e251e2139c61f48043e81c04ef59ec47c9420274222466060fae37ba806e88e64485e8872"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f9e3b581-059d-429f-9f0d-1d1167ff7e32/bd7661030cd5d66cd3eee0fd20b24540/windowsdesktop-runtime-8.0.0-win-x86.exe",
+          "hash": "711134538d6e7dc827c99914e7ae74cb2a0c41ce2b1b4fd2b6323032c05db31737a4370f613621bc04787e7ab4b6d377e62dd777c2b51db6636afd751e874ae4"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cd53bd89-9843-495b-8930-45987bd1cf8e/799ac0f301f219baf3dc5e978b0ad30f/windowsdesktop-runtime-8.0.0-win-x86.zip",
+          "hash": "2fb749cb6dd37a2b5e8789907fcc15711825cb7342cb1c4480003d7b76f3abe1dab543001189ac0d62626db143241336759cb1ebd53fe79cc771f348ef9b54fd"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.1/release.json
+++ b/release-notes/8.0/8.0.1/release.json
@@ -1,0 +1,520 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-01-09",
+  "release-version": "8.0.1",
+  "security": true,
+  "release": {
+    "release-date": "2024-01-09",
+    "release-version": "8.0.1",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-0056",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-0056"
+      },
+      {
+        "cve-id": "CVE-2024-0057",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-0057"
+      },
+      {
+        "cve-id": "CVE-2024-21319",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21319"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.1/8.0.1.md",
+    "runtime": {
+      "version": "8.0.1",
+      "version-display": "8.0.1",
+      "vs-version": "17.8.3",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/809134e8-66fa-4f0c-a84a-9e981e9bd2f9/efb33d1a4075101410c82a617f4f7c42/dotnet-runtime-8.0.1-linux-arm.tar.gz",
+          "hash": "40cd226ee1b25a24eba395a6037d59ae6ead9c0ca625abf3e257564c9308f5e7fccfceab0058f3aa348698ee8be6d10031f23854d1876384476ed171772af299"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/39e79317-94d1-4e57-bb90-d5e004f4f3d4/cdcf3c0d8dc2560dcfcb160acb193785/dotnet-runtime-8.0.1-linux-arm64.tar.gz",
+          "hash": "29707882d4fce61eb4b20763473d548570f89f9d028bafb76b646911a5e7bf793dc75e33a6903622d7ba46e9eea0eac000d931cd2f45da118ef05fede6d4079b"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fd50b40d-20ba-4fde-8100-eb5dd4c5d47d/1c801abf25f2166037b772f14252ac9f/dotnet-runtime-8.0.1-linux-musl-arm.tar.gz",
+          "hash": "fd4b339c66ae1e2193c6ac09fb00f3d1ec1d70ce63767d88e26efd381f235b7153c7a4064998116cdfabaf47e8be13b5c2dacb39229d19a66e17eeeac9515d49"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/788ff867-ada8-484b-aadb-cfe85e846a07/cdb07410754e7e42de1f02dc2f238be1/dotnet-runtime-8.0.1-linux-musl-arm64.tar.gz",
+          "hash": "3f54f8203af3851332d7c706a76af3faaf6b853f17941c4bc5d95f0589d28f115dc45a05dac9736c50e8ad1b5318e64d8262a187dfbe8cfdc610f6a1d8d64b7d"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/96967996-531c-4ff1-8848-dd981aedc49e/8e70800721e5dc182075e8bd2ef86451/dotnet-runtime-8.0.1-linux-musl-x64.tar.gz",
+          "hash": "a935d7b6c95e9852ba485faf5712214704eebfd5b8e1ab7b993d054f957ae0a551f57dc39a38de7064a1ab89bc1fe0bcaf908163daf9625174ec27aefd23c016"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d5166de-c1ac-45c5-bb8a-d47f8ee93ad9/ffab59440a3eb74359dd3009e4da5a81/dotnet-runtime-8.0.1-linux-x64.tar.gz",
+          "hash": "cbd03325280ff93cd0edab71c5564a50bb2423980f63d04602914db917c9c811a0068d848cab07d82e3260bff6684ad7cffacc2f449c06fc0b0aa8f845c399b6"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a7984b93-92dc-41e1-996c-fd059c17afb4/c44ed6a09d648e289e49002c0d7297c2/dotnet-runtime-8.0.1-osx-arm64.pkg",
+          "hash": "ae9c838db2971ca014edf54e48677865a8f0ef14040243d651209aeee2714a9d74d1745479744aae91af2cf86dcaae2ef2d6014ecf77873c803cde8f9235e2bf"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/43ed6ef8-5265-462e-bbc4-2055a0f473e8/28d78788aeca160f615dcbd63c79b621/dotnet-runtime-8.0.1-osx-arm64.tar.gz",
+          "hash": "9d716e324c041ecd210ae65bcdd9bbf8c884d8fb92cda72d5bd13429581d47d7837d51f63c2994dfe17c5cda77de1c727308b590367d3181c91fa1f173c66b04"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2dc0cd09-9e3d-4329-b01b-12b417e610de/38a37e5f8b93ef55e6630f216265293a/dotnet-runtime-8.0.1-osx-x64.pkg",
+          "hash": "c8fb970e14f87179bfb4d0a865fda631b43f9b767a82909f0490fe94d922207c3e4bed0ee9264f2d66154ac89ff8569338fc5f040cf2ae6f31238d2787f61ebc"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/220d43f7-eb7f-470d-a80b-b30210adbbf2/dbfa691328557ee9888a1f38a29f72bd/dotnet-runtime-8.0.1-osx-x64.tar.gz",
+          "hash": "8c88db692cd889d8f4d6a1f0a82a3eb0b3f49a4771318127c294822f20ee83a87668c6a54012ad87242936d4412b3f8adc0448b8d5ff623f0a6faa3cfc544309"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cc502ccd-70f6-4714-b1d0-60585e24bbed/7ca46f9ea9958f8a4455990641418a92/dotnet-runtime-8.0.1-win-arm64.exe",
+          "hash": "2477fea2f36c380943eda8174999f2b897322c0db607b17ee4df8e486536f8cbdfccd72cfcebb346b2320a58085558f28560431750b3b2786ecea2f601159b5a"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/219a8418-3f0b-45f9-b733-df9094b15a68/aa98f0d154b3ef8d01f679c579f30d00/dotnet-runtime-8.0.1-win-arm64.zip",
+          "hash": "1ac512be0760d22ef9a6a4d21ae3a07b8709cd265386cd8d04f714959975688e8961792a5f82f8dd5426218712c275a57eb70cdccaeab04cb222385ad9b14c18"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cede7e69-dbd4-4908-9bfb-12fa4660e2b9/d9ed17179d0275abee5afd29d5460b48/dotnet-runtime-8.0.1-win-x64.exe",
+          "hash": "46f2561197aa33f6fd33d40943f2c76d1b8d5c7ace39ba5555d9eda6cc4ac3f8cbae10b353cce9c7a7b4fdb30f2b6d1897461811880271e07555982100270347"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eac51dde-7bac-4bdb-aacd-e8c870f29aa4/d6c945e85adab9af2446856f90f6d326/dotnet-runtime-8.0.1-win-x64.zip",
+          "hash": "21608914ccb6d872ce8a9a66ab37af1fed4e52e01f0b2a1f7fbea077f8d8cfc287d2d7a761049727d948c25dfc5bfbfa0aace8541d553a67ef8bd06fc215b803"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8c884ea1-2ae5-4359-82a4-8ce8fb309b0e/53a67e660c7b331577c95b02f87935fe/dotnet-runtime-8.0.1-win-x86.exe",
+          "hash": "cbcab96d341a3d49da8cdce87aa7c23ee2186c36408cf90b61636ab0417720b203a83e1699ccda34b2c4097019384e9add62b621d623528688896e441b04306a"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/edd19f6e-419b-4ce6-8c58-eced8309bda3/98ae2907a522f3bdf8ee700c2e0daf50/dotnet-runtime-8.0.1-win-x86.zip",
+          "hash": "8784ce84e0c51687bbbb839bd03c20f4526c6c29fbb7e52e465fcff4b31257bf2833e77ca529251f311406328d7b05433b9b9994a39bff74efe468bc4cd4d000"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.101",
+      "version-display": "8.0.101",
+      "runtime-version": "8.0.1",
+      "vs-version": "17.8.3",
+      "vs-support": "Visual Studio 2022 (v17.8)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/28bc9d47-631c-4e28-9e8c-3e8d025cc999/c4302b73c98da0dc26bcb36ed1e148d2/dotnet-sdk-8.0.101-linux-arm.tar.gz",
+          "hash": "59e0902fa190dee8da1644135e0477ced70fa02ecc12f79c8947743a77a160861ed5e44f8a4228815f853141856d4e3a1db1bd057759d3bff980a79b7d849689"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/092bec24-9cad-421d-9b43-458b3a7549aa/84280dbd1eef750f9ed1625339235c22/dotnet-sdk-8.0.101-linux-arm64.tar.gz",
+          "hash": "56beedb8181b63efd319b028190a8a98842efd96da27c5e48e18c4d15ba1a5805610e8838f1904a19263abd51ff68df369973ed59dab879edc52f6e7f93517c6"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2a7a9a1-69e7-40ab-9130-30d0ab771564/3a5280c98c262c576d6cd6025d868419/dotnet-sdk-8.0.101-linux-musl-arm.tar.gz",
+          "hash": "764edb8803a68f074391714029800ef2309d212618790ba00506bba201a9655ea46e47d6017c89d78c9b1ef57e8e47352a63e8116a8b1f9fb169844745170172"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e024f0c4-88f2-4d8d-a7ee-d98536bc7aac/53b09f1040e29b65d90bc78a10c1cf09/dotnet-sdk-8.0.101-linux-musl-arm64.tar.gz",
+          "hash": "796d9fa4fda9d7d0f014820e20a8bad63052ba5e15dcb4fcb44ce33438a1aa4cd5e2ea0ad4a538b07946302b9649638762e3bfaa22a70318f0f17bc50c105193"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f75f8192-785e-4199-8643-6ee8a87dca34/6bd0c5e0da66cc807be5b76e18092750/dotnet-sdk-8.0.101-linux-musl-x64.tar.gz",
+          "hash": "95751235b774ed1050b721528495c1ba561c0bce99989a5fd6c0d0510b8b7d07a34ef186f347d16194b07d5ec4966ae8cb47aa7c1a65eebcea8a68fd90fb22e5"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9454f7dc-b98e-4a64-a96d-4eb08c7b6e66/da76f9c6bc4276332b587b771243ae34/dotnet-sdk-8.0.101-linux-x64.tar.gz",
+          "hash": "26df0151a3a59c4403b52ba0f0df61eaa904110d897be604f19dcaa27d50860c82296733329cb4a3cf20a2c2e518e8f5d5f36dfb7931bf714a45e46b11487c9a"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d6fe60e-611f-4db0-8b03-fc15ee03ca7a/e24b834bd82a75fb2a50a59b8a27aed3/dotnet-sdk-8.0.101-osx-arm64.pkg",
+          "hash": "7fc9c51a0b98654a82d088ebcaca925e3bebadc7d7548957791a644895cdfee191f8e59061d346c464cb16fe3721a499ccad3896a7265c78a92b70271af5b46e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ef083c06-7aee-4a4f-b18b-50c9a8990753/e206864e7910e81bbd9cb7e674ff1b4c/dotnet-sdk-8.0.101-osx-arm64.tar.gz",
+          "hash": "a6048ca248aef3c430c8bdb65b534d5f58463a9d3c314fd70f5c7c4a9ac7eaabfba7786c40c76c73e5abc1a95ba957a682e73fb228e15bc9808adb47b4a1b291"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3b11b408-68e1-4a8f-a0ad-55b21456c4f6/03819d38c79a9aa4fd806f8c7b64130d/dotnet-sdk-8.0.101-osx-x64.pkg",
+          "hash": "e40b9fd4a5c814e1d44fb58a7a78284244f77797c0dd5a60a5dd478b4f3eddf8cf6b51b4b63aa3d4a24435bedaa5e6df944da19728732ae23ff645ed5caef2b5"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c7f806d2-1483-4a52-893a-4de1054b0bff/a6f52ed50876c45f859192b6576a14d5/dotnet-sdk-8.0.101-osx-x64.tar.gz",
+          "hash": "5c18dd1c0bb8199660dea5793eb2a568c63adbde492ca5080a8130e723a6260c6b9c6a055c299a3b8ba2497d6875959f86da8b9c9bf85e093bca2e08724d46a1"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0047e089-cf40-49c3-a8a1-8d1daa9d5a75/67300bbb26dab5d0a33b7401f6aa52ef/dotnet-sdk-8.0.101-win-arm64.exe",
+          "hash": "59c76d112728c318291fc48411dd489848839f3c3b67354458d3f80f4262cfee16e22b6fc17e774dd1d259eb411a1d95490909c9a8bbe79ed054d424eda3e371"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bfcfe7c7-d722-45b0-80df-663516a401ce/d7b91a51df647c710c96cde20aa8b100/dotnet-sdk-8.0.101-win-arm64.zip",
+          "hash": "68c2333f74434138846f49301ae0ff94302c55aa278e2fad09a0e03fc28f3f3dfb90a68a5e2633bd5e119957044118fd92d1cd715d9a76c8b1843e050cd02894"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cb56b18a-e2a6-4f24-be1d-fc4f023c9cc8/be3822e20b990cf180bb94ea8fbc42fe/dotnet-sdk-8.0.101-win-x64.exe",
+          "hash": "5de43de4f468dbaeb1b0bca6cf4774daf2c4ef8594451f1674a9a4a65149335ee956abaad4492be636161ed3d3eb5072099aafd344f94b0b55e04acba255d246"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6902745c-34bd-4d66-8e84-d5b61a17dfb7/e61732b00f7e144e162d7e6914291f16/dotnet-sdk-8.0.101-win-x64.zip",
+          "hash": "e05953b32429ddaa60dc27fb5f5077d7523fc9f9706d30f42cd1855e2469eb003d5250587468062df4e331817059f2f46a44d5ed10ce2eb599710897e6659d83"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/88238db3-d71e-4431-bba5-1f6d16f7a415/d1e7b4c6302c51f1e968d07391cac7e1/dotnet-sdk-8.0.101-win-x86.exe",
+          "hash": "3313919a647dbfa16afaec8a0a0292212fa7e7e612a895d5c0cd2df6a5bf09b2a47a213cdf3c6053637d5aa0e9d12d927dc28d20602768977a417edcef9bda05"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/059613f3-d3e9-4585-b8a9-3814e675b6d0/01150dbaaa7f392f103137bd325786b6/dotnet-sdk-8.0.101-win-x86.zip",
+          "hash": "df5248a25d351d866ac2d1ca6cdebf7b20ce5cc65aedc1a988166491d022829435daf67e07993ba71bfcb99f79fc19b8ef047e1d4a48ae9b6e8e31f3ea9a4107"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.101",
+        "version-display": "8.0.101",
+        "runtime-version": "8.0.1",
+        "vs-version": "17.8.3",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/28bc9d47-631c-4e28-9e8c-3e8d025cc999/c4302b73c98da0dc26bcb36ed1e148d2/dotnet-sdk-8.0.101-linux-arm.tar.gz",
+            "hash": "59e0902fa190dee8da1644135e0477ced70fa02ecc12f79c8947743a77a160861ed5e44f8a4228815f853141856d4e3a1db1bd057759d3bff980a79b7d849689"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/092bec24-9cad-421d-9b43-458b3a7549aa/84280dbd1eef750f9ed1625339235c22/dotnet-sdk-8.0.101-linux-arm64.tar.gz",
+            "hash": "56beedb8181b63efd319b028190a8a98842efd96da27c5e48e18c4d15ba1a5805610e8838f1904a19263abd51ff68df369973ed59dab879edc52f6e7f93517c6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c2a7a9a1-69e7-40ab-9130-30d0ab771564/3a5280c98c262c576d6cd6025d868419/dotnet-sdk-8.0.101-linux-musl-arm.tar.gz",
+            "hash": "764edb8803a68f074391714029800ef2309d212618790ba00506bba201a9655ea46e47d6017c89d78c9b1ef57e8e47352a63e8116a8b1f9fb169844745170172"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e024f0c4-88f2-4d8d-a7ee-d98536bc7aac/53b09f1040e29b65d90bc78a10c1cf09/dotnet-sdk-8.0.101-linux-musl-arm64.tar.gz",
+            "hash": "796d9fa4fda9d7d0f014820e20a8bad63052ba5e15dcb4fcb44ce33438a1aa4cd5e2ea0ad4a538b07946302b9649638762e3bfaa22a70318f0f17bc50c105193"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f75f8192-785e-4199-8643-6ee8a87dca34/6bd0c5e0da66cc807be5b76e18092750/dotnet-sdk-8.0.101-linux-musl-x64.tar.gz",
+            "hash": "95751235b774ed1050b721528495c1ba561c0bce99989a5fd6c0d0510b8b7d07a34ef186f347d16194b07d5ec4966ae8cb47aa7c1a65eebcea8a68fd90fb22e5"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9454f7dc-b98e-4a64-a96d-4eb08c7b6e66/da76f9c6bc4276332b587b771243ae34/dotnet-sdk-8.0.101-linux-x64.tar.gz",
+            "hash": "26df0151a3a59c4403b52ba0f0df61eaa904110d897be604f19dcaa27d50860c82296733329cb4a3cf20a2c2e518e8f5d5f36dfb7931bf714a45e46b11487c9a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4d6fe60e-611f-4db0-8b03-fc15ee03ca7a/e24b834bd82a75fb2a50a59b8a27aed3/dotnet-sdk-8.0.101-osx-arm64.pkg",
+            "hash": "7fc9c51a0b98654a82d088ebcaca925e3bebadc7d7548957791a644895cdfee191f8e59061d346c464cb16fe3721a499ccad3896a7265c78a92b70271af5b46e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef083c06-7aee-4a4f-b18b-50c9a8990753/e206864e7910e81bbd9cb7e674ff1b4c/dotnet-sdk-8.0.101-osx-arm64.tar.gz",
+            "hash": "a6048ca248aef3c430c8bdb65b534d5f58463a9d3c314fd70f5c7c4a9ac7eaabfba7786c40c76c73e5abc1a95ba957a682e73fb228e15bc9808adb47b4a1b291"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3b11b408-68e1-4a8f-a0ad-55b21456c4f6/03819d38c79a9aa4fd806f8c7b64130d/dotnet-sdk-8.0.101-osx-x64.pkg",
+            "hash": "e40b9fd4a5c814e1d44fb58a7a78284244f77797c0dd5a60a5dd478b4f3eddf8cf6b51b4b63aa3d4a24435bedaa5e6df944da19728732ae23ff645ed5caef2b5"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c7f806d2-1483-4a52-893a-4de1054b0bff/a6f52ed50876c45f859192b6576a14d5/dotnet-sdk-8.0.101-osx-x64.tar.gz",
+            "hash": "5c18dd1c0bb8199660dea5793eb2a568c63adbde492ca5080a8130e723a6260c6b9c6a055c299a3b8ba2497d6875959f86da8b9c9bf85e093bca2e08724d46a1"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0047e089-cf40-49c3-a8a1-8d1daa9d5a75/67300bbb26dab5d0a33b7401f6aa52ef/dotnet-sdk-8.0.101-win-arm64.exe",
+            "hash": "59c76d112728c318291fc48411dd489848839f3c3b67354458d3f80f4262cfee16e22b6fc17e774dd1d259eb411a1d95490909c9a8bbe79ed054d424eda3e371"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bfcfe7c7-d722-45b0-80df-663516a401ce/d7b91a51df647c710c96cde20aa8b100/dotnet-sdk-8.0.101-win-arm64.zip",
+            "hash": "68c2333f74434138846f49301ae0ff94302c55aa278e2fad09a0e03fc28f3f3dfb90a68a5e2633bd5e119957044118fd92d1cd715d9a76c8b1843e050cd02894"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cb56b18a-e2a6-4f24-be1d-fc4f023c9cc8/be3822e20b990cf180bb94ea8fbc42fe/dotnet-sdk-8.0.101-win-x64.exe",
+            "hash": "5de43de4f468dbaeb1b0bca6cf4774daf2c4ef8594451f1674a9a4a65149335ee956abaad4492be636161ed3d3eb5072099aafd344f94b0b55e04acba255d246"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6902745c-34bd-4d66-8e84-d5b61a17dfb7/e61732b00f7e144e162d7e6914291f16/dotnet-sdk-8.0.101-win-x64.zip",
+            "hash": "e05953b32429ddaa60dc27fb5f5077d7523fc9f9706d30f42cd1855e2469eb003d5250587468062df4e331817059f2f46a44d5ed10ce2eb599710897e6659d83"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/88238db3-d71e-4431-bba5-1f6d16f7a415/d1e7b4c6302c51f1e968d07391cac7e1/dotnet-sdk-8.0.101-win-x86.exe",
+            "hash": "3313919a647dbfa16afaec8a0a0292212fa7e7e612a895d5c0cd2df6a5bf09b2a47a213cdf3c6053637d5aa0e9d12d927dc28d20602768977a417edcef9bda05"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/059613f3-d3e9-4585-b8a9-3814e675b6d0/01150dbaaa7f392f103137bd325786b6/dotnet-sdk-8.0.101-win-x86.zip",
+            "hash": "df5248a25d351d866ac2d1ca6cdebf7b20ce5cc65aedc1a988166491d022829435daf67e07993ba71bfcb99f79fc19b8ef047e1d4a48ae9b6e8e31f3ea9a4107"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.1",
+      "version-display": "8.0.1",
+      "version-aspnetcoremodule": [
+        "18.0.23334.1"
+      ],
+      "vs-version": "17.8.3",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6d73b0dc-fd8a-4f4a-9b16-bf075c2985e0/345ca37b7db49d9528406707aa97ff6c/aspnetcore-runtime-8.0.1-linux-arm.tar.gz",
+          "hash": "1865185af78ee742588187f4a3e98aa30e1bc5da0180512e5fb6e40274c68a45052bc06d357f8541b6fa2bc6d4855efe4b45f706a48230da8a4b4078ca2a21c1"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0688a08e-fdaf-489b-90e4-033cc19cfffc/c9a9c648862b0b18c9aca77d3be0ef9f/aspnetcore-runtime-8.0.1-linux-arm64.tar.gz",
+          "hash": "7d34b6986363e54dca53828ca7a4d658aae1b24f8f33c6a82f811e12ce6d56698462db746d9f19e4ad245cc8d130a19930be28e0a0c2da2c96fd74b1cb2d8192"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9996eb25-90b1-4fbe-b02d-2cc84a4facf4/b31e737c1372e0d3642fd5578612e914/aspnetcore-runtime-8.0.1-linux-musl-arm.tar.gz",
+          "hash": "3ad47bf2c6d6c24f641c1ef52552ab4a3dc093bd83ae430258f9285b108680813f894977745441b0d67662f5eba80f7b28e24b98f56306ec20a523ce74d93d49"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/276629d4-54be-47ec-a34d-24c0aeb7bf71/1cf737f170cdc6a15dd70ae8e294b336/aspnetcore-runtime-8.0.1-linux-musl-arm64.tar.gz",
+          "hash": "5e48a721b7e4c5b2046b4c64abc29bfe0a931fa1887dc00ce1e75a7eede6ccad339370029c061774a123526def6b4ade934334bf7178d57bcb87717fe8d228c7"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3d20e634-d5b8-4822-992f-801cf11b3fa6/76313771ec5cc707999190afe2ea40da/aspnetcore-runtime-8.0.1-linux-musl-x64.tar.gz",
+          "hash": "b749398f5ad059c9d51e3153c9f41ac23145aea38e83a736259c4206fdb920c245685a60a6d4bcf74ce41c70f751fd133219fb66b263018ae53025e129535063"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8e19b03a-93be-43ae-8cd6-95b89a849572/facbb896d726a2496dd23bcecb28c9e9/aspnetcore-runtime-8.0.1-linux-x64.tar.gz",
+          "hash": "64eecc0fc50f8c68205123355c43eae5ee29b7f6061a260315818960153fdf25f2bb25a51dd3f051e2362e228c032f2d0b9e7b6b476ac52141c17cfd8de0bfd2"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/73548990-4198-4c80-ac97-29ff5064cb11/da52a05fbc9a0cc6b997c14284753589/aspnetcore-runtime-8.0.1-osx-arm64.tar.gz",
+          "hash": "ac12b846bd8c65035087b9a77cc44edbbbdcc5f8b8b1b9cf47bc282b3505d3f8670188e1dbffebdc26233f7a5c35ae6b2c1dc61b26d7ffc3233117436399e46d"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6032140f-ed94-431d-94b3-afa360230225/eabd66a040f8a926694f78bf0f4a417e/aspnetcore-runtime-8.0.1-osx-x64.tar.gz",
+          "hash": "1a573a57d7eae9162976f915b065fcba8f4069e42f8aff4bb93b131fff16d9f54ce17d7a9392aeea27fd693c5d5932a94db8a8220ca34f481429824639a4819f"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3ef1610-6e16-4763-8770-ad9847865ce2/798fd19c3570257a14c552813aff564d/aspnetcore-runtime-8.0.1-win-arm64.zip",
+          "hash": "7dd3b5560944e333a2faad71692b55b0411746ce2a1c667db689e8d2dface32095da739ee37cc09037472ae52f5558e19ca909e252f2fcbb7b170f0be7557c01"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4b805b84-302c-42e3-b57e-665d0bb7b1f0/3a0965017f98303c7fe1ab1291728e07/aspnetcore-runtime-8.0.1-win-x64.exe",
+          "hash": "32e436e24a9b6090070ece3d325131672dea9f0e95d7c570e83de2983c06523c40ebb26edecfaabc3d54e4c1ad5ec56111d322343b9ed1c4139c6e807795ac0c"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4fe2aae0-2d64-47b6-ab89-7af36e696bf7/1327a3ad7c6797951ae0017dfd0efbd5/aspnetcore-runtime-8.0.1-win-x64.zip",
+          "hash": "3e1556f5e6e681bd02f7409cdabf9ddafe9913c9e9341d5abca4e9a3250a7bd46f1de7f29cf26fae8ee2d60d5f86038aa7143748e80005d0356a57cf74308228"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/054695b5-a7fd-43e9-8e7f-c8422e9766c4/78ff5d8a3ea0f03af996456dd260351e/aspnetcore-runtime-8.0.1-win-x86.exe",
+          "hash": "c05dda744d9718d3bd32f17426a2c9ce958c677fb585dcbd6749a45ae242f9e2f50d4bfaa50326925726cd554540f531f94e05ef985893f9a4dd4eff3bc10ee2"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bd8879cf-4cca-4f2c-aee0-8aca9b382614/5e0357446e4c988e9805adf99dbf2b22/aspnetcore-runtime-8.0.1-win-x86.zip",
+          "hash": "d4279a810381a4b9fb6b54223955ef21caaabd2506ffddc5dc349e4af8af73dd47c3a2595d6af98fbe3761525c577ed81ad1050bb11f7db1a2d7ef785cceb366"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a2db90be-db6c-446a-9851-87a7cc1b0c77/e186785ae5b67a280c585711a0cb2e82/aspnetcore-runtime-composite-8.0.1-linux-arm.tar.gz",
+          "hash": "489d96231983b4c786133723d626659d907ae49a45765b7080aa40c522113a26cd48696bbddd09202074fd5547814c3bcef7b0bc3d88fb8c137ab7ad44851826"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2503a66c-c2ba-4e25-913e-d54a5f89375d/d8d06505e674cd235bfca177cb90cdea/aspnetcore-runtime-composite-8.0.1-linux-arm64.tar.gz",
+          "hash": "7dc3087c154dc0b3cf000c2a525d71d4b344b1bf5444c87d0eafe04ffec352dc0b57fcab4f1a36722a4b438ba9c68027de79fb83e13f417b779ca5d66ff9611c"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4feba7fe-f35e-4129-8548-6e8de76d0d52/0ee6b0e3849d17beb00c5b15e63e5634/aspnetcore-runtime-composite-8.0.1-linux-musl-arm.tar.gz",
+          "hash": "030a5cb3b80dc6422ad102e66cfd473eb96d07e6bf577849b4e15fb362f086516d08dc53335be9514ad712e6f46d204d437dff2196a1228796d096e9e67c180b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7bf1bb8-5e79-4eeb-8a8d-b1427c9d9820/0d5abd9842f2e2cf8cca75d808b2bf19/aspnetcore-runtime-composite-8.0.1-linux-musl-arm64.tar.gz",
+          "hash": "99fd7999641ca8574afe28e056d2235694b8f82aaa4e6306bfebc0000dd9f1f207991c72b482b5d02cb6691ecbba88ff0a63849acfd30482480a7a4b02296974"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c6fc9b8b-ba8e-418f-9429-ae0c7790d367/d85fc973f0fef00128fc6922274f73ba/aspnetcore-runtime-composite-8.0.1-linux-musl-x64.tar.gz",
+          "hash": "c1d3f658dd3bc07dee5c5ce474c01f344c7a2aff2ee0ca9e5c28c89edc5e07bee82a7646a6b87aa999df8ffa06ce0a2fe7192c3dc2c0c72364c976419b6bcdc0"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9dfa873-f3a9-42a4-bf76-9b8d1c0d4462/cf3dfae1fd46c5fdf9684dc9132cd8ed/aspnetcore-runtime-composite-8.0.1-linux-x64.tar.gz",
+          "hash": "8a09b2f0d5e3e04934e794127269a84b49cdeb9c5ef14b8c3b68abae6048a5beeb36acec617501dd00b83e1166e18ac59b99eda24f3c18210cb1bc228c74140f"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/016c6447-764a-4210-a260-bf7a2880d5c0/a5746437a3862d7803284ae8c2290200/dotnet-hosting-8.0.1-win.exe",
+          "hash": "ba6a820e6644f7bd6dc66e78777105698dd5470c1039ffcb35522a904c820a268e54334f2763bbc44283c52ae6b3c8ba030a016f725453c9db3a49adf79570df",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.1",
+      "version-display": "8.0.1",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/627d7473-7de1-4285-ab75-16e89f861f0e/54e8a293cfc12144c111155b65a6a41b/windowsdesktop-runtime-8.0.1-win-arm64.exe",
+          "hash": "5f9c1ee5ee2c4dfe80fd2d3a686dc33142f17a9bd37e6f60d63f95e7bbff15d65c1f2f30f4fb1f18f24ffcc3d7feb6d95953d7e7314945a8989df8b86d069c7d"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/55e981c7-adb4-45ae-9f21-ede2c4016290/c250573c1d02c1f37632b202e78c1eb9/windowsdesktop-runtime-8.0.1-win-arm64.zip",
+          "hash": "adf3dbb60e151fb399d20a8ee9179505eae51a1cf50bc38c1e934f3c3ddb96d139235d8b2c72269e08816beb43a065e905bead7fd713c995a967dde12db97511"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f18288f6-1732-415b-b577-7fb46510479a/a98239f751a7aed31bc4aa12f348a9bf/windowsdesktop-runtime-8.0.1-win-x64.exe",
+          "hash": "233d98b280eb4353fff7e45fa45e0de510403853e881c0bdcd3eb2466df4930795a62fec14cb30d05e00bff37f17b4d6c9b95511ca71475b739d6d9be9d2ebab"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0a1e339f-cfa3-4d99-93d6-1ef32a1e42c6/89a0f5a9cd7ae0fdede93ce3c931d109/windowsdesktop-runtime-8.0.1-win-x64.zip",
+          "hash": "f0922bcd8d91448a765eba9928b4a34bfbe7de441f9b76d90e97119b69065892e6f4d7d31342f20bbb4cacca84e7b03b1c0dbb721339c6ae5d23085aae226170"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ca725693-6de7-4a4d-b8a4-4390b0387c66/ce13f2f016152d9b5f2d3c6537cc415b/windowsdesktop-runtime-8.0.1-win-x86.exe",
+          "hash": "1d2cdb417ff9d72e4766255a1d7568bc16348120c72db58a020f35917b47a0f39dd74e185371668419a9f8a4fc2e9aad4073b5dcb273d010fbf9b16a718d018d"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1f19390e-a6eb-4dad-bf62-2f30e03e910e/a9f6a26833b41c796ff40f2b217dc445/windowsdesktop-runtime-8.0.1-win-x86.zip",
+          "hash": "3b579856c14ecdbea256f044dd9158461e0042aec15260d5bc10328179555e4e98dae0139cf5922a7970f36fda516c2d980715c087429d1de00e0265b9e9941e"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.2/release.json
+++ b/release-notes/8.0/8.0.2/release.json
@@ -1,0 +1,732 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-02-13",
+  "release-version": "8.0.2",
+  "security": true,
+  "release": {
+    "release-date": "2024-02-13",
+    "release-version": "8.0.2",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-21386",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21386"
+      },
+      {
+        "cve-id": "CVE-2024-21404",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21404"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.2/8.0.2.md",
+    "runtime": {
+      "version": "8.0.2",
+      "version-display": "8.0.2",
+      "vs-version": "17.8.7, 17.9.0",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/738dd855-9340-4dda-93b8-e11444113a66/9516b9e2023e158cc2439ac5dd7dbee2/dotnet-runtime-8.0.2-linux-arm.tar.gz",
+          "hash": "ee03411c04ab240b6356a6fcbe66948d688a90afdade6dc2b0229d9ab3b2df851a66211a2bfb3a5c142e7256fcc04412b64bec8794c1e9117dc2f9babd01adf5"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9de452db-acbe-48eb-b3f0-305a4e48e32a/515bbe7e3e1deef5ab9a4b8123b901ca/dotnet-runtime-8.0.2-linux-arm64.tar.gz",
+          "hash": "12c5f49b7bd63d73cae57949e1520eaebc47732f559f68199ecd3bcca597f2da702352313a20aa100c667ede1d701dc6822f7a4eee9063d1c73d1f451ed832ac"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f9331fe-31a9-49a8-bd70-8a55a3318936/54c8b154eb5a78355b013af0cf78bad8/dotnet-runtime-8.0.2-linux-musl-arm.tar.gz",
+          "hash": "73244d5b97695060eab975d620deb9d438b8e299348483f29e9f1964b611886b5d4fc46900fba941ac5e952d8ef948645e6550ad74e3c802a4ac38213824fd6e"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e13608d-2f8e-44bb-ab1e-f4d804100074/3cdb710d3949c31a4648552f3b1d3184/dotnet-runtime-8.0.2-linux-musl-arm64.tar.gz",
+          "hash": "0b91b9bb9c8932a86ce4d84c6ecce623192ccf20b5243ce8aaaa837f92c6352b112e183efc9877fd883d072696be8b6ccb106430d88fdf044ae555d481d45319"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e57d7fe5-06c8-44ad-861b-e6b598adf5d3/d682ed25fe5bd0cedd8676d95603072d/dotnet-runtime-8.0.2-linux-musl-x64.tar.gz",
+          "hash": "a585682ccc94de1eece4fd61f01eac99bb735ebc59faee6358022a9fe383124c68ea3ea166eee26edf21349ddc289ed81ffa46f815a7731a6c5c0ba9f37b9aff"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/307e4bf7-53c1-4b03-a2e5-379151ab3a04/140e7502609d45dfd83e4750b4bb5178/dotnet-runtime-8.0.2-linux-x64.tar.gz",
+          "hash": "f30f72f55b9e97e36107f920e932477183867726a963ea0d4d151f291981877ba253a7175614c60b386b6a37f9192d97d7402dafdad2529369f512698cb9d1dd"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4e5292ef-8f26-4ead-9632-03243fd4f907/761efaa7a63c52d69e6ef085b338ff41/dotnet-runtime-8.0.2-osx-arm64.pkg",
+          "hash": "51925aca346e566ccb09ad581579e7a6c53ebed0bf572252275e0cd363836fbea0df89e75283e6afe2c335b61ec2bc21d86a093b5f6308750750741fe9436622"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c7b73f69-39ca-4d2a-bd02-a72abb3a4fc5/6d68aa25f4576b70fff4925fb4e69c4b/dotnet-runtime-8.0.2-osx-arm64.tar.gz",
+          "hash": "c410f56283f0d51484d26755349a7b62364e2c54650c87dcee6fea0a370fa84b14b4ebc8c5e121e2b3ea4f0ac2880ebe40a43bcb02aa30ce360fd0dbc12fbfbb"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9899395-7f5a-45b4-acd0-8f0ad2d3dad8/008391ac2859dc0fca2eed8ff6bdd3f6/dotnet-runtime-8.0.2-osx-x64.pkg",
+          "hash": "59a673c4de17f658d91c61a55ad0fb7ddd8014fdbda646930d874b1e4f1eeaf76025342a7084ba5058bc581d066af6468d3eabf8f87612a1d8b391888dd58a4a"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/414af43f-fdc6-4e8e-bbff-8b544a6627a8/0719a2eafa1d0d5f73ee0a7aae4ce670/dotnet-runtime-8.0.2-osx-x64.tar.gz",
+          "hash": "e8945057f5fdf55994675caeff07ff53ba96324edbfe148ea60f58c883548be59cd1d891552b55ed5a594c1cfa549bd783ce9e25b5467ae48ab3f97590f36003"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f6128726-3c33-4cc3-a3c7-69855be7a734/cd59b37c259abbbcb1e8f6dc263a5d29/dotnet-runtime-8.0.2-win-arm64.exe",
+          "hash": "63a8456c1ba1296eceb9b2209ff9591a70e2f86f3a7f118f15a37f7cd211019c19bb3fe4d2be7fdef964185d40a87070326e2c7ad0c6933a5010a0ca73f572b7"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e795f0e-2907-4b42-946f-c863c6505edf/128bad1a73f85294017255ea71a71866/dotnet-runtime-8.0.2-win-arm64.zip",
+          "hash": "5c1945bd6675afbfee837dff510d195676df579724014a6381911761cef8a1e4e6b190e7a96edb73b166b175b3d56f92ab412ea0cb544de7d1193bc564171987"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a4bc7333-6e30-4e2d-b300-0b4f23537e5b/4b81af6d46a02fba5d9ce030af438c67/dotnet-runtime-8.0.2-win-x64.exe",
+          "hash": "69e15dbbc9a85eab07e25960a6dfc35f88224d9a501ab4f1e5e2ff9f41fc825863160a52e01d30aff3ba8a196f8f5ab7f5e9c975f2ff27f38ef85fad02b4d97e"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8abf4502-4a22-4a2e-bea0-9fe73379d62e/88146c1d41e53e08f9dbc92a217143de/dotnet-runtime-8.0.2-win-x64.zip",
+          "hash": "d2a927dafece90f200957eeb1dd00f86799bbe06dff01feda9bb5e63a12ebe8bc4c2a1861506f83a37179ce5d96aa59367f0425c4b68acc4112dccdda908b393"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4987764-bda2-4a72-8820-52605f30e899/f5b412fec80d7f4b20fc4ac7740f7279/dotnet-runtime-8.0.2-win-x86.exe",
+          "hash": "18d2e81e0ce1770a72dd8c8106811050792cfe2bec1480af7c710d1920857d2c1281ba08632da668fbe4829d24454595f994520307aa0b460a583bfde2eeef2c"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/265b103c-39a1-4f44-b85a-1d90373d26b1/7fc1a69ab29cd2705933ec761c18fe7f/dotnet-runtime-8.0.2-win-x86.zip",
+          "hash": "60a0e8ded65593ad481da65c8cdff421838b60b7f007ccff4d00395684a2cb458b9ef0db55cb1486269c4545a633e51421691bf23db8877986570fe2de0cda90"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.201",
+      "version-display": "8.0.201",
+      "runtime-version": "8.0.2",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2344ad1d-ce80-4d98-bf9c-f935576deb39/591ea75057045e2284a7d70d5dd01bc5/dotnet-sdk-8.0.201-linux-arm.tar.gz",
+          "hash": "92760c4a4f3bf559daa41b8b87d7f10995aa5ae11783af053d854e8b9e8b042cf6e984bda40490aff051e4463f7cc8ed25d905090e5cee029c81afdb7f8b32c2"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3bebb4ec-8bb7-4854-b0a2-064bf50805eb/38e6972473f83f11963245ffd940b396/dotnet-sdk-8.0.201-linux-arm64.tar.gz",
+          "hash": "37e230970cfeffdc3873e42595b79ecdf6bfe266a01ace6953725e69a2b64313ce144bf4d4f861130f61f680ead9b4d8a819dd5543c5470c37bbc13d88a78c80"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ea076cb1-d45c-46e8-b669-4c3f082e98e3/487bdc4526ca29794a90ff00587b402d/dotnet-sdk-8.0.201-linux-musl-arm.tar.gz",
+          "hash": "687e3ad0ba66825f3dd5b83ca6decd8a09b16eafb5a8c58fdcb7118b306b699f870393a0cd3d163c98deaad2f38f2d7df4c96678537b1e49b73b421073e14aed"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3f90a0b4-07b9-42a0-84ad-f56264d81a60/2303c6a9fd684fbc598f5a4b88fec701/dotnet-sdk-8.0.201-linux-musl-arm64.tar.gz",
+          "hash": "4a7c7dec45239a3ecbbb88dd4dc43b2ea66b016a974ebbbbe8960885d6118a0310679c2ced8f27ba5963311fedcce29ad31b0e43a20a01225778d8b6a1fe6e8c"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/751363fb-4dd6-4bdf-a392-35210dd7c03e/f8759108ec5b0e724266b0b41a433f89/dotnet-sdk-8.0.201-linux-musl-x64.tar.gz",
+          "hash": "06483d787d1cc0633ed94175747a90fded1bbbb4744f82db003f691b291da112d47e27350e5051cb7f413b913a44611f21dfaa5556c798a95f64b5026e9b4923"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/85bcc525-4e9c-471e-9c1d-96259aa1a315/930833ef34f66fe9ee2643b0ba21621a/dotnet-sdk-8.0.201-linux-x64.tar.gz",
+          "hash": "310cf54f595698435b533931b12f86d49f89d27243cf7c87a5b926e0c676b80e869aa58aaff17b5095536c432f377c67d92bf0ca8941b9d891d4b3879637d488"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ca8378e2-a2b8-4dc9-b54b-206feeff5ec5/22fdb7f35fab91ba799ea05bcae84742/dotnet-sdk-8.0.201-osx-arm64.pkg",
+          "hash": "0d70bca738988ea688104eb5eeb9417c6dcb607077a21220a1360bc54465f225c6c440b329d4932227c5c2b08796a305e18f97585377d36669fdd226c98ad18a"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d89ef89a-8e7e-4e04-b32a-8eb6d32a4409/ff889260b90ff66ec8818dd5619de64c/dotnet-sdk-8.0.201-osx-arm64.tar.gz",
+          "hash": "7457d5413dfee375d9e418707ebd726ff8ca9dbb7c34476e9fe33fd77962fbed5827bcbcc6d7978e918faf58a4e2470456b7383df6c0e47ed3b49d00b563611e"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9508dade-753c-45eb-8220-216e8b552548/a5fc65c2b7ef2df9dfa003fbeac44f9f/dotnet-sdk-8.0.201-osx-x64.pkg",
+          "hash": "e7c2e9c1a6ad7d9ebb4c6f994dab7684ab17d72e3faeac08e62bd90faa85a47d51e1bde73750c1f17fbf7e810b43a2b693ddb2a65c288e2f1d3b1a01a261d7da"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b61aa134-3109-4aea-915b-f4ad9fddac27/63f2187933dbefad3ae2df55f3a032d0/dotnet-sdk-8.0.201-osx-x64.tar.gz",
+          "hash": "254e578bae6150f194ec9e7d5cfe8a8cbaf048dedafd78afdb421cb0cae22364d21742eb2d11619a8330974739256d45a5d477483a1f82129acc3d12c6805767"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e5cb6432-349c-4ee5-b250-5cf7b825fbe8/7eb3d1ec87b9aab1debccd2d3f918d99/dotnet-sdk-8.0.201-win-arm64.exe",
+          "hash": "216e1485e95cc50cca23585169cd35df0fff55f54288c0b7f88c686f9cedfa3b16e9db0e9ae9c30ab725c676f38f4c1528182263545866312e5f431260e854f0"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53f1d7b5-3672-45b1-a50b-b8d6a910e538/eaa22c51a410766713c8ba7a8055f5ad/dotnet-sdk-8.0.201-win-arm64.zip",
+          "hash": "28f29033f2dec660846aab3684d9c20339cd63bd98f550786b24c3cd8515112042982e50bbc31192c8636859a9a2412f00cfe6d81c60b7d00a8a736c2d16bc06"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ab5e947d-3bfc-4948-94a1-847576d949d4/bb11039b70476a33d2023df6f8201ae2/dotnet-sdk-8.0.201-win-x64.exe",
+          "hash": "788228ffc0e97105f12d32cc96645ae3f7111865e16b01a34f9bd7a574a7a7fca4d9b29eb44fb85074f467b8b01e75455a51ce24f2b73055e95dc55bae00247a"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a98272cb-1559-46f8-9601-16a80827557e/c5cab2b6e195e8a8ee42ea484cca5f80/dotnet-sdk-8.0.201-win-x64.zip",
+          "hash": "73f27fc52d41ce652908d2b4133cb22a9e77691576fb16ebe5e283bee5fd7acbf5b70f54328a61da358cb04981aaef0d9ebb715285fbcee8666dd1151d7912a2"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8ec9b629-825f-4c8e-82b5-44441b820c1e/f53e02358a5326cf9af83591ed12fb78/dotnet-sdk-8.0.201-win-x86.exe",
+          "hash": "5cb0afbd33ddce5ac6042348b59ee006897011c22349e887167fd8be20a84da817ee7c73c1efc94fcbd4528823793107e87fdedd07c7a8eed05a4b6a056c094a"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1ddb8882-bdf0-4b1d-816e-e0130f6a4c1f/be0dfd4200c46f8485c44c98262f4f16/dotnet-sdk-8.0.201-win-x86.zip",
+          "hash": "6f40d27ddae36b313f0a750052b2b8ac9de276a24eff7f136f261e14e5ccffa1b0c863aaea4ff79966e6114a4a2b79b32ce4efdcb24fd9e02b7d4566e239debe"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.201",
+        "version-display": "8.0.201",
+        "runtime-version": "8.0.2",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2344ad1d-ce80-4d98-bf9c-f935576deb39/591ea75057045e2284a7d70d5dd01bc5/dotnet-sdk-8.0.201-linux-arm.tar.gz",
+            "hash": "92760c4a4f3bf559daa41b8b87d7f10995aa5ae11783af053d854e8b9e8b042cf6e984bda40490aff051e4463f7cc8ed25d905090e5cee029c81afdb7f8b32c2"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3bebb4ec-8bb7-4854-b0a2-064bf50805eb/38e6972473f83f11963245ffd940b396/dotnet-sdk-8.0.201-linux-arm64.tar.gz",
+            "hash": "37e230970cfeffdc3873e42595b79ecdf6bfe266a01ace6953725e69a2b64313ce144bf4d4f861130f61f680ead9b4d8a819dd5543c5470c37bbc13d88a78c80"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ea076cb1-d45c-46e8-b669-4c3f082e98e3/487bdc4526ca29794a90ff00587b402d/dotnet-sdk-8.0.201-linux-musl-arm.tar.gz",
+            "hash": "687e3ad0ba66825f3dd5b83ca6decd8a09b16eafb5a8c58fdcb7118b306b699f870393a0cd3d163c98deaad2f38f2d7df4c96678537b1e49b73b421073e14aed"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f90a0b4-07b9-42a0-84ad-f56264d81a60/2303c6a9fd684fbc598f5a4b88fec701/dotnet-sdk-8.0.201-linux-musl-arm64.tar.gz",
+            "hash": "4a7c7dec45239a3ecbbb88dd4dc43b2ea66b016a974ebbbbe8960885d6118a0310679c2ced8f27ba5963311fedcce29ad31b0e43a20a01225778d8b6a1fe6e8c"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/751363fb-4dd6-4bdf-a392-35210dd7c03e/f8759108ec5b0e724266b0b41a433f89/dotnet-sdk-8.0.201-linux-musl-x64.tar.gz",
+            "hash": "06483d787d1cc0633ed94175747a90fded1bbbb4744f82db003f691b291da112d47e27350e5051cb7f413b913a44611f21dfaa5556c798a95f64b5026e9b4923"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/85bcc525-4e9c-471e-9c1d-96259aa1a315/930833ef34f66fe9ee2643b0ba21621a/dotnet-sdk-8.0.201-linux-x64.tar.gz",
+            "hash": "310cf54f595698435b533931b12f86d49f89d27243cf7c87a5b926e0c676b80e869aa58aaff17b5095536c432f377c67d92bf0ca8941b9d891d4b3879637d488"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca8378e2-a2b8-4dc9-b54b-206feeff5ec5/22fdb7f35fab91ba799ea05bcae84742/dotnet-sdk-8.0.201-osx-arm64.pkg",
+            "hash": "0d70bca738988ea688104eb5eeb9417c6dcb607077a21220a1360bc54465f225c6c440b329d4932227c5c2b08796a305e18f97585377d36669fdd226c98ad18a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d89ef89a-8e7e-4e04-b32a-8eb6d32a4409/ff889260b90ff66ec8818dd5619de64c/dotnet-sdk-8.0.201-osx-arm64.tar.gz",
+            "hash": "7457d5413dfee375d9e418707ebd726ff8ca9dbb7c34476e9fe33fd77962fbed5827bcbcc6d7978e918faf58a4e2470456b7383df6c0e47ed3b49d00b563611e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9508dade-753c-45eb-8220-216e8b552548/a5fc65c2b7ef2df9dfa003fbeac44f9f/dotnet-sdk-8.0.201-osx-x64.pkg",
+            "hash": "e7c2e9c1a6ad7d9ebb4c6f994dab7684ab17d72e3faeac08e62bd90faa85a47d51e1bde73750c1f17fbf7e810b43a2b693ddb2a65c288e2f1d3b1a01a261d7da"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b61aa134-3109-4aea-915b-f4ad9fddac27/63f2187933dbefad3ae2df55f3a032d0/dotnet-sdk-8.0.201-osx-x64.tar.gz",
+            "hash": "254e578bae6150f194ec9e7d5cfe8a8cbaf048dedafd78afdb421cb0cae22364d21742eb2d11619a8330974739256d45a5d477483a1f82129acc3d12c6805767"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e5cb6432-349c-4ee5-b250-5cf7b825fbe8/7eb3d1ec87b9aab1debccd2d3f918d99/dotnet-sdk-8.0.201-win-arm64.exe",
+            "hash": "216e1485e95cc50cca23585169cd35df0fff55f54288c0b7f88c686f9cedfa3b16e9db0e9ae9c30ab725c676f38f4c1528182263545866312e5f431260e854f0"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/53f1d7b5-3672-45b1-a50b-b8d6a910e538/eaa22c51a410766713c8ba7a8055f5ad/dotnet-sdk-8.0.201-win-arm64.zip",
+            "hash": "28f29033f2dec660846aab3684d9c20339cd63bd98f550786b24c3cd8515112042982e50bbc31192c8636859a9a2412f00cfe6d81c60b7d00a8a736c2d16bc06"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ab5e947d-3bfc-4948-94a1-847576d949d4/bb11039b70476a33d2023df6f8201ae2/dotnet-sdk-8.0.201-win-x64.exe",
+            "hash": "788228ffc0e97105f12d32cc96645ae3f7111865e16b01a34f9bd7a574a7a7fca4d9b29eb44fb85074f467b8b01e75455a51ce24f2b73055e95dc55bae00247a"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a98272cb-1559-46f8-9601-16a80827557e/c5cab2b6e195e8a8ee42ea484cca5f80/dotnet-sdk-8.0.201-win-x64.zip",
+            "hash": "73f27fc52d41ce652908d2b4133cb22a9e77691576fb16ebe5e283bee5fd7acbf5b70f54328a61da358cb04981aaef0d9ebb715285fbcee8666dd1151d7912a2"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8ec9b629-825f-4c8e-82b5-44441b820c1e/f53e02358a5326cf9af83591ed12fb78/dotnet-sdk-8.0.201-win-x86.exe",
+            "hash": "5cb0afbd33ddce5ac6042348b59ee006897011c22349e887167fd8be20a84da817ee7c73c1efc94fcbd4528823793107e87fdedd07c7a8eed05a4b6a056c094a"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1ddb8882-bdf0-4b1d-816e-e0130f6a4c1f/be0dfd4200c46f8485c44c98262f4f16/dotnet-sdk-8.0.201-win-x86.zip",
+            "hash": "6f40d27ddae36b313f0a750052b2b8ac9de276a24eff7f136f261e14e5ccffa1b0c863aaea4ff79966e6114a4a2b79b32ce4efdcb24fd9e02b7d4566e239debe"
+          }
+        ]
+      },
+      {
+        "version": "8.0.200",
+        "version-display": "8.0.200",
+        "runtime-version": "8.0.2",
+        "vs-version": "17.9.0",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c8caa3f2-2b14-4aae-8829-1e5229f8f547/f3f059cc07aa6c23156670f71cf8dbb5/dotnet-sdk-8.0.200-linux-arm.tar.gz",
+            "hash": "a7359c6b714bea6a0e56a89465866e78e241a3587b916fbd8ce4c9ea89c3bf987ab95d8b12d64308257ae0213c724ebafb34e0ff244058172b58719cef0184d5"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cb9d4eda-118d-4db0-823e-77486a94b1c3/f12cc8c101479f59cb18700b4433de15/dotnet-sdk-8.0.200-linux-arm64.tar.gz",
+            "hash": "ebb11b2dba2843175f55b6a78a29f6a22860eb1198e4562f206f5fd3c0cd1711bb5c8919967396ac6a0e354c43bd6d012e47fdbd85ad951c7ff0e3e87b0a0b19"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/54b8d299-2657-4816-90ff-2deac10770a0/11b5552623a49d71be22d59f43dea313/dotnet-sdk-8.0.200-linux-musl-arm.tar.gz",
+            "hash": "2995e624ddc1dfb81b37a2865e1cef9227c473c50cf48b4e6d47032dd3763b57a2421aee1bb221c7307b18d8c2cec1a0531dda61b0ea33dd2d7b8c3b33055943"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1db2e933-d512-4cb2-bed1-c97abee06dd0/bab7a156742d296c2bf0c9fcbf3a8798/dotnet-sdk-8.0.200-linux-musl-arm64.tar.gz",
+            "hash": "a65149b1b6eca4ebca30bf0f537e0759bc84ae6bb6ab528dcbbc357a0ebeaac21dbaab320ee97a9cb107d6b43b2f042837d669cf6c45df7f5756cfb3e7beab21"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4501f260-dcda-4e91-bf47-e0c0aa7cf0da/8cc97d74df5c140b1d5c1f85e31bffc9/dotnet-sdk-8.0.200-linux-musl-x64.tar.gz",
+            "hash": "c13d33ae2ec4ffbc8269ab89bced97fa659eaf173b0ca146f06174d51990b74bcbfb13333c9162973754ef5c328e41a52643f61fc33474c5335b6bacb9bb5fda"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a1bac6e-364e-4de4-b76d-a1e3af5af8d2/292c64839df2435b4289766af556e144/dotnet-sdk-8.0.200-linux-x64.tar.gz",
+            "hash": "58417468b72c89a66ad0bf54a0e4af13f8a3a37f2aae6e28ef762b9cdd783af0c13ad62ce185446d920b2709ec73c980d888fd73a413a8dce154ac15cb0056a3"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/87f99dbc-f7aa-4247-b40b-b1206093c33f/86625a11ac2b702bbc5aa49f529ea8da/dotnet-sdk-8.0.200-osx-arm64.pkg",
+            "hash": "f12f5c5e109ea597a9ed056b9acddfd2c42654970285d4f7aa800376ee7569b87be4bf842b962232ce1bf3b44cbc244d6e71b36639c9f1a03edfe79528e3eaab"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/86934007-0cb8-4cab-9ea3-393654979909/07d71dfe0110f4b89c17af9c87e88948/dotnet-sdk-8.0.200-osx-arm64.tar.gz",
+            "hash": "9d62beadd090f940d7dbada4120aa01f0e1cde14c4ccef570a3fbd6a44dc347ffa27baa44efdae46bba7307e647700329aea15f8b79f3e96df906a267b98b13e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f1e3adeb-edfd-4429-a9bf-e4c790788e2f/1d57d12283ee0086d5652f9ccc2218c7/dotnet-sdk-8.0.200-osx-x64.pkg",
+            "hash": "dccf82709f6cede1e87116b9caaee637eb65365e761c5fe78bb4f49d4f1abe883ca6fd6827556329488f23948d07ccad16dfeff83a39d96c4bf76d9d5ef78add"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4aa51c1b-65de-4f5e-baaf-d9eb5aec2cd0/5613f60425a4ab151b299ec4ecde39ea/dotnet-sdk-8.0.200-osx-x64.tar.gz",
+            "hash": "6d8d6ce6ff9c8c08451d9e7f1faf6ec934b8c9d6fea43a8b547873094c03ac8483cd6418429f89b64016d2c9fb3eeab2080b2f639f41d438c341ac0e0804a4bb"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3730a321-327e-4576-b1c9-3784c7622767/11c56f7342a6f0e1242684a0c1234f58/dotnet-sdk-8.0.200-win-arm64.exe",
+            "hash": "f684f9e27c71ce5b02666ec94956de2d774f9e6bc6f83611943316377931aed05f22ab54e4cb711a9a118def462795909017b8109488c2ed5ea47ea3912d3663"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/acbf59c4-c194-4ff7-88e5-1dbd12b3a158/5a2ebb1e32be3704f67f48aa2b3a7da2/dotnet-sdk-8.0.200-win-arm64.zip",
+            "hash": "bd43f6d3272ae9ffafcdc856f33bc10c9c0981e6de19fcfa32c3a674154cee8be68506fe08b3d8de97b83ab918b22981f7e370ff0fac7c227716972644ccf459"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9f9ad302-a698-4fab-9765-e313f7e14151/8ad751b6cfc11276b4e2adef4e319db7/dotnet-sdk-8.0.200-win-x64.exe",
+            "hash": "696d9b5b931114be12eab8cc81fd7403a5143ada38d8b0f2423e148d85309dc66602c86dfed6dce40f4ce1e0d141d01c774b3d34750f3d294673ca5b7c67649d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4061a59e-63ff-4c53-8070-e6fd6825eb6b/86d97324d285174d4110b0fd7b3a9808/dotnet-sdk-8.0.200-win-x64.zip",
+            "hash": "b4129eaeccabc2f66d92827c4bd67535cbf42208648d99b9b7235d6ba67252b948bf9ad5e5fa8d34bc6907cdc7fe9bcbd60dcedbc75b81dd1b674c3af8cdaafe"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/82d826cc-3aaa-4d8c-98af-889bd40fe50b/32ae8125fb5b475864ee91f9a618a2ae/dotnet-sdk-8.0.200-win-x86.exe",
+            "hash": "7feb39c58058f79392634059ca3aa381bd14522cd6013d8980a1651479899f8726c2069bc9b5596336133c27eb2672faa2d3d986254f96846430dcc1a388b56f"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0a25c416-3109-46f2-99ab-c776b549e39d/43f477139ece7d8e937ea05210e35b3b/dotnet-sdk-8.0.200-win-x86.zip",
+            "hash": "6dae83edd111736e8e4b930cbd260f7b4ac57f7379e35afba310af9a2c6630bf7aadee933209fed345434af3afee49bffa63cd81e8a0504ded759c679918f5ea"
+          }
+        ]
+      },
+      {
+        "version": "8.0.102",
+        "version-display": "8.0.102",
+        "runtime-version": "8.0.2",
+        "vs-version": "17.8.7",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1b3901b4-1a77-47e3-bd75-372da6a29e06/7563a332173ddb5522332c84e4c75940/dotnet-sdk-8.0.102-linux-arm.tar.gz",
+            "hash": "7bfa9cca1d2c8321036ea33c96327005e4bceb9bc8dabc0a35e28b24dbea5cd5cf78c6a8fea3b419c7da47e6ef953ed8b93d0b293da58b86ae737792900b51f9"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/23568042-614a-41d3-a6b9-51e178e42977/cb1e1f4f5fb5d46080a60cd14d631660/dotnet-sdk-8.0.102-linux-arm64.tar.gz",
+            "hash": "5e0b5762ab2f038de50859a2e18a3964ea6b754faa01d72f9824100546a271148908e84d666bb63d25e5d9a92038bc8a2f944d0342bbf8834cb5d5e936878c76"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1a48793f-9955-4752-a6a1-6a73652210db/d6ac448b35827cad0482b1f4a89c3af2/dotnet-sdk-8.0.102-linux-musl-arm.tar.gz",
+            "hash": "1d336d717b0c127ebdfba422619f5bdcbf328826c6f8eb427fb9b80df3b5615028378d5fdd75bc216770de83c7ef34b1059ee4cbc2f4ab39cc504c5b0fa12236"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5de149c3-37b7-4452-a7fd-78f352818212/e9571797b0d0e2df96749ca52dc971c1/dotnet-sdk-8.0.102-linux-musl-arm64.tar.gz",
+            "hash": "3e7581ed3fcfe601593ea8b75d45c4f4f3f0e1b02f6fdfad484612383c1fdc66d904be75d06e5e3b36085dd4eb85ed5ccd8ceb55129e019d74a3255858f05cdd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/897ba6bc-da45-4c09-b7b8-f530b0c4fb1c/658062647dbcccab75e9c2d19fcfeea2/dotnet-sdk-8.0.102-linux-musl-x64.tar.gz",
+            "hash": "ea8862773e8eaf32ffc43646fe273266fffc7e0c56fa59541e6218ccf459b27cb93f4cb33bf895fff54723717cc64c4faf2527a307f46da587ee3e970908c8fa"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/672cfd95-c7fe-42e3-8b68-30c74f7af88e/ecdaa65fe42b6572ed37d407c26de8a2/dotnet-sdk-8.0.102-linux-x64.tar.gz",
+            "hash": "f5928f5b947441065f2f34b25ae8de1fbf7dbae2c0ba918bfb4224d2d08849c79cbdc1825c0d42a5822f12757f78efa58e295a8ee0f0e6fce39cc7c6ed977b8f"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db4088cb-b3c9-4a73-ba9e-f6321e5a7e02/8d29bd7164618130a5df5ab38fdf073f/dotnet-sdk-8.0.102-osx-arm64.pkg",
+            "hash": "b7219a5cb1de7d16c4408aef20650bb2390fb08266cf342695aad440e8b283b3880528abc5f1d1cfbbe0a0808bad1f7405ca1efaf974e831ab92cf43a536230a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e89e4d12-89c6-419c-a2be-9b2ec96b209f/0f393a6b611b26d7e4599694dff857e2/dotnet-sdk-8.0.102-osx-arm64.tar.gz",
+            "hash": "69d702b561ae7ddf4c47fe228c16472fd8d7065de1a4a206fc07c6906db49e7da25b21c06f0ef080f41658aeddc0f3c0a23ce1de7e65b830c308bfe13cf95fe8"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2fb209ee-7941-46a8-a712-a518b50b5a02/073d5294fc72082299c95ac2364c0220/dotnet-sdk-8.0.102-osx-x64.pkg",
+            "hash": "1b930dbab28ff363a20e255f0ec3c270f2fb680288b96f0cf6f59604d66b72e87af67218a561e1193b9ea197741c6c98735060cb030a096f3cfe86a8d6f46b9a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e60574bc-0bb6-45c6-ad3f-5c5fa29c75b7/1d903893164d767b98e9998153ed4c88/dotnet-sdk-8.0.102-osx-x64.tar.gz",
+            "hash": "963432c5c7d7d0b204a92248c61d1be227369c6bc1d47f977c913c416c61584451fd05d0e95a6fbe51f0e1958e1c1a71f2530f478dd036ed2b0e123944b3ce00"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/84345e47-5324-4744-97d9-5806d2fca863/519cb0f25e7afb364fdfb3056e9f8a1a/dotnet-sdk-8.0.102-win-arm64.exe",
+            "hash": "b5eda65c8deb139fdcf8401c96fec2d0ddf361801672f2f64b6bf9ae142f52c6ca97e140b2475c8ebd0775739d70a8bc4ca5064821a863bf7b0a8cccb15f8274"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f601d9fd-def5-4287-8b10-372458d278ee/84eb9a0ca8fa11e805994a47618aba4d/dotnet-sdk-8.0.102-win-arm64.zip",
+            "hash": "a865bfbe246acc024da5322f7602229d4621ea48aaf7ed499c346b3cc6ab78ff2fa3dd0a7c038f5bf900510d846c9e00f9c6ca2f3faeb750e61fec7689955ed1"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c44a5979-abb5-4b4d-aa4c-090c008325ae/79499ebf6ba5c887a6fc5f98b9a9ffcf/dotnet-sdk-8.0.102-win-x64.exe",
+            "hash": "c627c09208a37d600fbf809f21fa9ec15905ef98c3aa3ee6e5163c45405dbeaf38988d8803308ae948d86aaf18b2f23e6be6734dfb3a18b682acd9eec7d8a7f3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adbd9a00-b9ba-4773-b5e9-32cc6a90b377/1aa46b49f8dd01a1a1c7d4034a282212/dotnet-sdk-8.0.102-win-x64.zip",
+            "hash": "6feb4737d60f9e085140ccab2669f0f24199e36ab60c671ad47392bbd206abae4485c18abade08da487b74c997abde1016825e630e0df3c691dba24554b46627"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ac3a5952-9948-461a-a154-4bdd247698da/becc41c334da44aa0e4604813aab7097/dotnet-sdk-8.0.102-win-x86.exe",
+            "hash": "2c6bf400ca0eb88fbbe71efcc3bb1e378cc1f523d45ef44560c8a42c09e056121f3502b053dcd9bd4ebc3d91a2c4e2f29eb27458bae874888cc13a0524acd837"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/146be26b-ea1e-415c-8339-2a5d5ca6f5c7/ef3873d77d9fd168468bfe5454cc37c3/dotnet-sdk-8.0.102-win-x86.zip",
+            "hash": "4b5f55d3bc8a57901f327a4fb6f724a22d79a9898e00159feb2652c9fe019039f4439336607d07ffec8465ec4bf1380a7256a0cbb50e990a74920412d263a21b"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.2",
+      "version-display": "8.0.2",
+      "version-aspnetcoremodule": [
+        "18.0.24018.2"
+      ],
+      "vs-version": "17.8.7",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/272dbea2-057e-4032-9857-7e00b476ceec/3c472df94b1c3f5e0d009cbccc9256a6/aspnetcore-runtime-8.0.2-linux-arm.tar.gz",
+          "hash": "427e60fb1ed636ed6c8b8be22b125019f0cf8cad3ab07bfc362d56a05f12206eaf245c8003b5a1c1b342c65d703f3f401982aaab92f86de5d73650f742a2fdba"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bdfd0216-539e-4dfd-81ea-1b7a77dda929/59a62884bdb8684ef0e4f434eaea0ca3/aspnetcore-runtime-8.0.2-linux-arm64.tar.gz",
+          "hash": "9e5733a0d40705df17a1c96025783fd2544ad344ac98525f9d11947ea6ef632a23b0d2bf536314e4aeda8ae9c0f65b8f8feee184e1a1aabfda30059f59b1b9a6"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d0a94580-5249-41d5-be77-5500507a4336/eabf58603de2533792aafc0a35f668c2/aspnetcore-runtime-8.0.2-linux-musl-arm.tar.gz",
+          "hash": "78af2bf6c79cd06449808e54ce66f9b67976773aefe826eb69834c66280cd3a612ef2c41594e90ff12d6223194a0935a2dd5b1342415b767175f7b23ddf4788d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3de102d9-40b6-42a4-b3bb-6e58a210ef3d/6379916327625a9e9166e66a02e66d15/aspnetcore-runtime-8.0.2-linux-musl-arm64.tar.gz",
+          "hash": "1e92f8b880a30c71b1620dbd9600dd77e7bf44f175dc8d7d3579f814b419305d0a242c130d82528804ac0ca4b486df0959d7fde6bd6fc322a2bf63d6f815828d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/563ce630-fc25-480c-bff8-5c087e6dc8bd/403acb7bc6825deab9bc426740cd4cd8/aspnetcore-runtime-8.0.2-linux-musl-x64.tar.gz",
+          "hash": "cf9eccbadaee5cbb7787acb30c2826ef2ace343a443034b2695ab362d867657d0c10218ec3d13706c85d03921599a463105b2ea58d684c911de6a97df3c93933"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d6d79cc3-df2f-4680-96ff-a7198f461139/df025000eaf5beb85d9137274a8c53ea/aspnetcore-runtime-8.0.2-linux-x64.tar.gz",
+          "hash": "c8d4f9ad45cc97570ac607c0d14064da6c1215ef864afd73688ec7470af774f80504a937cbb5aadbb0083250122aae361770d2bca68f30ac7b62b4717bee6fca"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a5692569-6092-4db1-9d5c-4862265a7b5b/7173de926da466e21ab9c7666a31dee3/aspnetcore-runtime-8.0.2-osx-arm64.tar.gz",
+          "hash": "9e79556cf58f9d0b0f302a50ef9724122a9b18daba70e715b7334f9ed97a4983be0386e4132f5273d120f00d18f8af8a8ad7ea1ef0a82c610e268a33e76a30e4"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a44da2c3-cb74-4ffe-af5a-34286598a885/263f113228e88df3f654510c9092f68b/aspnetcore-runtime-8.0.2-osx-x64.tar.gz",
+          "hash": "a7edf091509305d27275d5d7911c3c61a2546e0d3b5b0fe9fcb9e704daf3c550ea0a5ae659272a29b5e218d02f28b7d331ab0905e9459711624692f1589d7285"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6a412067-1e24-474c-92c1-fe14cc33eb14/6289222047347ca3d5b388463614bd83/aspnetcore-runtime-8.0.2-win-arm64.zip",
+          "hash": "f8d25d220eaa06e9e7a85aa347da9090684e8cb9dc286428bb7f44d19d8e028c93de89c3fc8677e2e1a6a0182248d79e013fd5fc53f7f44c4a7cb224bbbedb74"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/34d3e426-9f3c-45a6-8496-f21b3adbbf5f/475aec17378cc8ab0fcfe535e84698f9/aspnetcore-runtime-8.0.2-win-x64.exe",
+          "hash": "64f0a3f63ef5e80e7e61725639723c91368add464d08273444eb84d4e3c45ad841be24849553272b34e246180a1f497a61964da53cc42badc910ab48a6c2d1bb"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f2b824c4-d65c-406a-9d3c-3fc4c45f402b/54a17e458c67caf84e4117783e1d2c40/aspnetcore-runtime-8.0.2-win-x64.zip",
+          "hash": "ec88ab44fdc3116c19fcfcc08a24d9bb5c52d0f1825fd976c51a6f58fe6af9a79f1101eb3b0ea507e8b72b326dba6005c7ab10a8399993f801ea5a85acd09765"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a1c05bf-8147-4bb9-abf2-ef886871eb73/fec274762cdf5935369116a4f38d43ad/aspnetcore-runtime-8.0.2-win-x86.exe",
+          "hash": "2b530d4afad2e7ab6bb4008c81fe07ab0b241e68cfb0c52db78e1e323b8d6a118adad55864f3b7768d27bc30190333e6559f3b9f86a37c7914bbc5acdb486d6e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e2585d65-56c9-4e68-b117-674764461a7e/dd5fe9ed35d2d2584aab61278429f53d/aspnetcore-runtime-8.0.2-win-x86.zip",
+          "hash": "b04ece77d49a9261554ef17af4668472df2d756e831d42480091aa1710971793dfa24fc3a798f888b827a6f23abe717589ef918c1693eb70b4ee680aee6bbb77"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/208558f7-99d0-46e5-8ee0-49c0aea0bd98/bf08ddbb231ec89e7dc6a86935358e43/aspnetcore-runtime-composite-8.0.2-linux-arm.tar.gz",
+          "hash": "8c9204cb9094b5e8f4f7aaae87b6786d57d4c79fd24d550f6c74a6682c4df2adb4e948288498b276f2cf39d7c23b2d0099f8a3694f0357dcde05688ff4eb4329"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9637484d-7b26-4b24-b1f7-d36a8014f822/beaadc6e41f89cb1e9603ebc52e32b63/aspnetcore-runtime-composite-8.0.2-linux-arm64.tar.gz",
+          "hash": "aece5cff73dd05d7e51fcc29e429572b7f55f9ce6a213b8ce26a8f4cc236a2d36cfd39af5dd59c6abcfa8b62f510a99f2351098c72782fe33feb332119ae0461"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ac829988-bbd8-44be-ae46-4b0aecbbe3f9/981efee9eab033fdc679d023d9689a08/aspnetcore-runtime-composite-8.0.2-linux-musl-arm.tar.gz",
+          "hash": "6cc71a0c8a3e74c26fe3540e0f7c057bbff9ae98888d8239f057fd1dfdd8dd430ad2a3120d399e825187735487f89174687067bb237fd21f4cd03bb598884d08"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e2ea6875-805c-43f7-9caa-cb767d3b643b/8296236168dfdf269a569bbc1d685896/aspnetcore-runtime-composite-8.0.2-linux-musl-arm64.tar.gz",
+          "hash": "0da9ab1fa9f08633d9277c1c49a792bb9cda481c31773f824342fbdea1d905926d09a190f37f455e66c44ecf9063cf1c9fefe6829886a5e526fe789457690803"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d409796e-4c01-4722-b1f4-7ad09f51083c/d369363bb63759f0a958e3c57ca1e3a1/aspnetcore-runtime-composite-8.0.2-linux-musl-x64.tar.gz",
+          "hash": "833a646b8569436623b6e2761051916585d659792254ce7da0db2b665e1682a15b765761584f369027987944657445fc6cd7eba727d24ff020842c1a0b562605"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bfd1bc98-e950-4e26-bbc6-309d1256f056/b1e9268c8d44bbe3c1b8a8104925e20b/aspnetcore-runtime-composite-8.0.2-linux-x64.tar.gz",
+          "hash": "91a8173771b21e602c2365ff39db71e18a77d8251dedb70eb1ac84c180d26cfcb017a3e2f866a6f9c1dcaca0f8efae60c19f9a23b17794a3c34d2b8f5863f4e3"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/98ff0a08-a283-428f-8e54-19841d97154c/8c7d5f9600eadf264f04c82c813b7aab/dotnet-hosting-8.0.2-win.exe",
+          "hash": "7edb966eb7c2cedb592feeb28d95e94de82c3a9cef4906a00d1d2efef73372839251d5b1ea39917ca37d48e22849bf78dbb5910830e8263ae9f818e08f9c1565",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.2",
+      "version-display": "8.0.2",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/851642d5-5a3f-48f5-b608-a8bc8251591f/1e5beaba1586f70cf882323d91fa7be1/windowsdesktop-runtime-8.0.2-win-arm64.exe",
+          "hash": "ded156143841a9256cf077527973ebd131e54d3413be5ab0286638e73f88e504fb553ca7dddb390ab917be652938d8be28caf82f8a454d78093791c02c8b9002"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5d6235b4-17d3-462a-84e9-0646edb28d80/f2234e0e4c09c2a362287d97a39ffcb2/windowsdesktop-runtime-8.0.2-win-arm64.zip",
+          "hash": "dad3741d6af5314d731f7d3837754ed555c97e812a4daa55925b3491e9038ddbf1ef8c75e0179f4d554159b034380dd9a2f8ef011fb9847227aee889536e4232"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/84ba33d4-4407-4572-9bfa-414d26e7c67c/bb81f8c9e6c9ee1ca547396f6e71b65f/windowsdesktop-runtime-8.0.2-win-x64.exe",
+          "hash": "62cd6be9ea5c397b607c75a3a9da332476b456482e20a3e786e964eae352965678c979792f3e0577d76205761b9c53da86c3aea6ae122934e4be7cf38648e950"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d8d5df9e-52a3-413b-9db3-fe4740e308eb/d9be81be4541911ed2be53cec3f460e0/windowsdesktop-runtime-8.0.2-win-x64.zip",
+          "hash": "0256add3c5bd08ccd1e0e56d69ad63ae3a3a93fd869420f9f251f2e7a77e63c7aa00f0381453f0b6bacff4f120687a4f135b738b338662f1816225e9952ae3b0"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9b77b480-7e32-4321-b417-a41e0f8ea952/3922bbf5538277b1d41e9b49ee443673/windowsdesktop-runtime-8.0.2-win-x86.exe",
+          "hash": "3700642786b3f9a67218b6a834a8472c31d8e5ae6c2436c752e2ade37d9cb0ff808e35bb9fc3207ecbdb6e4e934c1dc77796d47ed0b2d228755f9876d4e0af0a"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bb0b6ab8-649b-4c1e-98d1-8c175a355d88/5a44e15273d8b7063e6da2365c7ba3c9/windowsdesktop-runtime-8.0.2-win-x86.zip",
+          "hash": "4c5c2b7ec412e6fe021ec7b40cb09e66ac930ff6399e94f495efba6b052c7b7000d3185d3661afea689efc493cfff18c3024e3a6d242fcc77356ce32f1d0a78a"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.3/release.json
+++ b/release-notes/8.0/8.0.3/release.json
@@ -1,0 +1,732 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-03-12",
+  "release-version": "8.0.3",
+  "security": true,
+  "release": {
+    "release-date": "2024-03-12",
+    "release-version": "8.0.3",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-26190",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26190"
+      },
+      {
+        "cve-id": "CVE-2024-21392",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21392"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.3/8.0.3.md",
+    "runtime": {
+      "version": "8.0.3",
+      "version-display": "8.0.3",
+      "vs-version": "17.8.8, 17.9.3",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3caf5aa-a29a-41a2-b3db-7d68b606dc1a/478f27b65c19dafd3c3120fbdeb99295/dotnet-runtime-8.0.3-linux-arm.tar.gz",
+          "hash": "ff57e94bfeca1c44beef4f960caa9e3600ddab4a75c4df09611a667d95d8aad56f7c8b4b89dd8919a9dacb5a79b90a516e6420d6ce39047f89b9d313d45acc62"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/988a1d6e-6bfb-406c-90ba-682f5c11a7fc/28208806b0a6151c4e5d9e1441b01a6f/dotnet-runtime-8.0.3-linux-arm64.tar.gz",
+          "hash": "a78f51500fe180936152f561b3c2385939053aaeb1c2eba5e1353c6427a57fc1c6de8ffcc398afa0d2051ec696813b7c635917f6f0554028b725c58fda981871"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/da52a443-fcc6-4922-b21a-613400853807/823cf334f9915cca2a9782d8aa6394a5/dotnet-runtime-8.0.3-linux-musl-arm.tar.gz",
+          "hash": "2e047f0840ae83a86942452d1b5aa96685d1ec64259d7cfd51b944d05865eb4c32d80fca48ab0b70e651a7b6f9b2d43bf150f0e6ff841e719be28342bc26fcc5"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f4adb123-7b54-4b22-8984-559154ed94e2/88a4fcb21274d9a6118dd99994e724d1/dotnet-runtime-8.0.3-linux-musl-arm64.tar.gz",
+          "hash": "3d464b41b9ba8c1f318295f0628c80c9e3d6c9ff017e24bcf4dcaad740c22d0593d5b47a158aa5b2dc956e14fb6e08d2720695e2416611fef291236ef913cbc6"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bf4826c7-86b2-4811-b474-7e9052ce4de9/6cc534eb1530c8c28745af317c3b35d5/dotnet-runtime-8.0.3-linux-musl-x64.tar.gz",
+          "hash": "bbed0cf924d103e15d07e069522fc89d921e8d91adccbd4e161345b52fc8bdb26837a18c83d06ccd092d14d3df0e6acbe3b8d348e0825822807a1cbc1c8f549f"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ed0c9129-950a-48db-80be-e770daf2db41/53879e5802bc6e76bac55c1b8154ed06/dotnet-runtime-8.0.3-linux-x64.tar.gz",
+          "hash": "08ad7065abf73d09bd718963bd1277c4736f9d51c7c51849255732db03b59f2321d321235be8be35ca5ef2bbd4f331a0fecaefb48d3e1075659e075bcd1f0169"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ce5fba93-9d2f-4f16-b091-76ad1be06f05/ea39bddf82f228c7ec293ef1a34ce944/dotnet-runtime-8.0.3-osx-arm64.pkg",
+          "hash": "4436beb94b2d7b52c0a03e282ea06328d85fe2012fe6bc16d24813e8e7249ba629dcf8f635a467c03e00bb63699730cd93dfdf32d4f9a5335f4333d573bc4029"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/08f11d3e-84de-440c-8982-0c8c62273548/d8a497c6cae9b84456d0b90cc7635231/dotnet-runtime-8.0.3-osx-arm64.tar.gz",
+          "hash": "c70ec1c2f258adc07b585896d5cee6246d8ee5a2f7228c9a52c958c0cad2e6bd8dd6803bfb0c5243635e89dc5a5fac6e32274f1b574b79dc4fd31d69e1aba2cd"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/02be54d9-bf36-4a01-8a68-cd0cc05e93f2/ab893ef01800b28b66a99c61c4dabdc4/dotnet-runtime-8.0.3-osx-x64.pkg",
+          "hash": "70b84e73989b4497f971aceb8e4797242b88436b334b9f91ab510d99e7043eee1bda38bf5a8a2c6fedf3b92b0b8c74f2fcff91e894eddb053fdd7d8cf7d23568"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/564a929b-4f15-490b-895e-5260338cbae1/1db7fd97d0907d3911ac3e4dda32fbb2/dotnet-runtime-8.0.3-osx-x64.tar.gz",
+          "hash": "5ea3f5cbbd9855cb0f305b8b3252e10af03bb0e116ce04f8c764cf5512bbcf7803378ed48cd9fc394e5282761f4137d061a1e2447d2d5cfdf3a2226a2e14a9e8"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4b679ae1-8e5d-4e91-a949-94bada37356a/662cd1bc6d6c058c94df4113268da17c/dotnet-runtime-8.0.3-win-arm64.exe",
+          "hash": "7e2ac73884a5c11f76c4690ff0b31bcca9b9ddfe9e5dcd91673e38addb2dd6780ac9d11bd3b2d38be63efff4b321ee347c9007c2c3a646e16b884b412a58453f"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bec390b1-bfea-401b-a6cf-9f47a84f45cc/710adc347accf08a2ece2ccfe98abf1d/dotnet-runtime-8.0.3-win-arm64.zip",
+          "hash": "164daedf2d691c41b4e99c98dc3f6631f4490d724c206d1f3cbd6aaefc81bb2355a49fe8a52c4a01fa9a278b910f7249262baaff688a84ff07122e6970472694"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/961dfc84-ea72-48a2-b3f4-b82cefc34580/6ac50b6bf244a2c5481ad705a92cf843/dotnet-runtime-8.0.3-win-x64.exe",
+          "hash": "7aa39c24f01d6ea13f2623a742ed6799ef29a01fbc79f9294aebfc1ed9bf13777da023594456642b278b2a92c67f392264daddfbda60e121104cdbb50ed6cc89"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/420ca01f-4528-43c0-893b-321ed0f9087a/c340930ab3e48da2abe868244415c846/dotnet-runtime-8.0.3-win-x64.zip",
+          "hash": "b1408b34fa96c0ff197154651910c16ce76bcc3fa042aac2243f46758fb48593a24726e3fc4ccbff608970038b3ab6635a0881ffe083149c1d1ffbb1a2470699"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c8d7a77c-5647-4e38-9ed8-edf82328497d/56130e071ac13c3660b0f3a0d60914c7/dotnet-runtime-8.0.3-win-x86.exe",
+          "hash": "fb9100cdb4d3c697a0ed3d77ad23fc28e0ced3a0fd541148c0ca9caeee504ecbb97bc440da237097d48cc03699ce4a29cb89fec3951f826b3013037a0f17dbc1"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/de7b59bd-9b75-4cc3-9fa9-e0226a491a6d/66a8866da41f8ca1485455778b0d8279/dotnet-runtime-8.0.3-win-x86.zip",
+          "hash": "cecf20386c9c3e3ebd00fddaa3421d52fa71eb7081ae4f61be8f881b453839fa89015f0d7ca403225236dc45a17af36c0f74ff1e29a88d09ab91c74b44081e4f"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.203",
+      "version-display": "8.0.203",
+      "runtime-version": "8.0.3",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/61815861-c922-4462-a937-f6929747f0c2/7280600442a58ce080cd3d1494eca08f/dotnet-sdk-8.0.203-linux-arm.tar.gz",
+          "hash": "ebebd4f3be6e9772f23d313b991950d6997716fc0f9c079414a72a0f998c55a32ea19f145ea1b1724fea527ca12a7cbea7afefa60a520679a20b99f68f184e15"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/aed2eece-af6d-42e6-8683-21e7835b7479/786b4f225591440a741c1702407fb7b3/dotnet-sdk-8.0.203-linux-arm64.tar.gz",
+          "hash": "cda16b2141c1115ec42303d82f2720ddf5368b7242207e21d3fdd81fa89df2676f0d394ca7293c76c35ed2448b289174739771ec447404ad9c84c72459cc0d81"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ba2d9653-c260-43f3-b99e-e09b66981cf9/697856da1aad004061b2248b78f55372/dotnet-sdk-8.0.203-linux-musl-arm.tar.gz",
+          "hash": "4ae716cac29a5381dc6341b2e5214f57c7b82928a0a756a2b3cef7d8063d52a29a66cea10e3ae03e379ec220a833e479f944dc762b3cc44c255a02bb715b84a5"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dad93260-0167-4aa2-aa6a-bef95fb7b2dc/51819f2e8a5e2e9734f315f7a50e59ae/dotnet-sdk-8.0.203-linux-musl-arm64.tar.gz",
+          "hash": "33cf09807d9280d3f4a860ea7650f73732c7d86d462a06b6e40e7945d0fc8c6e9c5e799059de86939cd0de88d35afb67d1829150b9fc2e5ccdce0d55d9e771f7"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f733297a-2aac-4016-b91b-8820ecd145e6/c89c3f08433123f07f03341870ec16e1/dotnet-sdk-8.0.203-linux-musl-x64.tar.gz",
+          "hash": "d2b6d8b411470c1a856d546dea087285dad7adb3b3fc5335b024d6f9054ac869073742c283158294c7b866dbd58dda4d9fa2a2c245fb4618c44ca5a61ddec7da"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/656a3402-6889-400f-927f-7f956856e58b/93750973d6eedd17c6d963658e7ec214/dotnet-sdk-8.0.203-linux-x64.tar.gz",
+          "hash": "78b1913b54a1a4c9f13cc2864a11540b5fd3bdf4ebb49837483e19c0906a1890f2dfcf173635a1c89714bf735cbcaa01db0f7ae90add5295da69a0638ed5e60e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1951c62f-487d-4002-b3e6-92677e88b8b1/b1ed2348dbe68ac3f499252b7c9017e4/dotnet-sdk-8.0.203-osx-arm64.pkg",
+          "hash": "5f0d6a1b5647edeeb7b61622d7412367f67d2f4664956d2d1266e69c74998098c4d7b8559494580df0bc6556538b04db5fa71f825d16124db8893287b7ba4fa2"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9019f736-bf0c-45c6-8ea1-c2370f7c59f1/e88a79c0abd77fd38de8271b7c06b293/dotnet-sdk-8.0.203-osx-arm64.tar.gz",
+          "hash": "39fdb91136516f070b5f398b46a7503115493f1cc89d9bee7ea7ee4541ec9d69a4d673d87498e578ebb2cc81df8b062d05c4f7c8be80bc2b113cc61df1157c0d"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bcfcba7d-4a1d-4435-95c2-7c4143e01007/68804b02e9a3bcfd6f26b04d01219791/dotnet-sdk-8.0.203-osx-x64.pkg",
+          "hash": "a5d51a665f767869ea020067e150b690e755fae427fea45d548f67282e5fa4e9dc84028c94170b75d67258b7eb1394fcc9d7f6d4b662bbaa1b5c4a203501f019"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/87f31249-1415-4edb-87d5-7f16e63414e9/a1ad58c05a131c618ad458a1564784e4/dotnet-sdk-8.0.203-osx-x64.tar.gz",
+          "hash": "28588e173bcd185a2acaf26f029dc63e238e29027cab0659717549de15ea88c6075fd384b276265b39c4a91f0005dc81417fede62b6f2f81c1a9c5a4a9b0153c"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/77b4dd83-2824-417c-b1ad-24ed40f16af9/a5dce0ac46b86d59e2124380206192f9/dotnet-sdk-8.0.203-win-arm64.exe",
+          "hash": "d80553c6edc49c7cb1aef9ec88edadcbc7a5eea3195868e611851135d302d1a7657999b0a0808dc2ad0d99d630f974b781c836add27b54de9accce06611adfb4"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/11a9c895-540d-4686-a357-835a9d8ad8e1/c06641c9cd8acadd2fb6ddf8a019fb8a/dotnet-sdk-8.0.203-win-arm64.zip",
+          "hash": "1fd966b968ca2ed4882480a2e6fa09cfe89b706cfd4570e845786801f2889e40d3c1463d4753b59fa565074b673b09ea3c9e06d402713b33f4c6fa220f6eb7fa"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9e753d68-7701-4ddf-b358-79d64e776945/2a58564c6d0779a7b443a692c520782f/dotnet-sdk-8.0.203-win-x64.exe",
+          "hash": "f6f5609134d4006a16b96c2ca3be32acf7492bb7db233690204141a95952077018dc5f1503fd4dedf7ec44253a3427373fa21dab778a3b3d3d3d37df90c11228"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/48a48c8c-911f-45f0-ba75-900c093ed7fc/610cf5bc0a3c4a70b4b3b9478c22b03f/dotnet-sdk-8.0.203-win-x64.zip",
+          "hash": "d0f19867f73433b9b30b9dd678ed719163a61defe44db52487e321a3819a55c467073ab98c989fe867f03816411834dc77ba2e939c5ba40f8140b665acf1ce35"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d0a394c0-4752-464e-89d5-eac817741157/cd739061324f85ea2ceb58d4e019e59e/dotnet-sdk-8.0.203-win-x86.exe",
+          "hash": "e923d367c83a48aef4334d03cf4de46f41f8f44aa9636a7509793d38e2968138b03d9f23c4218923580b7870a5f56598709a5ddf1546af2ebc911b0c341fafd8"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5d954b58-6593-4e03-8993-305a072a4a50/ca4895ef8bb22ef6067ae1375197b60d/dotnet-sdk-8.0.203-win-x86.zip",
+          "hash": "fac438db0bfc77a41ee03b1c4cccfa6d6a31830276a0942b209e2d2f55c98f6f12c55f3ff4b295309a65d0bb8abea8256c40fe6cef13de43fbfe2327b7c3c457"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.203",
+        "version-display": "8.0.203",
+        "runtime-version": "8.0.3",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/61815861-c922-4462-a937-f6929747f0c2/7280600442a58ce080cd3d1494eca08f/dotnet-sdk-8.0.203-linux-arm.tar.gz",
+            "hash": "ebebd4f3be6e9772f23d313b991950d6997716fc0f9c079414a72a0f998c55a32ea19f145ea1b1724fea527ca12a7cbea7afefa60a520679a20b99f68f184e15"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aed2eece-af6d-42e6-8683-21e7835b7479/786b4f225591440a741c1702407fb7b3/dotnet-sdk-8.0.203-linux-arm64.tar.gz",
+            "hash": "cda16b2141c1115ec42303d82f2720ddf5368b7242207e21d3fdd81fa89df2676f0d394ca7293c76c35ed2448b289174739771ec447404ad9c84c72459cc0d81"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ba2d9653-c260-43f3-b99e-e09b66981cf9/697856da1aad004061b2248b78f55372/dotnet-sdk-8.0.203-linux-musl-arm.tar.gz",
+            "hash": "4ae716cac29a5381dc6341b2e5214f57c7b82928a0a756a2b3cef7d8063d52a29a66cea10e3ae03e379ec220a833e479f944dc762b3cc44c255a02bb715b84a5"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dad93260-0167-4aa2-aa6a-bef95fb7b2dc/51819f2e8a5e2e9734f315f7a50e59ae/dotnet-sdk-8.0.203-linux-musl-arm64.tar.gz",
+            "hash": "33cf09807d9280d3f4a860ea7650f73732c7d86d462a06b6e40e7945d0fc8c6e9c5e799059de86939cd0de88d35afb67d1829150b9fc2e5ccdce0d55d9e771f7"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f733297a-2aac-4016-b91b-8820ecd145e6/c89c3f08433123f07f03341870ec16e1/dotnet-sdk-8.0.203-linux-musl-x64.tar.gz",
+            "hash": "d2b6d8b411470c1a856d546dea087285dad7adb3b3fc5335b024d6f9054ac869073742c283158294c7b866dbd58dda4d9fa2a2c245fb4618c44ca5a61ddec7da"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/656a3402-6889-400f-927f-7f956856e58b/93750973d6eedd17c6d963658e7ec214/dotnet-sdk-8.0.203-linux-x64.tar.gz",
+            "hash": "78b1913b54a1a4c9f13cc2864a11540b5fd3bdf4ebb49837483e19c0906a1890f2dfcf173635a1c89714bf735cbcaa01db0f7ae90add5295da69a0638ed5e60e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1951c62f-487d-4002-b3e6-92677e88b8b1/b1ed2348dbe68ac3f499252b7c9017e4/dotnet-sdk-8.0.203-osx-arm64.pkg",
+            "hash": "5f0d6a1b5647edeeb7b61622d7412367f67d2f4664956d2d1266e69c74998098c4d7b8559494580df0bc6556538b04db5fa71f825d16124db8893287b7ba4fa2"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9019f736-bf0c-45c6-8ea1-c2370f7c59f1/e88a79c0abd77fd38de8271b7c06b293/dotnet-sdk-8.0.203-osx-arm64.tar.gz",
+            "hash": "39fdb91136516f070b5f398b46a7503115493f1cc89d9bee7ea7ee4541ec9d69a4d673d87498e578ebb2cc81df8b062d05c4f7c8be80bc2b113cc61df1157c0d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bcfcba7d-4a1d-4435-95c2-7c4143e01007/68804b02e9a3bcfd6f26b04d01219791/dotnet-sdk-8.0.203-osx-x64.pkg",
+            "hash": "a5d51a665f767869ea020067e150b690e755fae427fea45d548f67282e5fa4e9dc84028c94170b75d67258b7eb1394fcc9d7f6d4b662bbaa1b5c4a203501f019"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/87f31249-1415-4edb-87d5-7f16e63414e9/a1ad58c05a131c618ad458a1564784e4/dotnet-sdk-8.0.203-osx-x64.tar.gz",
+            "hash": "28588e173bcd185a2acaf26f029dc63e238e29027cab0659717549de15ea88c6075fd384b276265b39c4a91f0005dc81417fede62b6f2f81c1a9c5a4a9b0153c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/77b4dd83-2824-417c-b1ad-24ed40f16af9/a5dce0ac46b86d59e2124380206192f9/dotnet-sdk-8.0.203-win-arm64.exe",
+            "hash": "d80553c6edc49c7cb1aef9ec88edadcbc7a5eea3195868e611851135d302d1a7657999b0a0808dc2ad0d99d630f974b781c836add27b54de9accce06611adfb4"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/11a9c895-540d-4686-a357-835a9d8ad8e1/c06641c9cd8acadd2fb6ddf8a019fb8a/dotnet-sdk-8.0.203-win-arm64.zip",
+            "hash": "1fd966b968ca2ed4882480a2e6fa09cfe89b706cfd4570e845786801f2889e40d3c1463d4753b59fa565074b673b09ea3c9e06d402713b33f4c6fa220f6eb7fa"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9e753d68-7701-4ddf-b358-79d64e776945/2a58564c6d0779a7b443a692c520782f/dotnet-sdk-8.0.203-win-x64.exe",
+            "hash": "f6f5609134d4006a16b96c2ca3be32acf7492bb7db233690204141a95952077018dc5f1503fd4dedf7ec44253a3427373fa21dab778a3b3d3d3d37df90c11228"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/48a48c8c-911f-45f0-ba75-900c093ed7fc/610cf5bc0a3c4a70b4b3b9478c22b03f/dotnet-sdk-8.0.203-win-x64.zip",
+            "hash": "d0f19867f73433b9b30b9dd678ed719163a61defe44db52487e321a3819a55c467073ab98c989fe867f03816411834dc77ba2e939c5ba40f8140b665acf1ce35"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d0a394c0-4752-464e-89d5-eac817741157/cd739061324f85ea2ceb58d4e019e59e/dotnet-sdk-8.0.203-win-x86.exe",
+            "hash": "e923d367c83a48aef4334d03cf4de46f41f8f44aa9636a7509793d38e2968138b03d9f23c4218923580b7870a5f56598709a5ddf1546af2ebc911b0c341fafd8"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d954b58-6593-4e03-8993-305a072a4a50/ca4895ef8bb22ef6067ae1375197b60d/dotnet-sdk-8.0.203-win-x86.zip",
+            "hash": "fac438db0bfc77a41ee03b1c4cccfa6d6a31830276a0942b209e2d2f55c98f6f12c55f3ff4b295309a65d0bb8abea8256c40fe6cef13de43fbfe2327b7c3c457"
+          }
+        ]
+      },
+      {
+        "version": "8.0.202",
+        "version-display": "8.0.202",
+        "runtime-version": "8.0.3",
+        "vs-version": "17.9.3",
+        "vs-support": "Visual Studio 2022 (v17.9)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ff14287d-75cb-44cd-a581-d6132204848b/2a124effe81c79bd9e116be96ce33b23/dotnet-sdk-8.0.202-linux-arm.tar.gz",
+            "hash": "8cc8be3cad5c3e12ea8293e7b2e2d66647ff01fcf1d390791350a55e13f4c5e74a673dac85918e878b25f61eda690da5c7af7c2d289d6f4d0277476b43366961"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d0a8cedc-978a-408c-a9d2-07d22b45b5dd/1b985478744a545465c0af18cff40a92/dotnet-sdk-8.0.202-linux-arm64.tar.gz",
+            "hash": "83ba9a467487de49bb38d388010c3f0d51336e6167cf3e116e56cd18b0ffd3d52099f8567bc434ce02430beef38dee20ff1e4ceb71a6d7967fc0e1c2da12ebae"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6e4e49ac-d1de-409c-a1be-12713b1c0df4/cc1d9b80d2c7a8d742ceba69beffe623/dotnet-sdk-8.0.202-linux-musl-arm.tar.gz",
+            "hash": "7c96bad8f5cef25b499ace592536b85b264d66e5da15850b314035995ac6a157507e2744ff8207ea9db99cede9ea9773994a1319d488e8ec26a0f9edf7ea10a4"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7b3a5036-3c38-40af-ad38-e1936051ae32/069ce2295a75cc698b6475ba21396e38/dotnet-sdk-8.0.202-linux-musl-arm64.tar.gz",
+            "hash": "f5d1f025d18062247e7c392903c012b5e7f625609cff19d9eac81755065fc468a1d66b0396492258257bf42a88a07e40a040d0cb296bed620d326f58e2cd69cd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50073b70-82d3-4929-8d85-db176b930953/fe3ea3464258e296778cf27cbd520ce9/dotnet-sdk-8.0.202-linux-musl-x64.tar.gz",
+            "hash": "809d8e488723e7be053cf572222b0d81ea7dd10a5034617f044bd0c752f6eaa14034c2d13f093a06d64af6b5b5cc65efb5d9fbb9de8edd00d215cc8e9f26a587"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/14e4bb95-1b59-441e-87b9-58e9feb93426/b61087ddece464f4dc1a3d4e0f31aab3/dotnet-sdk-8.0.202-linux-x64.tar.gz",
+            "hash": "e0e790c7cc6f8129913317d326c599ff8e8ed4927d4e0adccbe55c50be5c353fe3d83043e529973ced2b302b8432c2ab31533b94ffe9c363eaa9964a7160643a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4f1f4135-d42a-4ede-9838-85672f82f08c/fffd37265287676bb7b745f4531d8607/dotnet-sdk-8.0.202-osx-arm64.pkg",
+            "hash": "a350e88e410acb63ec6d963389db430a476ce4eb6636354d22760aec58a945876494eaed525726963c6695b105c85955a185fc52e1d95aba67273601aa3b1014"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0b9cbb0b-0db0-4c8a-997d-aa85b883da5e/40699a42290e517061d38529c3e17359/dotnet-sdk-8.0.202-osx-arm64.tar.gz",
+            "hash": "cb140f98fee85802db2540b0a97bf5ffd3bdc871f4d88bd36d7c66491c9961da43bc08162dc43bfb8ef942f0d19dc70f1c92b22b55d1bead2fc757faab6d423d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/15530a86-8714-4828-a934-8058c3673e1a/738ed9cd4f6eaf7367c9bda26999652e/dotnet-sdk-8.0.202-osx-x64.pkg",
+            "hash": "91f9b2476d8633a29469f44c1862419760f5bf0679ad391a89dc14a6308826ba0cb404bff9c1df2a4e34f1d6a825b5a43589249a50282cae697d247224e7ef4c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b04586c5-24bf-40cf-ab29-60f508b9bc24/9f34421826fcfc9b7d4e785b1efdb99b/dotnet-sdk-8.0.202-osx-x64.tar.gz",
+            "hash": "0682ef3fa7f31f49c85e8e31313e957cd51b5175e7857f25462a7ab5efbd53debda21963aab17fbcd100addc9deaedb0b43d7ff62ad157370ddf1307cb82346b"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b9338ab2-1488-4770-a952-0d5a65c5def8/5c7249d5431d4cf3d91e9ca9b57c5e48/dotnet-sdk-8.0.202-win-arm64.exe",
+            "hash": "a4657930d06a1b02bec7b50544ba1de557d8c29cd5093648487ae7cf0c207b534f5d3a66d487084ed40975f60b630365e49174e5017d72185ca3c981e7e454d4"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/90ada9cb-1200-4fe7-9679-1ca78139017c/6608ba3bd280fc84e9f9e3c7f18a9c33/dotnet-sdk-8.0.202-win-arm64.zip",
+            "hash": "ffd8f797352abee1239dd788186ef5dcead73238aa4f6830a85e685d48b418840c12f5c018e4f1b42ab4fb93fbff9d511604d20933e88a57e292e09210b8c339"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f71e824f-ceab-444f-bd41-7a3852cb9d8a/f9227b2b0c3111777f349d9200592fbd/dotnet-sdk-8.0.202-win-x64.exe",
+            "hash": "2a9fdc8b7559757eb5eccc1d0e3fe3832f744071aa6d49508c8b62c7ac79bdecba7d3c4ebffbfbbe08ab262183516e8bcfa4236d77a3aff56f210dc223a43326"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5eaf9f28-b8a9-4fa4-a8cd-8feeb6d35b39/65c5410d191c9e7f561b94744c15e70d/dotnet-sdk-8.0.202-win-x64.zip",
+            "hash": "826db1c5c0d70cc53f12421af3e0fbe2ee682629f979c9db5ddeef3b53e945e013b20919e4abf791c096a2426c90717647f761bdd82e00505eedb6d94e0b75c3"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e619b4bf-5f5a-4e95-8f98-f46962592c88/f5538efb5bca899cda6718c237dd0988/dotnet-sdk-8.0.202-win-x86.exe",
+            "hash": "934fcfb4b4f01222bf126085db1bccaa1aee956bb3d745f72703a90787845d91d6f8a20a50b3326a5d342eb407d83b3abf183b0fe3e79870264c9474584589c0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d1cc5284-31ef-4aa8-adae-8a696eb57a09/d9a171bd3d227be64c6dd7d07d548a59/dotnet-sdk-8.0.202-win-x86.zip",
+            "hash": "440e7868dbbaf9f61c70389b33a95a4bbc9583afc1ea48bfde7baa3d08cdc885282800819ab50562528a78812cf89efad2fa3baa0a7e327741ac6f6349b41249"
+          }
+        ]
+      },
+      {
+        "version": "8.0.103",
+        "version-display": "8.0.103",
+        "runtime-version": "8.0.3",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0287480b-ba05-43a4-9728-9101c83ac343/82d0e6d6112f856eff9197decb9e6a7d/dotnet-sdk-8.0.103-linux-arm.tar.gz",
+            "hash": "67c45000d1a044266787cb144bd5b0afe92ce20348dfe1f72ab277cebc4fe5b44d107872904f0d11b3c622b6d0969a1c4f23ab8223fa2431cb9cb284bddc0af6"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af9ecab6-0ee9-4256-8470-1dc4530f637e/084a6690b85f806c06764846e3d9fb39/dotnet-sdk-8.0.103-linux-arm64.tar.gz",
+            "hash": "486c6dfd0c37771422fddaec155950663e79bf2afca085ffde68e2af20e42bcac1bcbf0d95dcc0df9469e643a7f81813ab828afa114d5f715057d2a3895e531b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4e21866f-c747-4a3c-bdca-c2e0d40e71d4/2769c7cac664dcb1d8aa75c9fee12160/dotnet-sdk-8.0.103-linux-musl-arm.tar.gz",
+            "hash": "83cef7d126034034331baca68d96b5fe892940ac80f9dc4451252cc74f3d281c67d1422f8d767759a566e1ff386c2cecc86f4e32b62c5928ec603d1919b7e058"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/41e324f7-aaa0-4800-86a2-71d6759e94e2/26d29d35035430e864c6d6d696ef6ed3/dotnet-sdk-8.0.103-linux-musl-arm64.tar.gz",
+            "hash": "3c83259178a053d1b12dfd296dac8981fce30f773e7dc59062bfc0491e76d2537d85419a890ba3658bfd70554e0591270bc920995de2959397e6446e801c4956"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/525bc9cd-20a7-46a8-abce-a5daca9692a3/ec695563f08de008546a0e82e6559372/dotnet-sdk-8.0.103-linux-musl-x64.tar.gz",
+            "hash": "4792107d445e8b9c8480f3771f0c4697a119586c55d05a8814e4ee97459bad8042f649a1719a37c7772f6707bae70e33477112d7b7ebb035c04866b6635e1dd8"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9e445c62-e14b-4a06-8913-ff19d8e7de50/39a40667f110cd352de02f7e7eeb4c6d/dotnet-sdk-8.0.103-linux-x64.tar.gz",
+            "hash": "5894942d53ff9acaacde589e6a761bd170f06b696cac465b2dc62b741bf9d9a635721ef4e7fe9477c52ff22feabc928bd8cbcd167a9ea92a6bf6a362c8b63daf"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/17c7f58d-d691-40b1-8d74-89d998fca6f9/6bd18e9d8b44be442b902ce887c56ad8/dotnet-sdk-8.0.103-osx-arm64.pkg",
+            "hash": "12ab8409b74038d5a79118343dcea926e428ee687d556693d8adfba9b684a1f39ac286c2bc822d66c5b78ec3a76ebd98f7ee255c1e3bb7517a6f0e03566584d0"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5218a7b6-0e8c-419f-9ea3-5115a194b954/02c7cc5c3bc4ff89c14893ecc299f05e/dotnet-sdk-8.0.103-osx-arm64.tar.gz",
+            "hash": "cdfe17109e0b55777e2ed95e9a538bed67ca532edb0e56eb1c52cbb53eec73959141a9f744c1c1a6c5f9e2863d2f845296b65afa94c726c1a7b3274bda869a65"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c2537ad4-4e31-4680-a215-b9858a679e35/c0d7c46595918a497cd3f2b1fc9e04d3/dotnet-sdk-8.0.103-osx-x64.pkg",
+            "hash": "852b7fad83d68a5abf2f8aeed1ad04092ac628a326810b44e7f2f6ee6b78da99e945d206499858e19f0abdadb91d7b78277be4bf709ddd0a77a3c3abcf1de006"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/89e38f58-5392-442e-b5d8-9c495d6710a6/5368de8a490982fe1cb191f76f6e9f62/dotnet-sdk-8.0.103-osx-x64.tar.gz",
+            "hash": "86174aee177e039751a5dbd019ed95e4cb56389c9725902c513e5f50fbf2d89cdcb113173a8f9de9bab844c70e1986b3bc3acf8f22402e09473af413df657a3c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/69a48c74-43ba-4673-a357-820db2fb8b38/483d5faeaf19e0a959e071bb2b478b4d/dotnet-sdk-8.0.103-win-arm64.exe",
+            "hash": "b5ccc5ad27f315721610c2c554a889cc7b08d0b4949d2d1f9e9495c286e82301d33a894de0b202f626a22f43bdcc7f2f3dd4e1a8cfa051539f6dd2abe795e775"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3debfa19-46e3-4820-8825-498a5f61f754/a0cc7a2bcd8a2d2ea041ea120694ce6d/dotnet-sdk-8.0.103-win-arm64.zip",
+            "hash": "82f2041c1dabdd738eefbb013111548b5d91d883d447095d9cc5e64a8822b1da2dfd6e329eeb69b4710c085ca66cbeba5e89de7760b17b13dbef76f5e3a43a7c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e3b4c8e9-ce7d-489a-8c43-0d56075ff787/cac44fac319833054974fa8a1123678d/dotnet-sdk-8.0.103-win-x64.exe",
+            "hash": "471a8193a83a507aae3df439039ce6d126906e077cc1c57a265f47c6b8439544e1c4b7e9515f0fad0eb2bba96a909d03f41976ad4cbf98dcbfea311d553a7ead"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1fb63fe2-c723-47a7-96c5-c14c0b0d4c3d/b231288bfa701ea8cabb245113b0036f/dotnet-sdk-8.0.103-win-x64.zip",
+            "hash": "02a344f1bb73a46a9f1f1c8579c1e3de005f0890920d6425edc59b8e250f1612b089584307af0a16beb660be7c252e05ab1cfdf773959574e0e2094dbde277fd"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6be0770a-1990-4c24-b593-6583542d63a6/75b3e22a96c4951039ea00bad523162b/dotnet-sdk-8.0.103-win-x86.exe",
+            "hash": "489aed32490f869127b71fa157ddb39639f353bb53d082629247e57bfdc351c9b6060a4d0f6ac30eb0ad332e278fb34e03c35b2e9fc075eb6fce6e4eb9e62997"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38bf61fa-787a-4a06-964b-9b6636a0939a/64fe9c5a6e6d7f10003ade08d3e8f211/dotnet-sdk-8.0.103-win-x86.zip",
+            "hash": "403b9cc516656ff736a897772a39b9606b90f54eead64ad7542aa31d90ba44a1f6da7a4ad5a189740353469fc7e71dfa107168c6ffc0a544c654333ba10e8908"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.3",
+      "version-display": "8.0.3",
+      "version-aspnetcoremodule": [
+        "18.0.24047.3"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/16463b95-fb59-4769-86ed-d57012b2da25/d7f5df1e4b840ebc8d001d01b8cfdad5/aspnetcore-runtime-8.0.3-linux-arm.tar.gz",
+          "hash": "a7853f77615d37151fd59dfd4916fc7794bc4d83b0cbced85b857f501dcd883ec681b303e8d2fac438e06a9e90f4cee9f68aede64d59b033d2f08144839a04af"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9feb7c60-3821-433f-994d-c6861b341d3b/5b90405a9978455b10ce6f1fc058fc1a/aspnetcore-runtime-8.0.3-linux-arm64.tar.gz",
+          "hash": "2ddf440be273febae8049df9b2837fe9b9d95d43a31898b915dbf39aedaf15a291ff28711e983fe099ab22a291ad244813256d57ebb6ef1fb94f04d712a96435"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9ac25bad-92be-493e-b21c-95210d6db3ce/ce350da31037d6adda3836fe01881200/aspnetcore-runtime-8.0.3-linux-musl-arm.tar.gz",
+          "hash": "f3e55caaec7edd9afdea587a8e6f00fbb62d3491cee23fae415d4bb3e7c4aa4b8257ec24f56baca8a1319a9a2072880aaba0fcce6125a1645058eb3ea9aafc38"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a4b5054e-8f86-4e8e-9651-c08218204718/7db506957e22a45007491efe607f8bb2/aspnetcore-runtime-8.0.3-linux-musl-arm64.tar.gz",
+          "hash": "6a658818999428ab40616cec032bb58d0fd04567d255d84bef6b1d57fde4186b0e2e0633c45ad229cb9a2c2e7cc30b6980fd9eaaf464cdd73ccc38d35247a469"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2db04bdc-48e6-42e7-a002-392742513cba/9b62b6516f8908f918c5de57732bcea3/aspnetcore-runtime-8.0.3-linux-musl-x64.tar.gz",
+          "hash": "438ed9f5fef9cc63bae18f52af4209a80d8265ef6f9c7b92661e5276538b76163a79e6c59f5fe3d40133e8cdbed7ba50135ce365194358f4abe9df9231a124a5"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c1371dc2-eed2-47be-9af3-ae060dbe3c7d/bd509e0a87629764ed47608466d183e6/aspnetcore-runtime-8.0.3-linux-x64.tar.gz",
+          "hash": "73a16e08402989f25ca780acc981c2ae3a41ef39b4bb6b6b4962053144b6eda7c175fdd5ee3c25bcd0c86a27d1a83d4f8b9b2f69f37d4e3972f5901a9e0600b6"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/794f6ac7-83e4-4af7-9150-7722bf51b5ed/fb380221e5933bc50e5266ddae54e083/aspnetcore-runtime-8.0.3-osx-arm64.tar.gz",
+          "hash": "06fddde704006f92eb3be4bfc95efb9971d54c24038dd739a78ebc2af2e71ca97202350211b53f82f23a4e3ca37ae89d23fb56bf64b5d58d404e7a153c17ded1"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bb76b58a-59e9-4652-b457-ca7ce7f124d4/1afc9b4da60ab79bd103caa9516b8259/aspnetcore-runtime-8.0.3-osx-x64.tar.gz",
+          "hash": "b9c4ecddbaa20aa707e7fd817895823d42211fc34b44146a2a994cbee1837ea0a2d3d5d5a84318039de0a0ed51af3249d11b2b31904e54b86114bceb05b31f0b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a5cc1bef-f350-4935-964d-7646f6b6a1ec/1a628279b86db34d77d94c76b0b2edad/aspnetcore-runtime-8.0.3-win-arm64.zip",
+          "hash": "b247ea3eda27fd3f8d0b4b10507dc415d4aa30de8f370cb57e1fd66d2dd8c456c145339baef57e81716e32580e073952d4fb34426780fa3bb642e98db8d31654"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e91876a9-1760-42cb-a6f4-97c57e9cca52/b433fcf4768929539f17e1908cb315bf/aspnetcore-runtime-8.0.3-win-x64.exe",
+          "hash": "ced75c39c5a2147525eebfd0977f6e7d774b7ea31d377937a6237dcf8b3f75c1b12b9b5137afcb1d1705bcafd9432ac0a60cb2f65fc1753d52d6eac080d0869e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/086d1dd6-57a5-437a-a1ef-549cf702fb48/dd4a8fe6c53a1016a414d6f2925c1323/aspnetcore-runtime-8.0.3-win-x64.zip",
+          "hash": "b5ca9e2c03a57f52ff6de957eb5e933da8d2eb946039d81ed439211c803fcc451b8e9822c3305e3d5caa05bcd77885c538768be0d0b1625291115856a3a100b3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6e92e2d6-32bb-4ff7-9424-78cd278076e8/7b23ff0e6bb04586ad90a0289b31d8d5/aspnetcore-runtime-8.0.3-win-x86.exe",
+          "hash": "16f0226043d4ce4a47538f495cd77363273c7286b1be518b6b32ad0e2ca3cbe268b4cfb3fb43ed4a9d3a9176b1986a399fbaed7f6c432149f2d16c67105449d4"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e1efd12b-9598-4b70-ad83-496563ae3f7c/da67696e4232886f52d50bb8ecda5ab1/aspnetcore-runtime-8.0.3-win-x86.zip",
+          "hash": "a85e76f85acd6c7cfe3007eb30042b1eeffecef947f9627c29ba78dbfe9466ca4151047b57e0ce718a62f03785c74fbffb46b245dbc40fabe17b6ca695e4dc64"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d051a9af-a43d-40ca-9215-7ef492d0b0b1/c4723cb6e5e24b40b5b8f70ab04d2ae3/aspnetcore-runtime-composite-8.0.3-linux-arm.tar.gz",
+          "hash": "b71d040c9e7ab63df4e7b3c6d2396ea270a3cc3698676cee9c60cb869a355c013ec96830d2cd1315668d97fdc565d63015e024e1a377052f6fe12d5c9fb8c13e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c05b3de1-d870-4278-847f-9fa0137876af/2f4f5a83ffafed78ce15aa1a3ffeef8c/aspnetcore-runtime-composite-8.0.3-linux-arm64.tar.gz",
+          "hash": "e2903e3da3164d4e3d4e2f5d8202d537d79e852f382d07cd3c69cb478bdc9fcde70a482ad25002b2fba2645a2eeaa6317ca4facaacf6f49c9a0e25af41e2f740"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/31c7c16a-cd4a-414e-96bb-6d3adcd111ce/3167aafc5a23e700cf51424cb070bee6/aspnetcore-runtime-composite-8.0.3-linux-musl-arm.tar.gz",
+          "hash": "ccb308ec8f68ef4935f9141589f59047065802bdbcec2ca8d92b0a87c8c5138639200b71d0eac15c1edb6ee99fea408b84c1d9e61798184bff5d832f5bb4f9f2"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d798189f-6d2a-479e-9708-54a3f8de331e/8bdb69c35c8de95de0bf740f18e224a2/aspnetcore-runtime-composite-8.0.3-linux-musl-arm64.tar.gz",
+          "hash": "5e59fc334b82502153f24a82d03bd424d370f9a4362b745716ccd5a4741d853b284448f33730bdc55f7f04acd9942372a4781540b95316a90ce67c51ddb63449"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/899fa9d0-6101-4501-9370-5747d89429e1/d547ff7de190cb1cb966607c142a2432/aspnetcore-runtime-composite-8.0.3-linux-musl-x64.tar.gz",
+          "hash": "0b581d81d16b9ca9064bf784515ce392403a8eb9b092e488686f33eeaae17be9d1dc5ffd543cb1fdf566a123fef1f71dfa8e8c67eb8ee144a25aa4a75f6813a2"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c6a46d32-ccef-4c2b-aa3e-333402eb9a07/99f0e14e6170923d519117e625fa7ba8/aspnetcore-runtime-composite-8.0.3-linux-x64.tar.gz",
+          "hash": "d80104dc94afd909d424718702bdabf6d575cd24c4b6f68b83d55f6727c1c06ce5ca40a22bd7f3e7172dbea4ecaf501e44823db25cd8bc55e86768a854bd7b1a"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/20598243-c38f-4538-b2aa-af33bc232f80/ea9b2ca232f59a6fdc84b7a31da88464/dotnet-hosting-8.0.3-win.exe",
+          "hash": "3fcc362d95527207f249716bc459ae4dc1ac169cc43e1cadc35ced56df1b90c755f27988861b9a2a079e435b02cb316653ea8eb54a666d34b96c54f4fac028eb",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.3",
+      "version-display": "8.0.3",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bd4bf739-106e-44af-9f0d-a6a777976512/e9f077b8cb33b574df2f5cf986acddd8/windowsdesktop-runtime-8.0.3-win-arm64.exe",
+          "hash": "97e5ad8ae1e6418476a8f972f5c1365aeda826e2cf883ee145a5c3a9090a747e6e53a1388d1962aeafbe35f779b3e970b1be02e625b4445d1b41af4b4400cc62"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8952a411-3d5a-48ee-bd24-6c8da21ad889/87a87f3a8f0ecaaa1c4c875e77b66a17/windowsdesktop-runtime-8.0.3-win-arm64.zip",
+          "hash": "5c0c483d941cad946683c2a901bd03f91802f7fb176876aa626dd5a14666e9a28c81946908fdf843105c632b4589fb98d04ec54fb6c03fba8570ac8b01d50eed"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/51bc18ac-0594-412d-bd63-18ece4c91ac4/90b47b97c3bfe40a833791b166697e67/windowsdesktop-runtime-8.0.3-win-x64.exe",
+          "hash": "f4cf0300eb4e1750b75a9d973db2d100cd8fb244ef0c7bc5ab448dcc72091055c516d7fe6ea41215bdccec13fc08c5b3c444400c74b214af7f996e5780275f08"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7b548de8-aa07-498f-8fa0-0cd0e6c1f114/b6b66ec9ba495b71332bebe337905174/windowsdesktop-runtime-8.0.3-win-x64.zip",
+          "hash": "6ae793f57dc5c250399daa20c944e67d58b2348e3818f2f2ed2d78d665f6771b81d10aaf069d28867c1c8d14ac73df6d42ea884c981286458f0be29bbe384fc7"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c629f243-5125-4751-a5ff-e78fa45646b1/85777e3e3f58f863d884fd4b8a1453f2/windowsdesktop-runtime-8.0.3-win-x86.exe",
+          "hash": "b9b14552661f35b173c1539ffb422f31b13926dcd0d7aeba5283a467288f4db288f6afeede2fe3e57ed7d3ef3847dba7bd2725b8791396a0633dd14d957b1d34"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6d278466-4714-4aef-b809-3f084c40640c/f593db8727573a64e19e843a8e33dab4/windowsdesktop-runtime-8.0.3-win-x86.zip",
+          "hash": "186c83e41ea4859a612ff86bc2dc995722cdcbe04cd48343a7fe4b39927ad4f7852bfdcd468161f34da92943f20cba80ffccf9884aa7a14b7bfbdba26801bcf5"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.4/release.json
+++ b/release-notes/8.0/8.0.4/release.json
@@ -1,0 +1,620 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-04-09",
+  "release-version": "8.0.4",
+  "security": true,
+  "release": {
+    "release-date": "2024-04-09",
+    "release-version": "8.0.4",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-21409",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21409"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.4/8.0.4.md",
+    "runtime": {
+      "version": "8.0.4",
+      "version-display": "8.0.4",
+      "vs-version": "17.8.9, 17.9.6",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a299eeb3-a9c8-42d4-a0ff-61713365c715/0f4d4139df6c700efd4c0d172c2c28eb/dotnet-runtime-8.0.4-linux-arm.tar.gz",
+          "hash": "4194840a6f1235808d1f1f4ff42046b6f11584c64fca65eb54b65c4dd924400679ae9e1f20efe582dda958f1838c5c125eb72da1d2fdcdd8628dcc20c35c6b88"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/761b252b-a0d9-41cd-b1ec-2dc33159c11c/b8285cf82db4ef340a191bfba9a9a73e/dotnet-runtime-8.0.4-linux-arm64.tar.gz",
+          "hash": "d11ce8867dc91d9e9b333753cc7b9677204898485d044dfbbfabe5c5eee43091580a11c3029fca4138cfa9576f84e23fc11bcffa44fcaf5c3d8e617a3cd18802"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1183b580-9664-4b23-924a-2db7cf57bdf2/70ae3e474bd338de7175d4c547f800ed/dotnet-runtime-8.0.4-linux-musl-arm.tar.gz",
+          "hash": "bec8b40e30e57a2f761b61d0c1e20202d17b54b1530a592ba0ed6039637aaa1a52e0cca85b0e107d9102cbcbe381b9350f7ad8ec5ad69f194b24eecbeac472ce"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3f8aecf-493f-4a7f-a1b4-a1cd5ac961ba/fd2efde18a0e0049d89a421b10912bf2/dotnet-runtime-8.0.4-linux-musl-arm64.tar.gz",
+          "hash": "335eb00e0b7aaace00bccc199a4bc5b632a9d2b5d8ed5f3db20343e85d897ae06b3302082c05d1f55cfb9688c2a626774fd7bc90527e757e35f7cb455fec31bf"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8e6b2e18-2bd6-46f0-a1b2-6b8ce1ec8a2d/17bedef454de7096b9d9d562a161813b/dotnet-runtime-8.0.4-linux-musl-x64.tar.gz",
+          "hash": "a2a4b3baf7f6477f44b88af6b83aa44bbfa2ab9c5b333826153ee956e95b4fd07cff3f95cd0eebf03cffec042576a2a554597753beb0ce0f99d06227a755abaf"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3ca3d31-f45b-4e53-ab4d-0f2f221cbc5b/47382078b4b72a66387d0fd6ed9ff963/dotnet-runtime-8.0.4-linux-x64.tar.gz",
+          "hash": "5c23889d3e6effa85d46c0e1969ce876c686723ae47bddf2cf9c0b1d99affde3f60c04063c2467027aa4163e9a981ef601250a7e8d14ddc6b365c89b24029c80"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8d8977c0-499c-405a-b687-00e7bca8c783/66057685d4fbdfe80b7b9dd96a47b45a/dotnet-runtime-8.0.4-osx-arm64.pkg",
+          "hash": "6bf136185186a90b6a578ce077b5be3985b177e6af93da901d4e0f5f15d7b648e3d4da5a6559b3149fd96057550475e7651357e714c55b7f1b28665c06c9b591"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d2cd56cc-5a78-460d-a45d-3893b020949d/8cf9653a23c91ac2b10c70f58edae60e/dotnet-runtime-8.0.4-osx-arm64.tar.gz",
+          "hash": "7aa4ea587348984ca959945a9e52bade7cb9cbcb8c5a32dbcdf0836d2da4148ca68fcf9815b0b274964b5164c9266b1891afc9406c1c7337642f09300efd7649"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f3f1c85-67aa-4b3e-b4d2-951b9f8468ad/d6b7b5f7c5cea4f72417a4738da3d941/dotnet-runtime-8.0.4-osx-x64.pkg",
+          "hash": "095c013f513e2c8423fe330e62d29e8a1eba690cb66fd27299159c7298fcc683cf551c332bc0d7bcbb7170095512fccf04c16c9d4a900733066ecdf1123d9ed5"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c999e42b-38c9-4d9a-9816-9a0ebece8afe/8e4471db5aa0756d812af23817b14259/dotnet-runtime-8.0.4-osx-x64.tar.gz",
+          "hash": "bb303991154582e1aee0b4850bec2ed92b5c4253bed08d76da0c9687c90c46c9ddddd7ffb9050fb7a4d8db6be6e8cd552156589679a3a169341a167952d76407"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9986b68-9a34-4499-a0b7-845819d6889d/2c62b88fcebbbf7b58339cc0e73b55a5/dotnet-runtime-8.0.4-win-arm64.exe",
+          "hash": "8235b142422f14cbef7cd2da28ffa7aa34df6810475e529e1a0697a927febca62a3087e9ac7f7a8a46bc2264e9c08b4554918adcb4dffd439b06f3b05b70f472"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d1eb519-88ac-434c-9fe4-59a189472c36/f8e3720e44fa35d9ce50f6f0db76b5fd/dotnet-runtime-8.0.4-win-arm64.zip",
+          "hash": "dea648e8bf546c45dbb905d0b873c6fbb4fec4f4ffe45be8285e7da4a95474ca13d6f02e448e5fcf38b780453862785835471cb4e21b210d3fb57fd7908b4f30"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4e4fef83-93d2-4bff-bc74-2c1b0623fbfb/f40b7f2752c23bd0a1046a2a8ed887c5/dotnet-runtime-8.0.4-win-x64.exe",
+          "hash": "726435a95141b6c0b96461f6dddee5980677be359027bf9fae87fe4671d33edb528b08e25440573af3ba3591535ef19fc55ca12321bd03ec2f1ba7e824d5190d"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1ed8f8a2-7bb8-41cd-b256-63e0e7102742/d0c4851d34ddd0abf041188553a3acae/dotnet-runtime-8.0.4-win-x64.zip",
+          "hash": "1eec71f0a3f1e48c6393498c914b9b12d89fbf6916a0611e82c9a43cf897957fc19cd4671361bd9d2c771645908e84f47aba2e831e9673e7bdd5a39e09f37c9e"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f846c59a-2d35-4609-aabf-eee9b1ea6758/2ccf71babeb0853c9de947dc57aec29f/dotnet-runtime-8.0.4-win-x86.exe",
+          "hash": "befd27f851d6008ed4ea694d8a12c74f693ff434d34c29fe6b57a69f0af6ef6c95c134aca3d956ba77fb83f0c69c5ff140c4ca4bba43927d837513c4a26b8a5e"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2f00ad36-c625-4e11-b6e1-d91eef43488e/b6ec44780ed852fa498d4c4b7a43cf73/dotnet-runtime-8.0.4-win-x86.zip",
+          "hash": "e6767785bbabb7a58a002afd78d6d3356f65124fdc0122672062e92c106379d7560dd21b93e836018b52862b8dde4b85d2c84cccafdd32fd71da5252b1cd87c8"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.204",
+      "version-display": "8.0.204",
+      "runtime-version": "8.0.4",
+      "vs-version": "17.9.6",
+      "vs-support": "Visual Studio 2022 (v17.9)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ac99d114-0422-475c-b75b-8279ff9f9a68/19efacb0358aaf945f0a8ad62a8ca718/dotnet-sdk-8.0.204-linux-arm.tar.gz",
+          "hash": "45230c8f180209c3b8315a3d9825eaa55d1b1dd2c9b427d038890b17987f9ccf4288f4661263862c4a19231a7657562ee09595d7e09799e38d22138f03c49047"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1e449990-2934-47ee-97fb-b78f0e587c98/1c92c33593932f7a86efa5aff18960ed/dotnet-sdk-8.0.204-linux-arm64.tar.gz",
+          "hash": "7000b559efe502e9a799e9fccb6bccc2e39eb21331d6cb2be54f389e357436b84f5ccbcc73245df647749ee32d27f7fb8b7737d449312f0db7dd3409f8e12443"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/67254d85-fcab-415e-be63-15d3a3b26f4b/a593418de05aedaf8278c6c5b9371682/dotnet-sdk-8.0.204-linux-musl-arm.tar.gz",
+          "hash": "49ec1d93764da0e726e691365b22545e935b96633175e5cbcc64d57f26c5ac13afdb8b668b7b481e85d31d841c8fc0850266f78589674d7a1d288001a57beaab"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/71f8cf17-ced9-4800-8653-7c6df11cec74/e79328b80df0976e4bb28a23e8ebc7c6/dotnet-sdk-8.0.204-linux-musl-arm64.tar.gz",
+          "hash": "07655fcb66f4d2c636efdc6605b20b44f64fec6682fae1a4a83ce9cfc1e3c81a7443a715ff0f46aaac25a0b61d12fc4da3d1fe46d6f74c0e93260f649dccf05e"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/890ae69d-17fc-4679-9101-dca1b58a06ff/33d81629d3f650b6b04eb2af137699ca/dotnet-sdk-8.0.204-linux-musl-x64.tar.gz",
+          "hash": "fc2f10626e5496aace5363af5d722ee71ae33d1856d76b90b0f4adf4f8898d53aa92cfc6efc765e52b2a0d092eb8e4c2ff15c691f82d7f449bec1fbd407e22a0"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0a1b3cbd-b4af-4d0d-9ed7-0054f0e200b4/4bcc533c66379caaa91770236667aacb/dotnet-sdk-8.0.204-linux-x64.tar.gz",
+          "hash": "b45d3e3bc039d50764bfbe393b26cc929d93b22d69da74af6d35d4038ebcbc2f8410b047cdd0425c954d245e2594755c9f293c09f1ded3c97d33aebfaf878b5f"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a1b04e7e-464d-45f6-ac93-f8901c46c247/7acd4fa3f321aaec4598a1492cc745c6/dotnet-sdk-8.0.204-osx-arm64.pkg",
+          "hash": "edcc44bba3e816b53122128bf73480017381edffc6d510fddc9ce98612c915e8b12b9977d7efd8affc0ea023a1caed0506d9dec0313428180a673325401cd60e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8746698c-596d-406e-b672-49a53d77eea7/74c28673e54213d058eec2c9151714cc/dotnet-sdk-8.0.204-osx-arm64.tar.gz",
+          "hash": "db06baa1d076549e393a9a402c03e81834e15641d2b5fdbd5beb7c4a55b5ed979f5e58ac6baa2048bc55a3a7b3aabe0e3c518310c66a17ecd107b7bf0aaaf2b0"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7bcf1329-6691-45e9-8fdd-96c65bcabd1f/cb618d2620974fc029e4f758eb267452/dotnet-sdk-8.0.204-osx-x64.pkg",
+          "hash": "c3c14809db4836bcc3c649bae78d8e9c94d6d9412c5b280cfdbcf3b6bd5c7f4d97a743e3af7d2f328aefd8ccc3bca2f0bd62f770aa7f0825f4f9482de26f2e32"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9548c95b-8495-4b69-b6f0-1fdebdbbf9ff/30827786409718c5a9604711661da3b5/dotnet-sdk-8.0.204-osx-x64.tar.gz",
+          "hash": "a49c3dc8f364dcf2f88353b80267062b557ef4afff333fa4494e84d01234d38c57619aaf7a3e2cacfb16d066ab1523b6e5953cf864e5e8f411dd38855408bb5d"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/89f6f8f5-c353-4436-aa33-47450e4938df/065cbcf0b8a2df03f2d6487d31cc365c/dotnet-sdk-8.0.204-win-arm64.exe",
+          "hash": "7c5acad71138a17462ed0941f09612d5d55d8ebbdaae41f73a390b59581305c8605cb6eee7819961c80ff311d90d714b4df79fd37e8fbd0fd8408a712514739f"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9e0eb19-33ac-42b2-a4e7-e6e0be232e9e/50a3f2722ca4e5e571a1d3843670abc1/dotnet-sdk-8.0.204-win-arm64.zip",
+          "hash": "cc6afd273a05954906109fba32d3a00804d788d7b7f21d1ce22784699001c434204ab44cf74b6dcd20f5bc9d20f39ad5087123c7af6bdf4a71fd5786807cf7b9"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1e9f5038-d1c3-4219-94e9-62d6f810e589/c28bb8c8a1a3d01c72f3db1646a983c5/dotnet-sdk-8.0.204-win-x64.exe",
+          "hash": "9c3bf9c027131a3ad9f66667c609b19e8846af795fa5a88558b49c6d6011d571aa1faea76f7b6a2dc5f5eb30d9ab5db7a4a9bea2348642b23c9968a4b73f3c11"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bf435b42-3f28-45db-a666-6e95c4faefe7/23e0b703124347b51f53faf64c829287/dotnet-sdk-8.0.204-win-x64.zip",
+          "hash": "17ee61b1addbf9d66455f95f1dc0988c34047928c072d02005eed283db8e64fc6a4e9f04ff1474e152af866c62fd8d51093abe587a6e2d177556d513a6bf4ce3"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ec1e77e-07d3-43b6-a688-847507046206/d83ec453d53a308d9f614de81b152594/dotnet-sdk-8.0.204-win-x86.exe",
+          "hash": "642cd8f5b171882cae3a019b4c3b25dbe9530ebabc7a673c55c2d989e27db480d76774aa2661b766fe2dec1298a0acc5ca7fa7d73c7d17131183cbac05ac08cd"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/149f911f-3448-438a-9d2f-8a18ad46757e/a0c233915e9a8451bdd4b75e6650954b/dotnet-sdk-8.0.204-win-x86.zip",
+          "hash": "e90502a3b383375735bd14741d626a94c92f798378cc7d0c38fa7c19ecfe6c4d487e7d6292b8f55ed2d91b62624ae2556cbecdd0ca7a176cd7509ff9ba426006"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.204",
+        "version-display": "8.0.204",
+        "runtime-version": "8.0.4",
+        "vs-version": "17.9.6",
+        "vs-support": "Visual Studio 2022 (v17.9)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ac99d114-0422-475c-b75b-8279ff9f9a68/19efacb0358aaf945f0a8ad62a8ca718/dotnet-sdk-8.0.204-linux-arm.tar.gz",
+            "hash": "45230c8f180209c3b8315a3d9825eaa55d1b1dd2c9b427d038890b17987f9ccf4288f4661263862c4a19231a7657562ee09595d7e09799e38d22138f03c49047"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1e449990-2934-47ee-97fb-b78f0e587c98/1c92c33593932f7a86efa5aff18960ed/dotnet-sdk-8.0.204-linux-arm64.tar.gz",
+            "hash": "7000b559efe502e9a799e9fccb6bccc2e39eb21331d6cb2be54f389e357436b84f5ccbcc73245df647749ee32d27f7fb8b7737d449312f0db7dd3409f8e12443"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/67254d85-fcab-415e-be63-15d3a3b26f4b/a593418de05aedaf8278c6c5b9371682/dotnet-sdk-8.0.204-linux-musl-arm.tar.gz",
+            "hash": "49ec1d93764da0e726e691365b22545e935b96633175e5cbcc64d57f26c5ac13afdb8b668b7b481e85d31d841c8fc0850266f78589674d7a1d288001a57beaab"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/71f8cf17-ced9-4800-8653-7c6df11cec74/e79328b80df0976e4bb28a23e8ebc7c6/dotnet-sdk-8.0.204-linux-musl-arm64.tar.gz",
+            "hash": "07655fcb66f4d2c636efdc6605b20b44f64fec6682fae1a4a83ce9cfc1e3c81a7443a715ff0f46aaac25a0b61d12fc4da3d1fe46d6f74c0e93260f649dccf05e"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/890ae69d-17fc-4679-9101-dca1b58a06ff/33d81629d3f650b6b04eb2af137699ca/dotnet-sdk-8.0.204-linux-musl-x64.tar.gz",
+            "hash": "fc2f10626e5496aace5363af5d722ee71ae33d1856d76b90b0f4adf4f8898d53aa92cfc6efc765e52b2a0d092eb8e4c2ff15c691f82d7f449bec1fbd407e22a0"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0a1b3cbd-b4af-4d0d-9ed7-0054f0e200b4/4bcc533c66379caaa91770236667aacb/dotnet-sdk-8.0.204-linux-x64.tar.gz",
+            "hash": "b45d3e3bc039d50764bfbe393b26cc929d93b22d69da74af6d35d4038ebcbc2f8410b047cdd0425c954d245e2594755c9f293c09f1ded3c97d33aebfaf878b5f"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a1b04e7e-464d-45f6-ac93-f8901c46c247/7acd4fa3f321aaec4598a1492cc745c6/dotnet-sdk-8.0.204-osx-arm64.pkg",
+            "hash": "edcc44bba3e816b53122128bf73480017381edffc6d510fddc9ce98612c915e8b12b9977d7efd8affc0ea023a1caed0506d9dec0313428180a673325401cd60e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8746698c-596d-406e-b672-49a53d77eea7/74c28673e54213d058eec2c9151714cc/dotnet-sdk-8.0.204-osx-arm64.tar.gz",
+            "hash": "db06baa1d076549e393a9a402c03e81834e15641d2b5fdbd5beb7c4a55b5ed979f5e58ac6baa2048bc55a3a7b3aabe0e3c518310c66a17ecd107b7bf0aaaf2b0"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7bcf1329-6691-45e9-8fdd-96c65bcabd1f/cb618d2620974fc029e4f758eb267452/dotnet-sdk-8.0.204-osx-x64.pkg",
+            "hash": "c3c14809db4836bcc3c649bae78d8e9c94d6d9412c5b280cfdbcf3b6bd5c7f4d97a743e3af7d2f328aefd8ccc3bca2f0bd62f770aa7f0825f4f9482de26f2e32"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9548c95b-8495-4b69-b6f0-1fdebdbbf9ff/30827786409718c5a9604711661da3b5/dotnet-sdk-8.0.204-osx-x64.tar.gz",
+            "hash": "a49c3dc8f364dcf2f88353b80267062b557ef4afff333fa4494e84d01234d38c57619aaf7a3e2cacfb16d066ab1523b6e5953cf864e5e8f411dd38855408bb5d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/89f6f8f5-c353-4436-aa33-47450e4938df/065cbcf0b8a2df03f2d6487d31cc365c/dotnet-sdk-8.0.204-win-arm64.exe",
+            "hash": "7c5acad71138a17462ed0941f09612d5d55d8ebbdaae41f73a390b59581305c8605cb6eee7819961c80ff311d90d714b4df79fd37e8fbd0fd8408a712514739f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d9e0eb19-33ac-42b2-a4e7-e6e0be232e9e/50a3f2722ca4e5e571a1d3843670abc1/dotnet-sdk-8.0.204-win-arm64.zip",
+            "hash": "cc6afd273a05954906109fba32d3a00804d788d7b7f21d1ce22784699001c434204ab44cf74b6dcd20f5bc9d20f39ad5087123c7af6bdf4a71fd5786807cf7b9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1e9f5038-d1c3-4219-94e9-62d6f810e589/c28bb8c8a1a3d01c72f3db1646a983c5/dotnet-sdk-8.0.204-win-x64.exe",
+            "hash": "9c3bf9c027131a3ad9f66667c609b19e8846af795fa5a88558b49c6d6011d571aa1faea76f7b6a2dc5f5eb30d9ab5db7a4a9bea2348642b23c9968a4b73f3c11"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf435b42-3f28-45db-a666-6e95c4faefe7/23e0b703124347b51f53faf64c829287/dotnet-sdk-8.0.204-win-x64.zip",
+            "hash": "17ee61b1addbf9d66455f95f1dc0988c34047928c072d02005eed283db8e64fc6a4e9f04ff1474e152af866c62fd8d51093abe587a6e2d177556d513a6bf4ce3"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ec1e77e-07d3-43b6-a688-847507046206/d83ec453d53a308d9f614de81b152594/dotnet-sdk-8.0.204-win-x86.exe",
+            "hash": "642cd8f5b171882cae3a019b4c3b25dbe9530ebabc7a673c55c2d989e27db480d76774aa2661b766fe2dec1298a0acc5ca7fa7d73c7d17131183cbac05ac08cd"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/149f911f-3448-438a-9d2f-8a18ad46757e/a0c233915e9a8451bdd4b75e6650954b/dotnet-sdk-8.0.204-win-x86.zip",
+            "hash": "e90502a3b383375735bd14741d626a94c92f798378cc7d0c38fa7c19ecfe6c4d487e7d6292b8f55ed2d91b62624ae2556cbecdd0ca7a176cd7509ff9ba426006"
+          }
+        ]
+      },
+      {
+        "version": "8.0.104",
+        "version-display": "8.0.104",
+        "runtime-version": "8.0.4",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/59ddc40a-8417-4312-8c5a-6f1788cbc708/664b648f68632d86eec5df02b775d406/dotnet-sdk-8.0.104-linux-arm.tar.gz",
+            "hash": "da01189ad5db3af839034cfb245ef4d68e37e45a1e87288b314fc3a4bbcaaa569d463298a527dab20fd4b15afd5c35bab8ffae1f97e021d4b5e939af628e0d7c"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/92652bc8-b312-4f77-ad95-cbbcbc9330ed/549869e13f1bf66b0b089b4e976e96ea/dotnet-sdk-8.0.104-linux-arm64.tar.gz",
+            "hash": "71f5fb65c88bfd14ebc13c5eec04d08b4f7461d1b9f3f5f08c31351a377e08cd002072a4487bfc2496ac7b4d5ba83c97eb979a5732de394c1a02a4528877002f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/401ce788-a055-42b0-a63b-c5b6a2c92aa3/6a93ddda20494500f56eba95e5ffa34e/dotnet-sdk-8.0.104-linux-musl-arm.tar.gz",
+            "hash": "6ad3749e824180fa3232a3e89cbf82ee622a3099872210e5ed029ae4a9c9207b515fd62aa4f6ddd8190df7cb63933f45afac2d0f1b913599c4b158846078c3c7"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/534afd02-2ba5-4e83-940e-804b3132f07a/f58e6ff016030bd73d150df418653fd1/dotnet-sdk-8.0.104-linux-musl-arm64.tar.gz",
+            "hash": "ec9cb0c1c5e6637c5eddfbcc54974022a00a4ce16553199200f6ff708594b3803753602297d29788222e15a3460deb57ab8a9fe9572524591943aef9b399f996"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aaebb75e-d846-4aef-a231-b7993eef8e7b/3b94635d3561008dc5eddd8482d54d06/dotnet-sdk-8.0.104-linux-musl-x64.tar.gz",
+            "hash": "8be015e2f18f96838729cd98aa14fd220b8433f23654eaa50cfafd3fb6402137f0586cded12abee8a2d8b1da017c366ab4a2711e5a4d2a6056b272df3aecc0b9"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fd4a16ac-5322-4308-b6b0-afa1821e63f6/0abd2e63358335f2235d22fd84b32a60/dotnet-sdk-8.0.104-linux-x64.tar.gz",
+            "hash": "cb7b5e509c16a7e27ccfc03b3a217460b9eac151ca973f262f82d4b4a494f7bdff3229e9aee91df1c110582ee8dd3d310dad39528c3bd292c5d9b7746ba3b6fd"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fb5d1740-0c86-44f4-86b8-c8e23c833ba4/153c6ae30dc522c8d6509c1472d8932e/dotnet-sdk-8.0.104-osx-arm64.pkg",
+            "hash": "08d944e429afa7c58d1a79220eb21adede96abc6f8d93212826ce1b7b5481ba92bf8cc3fff514623ec2c1fc2d3c42e130a1443df3f5429df45c6bd7cd9317a1a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/73d8ccae-9bcf-42e4-9a57-b6a4480eea2b/52e136f08e967c6ea9617be542921286/dotnet-sdk-8.0.104-osx-arm64.tar.gz",
+            "hash": "376fda994997e3ebbf15cafbc910ff25a71debd2d31d088cf7947f813ff013568f3f47514ec53d2c02a3e3f8432a5ca9344dab3ee07cc0df650761a3dbc6be68"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3514082e-8352-4783-aae3-950466b5a1c8/4fce1a8e70d6a5621df345bc5e10a460/dotnet-sdk-8.0.104-osx-x64.pkg",
+            "hash": "63bb40e9ad2e7f2ebf292ebab7248bc3649a28e30423ebb853db08aafc550573e9374049cfc1691da359e426d3c85f757a98d977a386fe3a5bd25cfb56095279"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5f790cbf-88b3-4619-b083-178e1eb6c16f/ab21721125a05ec751b22d689e19a353/dotnet-sdk-8.0.104-osx-x64.tar.gz",
+            "hash": "b451731c7fe151316df57d1e6a23129732ebc0dc3dd53479421b881652bd042d5fb9890c2c8e229fc578b3b05542a8e08986955154e590d8c1e274c5821a5666"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3f3292b-e649-43d4-a41e-cf35c3cbfca6/dc5359440c3ec5a97fa45344b2332293/dotnet-sdk-8.0.104-win-arm64.exe",
+            "hash": "8eae336c6bd731882f0828a6e916a042494740d710de400be230d3b57516eedc747ea17dd7ed8d785f5fd34207b9df2bca92c78e859bcb23d0fac038dfd2e61f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5287966b-72c2-4ecd-a2a5-25b98ae31f41/4031c20cec94d8434e01874357257c0c/dotnet-sdk-8.0.104-win-arm64.zip",
+            "hash": "e5f6c1d1224824ce9ff5acc128f4025154ab982021ef15dd2db9868314290d183fb1ab67c2b0431bc54465cfac3a3cc0fb65932905fe52414abfa941f44fd199"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1a47378d-52a4-4438-a229-7b359ca7963a/4ac438d361fbbfbd32bae7b1770f0f68/dotnet-sdk-8.0.104-win-x64.exe",
+            "hash": "4486ab02c5d4236fe0646e6b912a5dd53b4a0f05006826e534239c2c84f774c5dad1d08b70b88151dfb06a26bd5991bd68214debde061a6a68a68e0ed90a55f0"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6298a6cf-c784-45ce-a18e-fa206907640d/d496e0fd2f59ebdb99a0645afdaeadf7/dotnet-sdk-8.0.104-win-x64.zip",
+            "hash": "c49378267586d1982682fa89d89afaf9253a674e5dfd58e76b40fc98fe5a3c43570dfa60f8415f587d0b8ba69e3533239ea59a771fe8e81617c6b8229679c0ff"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2d0d0c17-cc24-4e9a-a101-0767d142c14f/cab1a83fbda1a56fdd82ffb7f4923120/dotnet-sdk-8.0.104-win-x86.exe",
+            "hash": "1df0685b3472498cd0b5401c100214cac2a928ce19e995a4eec03dd3fd8d85e36c6c550e5ffa490cce319817d89cc43a2fccba1873f63521d21bd573a0f0ddd9"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8ffd4ce4-a4a4-40e6-b83f-0847ba443896/9f27f0847303c2dcc28b5230b7aa9256/dotnet-sdk-8.0.104-win-x86.zip",
+            "hash": "8114344b79fd1887da1e9ec39da0c52ce968293989aa3c1264f0445525a55fcebed53126b8624f8a73115590eadf35ebe443a858b227c84cef59d3b0a9d7d074"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.4",
+      "version-display": "8.0.4",
+      "version-aspnetcoremodule": [
+        "18.0.24080.4"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f12a9449-04ba-454c-bc35-4cdb426accf6/2729a371b61d59794845eb309a46fba2/aspnetcore-runtime-8.0.4-linux-arm.tar.gz",
+          "hash": "f9fb78800e47e72498472decb7dc32bf3a22ed4b8b4706e381c86f17d70492d80e2946c4c28e6138aff3b9e9eaeffb6d78a0a856723580d0497abc0e2b4f7e28"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/80ec12e5-b26f-466c-a20c-f96772ea709d/606e7203912400b44cb35d6fcecf60bf/aspnetcore-runtime-8.0.4-linux-arm64.tar.gz",
+          "hash": "0b0b3dffe678211afcaeca5d7e381f2218f156421c79dd06e083b1abd92ceb2b5c04c8a159b7d67b866393b8169de826ede70240226e0164451b329b7d46b570"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d8e22573-ac17-4c4e-a35c-a9ca66777d91/bada3ddd0479a64045bf60988e8c7121/aspnetcore-runtime-8.0.4-linux-musl-arm.tar.gz",
+          "hash": "1da42d9a05a5580efd7f4bf32c9b5aa8095131100531dce577074c919099963f14175c921a35131ef8f197fb5fed7970566cc7b9931f1e355bab8e2ccf3d24ee"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/06714f53-d614-4a83-91e6-322f664796cb/5204a9f835636e9a08100ac3ec2e2f4e/aspnetcore-runtime-8.0.4-linux-musl-arm64.tar.gz",
+          "hash": "841e42b4779cba9ebb1d480adb4b18a80f136866979dd3f7afeb6a4e1e1f739caa48dbff661c33417902cf87aec49abb4988fb18f64dde0802d53362feb6ab1d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a588c4ae-771c-43ba-aede-1526a871a653/e2c5d22a837be58c2190547924768db3/aspnetcore-runtime-8.0.4-linux-musl-x64.tar.gz",
+          "hash": "5aed6acd57b212806a24467dc6a432c664d675fbba97433bd4e49cdc836eb7b97be3663308ba24222cca51a59da0fd4771fedb5aee109720386201b60138711d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0b0bc7f4-c6e5-4cec-a7ed-45c2fac0da4b/ae2090564274152b5a4be9f1e66c5d30/aspnetcore-runtime-8.0.4-linux-x64.tar.gz",
+          "hash": "8ab281977116bf59a672afe5463bce4433378cc8a67d332c564a012939b7dbdd8756df82a115a5ab93f8186c22700a6dc0272b99a0f484db837da96820c78e79"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/172cfd62-a126-4375-9a48-84cfbcf1b718/959ce27a010020f0e5d393578574bca9/aspnetcore-runtime-8.0.4-osx-arm64.tar.gz",
+          "hash": "15e8a7535e0b4d2deeccec32e6373cc2d79fe1156c2490ec263790723c5f660c03a61978826d825a427ebbad02cd0eef12a14e11cb8fcd9744c5ce2ef7176011"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8edd447c-bd4a-4677-ba33-8bdac6088dc8/a17a23a5d47642eb050288dea0322350/aspnetcore-runtime-8.0.4-osx-x64.tar.gz",
+          "hash": "544257738cd7265a6c3c99e83f331c20c631ee8064e47bd925e37191627223e2f39f19a025360de1f95915bde1a26eede757bea4ffbd115309d186d81d7d6b61"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3d040214-d952-4261-add3-d83badf84a05/dc1c628b30226f5bc89d9784f581f571/aspnetcore-runtime-8.0.4-win-arm64.zip",
+          "hash": "fa5b9a34ae3696b36ef68428b2347c18036f02972b94a5f888a57a99599eca0078e4ddc0f4b59356bf609620e47506c035d8c49d87c7b799594aacb31cf2bfa2"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eb04a61f-75c3-43dd-93d9-b6a7248116c7/f884863125730a39d7fa4139a00c0f99/aspnetcore-runtime-8.0.4-win-x64.exe",
+          "hash": "03759701074daa8815fda2a4893a29a9a8fe3532e7500b5351d6eea29ab89b2f50f31dc9b1c2de858cb117c69c8aab152a8568b73c63d074364391f2545712eb"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e9a37988-8a48-4b17-8392-0ee82ab325e4/3939e85b1668f2861d15ff098841349b/aspnetcore-runtime-8.0.4-win-x64.zip",
+          "hash": "a15fb7c1c7bb1247bb49f4477dfea7e53a168ed624b5a770616165bb22b11727fdad2bbb9448fe6418eddc427da4c56669aea9798bd9e1c6ff95d084010aa44d"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b53d938e-3ae2-4c22-8341-689a1c80fb95/84c2b40ac532dc2f9e6d8d1a680d3aaf/aspnetcore-runtime-8.0.4-win-x86.exe",
+          "hash": "b911dad38fd3437f0d639ee3b06f47c393b9a8f7c7dfb6592a11d32343a5157742892365b5bcc09d2c5c6c5b49551b411aa61108555b83a37ff2cd0a0db42404"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/98b91803-42ed-4f3c-893b-11f4f8e7de1f/2b5738505423f855472e0f1838a6956f/aspnetcore-runtime-8.0.4-win-x86.zip",
+          "hash": "f3625d6f61bf644337ae9006238c753bcdd90fefdc537830d5da0d7f39109beca70273ed78b22312942428ef8c13fcc9458ae970e9071fb45d1e07f985f2cbb4"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2f33b8a2-8ea0-456d-8733-26b36348e6ad/739d0e7e5079ac7e7b6b3a62373a12bf/aspnetcore-runtime-composite-8.0.4-linux-arm.tar.gz",
+          "hash": "ae75bbea80db5252ee7d469dad58c76cc4890a0ad159b0231cf5666fc30334479d4418483a7699971cc461ce0d0db5df171e5c53f291305057874a6f0f59eb09"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5aacfdfb-c4f0-4ebe-8459-7e2ab6ffb302/3a16c6ebd0d83d2346eedb3c77f6fcf1/aspnetcore-runtime-composite-8.0.4-linux-arm64.tar.gz",
+          "hash": "3e890c440579db198815cfc4a517f2084417147861c081e5d42670d1f61f83e8aad8b5488e2c84a11cbc67ed9c80582a2371befd53fa3b9b8c3d785bda08c33c"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d6f9f3c6-3e7b-431d-97ee-d30bf79d82ad/954d0497b602433bcf78d5ca0c733dd3/aspnetcore-runtime-composite-8.0.4-linux-musl-arm.tar.gz",
+          "hash": "5da3c453d7da72ea6482e0b9fe01037c293f3b3dc67ed2289856aded9b653795911ef47ea4fee8ab152e42326049e6cc5313e31cf3349b9e5f6f3b09c4ac2dcb"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fae3b6d1-8fc0-40d1-9751-bdaba52621a5/8d6622b0fea76911e4b891f8737a787e/aspnetcore-runtime-composite-8.0.4-linux-musl-arm64.tar.gz",
+          "hash": "fe67e2f4b045df2651deb4ec4984c140d20f12bbc3dea3760e74f45b96bc613a866daaa0784017196339112c6332f1c7dbed472eeab586d78c4b1311b6269c05"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ae505a55-142f-4462-bda2-3d3aa16379c3/daac7bf1dcab2e0ea83a3cbf9dd113ec/aspnetcore-runtime-composite-8.0.4-linux-musl-x64.tar.gz",
+          "hash": "d7c33772ac805e42ec0f9c90c0f5bbaf26942be1a318fec9ec5532fb73c98f13bfc42b63f9db5d1bbff8fdb0cd802170629709aeb8499856d40e4adebb8f712f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2ac9532d-ff0b-4323-84eb-ee9e39d37d0b/2903d6caf4b7002c4a715cea231e19ca/aspnetcore-runtime-composite-8.0.4-linux-x64.tar.gz",
+          "hash": "f77d90648c115f95760c0432611dde62c8cfe32241b82d21a030a57466ef1d89808be9ae7bb8f045278a7a05ada26c596b15980fd3a5f3aef17b4334705f7c5a"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/00397fee-1bd9-44ef-899b-4504b26e6e96/ab9c73409659f3238d33faee304a8b7c/dotnet-hosting-8.0.4-win.exe",
+          "hash": "2ae357f0d8e43c316874455ca56adee4d88081bf828721038527760d860beb3b510eca748aa18ebfc9509cd289b51e84156da388853d644cff308b539b04355c",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.4",
+      "version-display": "8.0.4",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/01520b8c-dbf8-4818-89c6-128d5d6d2140/efbc62901cd9543f57b697d2a72eb1a0/windowsdesktop-runtime-8.0.4-win-arm64.exe",
+          "hash": "88a4cc58dbef71a767d6cd0acb8e418f5a49cbcda43b16743db5621de4494dea3cd7bada712c12acdfe555dde7cbe8bec9928db30e6d09f44843c884a275eeb7"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/aae0a632-e442-4341-8143-7817df88afea/e1fcb8a968848820d815075d7ec177a1/windowsdesktop-runtime-8.0.4-win-arm64.zip",
+          "hash": "0cb2fd99ed33e94a570fa0987fd6547b46148bb4db6cc5f12f2a94713f0540f384cffb122bd960d693d9901a3c2000f5bc51354f190967bc14b480c779fa282e"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c1d08a81-6e65-4065-b606-ed1127a954d3/14fe55b8a73ebba2b05432b162ab3aa8/windowsdesktop-runtime-8.0.4-win-x64.exe",
+          "hash": "8a0b1ab3a774c33f46cd042783cf785c33f2d9e0bdeee4ff8bf96cfa90a2101a5711231840ef93eab101409e7f3f3770d86e1a55bd52709af08d1a6c908cc194"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7a74986d-61bf-41b5-8e94-4be88688b56a/371136c10ff4a8838d81e7910cdbad4f/windowsdesktop-runtime-8.0.4-win-x64.zip",
+          "hash": "53edc5cbabab50340fc915b112afe7c25739fcb19b333cdd48339d38f4814cbd2b86dc996e2cce8fc9ab917cb9f8019e5e81f752a435cdccdc45a512332bb1e0"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1fbf5c5f-9770-402d-8971-83da662d8cf9/4e37b3c24bcb6004875b9f8b08024303/windowsdesktop-runtime-8.0.4-win-x86.exe",
+          "hash": "edeee99d70e776e21f84af1e6c63690f43fa5c89d4ac2e3de4e376eede0c8b2aedea8b7c890e1b8e1136d44c8f4a103be68c972b3d6a771b88d4f3adda75e1b5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/454f117c-637f-4509-946f-250a99e07008/1db9424f1c44c1cf6bc20f3129cb1e51/windowsdesktop-runtime-8.0.4-win-x86.zip",
+          "hash": "921b24897cffea3ed1c2a828f32efd957117c555fd893c10f697743166bceeb71544acb71839a02e0df41bdbf8edcd891670602f970422aca604cccdc4409d52"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.5/release.json
+++ b/release-notes/8.0/8.0.5/release.json
@@ -1,0 +1,732 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-05-14",
+  "release-version": "8.0.5",
+  "security": true,
+  "release": {
+    "release-date": "2024-05-14",
+    "release-version": "8.0.5",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-30045",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-30045"
+      },
+      {
+        "cve-id": "CVE-2024-30046",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-30046"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.5/8.0.5.md",
+    "runtime": {
+      "version": "8.0.5",
+      "version-display": "8.0.5",
+      "vs-version": "17.8.10, 17.9.7",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b52720a7-9dc4-4b9c-97fa-d1caebdaf946/443750ad6f47c855a395abbd36bb3b3a/dotnet-runtime-8.0.5-linux-arm.tar.gz",
+          "hash": "84d135e0c18da840f8e5555cf6e8b7d57776ceaccb0aaabeb5c75c54b6b78b3844e09cd9f1ee495caddab52e4b80455423200e23c17cb9ce83bc5df7bd99729e"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/00ca4d7a-e529-4384-8ad4-acb8237d540f/a7df4c26e3c0e1dcf8e17d2abb79aad5/dotnet-runtime-8.0.5-linux-arm64.tar.gz",
+          "hash": "cd6c0ac051c3a8b6f3452a5a93600e664e30b9ba14c33948fbbfc21482fe55a8b16268035dd0725c85189d18c83860ea7a7bc96c87d6a4ee6a6083130c5586c3"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b3ee2592-2309-4820-b0cc-1d28d4aafc12/7caaf3c9db6c9fdf36ef9b724b637cd6/dotnet-runtime-8.0.5-linux-musl-arm.tar.gz",
+          "hash": "e0b38b3280a9ed109140776d14be3c8a66b38f66ea266987ab31ef969a0ce79aa2215c83298c24d31bdb2b77016653ec95d3089d81af4a83abb396aa069ab5f8"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cc5d9158-2333-4374-ae66-3af6c8230b10/5a6e467eeb1571256f28c886460bd17a/dotnet-runtime-8.0.5-linux-musl-arm64.tar.gz",
+          "hash": "629a3f018c949454e8b0361bf287b7646887844853819e7af0579730a0ea18b9f293dc687ef19ed085c57f758ed0a61083e9de4cd5741d0dd16dfc905ea5f0dc"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b6dedd67-f57e-4953-8826-914d109ff98a/e0c03409ea2d9835f3390c2c1d171e8a/dotnet-runtime-8.0.5-linux-musl-x64.tar.gz",
+          "hash": "b6c1bc44f068558c26d7a0114147c989f48feb5c43a4dbaf7035825477918e2e20a89b2934b47bfa9518e243147436ce58e6dec666e563c6637c582e00085dd0"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/baeb5da3-4b77-465b-8816-b29f0bc3e1a9/b04b17a2aae79e5f5635a3ceffbd4645/dotnet-runtime-8.0.5-linux-x64.tar.gz",
+          "hash": "3efff49feb2e11cb5ec08dcee4e1e8ad92a4d2516b721a98b55ef2ada231cad0c91fd20b71ab5e340047fc837bd02d143449dd32f4f95288f6f659fa6c790eaa"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e8661f5d-6298-4848-bd34-b3618665d0c4/b259dab85d1283a192200bd814cef7ea/dotnet-runtime-8.0.5-osx-arm64.pkg",
+          "hash": "baefd0f3f7ada4fbd5595d12716bd8cd0c8891e662cabf7106004769fd7dc1af29c9309cea73937b4238e54967d445a46fe78fbdfcd125a69557e10f78aeb319"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fac90ccb-5864-4d4a-a116-67387aaee61e/df82eea80efffad3c9ec8b0522847e68/dotnet-runtime-8.0.5-osx-arm64.tar.gz",
+          "hash": "5401135b8871d85ca6f774958e6a644ef2bf85a88d2358f15c3bdc928b21a700be428efede677d83640085461d000e55a28bfbacdc9f01af0334a6e8b257efbd"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/181bf41c-91a6-451c-aa7c-b709d1ba79b0/cb44db162c74fa57cb91a04c6926de70/dotnet-runtime-8.0.5-osx-x64.pkg",
+          "hash": "9ad36d9c9fa33648a9a07dde66173de59dfb1022d8c1a55ed8dbfc1a0187674f9e01189366f495cb217f06d8d130b3d3b60b79c4b7b93e2204d89bcbe08ec615"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0dabe69f-fa99-4b53-96d1-9f9791bb0b6b/f72acbfd3b0e60528d9494b43bcf21ca/dotnet-runtime-8.0.5-osx-x64.tar.gz",
+          "hash": "29a8be6dd738d634cc33857dc1f1f6cc2c263177d78eb1c4585c96b5bf568f8f2689f1a30eec728ccb96a2d005049936abbfd44daca1962caf4f6d53325ba42f"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/54678360-018e-472b-ad2c-ee0a523aba93/a9bedf02dfc29d11a2c500b682f8338d/dotnet-runtime-8.0.5-win-arm64.exe",
+          "hash": "1f37a83a1e9814da1563dd25b0de6943945c0575936c65d4ad64292dd458558f12e58c38eb29644b9e325f80446c25e5f15e60453edeb67f78e22e88871a9bd3"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3a9c305-7dc9-4cfe-a3ed-e852964ebebc/88f9534996718ed976f5e15c13ddc659/dotnet-runtime-8.0.5-win-arm64.zip",
+          "hash": "cfad855d8b3abc734d0f38a211b2eaea1ebca529915a15143055d682869b3e3ab5ff60e80f0630a10a5ceb5f865898f1186ab4bbcd689a170d044004a76817d8"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/77284554-b8df-4697-9a9e-4c70a8b35f29/6763c16069d1ab8fa2bc506ef0767366/dotnet-runtime-8.0.5-win-x64.exe",
+          "hash": "7bc6e21e4e07fb1b679f38538c28b4c5783570b00ac5f47e162c26abe2fb51193551acbc4f0c44de91359368931a04b7b18c4522a822ed0d3bcfca8b6ae376bb"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/77650902-a341-4f4c-934f-db7056cbfa78/176d961f8bbc798596f8d498ede4cc73/dotnet-runtime-8.0.5-win-x64.zip",
+          "hash": "5eee093b005e9120dfe32261436bbc626b53e535276da9314929f1c5248a72a9d5af3b639ff5545d9265b28a6136f535a0e46758c8717297ae3edb2ee67c88ab"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6baea142-1c35-44d9-a753-d2ff252b2f05/c8d7547c2dba48eb8a196f9210ad417a/dotnet-runtime-8.0.5-win-x86.exe",
+          "hash": "ff727bdb5e8eeb97ff2c20c6b45cfc297b4938937fdca5d0ce783f07e4a389000de86601d7faae1a1443cfdfd3754444c684fb804b526ea8bf6a5a2468224c3f"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2f8a6349-c15b-47d6-a45a-7b59e21edc39/78c224dcc55cc2684f30ccda1f029ee1/dotnet-runtime-8.0.5-win-x86.zip",
+          "hash": "a055e4699dcbb17d91afb6ed3c1c9de898a85d6687e19488f13d42c52784138adcc6f2bb18e12dbb6ebc9858ca54a96e7c99d9472c4449e7a42592488935a4ac"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.300",
+      "version-display": "8.0.300",
+      "runtime-version": "8.0.5",
+      "vs-version": "17.10.0",
+      "vs-support": "Visual Studio 2022 (v17.10)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d915a052-b50b-4305-978c-fbf644e71eed/de3ac6fbebd4db705413aac807aa11fe/dotnet-sdk-8.0.300-linux-arm.tar.gz",
+          "hash": "13fd4818d3cb64dcdbf23748d0e8afcdfb981c1d6f0a8721d41c3794c363dae615612838e0db1050fd8b218ccf8e27a2c97e5a0da61da0d384c008b08c1f066b"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/54e5bb2e-bdd6-496d-8aba-4ed14658ee91/34fd7327eadad7611bded51dcda44c35/dotnet-sdk-8.0.300-linux-arm64.tar.gz",
+          "hash": "b38d34afe6d92f63a0e5b6fc37c88fbb5a1c73fba7d8df41d25432b64b2fbc31017198a02209b3d4343d384bc352834b9ee68306307a3f0fe486591dd2f70efd"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/372c3832-0beb-4d86-b404-818d40bc57a1/2edb3d86bb767b682dc73e2027e842f8/dotnet-sdk-8.0.300-linux-musl-arm.tar.gz",
+          "hash": "768bc41911895272ed8b8629d3ae36ccedb74c9982b94c8bee6575870cdce6bd9ffab26751f48cedd4b3c7921b3fb6d3416364bc4102f61983dd0b18e9aca104"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d14a0fa6-f471-4e69-bc90-20003c3dd4b5/64348ba14e69c04451038daf7782f603/dotnet-sdk-8.0.300-linux-musl-arm64.tar.gz",
+          "hash": "fde1657c8e6be40dd7b140d8253dfb0323826797cdc3ae2217b689598262ac51bee409388f2b21cb499daf0db713ed27034baac92f43c0b529a68c2f8d8ad26d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d5817ef4-da4a-41f0-91dc-afd8436394d1/462bd8eee30ba9fd0fe152cc402bbded/dotnet-sdk-8.0.300-linux-musl-x64.tar.gz",
+          "hash": "87250809f75cbe408ccac9901a213afc54805526a613fbf88fd02a165c56cab5f770730de03d98f6e798e9013e6b98e8b8e31279e251a3c31c2976b89e643fd1"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4a252cd9-d7b7-41bf-a7f0-b2b10b45c068/1aff08f401d0e3980ac29ccba44efb29/dotnet-sdk-8.0.300-linux-x64.tar.gz",
+          "hash": "6ba966801ad3869275469b0f7ee7af0b88b659d018a37b241962335bd95ef6e55cb6741ab77d96a93c68174d30d0c270b48b3cda21b493270b0d6038ee3fe79e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9f854d0d-dbb2-4bd0-a2e9-d46d0d612be8/142646adaedce26ccc67b020b0123f42/dotnet-sdk-8.0.300-osx-arm64.pkg",
+          "hash": "b0e997cdeb9ac320e4ddd57537c4212c89084053544c04db9b18c0aa724260ad6c351b4c4eb3f610667746b6977ac03669df437541bc7c0192a1a2b65781fbfd"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d7af168-9a20-40a3-8744-b2f1c10c0227/3d6d8d16545d6c05125c51ef8142296f/dotnet-sdk-8.0.300-osx-arm64.tar.gz",
+          "hash": "98a9b56b2795bf6faa848062ed34d917b187eda220db50c8e73de1bfa37244dd68d8c3cbc598b5fc5be4620a2b92724f95d7c13299f8b873fdefe880890a1bbb"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7e9bfe4-8277-4b2f-946a-b49c2b910884/0a6c4853f7fec5d641087bf3ffabbd55/dotnet-sdk-8.0.300-osx-x64.pkg",
+          "hash": "c82c24dd16c3b87d88dcb2cdb5a63acbf44273902691b29c997798fdc06e281062d91b4b90b1430e35c88c5fc050cf91d29f69a4f40da43f5993f3b47267119b"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e05a3055-c987-4127-a315-51d6b982fd67/fbda30d8e461b2c5098f3c405378b559/dotnet-sdk-8.0.300-osx-x64.tar.gz",
+          "hash": "12ed6044dad31c65d6894d7e1cf861a6c330c23761fed90ca2fe0c7d2700433fb8b8541c35bb235b044762f5fd33496cd6e92dbd70deeeb7b9e59423d9d49f5e"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e195e4f5-00ee-4df3-8736-199aacf00b2a/1663c4f5dc168d390aa4507f09200423/dotnet-sdk-8.0.300-win-arm64.exe",
+          "hash": "fa4ea87500305183866d27d096c4fa6aa117502f06eae57f963473464887198cb5e5a630f1e0cc55382c48ebc7df93b7d5c94e6180683ef66dfc683174d827ae"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e6b2f6c7-43fd-4c8c-9a7f-5fedb699d8e7/b24f635b4bd15493d0cb148e8372fb5f/dotnet-sdk-8.0.300-win-arm64.zip",
+          "hash": "46a3909a070203a499e924c790fc42cbc6c4faf1b83e327ae746306478fb3b2d9eaae5c6492344803ca55c1858677cb7b16b1c6347847e4f680d0ef18b0b4e16"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/90486d8a-fb5a-41be-bfe4-ad292c06153f/6673965085e00f5b305bbaa0b931cc96/dotnet-sdk-8.0.300-win-x64.exe",
+          "hash": "8f0c9a65095750bd5356871d7fbb123a439e92eb10f4bdb1af894d1e7c3ad087d1bf7706def0bd39cda55f8251f45d245122dd2b19c28fb39e260e9ded735a6c"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6dd60d95-f5ae-414e-8259-b2a115e51714/c56f08471133d789dee9ffa52ddf5c1e/dotnet-sdk-8.0.300-win-x64.zip",
+          "hash": "c287cbd4084d381f715029be2878c2d9a326b47140d3636b1356c01ce28d887550d9629ca4bdb4029d2985955c48a22334bba8e628218e13ec0ae7d0a2c3407b"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9736c2dc-c21d-4df6-8cb7-9365ed5461a9/4c360dc61c7cb6d26b48d2718341c68e/dotnet-sdk-8.0.300-win-x86.exe",
+          "hash": "55bb2077df64c71f06e60512c55a001c2013e05b92d7d93624b888988045638a33639a8b0708a1ae87ed9f17895ccbb87f3fe7bd719c3089f463683c459a3786"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5c682e5b-7ad7-4fca-8c1e-d393b2cd2e13/46a259f7cdfe8fc5e5b626191962c22c/dotnet-sdk-8.0.300-win-x86.zip",
+          "hash": "d9956693e6d583b63fa5bd3f2bd570140c993c1c2ad8475c8e6cd43726fe291fbdb96e0177a7d88f511e4a3b75ca35bc2f531c562755f4b36bb06fc1b6579e68"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.300",
+        "version-display": "8.0.300",
+        "runtime-version": "8.0.5",
+        "vs-version": "17.10.0",
+        "vs-support": "Visual Studio 2022 (v17.10)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d915a052-b50b-4305-978c-fbf644e71eed/de3ac6fbebd4db705413aac807aa11fe/dotnet-sdk-8.0.300-linux-arm.tar.gz",
+            "hash": "13fd4818d3cb64dcdbf23748d0e8afcdfb981c1d6f0a8721d41c3794c363dae615612838e0db1050fd8b218ccf8e27a2c97e5a0da61da0d384c008b08c1f066b"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/54e5bb2e-bdd6-496d-8aba-4ed14658ee91/34fd7327eadad7611bded51dcda44c35/dotnet-sdk-8.0.300-linux-arm64.tar.gz",
+            "hash": "b38d34afe6d92f63a0e5b6fc37c88fbb5a1c73fba7d8df41d25432b64b2fbc31017198a02209b3d4343d384bc352834b9ee68306307a3f0fe486591dd2f70efd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/372c3832-0beb-4d86-b404-818d40bc57a1/2edb3d86bb767b682dc73e2027e842f8/dotnet-sdk-8.0.300-linux-musl-arm.tar.gz",
+            "hash": "768bc41911895272ed8b8629d3ae36ccedb74c9982b94c8bee6575870cdce6bd9ffab26751f48cedd4b3c7921b3fb6d3416364bc4102f61983dd0b18e9aca104"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d14a0fa6-f471-4e69-bc90-20003c3dd4b5/64348ba14e69c04451038daf7782f603/dotnet-sdk-8.0.300-linux-musl-arm64.tar.gz",
+            "hash": "fde1657c8e6be40dd7b140d8253dfb0323826797cdc3ae2217b689598262ac51bee409388f2b21cb499daf0db713ed27034baac92f43c0b529a68c2f8d8ad26d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5817ef4-da4a-41f0-91dc-afd8436394d1/462bd8eee30ba9fd0fe152cc402bbded/dotnet-sdk-8.0.300-linux-musl-x64.tar.gz",
+            "hash": "87250809f75cbe408ccac9901a213afc54805526a613fbf88fd02a165c56cab5f770730de03d98f6e798e9013e6b98e8b8e31279e251a3c31c2976b89e643fd1"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4a252cd9-d7b7-41bf-a7f0-b2b10b45c068/1aff08f401d0e3980ac29ccba44efb29/dotnet-sdk-8.0.300-linux-x64.tar.gz",
+            "hash": "6ba966801ad3869275469b0f7ee7af0b88b659d018a37b241962335bd95ef6e55cb6741ab77d96a93c68174d30d0c270b48b3cda21b493270b0d6038ee3fe79e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9f854d0d-dbb2-4bd0-a2e9-d46d0d612be8/142646adaedce26ccc67b020b0123f42/dotnet-sdk-8.0.300-osx-arm64.pkg",
+            "hash": "b0e997cdeb9ac320e4ddd57537c4212c89084053544c04db9b18c0aa724260ad6c351b4c4eb3f610667746b6977ac03669df437541bc7c0192a1a2b65781fbfd"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4d7af168-9a20-40a3-8744-b2f1c10c0227/3d6d8d16545d6c05125c51ef8142296f/dotnet-sdk-8.0.300-osx-arm64.tar.gz",
+            "hash": "98a9b56b2795bf6faa848062ed34d917b187eda220db50c8e73de1bfa37244dd68d8c3cbc598b5fc5be4620a2b92724f95d7c13299f8b873fdefe880890a1bbb"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e7e9bfe4-8277-4b2f-946a-b49c2b910884/0a6c4853f7fec5d641087bf3ffabbd55/dotnet-sdk-8.0.300-osx-x64.pkg",
+            "hash": "c82c24dd16c3b87d88dcb2cdb5a63acbf44273902691b29c997798fdc06e281062d91b4b90b1430e35c88c5fc050cf91d29f69a4f40da43f5993f3b47267119b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e05a3055-c987-4127-a315-51d6b982fd67/fbda30d8e461b2c5098f3c405378b559/dotnet-sdk-8.0.300-osx-x64.tar.gz",
+            "hash": "12ed6044dad31c65d6894d7e1cf861a6c330c23761fed90ca2fe0c7d2700433fb8b8541c35bb235b044762f5fd33496cd6e92dbd70deeeb7b9e59423d9d49f5e"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e195e4f5-00ee-4df3-8736-199aacf00b2a/1663c4f5dc168d390aa4507f09200423/dotnet-sdk-8.0.300-win-arm64.exe",
+            "hash": "fa4ea87500305183866d27d096c4fa6aa117502f06eae57f963473464887198cb5e5a630f1e0cc55382c48ebc7df93b7d5c94e6180683ef66dfc683174d827ae"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e6b2f6c7-43fd-4c8c-9a7f-5fedb699d8e7/b24f635b4bd15493d0cb148e8372fb5f/dotnet-sdk-8.0.300-win-arm64.zip",
+            "hash": "46a3909a070203a499e924c790fc42cbc6c4faf1b83e327ae746306478fb3b2d9eaae5c6492344803ca55c1858677cb7b16b1c6347847e4f680d0ef18b0b4e16"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/90486d8a-fb5a-41be-bfe4-ad292c06153f/6673965085e00f5b305bbaa0b931cc96/dotnet-sdk-8.0.300-win-x64.exe",
+            "hash": "8f0c9a65095750bd5356871d7fbb123a439e92eb10f4bdb1af894d1e7c3ad087d1bf7706def0bd39cda55f8251f45d245122dd2b19c28fb39e260e9ded735a6c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6dd60d95-f5ae-414e-8259-b2a115e51714/c56f08471133d789dee9ffa52ddf5c1e/dotnet-sdk-8.0.300-win-x64.zip",
+            "hash": "c287cbd4084d381f715029be2878c2d9a326b47140d3636b1356c01ce28d887550d9629ca4bdb4029d2985955c48a22334bba8e628218e13ec0ae7d0a2c3407b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9736c2dc-c21d-4df6-8cb7-9365ed5461a9/4c360dc61c7cb6d26b48d2718341c68e/dotnet-sdk-8.0.300-win-x86.exe",
+            "hash": "55bb2077df64c71f06e60512c55a001c2013e05b92d7d93624b888988045638a33639a8b0708a1ae87ed9f17895ccbb87f3fe7bd719c3089f463683c459a3786"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5c682e5b-7ad7-4fca-8c1e-d393b2cd2e13/46a259f7cdfe8fc5e5b626191962c22c/dotnet-sdk-8.0.300-win-x86.zip",
+            "hash": "d9956693e6d583b63fa5bd3f2bd570140c993c1c2ad8475c8e6cd43726fe291fbdb96e0177a7d88f511e4a3b75ca35bc2f531c562755f4b36bb06fc1b6579e68"
+          }
+        ]
+      },
+      {
+        "version": "8.0.205",
+        "version-display": "8.0.205",
+        "runtime-version": "8.0.5",
+        "vs-version": "17.9.7",
+        "vs-support": "Visual Studio 2022 (v17.9)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/98f9d993-ebab-426f-baed-f2375b7f256d/01651402e598e0df30c28d93a556cf7a/dotnet-sdk-8.0.205-linux-arm.tar.gz",
+            "hash": "6021c246d4b57adfd27b6b56548e27b59af64e35f585612cffc3298ba4a054ef09c6f78c7906bf541c48d2f7d5699025af6c2e77900acccb46fc86833f0704b0"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/96b5cb76-37e3-4514-a8c5-bb4834e275d3/b541205fa6efc3bd223b3201dcb7735c/dotnet-sdk-8.0.205-linux-arm64.tar.gz",
+            "hash": "092ce55cc45ab5109c9d991382e7ed7f40bc0281e94766738dbf179d618f03dbf8ba38e43c418a3d5cac0377afc5e5b82a969e36832e386b851f3679a2e988e3"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/924785d1-f586-425a-b6d9-84d06f4321f8/0430cfb4362fbf99ed0aa757b1c11289/dotnet-sdk-8.0.205-linux-musl-arm.tar.gz",
+            "hash": "75e7ac7aa045f9eac46a969ff1afd2304d043cd7e0f8917118153807e0461dd0989b03bbc5a3d47f92eebce5961b8a8ffa10db8726ae3d40c17996d4338d54e0"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0ad7415f-f55d-45ae-a8e3-9058eb4dd1df/19958b245b4344ab46f597e06e332926/dotnet-sdk-8.0.205-linux-musl-arm64.tar.gz",
+            "hash": "f4c33fc97e14204c54661b64b3339f085fa788b4c65233c5cce1315994b2ade4cde244d3e9968f6d15c27bcda766d1484a691d0303d512e5ad151ac5ea41c0dd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7e1eea84-e4e8-4422-bed3-520cd21f384a/2b62a9f6b4c2dd3a5daa9a2f12bf019b/dotnet-sdk-8.0.205-linux-musl-x64.tar.gz",
+            "hash": "77cdef96aa55ba41a4e254a932f7dc6cf4abff271ae54b2d9b4fcb0ed9e53196380e02b065c0a5ccc5d8e9eccfdc0d208d661e823590130075fbb3785bef7bae"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7cdbcd68-c4e8-4212-b4a2-f30ae2ffdb19/48a359550fd7eab1f03ea18eb2689eb3/dotnet-sdk-8.0.205-linux-x64.tar.gz",
+            "hash": "2ec774350ca3192e1c68c9c8ee62d0c089f9bd03fe1aaebb118fbe7625f2e0960f5dbd800ea3f974cc7ac7fba32830f41faec9ee1bae736497ba05d9c7addb59"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ff40dda0-1f33-4a55-8c87-bba1118fab29/7a69de08506f973e3d9094ba66f9ffbd/dotnet-sdk-8.0.205-osx-arm64.pkg",
+            "hash": "b1bd559fcb39458c921a703961d4f4976ddd28eba5329423590379fdf35d1d54fb354231b8fc704b9febb800288501e615c17f024d7e0aa8b5e6dc92e6641530"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c8126855-4f38-4d01-8e22-b7f93452a9d7/725dda9ebd1ae3486febf496217ba0b9/dotnet-sdk-8.0.205-osx-arm64.tar.gz",
+            "hash": "2792e9b0cd4fd69373022c5e4c17bd128dd8e31db773f51b39c8696f37e72af8c4b67d0c017ee068587c0f664efa8bbd9a0bc4472b072a7897d2ff4ef8fafa58"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8df31795-667d-4ea6-9b21-7af5d7e90a08/2b659ac09ce0fe224c11740ea0ad12ab/dotnet-sdk-8.0.205-osx-x64.pkg",
+            "hash": "09bc19b2a418cb523aa368329ee2656e4c717f106b92fb866d214c054b9c7f29ecb120e25029d826f481e35c560ad0c04f90f88e7273c1eb073eb7480b7bc4be"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0dcb3b2f-6bbe-4dc0-a42a-283826d8b9ce/16767a67d602bd267122a26f4c4c2935/dotnet-sdk-8.0.205-osx-x64.tar.gz",
+            "hash": "15f410ae81027f4537a03a00114873fe9bacf799d5ddc24663fefc3b1d977d237269fef48c80334bcaf7230495f304bb123f310692f880fea8cb8e0072abb4a3"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c2f84613-8730-4492-946d-9b3d98c7d7ec/c1fbd213843933b0df0aba1d764ac8e4/dotnet-sdk-8.0.205-win-arm64.exe",
+            "hash": "7b20ad0671ad7b3368450f8e3732c2d776a88f8e0034a5c7f41d2ee8bcce956eb5479367f785b3ff092bafd30351581c2c14b6619ef1beef3c29a67201fcd0df"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/979e4d60-f823-44ee-b583-59130989b40d/6323b02fcfc7c95ddae022df609b88db/dotnet-sdk-8.0.205-win-arm64.zip",
+            "hash": "6ffd918887328ffd8784fc0500b9ef4c0cd0ed99a277b3fc2e35de32bff375e1468e5b33d8499faa2a7819ae495dac4dd4f31639a165aee987d5bc42f6d020af"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f02cf3ff-1426-4361-b732-fd96f1fe4cce/f5800224ea1fb316b74357775af99e9b/dotnet-sdk-8.0.205-win-x64.exe",
+            "hash": "52e5efe5e461d655e98d0d0de84df8bb7cc483972155425c86a4441f625dca482cca1ff0a50d4654bd9039cfd4a32733278ee3a62c9bf641c899addb0aa2dee1"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/71244948-0e37-4c2a-ae2b-cf8a1ea9cc49/58a7be86691c86ad53e15e6a919b6887/dotnet-sdk-8.0.205-win-x64.zip",
+            "hash": "ef286574b5006ddbf96593fbb907854a3e11d8a899c9852507411be277eaca4ad1cc161b02494f4fbcd2fa67572c89fe5b5d2ac80ca854051c61685a15c32740"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c5a6492e-9594-4b67-9eff-c3386e1f49f8/6bc80ceb2e4d6dbee3e909eae050499e/dotnet-sdk-8.0.205-win-x86.exe",
+            "hash": "ed8b099760c8862adc45a6b3292a0b59f2e71c2287203732f1c49bac7d5348815c10c1c4612575ce6c08e283ed4c07b1e2dea01687775bb30fbd84182caebbf6"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf73577b-7d63-4e22-ab14-c4b1f0bc386d/f5b361f83b4f144d00b83570b6c6cb2d/dotnet-sdk-8.0.205-win-x86.zip",
+            "hash": "65df88641c7731184f3a60bcfcb7c32fd2abec961c099374353fcd6486e6f9852436972c1c88ad21387d28ec690a0161d327b1b3a2f33793b426cc3763c19ad5"
+          }
+        ]
+      },
+      {
+        "version": "8.0.105",
+        "version-display": "8.0.105",
+        "runtime-version": "8.0.5",
+        "vs-version": "17.8.10",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/826d806f-13e0-4df4-90ff-945e56426ea5/50ee1d9c615f5c10426b4b0fa2eeb940/dotnet-sdk-8.0.105-linux-arm.tar.gz",
+            "hash": "6aa5adc487b2f5e887a7c91ea9a6d1f948ea5ca6520e93826610c5ea58827f37421bd0ef09ebc0d9e2d3108dcb41aedb51188630df5e1da199e0ab2ee0d6acf8"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ffadc6b9-6f16-4671-866d-4c150f2888d1/256d5909ff60dae42cbd251347cc14df/dotnet-sdk-8.0.105-linux-arm64.tar.gz",
+            "hash": "8f04afa385676d2ec879ad22734a4c869d931ba4bc7507d0aa5889561d0230e382598057bdf75792048b28bd9a1c8eb187e80691f603309a46d6c50d71373381"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b037c08a-e56a-4405-9b38-a02494d97351/8db77c3d178933b53c6e6f765596b6d6/dotnet-sdk-8.0.105-linux-musl-arm.tar.gz",
+            "hash": "b898fadd8b4a4e6a6ec2c3d936d20729dd03f912123fe7b8a40bbee609839ad019a6501a21712ad4e9b6c93d6a1ce5f8c9227f0fb5387edb08a0a8bea44d3c31"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/98e3b8b2-c105-4fa7-a860-0f4c30b3db24/fc278a7e9771163cb67625ae87e2e044/dotnet-sdk-8.0.105-linux-musl-arm64.tar.gz",
+            "hash": "ea1cbb3fe35447418f552d51a359a4f133754240aeca91fea8e5ed97dcdd9b01a4cbfeb6354ec1a3f71c7fcdf82000c7f9492c42b66fc69caafd023927e6f658"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f379345-cd2f-4008-828a-450b97dc553a/ab9c25bd78793a88d3ccdc180550712f/dotnet-sdk-8.0.105-linux-musl-x64.tar.gz",
+            "hash": "d8a8b2ea25b70139a4ac1356c210221243add6956a946fbc24c7195850624a4f25569e22024188dd718b1ff0fadbf775a6df97f8aa5ec2244159adfd81bb14dc"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e898e5ae-041a-4e64-95c7-751479f40df5/9e36a84d3e1283e1932d7f82f6980cd8/dotnet-sdk-8.0.105-linux-x64.tar.gz",
+            "hash": "60ff271ee7851ff9ab851f9dc3e3d0abc87ac9b982959abfc8f0a3b58301fb6a0ff7b9f07f8df18668e1e8182c688d0d661bb9cb1771a2d40a0015d02009fce8"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/abb91b42-1cae-4593-b65d-197c40d14c64/efa5469ce7a554f911a86c18fe5fa7db/dotnet-sdk-8.0.105-osx-arm64.pkg",
+            "hash": "04b86271a5bb8c949d553a4e76746cb30f4f62969cbedcf77328ceed48eb8df8b74dfa488562ec101dd0d49331b501e925e71eeedcf307966f9df053b6f54608"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8d741dd4-ab83-4bd8-8667-998cc1c6d345/c7ac6cf87561262db36b18e505150e89/dotnet-sdk-8.0.105-osx-arm64.tar.gz",
+            "hash": "f910adb274065fef581728e7d043bc3f0c105a939f659865753c11a0dd0b550bdc4c0bc01e2ce6f710efcdebb3966ef138986113f595af4d6a9be8b15008abc6"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5c40a9b1-cab2-4361-8034-3573cd258f47/db9e692708347b4dd4028e615c1094e3/dotnet-sdk-8.0.105-osx-x64.pkg",
+            "hash": "0e3ab717ad1a9296a8cd3b06dd1de5e619d075ab31e600e2a4366b23cc6fdcda7bcd2244932c8caca106a8f1a74ca698cea62d8f2542df9407c7637bdea38d3d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/54b48c6e-1a50-4dd5-9592-8ae5dfbe9d2f/913341d866eaf3149a6158cabf9ce2ad/dotnet-sdk-8.0.105-osx-x64.tar.gz",
+            "hash": "052fd0783bd0901876a29b57a0f15e9f9cf859373bf4f3867a8f3e00b4edac5f3814b066be81c76d6bc74a20bd696e4ec65db48dc19703bbb4ee56d60aedd96d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3728e709-74f9-46e6-ad79-7653c9d023e9/6195a111f6d7d79f10717fd64a92e498/dotnet-sdk-8.0.105-win-arm64.exe",
+            "hash": "5ee260ed89df931d2b427fe92ed69188b2e484965a66fc4896f6e58837f3e49335cdc9791f689b5233bfa3541643feb101d00892484f0dd0a7ce6e27a35a759e"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b7f700c2-7f32-435e-b074-8ca7f477973b/c2e4db4be3831c918510044188a2fc84/dotnet-sdk-8.0.105-win-arm64.zip",
+            "hash": "b30705d21c474c762d8c6abe3aa12f3af47a21a3531167e8bf2383645c1ef670240f1a7ea145af4732958386995c09476de4390ed604834d402a6af636ab3f9a"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa862cb4-4a66-4be3-a8da-a153194fd869/4e066e305579144e6d1de6e2b22b6445/dotnet-sdk-8.0.105-win-x64.exe",
+            "hash": "30d4a88650c0c970587cdd91d117e3ab92d51a1a05801789b6746c936f3cb395c398b6954f66d21b8c388b8a692e1ac8b72b585d17d54404e26d53a6724fa793"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4aee5b99-46c2-4ffc-ac42-2587b23bd25a/7b37b47493bf1426fae61b144b75230b/dotnet-sdk-8.0.105-win-x64.zip",
+            "hash": "0530a4d3e4eb67252f8bd193a88bf92c9ec2b07ae22574b98d2ef7a51065d411a930a769a66e04a3d3d75421c1d89e78c6a7a825fbd04381b89e3a62e35f2292"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b29ee44d-c389-481c-9f18-42260bce77d6/6df9ce592e0f5ad84e6461149cb82b97/dotnet-sdk-8.0.105-win-x86.exe",
+            "hash": "7a920048ca5d87a22ae6c6d70349e1997aa1f2809295976f59f186a7bb09b4bfc38ff6f6feda3f184a5ff9df88cd8d6257a22367d5acb6988e17ae7b986808d4"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/602378a2-8fb6-4ff9-9b3a-c5135935f928/fe3c7d894ff4310b55a1022b4022e6d8/dotnet-sdk-8.0.105-win-x86.zip",
+            "hash": "315886da57ae01d43a3e4ff4d3f1b5890f1dfe83f537d77753c108d398ee0c663736226b1d93cfa952f4aebe7b6f90bbf41f0a57d7b974dee19e1b21c28d1a4c"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.5",
+      "version-display": "8.0.5",
+      "version-aspnetcoremodule": [
+        "18.0.24115.5"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4a8e69b4-5f79-4b86-b922-5b431ff02736/db7eb177e07a80137aba9abaaf3246be/aspnetcore-runtime-8.0.5-linux-arm.tar.gz",
+          "hash": "f648c58794f217ac6faaaf67c17370658445655827d720335e38762541fec808d79aee0f87d0e27a6d3bb525c5a9ebcd3d94243190e7a5c126489f1840cd5373"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/208a57a8-fcc0-4801-a337-79095304d2af/d1ffa79af24735af4bd748229778c1a9/aspnetcore-runtime-8.0.5-linux-arm64.tar.gz",
+          "hash": "54ad859a3307a4ccce6aa794df20dab3fc38cb4a8fc9f1c2cb41636d6d19fed1e82f88a0099bdc9f30e08c919ae5653da828ae54b0299291dafcc755575f02db"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c5190a93-22f9-4e44-afe9-195409867dae/a688dd1e97b5affb7c97936be330f901/aspnetcore-runtime-8.0.5-linux-musl-arm.tar.gz",
+          "hash": "534d395e8d9a82995a190e63ebf971654d7b411285cff823396f598df5eee393d50db5f990b7022f50e53b105807d06df3ce3b4918f843dd105a7fc2ef8cb226"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7a0cdac-8a36-44f1-8c99-89473786a71e/f3f0dadb7ca11fe381fed11dedd9410a/aspnetcore-runtime-8.0.5-linux-musl-arm64.tar.gz",
+          "hash": "1f3e24565c2b6d0541bb3f919451f4d554ed028e2bfedf8c15bc063f852398ce88f167130438720b82998bfaf7c78f80dae3a8c3e8a87499fc9e18ac606c4eb8"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f882401a-2f21-4a86-8c19-1e69f3fc14ed/9dcf9a68d11f46bdf0272d692347815f/aspnetcore-runtime-8.0.5-linux-musl-x64.tar.gz",
+          "hash": "46db57d8c204a216027c3737d96e91e421cc39db7f346911d7784c54df57907506af8815a5e0ad4164a7533d000ebf57a27da7fc820c8e0b6c95847c308eb338"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ccccfeb7-0af4-4713-b4f1-cf49b5c8bd6c/5b04c0188dfcf78b70da78ae3bd7f3ab/aspnetcore-runtime-8.0.5-linux-x64.tar.gz",
+          "hash": "ffe6a534ed7dffe031e7d687b153f09a743792fad6ddcdf70fcbdbe4564462d5db71a8c9eb52036b817192386ef6a8fc574d995e0cdf572226302e797a6581c4"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c264657c-7a93-4ba5-b6e0-91bf41341e1e/90fb45ed7d2f92c374899b1c7a5254b2/aspnetcore-runtime-8.0.5-osx-arm64.tar.gz",
+          "hash": "b1a47d2ae3b528f5c32b57e3a03b46d12a14126b9768f9dd5dd979d49dc6543c6aafe55684eae3890ffe6b867aa664805b920ae1514f67cc841b882d5da7c091"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/77cd03cb-5575-48c9-8714-6498ee88694b/8bfba2913a4db23e3dffdff779fb7866/aspnetcore-runtime-8.0.5-osx-x64.tar.gz",
+          "hash": "d214a8b6a60547acb1a7f879e7a82348585b699f714b73b168918ebc60ee580ca5ff973f64e7738063f79dd04f0807bef0d73e90ce42c3b4464b87b768ccd789"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5f73667-df10-4877-85c2-9340d5d428be/3309721b7482738b592e03715c76c616/aspnetcore-runtime-8.0.5-win-arm64.zip",
+          "hash": "5eaaf55397bbef263464d81a86b0641a2c69c351c1e1d40452ddd16d711e83d646aacca72ce0cfe9e2da687a83355e832bc18d155a45dd95f2f9c2125a1112ad"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e2ced2b3-e1a5-401a-bcc9-6689e4eea673/93f77de4a39a219d775b403b7ef0cf58/aspnetcore-runtime-8.0.5-win-x64.exe",
+          "hash": "2c1f3088463bf3da70edb6e18412da7cd45baddcaa54f8fc8e1c7ef94cb414b3308b097531a61d68622c977b3db79402ebbf84ae9f45a04412d9056cb0f67027"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/037d4b04-c96e-4f1a-a754-faa533c151d9/383663d155777ad71863cd951d24224f/aspnetcore-runtime-8.0.5-win-x64.zip",
+          "hash": "c79342e7d56b81e747b97e65f2c1323e70df83ab226152b5c451e48de1b27d1c5f057fd4a013053ea1c52cbb08f94db83f594ded06337e9c9cf4250a2b20d3c3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/24682756-e652-486d-a9f7-c4411f3141e9/39e6bb61fab38fdfb3472305174422cb/aspnetcore-runtime-8.0.5-win-x86.exe",
+          "hash": "171dcf56091ce0cddc31a74e1aaeacd06f7ec3c4ad63293afaf2f9c0af6e41b8e31ea51a69c0be1a910ad32fc19796f2c368a75c6a078e362897477815c48f7e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a814686d-474b-4673-8c2a-501bae44e581/04a883d6d9856ff5999603828daa7153/aspnetcore-runtime-8.0.5-win-x86.zip",
+          "hash": "6191811b8e0b031a882fc3460ce36a380cee9969794ba9a3bd5fc63297691bc7629b61744b0a34958d3882d361b68f74790c396c7dbc7c0faaba0dc418533bef"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e396a133-44f6-4f3b-8622-699def46a2e2/e0377da1eb746d6915f5f6bbdc5289dd/aspnetcore-runtime-composite-8.0.5-linux-arm.tar.gz",
+          "hash": "ab616bd512235c9a90aab83bd2c7eac7cea24f40894c7549ff3f39a60cbfe35bbb0f9522d004b0e7f875f6e5ee4ba2d344b141ad6aa18165ef23a7af95bb8eff"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ef17fbc9-1bac-4346-b04b-db0114e2714f/74c4636b4fb78509d65be904c9c1e71e/aspnetcore-runtime-composite-8.0.5-linux-arm64.tar.gz",
+          "hash": "e5ea9700bf8b82ec11f9d8a6d6057534375e902b462c417ef7f2072b9865d9d561cc6c6d90859e3196de9862d17970cb47ae6abc1a96ec39e4345792d9551ada"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/60285a37-71c8-4544-a965-ead53392ae14/67b0f0b4e12a1533f66f09073db91e67/aspnetcore-runtime-composite-8.0.5-linux-musl-arm.tar.gz",
+          "hash": "d97bdf5c4cd7fc0d168a3abf1ee377515a28002111dec2e1f745da0bdc351edeb00af3d784a1c65738c4a3df346ae039d037e00ae30b21144ef543e71688a96c"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/89822e3d-7a9c-4a9a-98e2-39941002d776/0b5847a6b22171f1ab241defa8142977/aspnetcore-runtime-composite-8.0.5-linux-musl-arm64.tar.gz",
+          "hash": "3d982d42b6f3c46d111d253121d919841d8af747ac0c0ee645a2297998cd9d60415662748b315fe5a3be22bfe44cbb6161bfe14b9777aa03ebbed0dacffbea4f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5aa0b2bb-a909-4e76-a338-aae7007e3107/8d435893e3da0f1f83fd01babb154b31/aspnetcore-runtime-composite-8.0.5-linux-musl-x64.tar.gz",
+          "hash": "9d1dbb50684ec431fd6c979a57834295bc5aeb561e50aeac9f325b0aea9fa1c35927c458ec783c93863cc42debd87a9771405baff6b99c7faa2b43ab2e6815c5"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ce76101f-0ea1-45ee-b38b-1dfa0ffc60e1/8134663bd2d175725ad37733150c1901/aspnetcore-runtime-composite-8.0.5-linux-x64.tar.gz",
+          "hash": "5c22f047cce57cea17e189af3305e6b0f8b1aeaff59b471907f99a8e936b9442755edfae015b2b3ca635ee160a8a33cb71cea7e71391a26d04866dbf64339bb6"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/70f96ebd-54ce-4bb2-a90f-2fbfc8fd90c0/aa542f2f158cc6c9e63b4287e4618f0a/dotnet-hosting-8.0.5-win.exe",
+          "hash": "cf3d170c977acd119cf3a261e88ac51de86f165fde01d4545951a145fbbecd62d9d6a6e2af3630065d982a14b264e10f5980c2de72ef3c6e49097dd4c18e03d0",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.5",
+      "version-display": "8.0.5",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3f8a1e03-75f8-4a4d-9454-661951c7766c/d009696cbfdba724337e226d3a84a3f1/windowsdesktop-runtime-8.0.5-win-arm64.exe",
+          "hash": "c57b27abb9cff269ba2aa4ad768be22755ba87f32a7cd14c5919b1839fbcfa0394656c2207e16117e51711f21533b20b115f9fa228d98febe89654419de13b25"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f909f3a0-6cb9-420b-b0d5-2f813c4ff47c/1fb5b6ad0b8442232aca852978ffb3bf/windowsdesktop-runtime-8.0.5-win-arm64.zip",
+          "hash": "a3cc06daa9c96831f9a29b7f4cdb578d9982f51657830571051f04f0fd4b7594ec611e6691c17545e1fd3548254a1284aab312d8690163ef3d358983c084f9a8"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0ff148e7-bbf6-48ed-bdb6-367f4c8ea14f/bd35d787171a1f0de7da6b57cc900ef5/windowsdesktop-runtime-8.0.5-win-x64.exe",
+          "hash": "669610963dfa67d1da4ad84eed34df362455389347c0196bcef003f2fba69a69a71e011f6ed3dfd1b4b196338708f4a95e766520b69cfee2e08a3c435b97d276"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1825c526-cca9-4528-b4d8-fff62085ad49/16b2cdd02ac62cc38c912a500490ff23/windowsdesktop-runtime-8.0.5-win-x64.zip",
+          "hash": "7be9f81d3d8795bd6eed2b2b78fcf05e364a64063e2dc425bb505df4127105ee1104fc42293947f7835188fb15dd132cbd302e1e1c954a60cf4d0a6c4a432e59"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/44a63708-94fa-4edf-81a9-50612e4ef82f/1c9f61bc16d3bec6217337951898dbd3/windowsdesktop-runtime-8.0.5-win-x86.exe",
+          "hash": "609783925795183be3281f5d2963cf52caa8eca9e129f9184a7886a7472020e179d2d269aadc5532cb760091fc4e936a2f05536bb1a46024dabaa25d789528ee"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5fc6bfd5-8e73-4bbd-ab9e-2e12317cde99/5b195f89f5f5538d3d35cc6969f4e12d/windowsdesktop-runtime-8.0.5-win-x86.zip",
+          "hash": "9cdcb60599d9757d20719f9b12f457d0bd3130e1c05c13842509d601044b735ab5516c6c062bb0bca6f6a38de3ae29020719f21daa91a62c9079656af0273e1c"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.6/release.json
+++ b/release-notes/8.0/8.0.6/release.json
@@ -1,0 +1,842 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-06-11",
+  "release-version": "8.0.6",
+  "security": true,
+  "release": {
+    "release-date": "2024-06-11",
+    "release-version": "8.0.6",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-20672",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-20672"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.6/8.0.6.md",
+    "runtime": {
+      "version": "8.0.6",
+      "version-display": "8.0.6",
+      "vs-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eda981d2-9e7c-4764-b0f1-e677dc0d89fe/be9ad5e056212ca31ea1ef7a5dd2d9ba/dotnet-runtime-8.0.6-linux-arm.tar.gz",
+          "hash": "f50a3acef2d10282a2a236c4eed6f8a6e02b929123c297e3a2cd52deb442a7aa9571ea8529fdf6fdc5b140a076f0e69cfd8358cedaf399ec443441a9c6389817"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0039e2c5-d78d-45fb-94c0-e258ff0335fe/c3bff45767f679bbab149398e9ee2c6b/dotnet-runtime-8.0.6-linux-arm64.tar.gz",
+          "hash": "428c5a81938273c5e63b04858dbf2f4e82c9bcfa3bd33f954081238be2fb52aadce99296698eabac72e4be55c61e6c1ff06d2d8d1fd5d6a2d0c7a2917cd50739"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2e0537ca-4530-42fb-a2b1-6e0ffd34859d/aa6158265cbc0fd4554d991a9156121e/dotnet-runtime-8.0.6-linux-musl-arm.tar.gz",
+          "hash": "1ab5c0ced0444f557547266e80dc50ce2778ea24883fbbaead063f659c2fbbeb9e52f6c92257b1b00c77a743df76effef4d7efd34736acb0e44f5914e75f5d7d"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/64add4b1-bd51-4710-a2e7-249138091327/72c5112bc9904b36b4d4294a381e8a01/dotnet-runtime-8.0.6-linux-musl-arm64.tar.gz",
+          "hash": "dc8383bf283e76a2fcf22bbc53eab10faa6dee72aa6ff542427e1a1fdf14c4071f1b3016d895984f15c751707e2e05791c1522f361f3389ba6068c235550e484"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1f540ce8-5cf0-4429-907b-46fc4a01978e/6f30eb80be6c69043e96b18936894d61/dotnet-runtime-8.0.6-linux-musl-x64.tar.gz",
+          "hash": "db25afb6603cfd1cafafb3856ea59205b350b263441928c7010372dc1ee813f03d9ba01186468c95402cc09c49367f129e84f8e30b9ebb4a27f5ed66bb573cc1"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/021c3de8-14d5-493f-92dc-2c8f8be76961/6ee3407acebf74631bfc01f14301afa6/dotnet-runtime-8.0.6-linux-x64.tar.gz",
+          "hash": "c0c5e93d4e68e2075c4c63336dc74246efb704ac9663411351efdefc4cc7da5a7750f44b8a23aebe959bb4308575bead443a41b2524ae03b29ac41929d27e0e0"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ea249dde-337d-417d-a615-1f2e0a29b1fc/ef9f8aab388fc5f9ef11a188c4da92fd/dotnet-runtime-8.0.6-osx-arm64.pkg",
+          "hash": "93eab830c568e8aabcdee81a88b4199e9cbb6a286631ccc4e041d2b7703a6c8e9a80896f01714e2cc6ae499ef4dc467040dced680db5cfe0ecb6b8f63ec0c603"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f090da0-5f55-44f1-ac17-9bd001b33d66/eae314b23ab350b375e794e136a2ca9e/dotnet-runtime-8.0.6-osx-arm64.tar.gz",
+          "hash": "21ae6420914e45be9fe17bfb0c89948eead27756dedb13fc2c6b9b08d78aee80daa2b8cda358268c819f00ba7ca33ed75e21bed387045b3a62160fea159eaa3c"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9d3fae98-a6af-4ce8-868a-db721c5825a1/e70f1e87a433ab1fbf6b94eb5d0c162d/dotnet-runtime-8.0.6-osx-x64.pkg",
+          "hash": "fb427c00f96458a6b6822974c72178639d82ab9f2111d0a8d1493a58353e8d95dce41b08cff7bb4b91b87a72c31b21f9801692838194de4e30feffaa97b3ab73"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/20271d05-67e0-4356-87a9-0ce5102b5007/b7c91c6470e1c2ffbb493a35dd6883c0/dotnet-runtime-8.0.6-osx-x64.tar.gz",
+          "hash": "44c0ad9fc613975fa0c12b12b91ff8cd8ba0be5e8ed59510e7a5ab22e55267a468b321ce34515daf070ffc8d557c09d7ea3ed3c3407887f706553b5d378e3232"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3add2bc-3173-4266-a1de-f68779aaf1d9/7bef323356317da51eb19674fed9a9a8/dotnet-runtime-8.0.6-win-arm64.exe",
+          "hash": "c78c72a8024fb2d686bcaecea673f69b66834c81011be4505a2964e367b15310c5a96466b9baaa4adefe1766d8325b4686b3c1d3175b32e0ddeed4da12052dbd"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a4176606-dd6e-4419-9080-01c8c125fd45/162bceb73747f014725c6151c0d1c536/dotnet-runtime-8.0.6-win-arm64.zip",
+          "hash": "e712bdf4127ab573ad3c7610f61438ee3abc7a20a6a84d584ef2675c4a3762ea2fb6164852a19df9c86eef69246b8d80fa88477a9cec46218cdb826ec26e9388"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4d4b66c-0581-41a1-b7ee-f23ccc79e4ec/1b56841378536d2795faaa214b2872e7/dotnet-runtime-8.0.6-win-x64.exe",
+          "hash": "b3456b1d2b8b9b4269234c0fcd9d154109ec4cae623149f6d3d104ae43d08ef247c1c6a7e0117c0c7dd3db8ae17c999c637edaa99156d99c270b1b41782b4273"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3c5bbae6-d848-46b0-bb65-c4f7a7ad4b2a/afba8a75f7e7f4f304362de0f1d4b3ea/dotnet-runtime-8.0.6-win-x64.zip",
+          "hash": "2c0407df76878fe518105e132e5435f7f3ac42415fecf099e1a056ef4c068ed9d4e3bcfb5fe49b6c138cfe8b77db609bc6af28be5f11b5beca9eea7c1092ee51"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e43df68-58d8-4b50-b334-4ebd6cd017ea/4043450c7ccb64a6ce80780cc0659841/dotnet-runtime-8.0.6-win-x86.exe",
+          "hash": "ab9bad248e97dbe87581dd8ecb0db22b3972de60fbde596f36ce6ffc7d5270457f9b7f6b7328ade901fd7234482c6d5907f2450a30699fef2cfae8d9ccfe1a9e"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53f7cef2-50bf-419d-bf36-69f2989729b6/31261cddb6f9517e76cc4ee71d67be8b/dotnet-runtime-8.0.6-win-x86.zip",
+          "hash": "4801ea1f67811ee368d78e03447cf972ba71e4d02818d5ed019ce99a241498eb4d242ceb520744141d6c3047bacb80c64be5b0f9a64f339087bce76e83a0b444"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.302",
+      "version-display": "8.0.302",
+      "runtime-version": "8.0.6",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6a909983-cf0f-4b23-823d-8db56fdb344f/6455cb1f9a9a0eebc8fa541d08d7717c/dotnet-sdk-8.0.302-linux-arm.tar.gz",
+          "hash": "2758d4844986794b34bcb34f24a153cee47d73fb787702dc7b6727e8dbe1e8c1c9e6bb350bf990c974be46821bcbf85e116ff2007727e2c3dcfa010c6f4cd3e0"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ccc923ed-10de-4131-9c65-2a73f51185cb/3c04869af60dc562d81a673b2fb95515/dotnet-sdk-8.0.302-linux-arm64.tar.gz",
+          "hash": "a6432f93056d74a7dd666f0deda80c96e6dd6a5e6291f71a0128846df9dee5aa0016fc3bd39f34ce5a859bb82ea4e4302790a78ffc2d05216f07f9bf94440c40"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/589452aa-fd0e-4b6a-92a1-634ec7453f70/f5e605008dc538ffbe3f650b562e6dec/dotnet-sdk-8.0.302-linux-musl-arm.tar.gz",
+          "hash": "ad01cf664b42e85bfaa1f8cd13b159266b5b332e4b9c54b8f01e0d08da85c151437be30e142661b38e90b5896c17db30e086c78c47d1f3bb6b57c17e52c1483b"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e1b95b3b-5c79-45bb-b2f3-72c7cdccefac/be97cd1f75a28f4f287d2fb620765bea/dotnet-sdk-8.0.302-linux-musl-arm64.tar.gz",
+          "hash": "bc504f76a5eb984373f96520c3ae0d439da9778bc4ba39455f89b809e203543ca164f3c27523b84245a5223ae7eed64931ea78a136041eecb1d1a226cd60471b"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/409fd86e-c7f2-49b8-8df7-a7ccf588bac5/db5f8d02d688503e63a72938640648ef/dotnet-sdk-8.0.302-linux-musl-x64.tar.gz",
+          "hash": "8b5c2f13162ab667c84b371c5a9826173872f2485f806826b9df252537ca77c354b32cc58532e497fdf619f666413b1627e84d18bad616165b5454a8e2d110d2"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dd6ee0c0-6287-4fca-85d0-1023fc52444b/874148c23613c594fc8f711fc0330298/dotnet-sdk-8.0.302-linux-x64.tar.gz",
+          "hash": "43d0ea1df12c15a0e47560d2a84857ab50eb04ac693ab41413c04c591719101c4c8165e052a42a66719c67bd07ac299ca47edbb4944a2901df765042e56b316f"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/348456db-b1d0-49ce-930d-4e905ed17efd/a39c5b23c669ed9b270e0169eea2b83b/dotnet-sdk-8.0.302-osx-arm64.pkg",
+          "hash": "39019856e704be3acf9359f3f90aa925f6283aa13555b97fff43cea4553e5a7c7d04addd56d25f4d3e60c5b86b8f388c5b52b9dda4ca47b38583ccc48d34c34e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9d5ec61f-58b3-412f-a4b7-be8c295b4877/fcd77a3d07f2c2054b86154634402527/dotnet-sdk-8.0.302-osx-arm64.tar.gz",
+          "hash": "e3589d4da75b9fa4b84c9e6e23cdc97796d59dc27efe3c25e5dffd1fa074f770876eda7087d26eb221369355dcce89c7d7724426ee24269295ca1d4e6353bd7f"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5b488f80-2155-4b14-9865-50f328574283/e9126ea28af0375173a18e1d8a6a3086/dotnet-sdk-8.0.302-osx-x64.pkg",
+          "hash": "c2ea26ea51797e00a809e44902437ede2231e5a84a3900994aecd3de3e014abd9b8054c766ffedf2c9fbff4991fcd63490a3c8527d7afc27fc7be0dd417c229d"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8893b99f-aca2-4f93-af7b-cf6017cf5f7b/e45804f1d91b9b01ebd5b15a29e9c088/dotnet-sdk-8.0.302-osx-x64.tar.gz",
+          "hash": "028f784cffe5289bd324b1804e0b49694207a124e00309bc8f13568ebfd6ae9bbb7db52ddfaaf3a99886b568b9ce9668f74aa67792fe453f1ebeeea30ec1e984"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a98d10f0-ae96-4d7f-be23-613fe9fc22cc/cd29f30a839a98d39d3df639a810f658/dotnet-sdk-8.0.302-win-arm64.exe",
+          "hash": "e366bac665617c305c2646d621d00fa3e11b902c5ffe98eb7b292c35e3bc9d740f5b171a1cad3617262add29981c6d97a39ab052074dd70475d5093a76d8964b"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9aa1d0b5-3aa2-4d9b-bd61-3e86803691da/33187a91d8fedd213404569b153758c4/dotnet-sdk-8.0.302-win-arm64.zip",
+          "hash": "52afbfe900245431cf3461faac1343220066a010c8187a5276536f29774d87f6c3c529064ef56b1316f2f27c5e465a294ba042c3a44bfbcfce6cdc0ba6fc69e3"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b6f19ef3-52ca-40b1-b78b-0712d3c8bf4d/426bd0d376479d551ce4d5ac0ecf63a5/dotnet-sdk-8.0.302-win-x64.exe",
+          "hash": "ade97369615e40e6704fa8af0d24fba1d784d5bffa2af27b0c9b29273a426b9fff33fae8b72172e95cb15fce4d2188f88486edc21d75b9f9e33e81b1eed3dba3"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5af098e1-e433-4fda-84af-3f54fd27c108/6bd1c6e48e64e64871957289023ca590/dotnet-sdk-8.0.302-win-x64.zip",
+          "hash": "922b60ec1730d6a4fc37b9d769646d1782a1cf0293846cb4e1991a61cab4892f5c792a88df471e65b82df512d6f3c8341cce650d5260d0fb64e3c6b620efe5c4"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7233e273-599d-4484-894e-75a66bad721c/30f52fb3ca0e2067173538f759bd6090/dotnet-sdk-8.0.302-win-x86.exe",
+          "hash": "5a6534f1906c963293e8e7ffbc7b906cb66adda402f44525f3e32aa7c4d64c6fd89c8fcfd37eb1da39500d0cf3890f338bd56314072530d82c8b55a863066657"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2c6870d0-310c-425d-b023-5244793c1e35/2f9d8c6e3a1b570c16fbb879b6cd6ec7/dotnet-sdk-8.0.302-win-x86.zip",
+          "hash": "56d435d933d089fe993e5d40388ece8f139b4e19b3aefce939cfcdba39796452326b43a53241b6d9613d1561b87685669a5a965cf08d3bf647d6edaf90997494"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.302",
+        "version-display": "8.0.302",
+        "runtime-version": "8.0.6",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6a909983-cf0f-4b23-823d-8db56fdb344f/6455cb1f9a9a0eebc8fa541d08d7717c/dotnet-sdk-8.0.302-linux-arm.tar.gz",
+            "hash": "2758d4844986794b34bcb34f24a153cee47d73fb787702dc7b6727e8dbe1e8c1c9e6bb350bf990c974be46821bcbf85e116ff2007727e2c3dcfa010c6f4cd3e0"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ccc923ed-10de-4131-9c65-2a73f51185cb/3c04869af60dc562d81a673b2fb95515/dotnet-sdk-8.0.302-linux-arm64.tar.gz",
+            "hash": "a6432f93056d74a7dd666f0deda80c96e6dd6a5e6291f71a0128846df9dee5aa0016fc3bd39f34ce5a859bb82ea4e4302790a78ffc2d05216f07f9bf94440c40"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/589452aa-fd0e-4b6a-92a1-634ec7453f70/f5e605008dc538ffbe3f650b562e6dec/dotnet-sdk-8.0.302-linux-musl-arm.tar.gz",
+            "hash": "ad01cf664b42e85bfaa1f8cd13b159266b5b332e4b9c54b8f01e0d08da85c151437be30e142661b38e90b5896c17db30e086c78c47d1f3bb6b57c17e52c1483b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e1b95b3b-5c79-45bb-b2f3-72c7cdccefac/be97cd1f75a28f4f287d2fb620765bea/dotnet-sdk-8.0.302-linux-musl-arm64.tar.gz",
+            "hash": "bc504f76a5eb984373f96520c3ae0d439da9778bc4ba39455f89b809e203543ca164f3c27523b84245a5223ae7eed64931ea78a136041eecb1d1a226cd60471b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/409fd86e-c7f2-49b8-8df7-a7ccf588bac5/db5f8d02d688503e63a72938640648ef/dotnet-sdk-8.0.302-linux-musl-x64.tar.gz",
+            "hash": "8b5c2f13162ab667c84b371c5a9826173872f2485f806826b9df252537ca77c354b32cc58532e497fdf619f666413b1627e84d18bad616165b5454a8e2d110d2"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dd6ee0c0-6287-4fca-85d0-1023fc52444b/874148c23613c594fc8f711fc0330298/dotnet-sdk-8.0.302-linux-x64.tar.gz",
+            "hash": "43d0ea1df12c15a0e47560d2a84857ab50eb04ac693ab41413c04c591719101c4c8165e052a42a66719c67bd07ac299ca47edbb4944a2901df765042e56b316f"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/348456db-b1d0-49ce-930d-4e905ed17efd/a39c5b23c669ed9b270e0169eea2b83b/dotnet-sdk-8.0.302-osx-arm64.pkg",
+            "hash": "39019856e704be3acf9359f3f90aa925f6283aa13555b97fff43cea4553e5a7c7d04addd56d25f4d3e60c5b86b8f388c5b52b9dda4ca47b38583ccc48d34c34e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d5ec61f-58b3-412f-a4b7-be8c295b4877/fcd77a3d07f2c2054b86154634402527/dotnet-sdk-8.0.302-osx-arm64.tar.gz",
+            "hash": "e3589d4da75b9fa4b84c9e6e23cdc97796d59dc27efe3c25e5dffd1fa074f770876eda7087d26eb221369355dcce89c7d7724426ee24269295ca1d4e6353bd7f"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5b488f80-2155-4b14-9865-50f328574283/e9126ea28af0375173a18e1d8a6a3086/dotnet-sdk-8.0.302-osx-x64.pkg",
+            "hash": "c2ea26ea51797e00a809e44902437ede2231e5a84a3900994aecd3de3e014abd9b8054c766ffedf2c9fbff4991fcd63490a3c8527d7afc27fc7be0dd417c229d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8893b99f-aca2-4f93-af7b-cf6017cf5f7b/e45804f1d91b9b01ebd5b15a29e9c088/dotnet-sdk-8.0.302-osx-x64.tar.gz",
+            "hash": "028f784cffe5289bd324b1804e0b49694207a124e00309bc8f13568ebfd6ae9bbb7db52ddfaaf3a99886b568b9ce9668f74aa67792fe453f1ebeeea30ec1e984"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a98d10f0-ae96-4d7f-be23-613fe9fc22cc/cd29f30a839a98d39d3df639a810f658/dotnet-sdk-8.0.302-win-arm64.exe",
+            "hash": "e366bac665617c305c2646d621d00fa3e11b902c5ffe98eb7b292c35e3bc9d740f5b171a1cad3617262add29981c6d97a39ab052074dd70475d5093a76d8964b"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9aa1d0b5-3aa2-4d9b-bd61-3e86803691da/33187a91d8fedd213404569b153758c4/dotnet-sdk-8.0.302-win-arm64.zip",
+            "hash": "52afbfe900245431cf3461faac1343220066a010c8187a5276536f29774d87f6c3c529064ef56b1316f2f27c5e465a294ba042c3a44bfbcfce6cdc0ba6fc69e3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b6f19ef3-52ca-40b1-b78b-0712d3c8bf4d/426bd0d376479d551ce4d5ac0ecf63a5/dotnet-sdk-8.0.302-win-x64.exe",
+            "hash": "ade97369615e40e6704fa8af0d24fba1d784d5bffa2af27b0c9b29273a426b9fff33fae8b72172e95cb15fce4d2188f88486edc21d75b9f9e33e81b1eed3dba3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5af098e1-e433-4fda-84af-3f54fd27c108/6bd1c6e48e64e64871957289023ca590/dotnet-sdk-8.0.302-win-x64.zip",
+            "hash": "922b60ec1730d6a4fc37b9d769646d1782a1cf0293846cb4e1991a61cab4892f5c792a88df471e65b82df512d6f3c8341cce650d5260d0fb64e3c6b620efe5c4"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7233e273-599d-4484-894e-75a66bad721c/30f52fb3ca0e2067173538f759bd6090/dotnet-sdk-8.0.302-win-x86.exe",
+            "hash": "5a6534f1906c963293e8e7ffbc7b906cb66adda402f44525f3e32aa7c4d64c6fd89c8fcfd37eb1da39500d0cf3890f338bd56314072530d82c8b55a863066657"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2c6870d0-310c-425d-b023-5244793c1e35/2f9d8c6e3a1b570c16fbb879b6cd6ec7/dotnet-sdk-8.0.302-win-x86.zip",
+            "hash": "56d435d933d089fe993e5d40388ece8f139b4e19b3aefce939cfcdba39796452326b43a53241b6d9613d1561b87685669a5a965cf08d3bf647d6edaf90997494"
+          }
+        ]
+      },
+      {
+        "version": "8.0.301",
+        "version-display": "8.0.301",
+        "runtime-version": "8.0.6",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/033ecbe9-b763-43e6-ae77-386cc6896f17/991838457685c131961652535f07c46b/dotnet-sdk-8.0.301-linux-arm.tar.gz",
+            "hash": "9a44abe4ab6c6a8b8b8c599b140722098e4c710fb86d3ff387402ce98fc5bdf2e8271558b2de0822b5ef73c8781d5fae219d69411697b3cd59ccfc0283286a69"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cd9decc0-f3ef-46d6-b7d1-348b757781ad/9ad92a8f4b805feb3d017731e78eca15/dotnet-sdk-8.0.301-linux-arm64.tar.gz",
+            "hash": "cb904a625d5e4ef4db995225d6705b84201dc7d7d09a0b1669baccc86e05419472719025036dd78983b21850f7663d159ae41926364d1d3ca0eab62862f75d29"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b49b3399-7f12-4c7d-8ed4-f91f9228464e/b2490a730a9808c22c1deb8352644ba6/dotnet-sdk-8.0.301-linux-musl-arm.tar.gz",
+            "hash": "19c32bf5cc14452cd0eaa40eceb0f5d63730c80ee9045cd9ee9057bb78b3add430b7337c2e2ddc05902777ba6517f879c10572c32da0ce21877ce1d9523a753b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f83ee59e-214b-4569-9842-30df94f5e618/c6d8088c5bd2989e2cb48de6275f0c70/dotnet-sdk-8.0.301-linux-musl-arm64.tar.gz",
+            "hash": "646716f924ab20826a3520a2f75fa0e188f2306b8b8a1695f15834a14688dfd9c871909401810aaa387abb2eb9397414b21ac3b6b0ce1f3458dc96fb84c951bb"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f7719d18-599f-4502-a04c-4362d2ec38d7/58df714cbc9fdff3384dd71b269caca7/dotnet-sdk-8.0.301-linux-musl-x64.tar.gz",
+            "hash": "25e11e1b658e89121650ac5ec2b21d0cda42442d807dc3fd32b79f2d818ace9ed505f0e95994ed6edac7392c62dc094a056ea43d8c054a190cb3fe395fe802cd"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/86497c4f-3dc8-4ee7-9f6a-9e0464059427/293d074c28bbfd9410f4db8e021fa290/dotnet-sdk-8.0.301-linux-x64.tar.gz",
+            "hash": "6e2e1ad5fe3f00e6974ad3eac9c5b74cd09521f19e06eb9aff45a44d6c55e4a2c1cd489364735215d2ea53cec2a7d45892a5ede344a8421be9ad15872c3496a2"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b07f0bc8-ce20-45e5-879a-a931beae3ca5/67426313b0bb8bc63ded3aeacaedca5e/dotnet-sdk-8.0.301-osx-arm64.pkg",
+            "hash": "40f5f59f166627f01d2359a6502f101f77e8ccfeee2aa69912d0e70860873d746af38b77759a8d256c5fc6fb247ea93bbc56c0c4a9a006201848966f8cdcbb0f"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c503e53c-0567-4604-b7a8-1d6e7a1357f5/53e78f56b01147a092c0cc273b443550/dotnet-sdk-8.0.301-osx-arm64.tar.gz",
+            "hash": "8d56980b6a6ffd78618a6e9833126d7e67052ca6041bd5f167a32e277aac7094a5cd37b9e7e145d5c9b74da95561535189a077d074ddb0fe710a76c2a2c9b1eb"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/825222be-354e-452e-ae45-f116d86ee0d3/c4ac600bb62a44265d54b8de48c1b273/dotnet-sdk-8.0.301-osx-x64.pkg",
+            "hash": "b699f9e1a3f7da86fc99b46e4a0a66e7ec8c65b522435204cf08e941512b8d81f08aafd6d6afea39af0be01454df836d54aa804cb721231c7795838eb1668e81"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ef47a54-b1c6-4000-8df4-486f64464c2b/ae87b597b19312fa9f73b9f2f8c687bd/dotnet-sdk-8.0.301-osx-x64.tar.gz",
+            "hash": "5d91fbc584f32f4d48dee303c7eb16b38b2e2fab9549bd54293bac28508a6d53f93782ff102266010f8cd8c15c6436a807a7e6efede2e1051fe206957ba73071"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/96a6ef30-e6d0-40c8-bd0d-6013b3bddc43/591a51a6e538c12a3e1d5e2b57c5c863/dotnet-sdk-8.0.301-win-arm64.exe",
+            "hash": "1fc51f6f7058ae4af975b4d6236157a28b3e376687b8e42f1ee489258ce5266f53f93e1a0fe84fdef73a3700f76db460649109e9a373dbda55ebc6ab5f89b80e"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/90961c76-55e1-406c-80b5-440306ac50cb/337ad62c9692c3e74e4e2b209f3a85f6/dotnet-sdk-8.0.301-win-arm64.zip",
+            "hash": "bdfdbb6304c7a768293612f74c880555e281a0631d0b0a3aa5f27709694a5f8319415aad960c821c74919607a7341cb96fcb05b97902d99c66a4651ebd570a15"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2e3d0e1d-ad81-4ca7-b186-49f2313547e7/ee8546e4148b87c6e14878b5055406e9/dotnet-sdk-8.0.301-win-x64.exe",
+            "hash": "4f6fbed3d79e8f8e782198c92d5a3454e817efd03c656b9cb2e1a11d67627070bd14eb78d7618efed29f5c958649d4e93ea6b6469c2e06f07110882fb63f39c3"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ac2d880-2d57-4008-850e-4b42b829c354/e1c92cb3b6a85f53cab6fa55b14b49e3/dotnet-sdk-8.0.301-win-x64.zip",
+            "hash": "cf00d4746cb063994e1a7a490d1ca29bb78e9c78505a733a4693353febc14e0cfb26775cab57baa7612b74be08ef91224b0d06cfa4eef0b9bf15b2843266a948"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/911f605a-faa3-4049-a215-749c8fd14d6a/a0f35ffe12843cbc69e484e7e02b857b/dotnet-sdk-8.0.301-win-x86.exe",
+            "hash": "90941838a7e98b088ba3be19b953e028480ccf417c463a1c3912a77ba814dd67aecebf2c9f9616298f46c50955d75b0645bc0017e7bcfc10a62bedffbb3aec3a"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8ffefb00-26bf-4dc0-bfd3-82003b4f122e/05aad9cf85a8456cdbe08b2b59da866e/dotnet-sdk-8.0.301-win-x86.zip",
+            "hash": "43545b42d4daee141e1ffb6895b796c744b5b47e790b7b6e5b303cfc6e484227dc6dbaa2c452f111d1dbb883c5c1ca77020b804dfabd3167ba7e2b6eef7a639f"
+          }
+        ]
+      },
+      {
+        "version": "8.0.206",
+        "version-display": "8.0.206",
+        "runtime-version": "8.0.6",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d147b096-bae4-4d19-8534-7a3e33983778/971723305d946b8b11e8f814d5ef4f9b/dotnet-sdk-8.0.206-linux-arm.tar.gz",
+            "hash": "97b8c1fc04d6d9e71777def4ac9e1989b5e03d481df31c924a1101e914ae2bfc38b7e47e14b4647ed384758a76854786b0acadcc35b9feddeafa6f55e7534e03"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f25f9e53-deba-4c1c-b9d2-5e026e5a4d92/c291c78eb71c30b1c66745dec87936ce/dotnet-sdk-8.0.206-linux-arm64.tar.gz",
+            "hash": "eb0489785dc5bf824bc3fc1014815ebd371fbc73eb02b63e5a1650bcadb158cab7e909904889f6e198a180a1742976351208a57796ef38a4205c52fb945b7d09"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/369d614c-5b86-4f62-b062-9c65bf5d03a6/9cb58777a7e590dfaee4d25262da2d23/dotnet-sdk-8.0.206-linux-musl-arm.tar.gz",
+            "hash": "14ffc6566dc4da278bb0d5a25dd676c88b1c9bfb6d728d9739237b41d80e85b2797d713482c7db2b061296e7634ff7146a3b9b031cd7858d2f995cde710f20e4"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9e1f644e-0661-45ae-aa39-40d40142a11d/d492283df2a2694fcefe4c340439bdad/dotnet-sdk-8.0.206-linux-musl-arm64.tar.gz",
+            "hash": "1de4f0ee791fe433b1e230c6621c8773921328fdc8fcdbe154e804fcc938374a950ed2c6f60e5cf4ffb26e03b346810d6b661bc544ac33ae2e249a98dacd421f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f79a292-8cc2-455e-a8a4-0cf6e15424b5/bd6e2c376876085ae1eab1ba5d588a89/dotnet-sdk-8.0.206-linux-musl-x64.tar.gz",
+            "hash": "9213697221d4ce977a80099f1df68a0e785729910ed3f2a2e44fda0e69ca9c9e08e70642b9975732695fbc5745f3dc862f4ba7cd79088858982e8ec0301189b8"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5fd599e9-4bf8-4603-8a14-87777293837d/1d5f0729055901dce471570bb82a441f/dotnet-sdk-8.0.206-linux-x64.tar.gz",
+            "hash": "d03cbb5ea44a6f4957d7c1fa0f7c19e3df2efcbf569b071082e37ac86776af0729540c3bbddc44668ae2eedcfcb4b098883bb560d26418f1583a558d60c99ef5"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6846dd0a-2c4a-41d7-99f4-c437efd48c4f/8ae0af925c534f1dc6e6ec4f3277812d/dotnet-sdk-8.0.206-osx-arm64.pkg",
+            "hash": "bc088f424e604b3a2b21a1d279ed79aeb22c8dc1bf3161c0c7abbe324684001fc47703b7a94953fb87295875b73927d921376ba51b6d02dfba9934f4c8e007e6"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bca24333-c463-4f90-8085-f856962fac39/ef02fb556ff3d92938a2c11e408c7d71/dotnet-sdk-8.0.206-osx-arm64.tar.gz",
+            "hash": "c4a17c17b02d9559e0029328179d22617321e439e9360175f25385d60789f91582a4024ce41690439d85852e4c85f0d0ae20fe818c0f4acf0d7d48ffac2d2b5c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5b8d3892-9a75-4d22-982a-de33c2f75626/c79a540f8e659028cd796dff9af494d7/dotnet-sdk-8.0.206-osx-x64.pkg",
+            "hash": "cd1fc1e745d4b51725d71f1e451409931cbc750effc425a5b7ee7156b4f5930a5673fec1153f8b8177e177ecd6fc17375e49d64dd2debcc5f5922e76147f86c2"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ea0371ce-1119-416c-bab1-578cb8c1fa77/71cb9d66778c8e2a65ca40d8456300ef/dotnet-sdk-8.0.206-osx-x64.tar.gz",
+            "hash": "d7742a0b00c4df835639eeb18f2ae4888ac33d7d7c25d097a8868c5172c878d7df8c5bbd54de9b34f877f07a2dc6c748ea510f783e1842058e8cfd0ad2cda83f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a300e198-9bc6-4a8b-b858-537210a0fdf3/80d1ea4c5a300c992a2f5b2345f74416/dotnet-sdk-8.0.206-win-arm64.exe",
+            "hash": "7b7663ac4970a987b56187fb7ae0cb8ed1d2e1c35b06bb0bd1e6fa2e57a2926e3e0ab4b01bffb9bd6fc3ae2baafa8d0aef9b54f9fc8a901cef695b683597708d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/81fd6594-a0f7-42c1-b432-5713df0dd867/66061305c6f2ef8aeea7732352f2b589/dotnet-sdk-8.0.206-win-arm64.zip",
+            "hash": "570b597c4d232b6c605f7cd89729d3b0a75071a867b8bb31406830b37dccb95f8e15284c4acbecf3a288484136af5844f16c7aaccd7a158b27502695e3231cc1"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0d50bf7d-90c6-4104-9a22-f4c3cf3c03dd/7d5d18eead164bdb64ff739a82ec3d3b/dotnet-sdk-8.0.206-win-x64.exe",
+            "hash": "4a28b10b6c73b02e36ed3805009aee54f14d55da7e0485e906ce8291397635066a6ef087491dcf898df1715a439cd3cbd2116ed6210d3b50dd9a5ae0a7f2cd08"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/882b888e-87e3-4089-909e-691f735ff629/b37e66cf53d5afbd1c1d8556ff79a54c/dotnet-sdk-8.0.206-win-x64.zip",
+            "hash": "6d194e3e897074198557fd3f917b60953c82d192497eb0ceb7fd1fad37357c30aee84d1a798f896355c33871c8fbcc621b5a95192dcf701139a9f5f58b0f1b0b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a980d129-1141-4fbd-82e8-e8cf1efd2b4d/cad14485113a2d2a1a251059fa057e41/dotnet-sdk-8.0.206-win-x86.exe",
+            "hash": "4a23345a1694c8a9e90873bf5f6357c745fc667d0be5dc20692cb2213a17c8d5fafd0dda6a1662bb66efcff5b13af83da1e83068bb008debefcee152de8b3d88"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cb9add34-05a0-4bcb-a8bb-53f0a9cb7394/4f582baf339cdc876d55e2b730f40984/dotnet-sdk-8.0.206-win-x86.zip",
+            "hash": "de9e053901f97b310422875a2c5d03685718a74b7ebe7fb199809cb5993b68dae6272510d806844d8ffc388401241fc9f628653a300e6c87d25666c8b5002fc6"
+          }
+        ]
+      },
+      {
+        "version": "8.0.106",
+        "version-display": "8.0.106",
+        "runtime-version": "8.0.6",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7882b3e-d70a-45cc-9a97-58c621767550/e30a1267744124d1b853d9ee3a521fc1/dotnet-sdk-8.0.106-linux-arm.tar.gz",
+            "hash": "ebedfc205f9301890c78c4176d1a6f910890cf224e7ac34fd69f798d663550e36c3a2a057111304aaeecea31bfd496007ebbae4a51f33cd674588f42d8b3df9a"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34676827-2699-4f0d-81e3-347939a91b7e/6f2f3851e005f57f8b6c132ead1952e5/dotnet-sdk-8.0.106-linux-arm64.tar.gz",
+            "hash": "e8f735d20d79b20d24ce5b2f7c25c60604cb6b694b6572488c654cbf14a4d99c269f64f4ca23ab78aefaedf14f35a0ae1f33adf6afac5556e2ebd22ec73e04eb"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/07c0b329-cd7b-4962-a6eb-7f32138e1820/f2be1eb952e5318bbf659ddc1c914fda/dotnet-sdk-8.0.106-linux-musl-arm.tar.gz",
+            "hash": "0d149ee7d5e3557d631ff96fff06e7bbf01cc80041d9a378cd8633f5304ba8351b3d25f7b889d68ae245329fd9cd86d9475cac5ca3a157e5fd98c18420857edf"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/60b547cc-020f-4e46-b7b6-808265320186/a43d298c6240189ab20b64090283db72/dotnet-sdk-8.0.106-linux-musl-arm64.tar.gz",
+            "hash": "605fd1210a69fe1e933b64cb0377bda7e7fcfab17854069e252d444431260292d1470dbe645acc68e7ebec52985893497bfde9ba25a03794dbff9987437b2b45"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/250477e9-be9d-425a-92f8-f0b5f20a937d/7f4ddeab9d0247af9b970ee2733033ce/dotnet-sdk-8.0.106-linux-musl-x64.tar.gz",
+            "hash": "ac5cbd009cb29624f6a686fe476ed9a6ad290aa22d9a613f2e14f35076f251e3e3ec6b7b1d1760daf5efff5e2d673654770bb9ab0761326a71dc7e190deb63ab"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0fe59d31-bc28-4f57-8d1a-285f47b5a0ec/e4c5def191daf9f999efc5812b085924/dotnet-sdk-8.0.106-linux-x64.tar.gz",
+            "hash": "06eecc146b16eef0654fb4fd17faec06c6dc1b7236acc7e4a33e4b13cbea1d725faeb9eda41a0c12e65ec4c89d6624971429ca223638387c66f1d3e4dcd1407b"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/67394dc9-c727-4a44-b58f-dae2550fe260/2fcda9a7dbf7ee29820c14c10b5e9123/dotnet-sdk-8.0.106-osx-arm64.pkg",
+            "hash": "78b02895c2ef1151613cf002fb8d91afb17352ca2afb67386ad4c15499bf81ce3160103673458bc5b5ad0de3c80dd6c37e850a93fc613642c4931211b6f9ce23"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d595db17-776d-4b09-aefe-44777823a4de/55867e85ac1b03cd5609a936055c8ee1/dotnet-sdk-8.0.106-osx-arm64.tar.gz",
+            "hash": "490c20abc3cf52f76fecf422a6fcc66c98b7500a56986f84e617860a2758f43ddc4b235647837fae69e4c46a9d1ab9177d4bbfe134258797599b69178f6b91f8"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f1c53ea-6e0a-43a5-83e1-acecb221c806/3db1a0c239cb116fa52736dd7db04905/dotnet-sdk-8.0.106-osx-x64.pkg",
+            "hash": "77902c9beb889fb1c1795ed13e4e3c33ad58b7f62c7bb0d27ab9c8ecea96b1cefd9d79aa2c71c2b46dc234c89dc677a46dbd44234d39f8d188a03566bb4518f8"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8380cce5-930a-43ff-8a27-981e175d9881/4ddeae425c3c344f4afd8adddb03af5b/dotnet-sdk-8.0.106-osx-x64.tar.gz",
+            "hash": "4e6d45b7b1618bdb528a865d1c89e7ec7750f8a73ae7e805675dd9d7d3974f0b19785e743298f0c468144cd7fe9e20e521f65e9fc081b89d8bd9e187b5783c2c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eeaad43a-199c-48bc-9cc3-c90671d095c2/78411c8334e0abcd7e9fc3c544b95e02/dotnet-sdk-8.0.106-win-arm64.exe",
+            "hash": "9baa1ba45bddd77a17d78a227acb57c4d6cbac2b049d259bd546dcf8a32257a60f529d2fc6524904320be000d2ab1c3af2a63cecbe6f08ef7069cdcef5937080"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/14cf89d8-2cf5-4303-9763-8d2f7c75d060/f56c3632991c2b1c1321e40ddabdb769/dotnet-sdk-8.0.106-win-arm64.zip",
+            "hash": "f7eb2414fda36ff08c62412d31a38fc3c8ecdbf7fcc1bc46400e2cb2c3858f257a1618f356f2e8e66e1b718b5d5142600677c00283d8b8ee657792b3de52750b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/244dcb56-6c42-484f-ad2d-0a8fedad4c55/6657f8fecc936920b633714942aac79c/dotnet-sdk-8.0.106-win-x64.exe",
+            "hash": "efd894eaa180f73a9192f250d339ca686853ee5fa39c7ad9b05500740d86414f6d7c7cd44cb051f504f608cc7061b2ea20cf7d142d7a23c022bf087ab5548983"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/934da9c2-3f2c-4861-92e7-7b9bce3dab1b/b6afd553b5384f72f8303c6cdfbac9cf/dotnet-sdk-8.0.106-win-x64.zip",
+            "hash": "3232294d0af733659ca8636e48e494a2f52bf6a3fb307cf088ab0cca11c0e59dff1318c11208a700d6a491930b3ec8c373ce8f57516c46dc86e476e1a9cb17f5"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3c69e1dd-9bb4-4b00-94cc-717b474b5bc6/d98fec76e4967bbe8bd7531a8b23a757/dotnet-sdk-8.0.106-win-x86.exe",
+            "hash": "f17bcc8c1cbe167bce1f61481fd7264496ce81d7f8e997ad62e4f541d6a8e12b430781ee002847ffe7cced1d276633d317cddb4700d8ef6583972a5e5c037ee0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/51b9ef8a-394f-4527-ae3a-50c6546cb834/1b3ed3b8b4bb994e47fc75069858902b/dotnet-sdk-8.0.106-win-x86.zip",
+            "hash": "d27c0e46c165d611c2765b7ecfa9977cc1395c3ae954cf95b16c2741f152df76b5e9f68b3ca86f2a89d21877308e2ce4986305f829c491c848ddb84942536088"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.6",
+      "version-display": "8.0.6",
+      "version-aspnetcoremodule": [
+        "18.0.24141.6"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c27a9707-8627-43d3-837e-fa144bab2984/40f243e656752b87ff033e568d49b510/aspnetcore-runtime-8.0.6-linux-arm.tar.gz",
+          "hash": "bc1ee3f85799038e14dc2b28a57ea367b0d837a778add03a23804595156ae333714fa54a13503b173412c082043e6212035fe6238d0914372491e09efb09de62"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ccdcbb70-a5e9-4753-b6e3-4461ce56a69d/240803fc1ffba38ab3603778c03e9b87/aspnetcore-runtime-8.0.6-linux-arm64.tar.gz",
+          "hash": "9ed12847e404a0a4fdd8fca33a9a787c5ac2e6745d23821c7890f731f2f8f5682e7f9166b2764b13b612b08e091c71e13359b68acc11bcf990afdef1d42f6473"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f8fc863-9b60-4106-843c-8805927cb87e/21589785dd727d63ff6c8c68decb6922/aspnetcore-runtime-8.0.6-linux-musl-arm.tar.gz",
+          "hash": "7b0e39b2f517539f261e4b193e02b991149ab5e520c350fad2463481afde461891b287aeefe642ee6df5fef33df4a639c9f94feceed84ede5980ff3f297dcded"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bf5ae5c9-6d2d-44ee-8734-219607b6cb6c/72613294eba7b9bb11bf436da149dab3/aspnetcore-runtime-8.0.6-linux-musl-arm64.tar.gz",
+          "hash": "80141d73f84c902c645b906fee34bf27d2bfae4d1905f259b0d89ac00887663301dc6774357b86736bb65f068161358a7db677a30a49fa613c5328b65fa48a3e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/66ecdc3e-be71-4e85-9d55-95c3fee1066e/5e77a37d5ff492217e703ee391b39635/aspnetcore-runtime-8.0.6-linux-musl-x64.tar.gz",
+          "hash": "bd5fea6fa65dce16cc3e9879cccb4a684253d40fe6c00e610dd513da2bd3a9f89eed4442fc2a660bf1749fe22fea03a0519291f01a10068376507070105a1d0c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ce31d92b-b514-4f9c-843b-29c466871369/b332eba5641cbc6eed1e3a98480972d2/aspnetcore-runtime-8.0.6-linux-x64.tar.gz",
+          "hash": "16cd54c431d80710a06037f8ea593e04764a80cbaad75e1db4225fbe3e7fce4c4d279f40757b9811e1c092436d2a1ca3be64c74cb190ebf78418a9865992ad12"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b90758d2-834d-4fe7-b97f-e8294b68d07c/71d63df9474999f831811dd6989d9ba7/aspnetcore-runtime-8.0.6-osx-arm64.tar.gz",
+          "hash": "85d82e90182375ca21326e3d57be0dc5a39d7e64f1a4005950fe21c720f1d1e1615f64030c950fa7a49f6a104f029b9845648cebeb98d48d892aad3309c583c8"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ccd03400-c514-4956-9e9d-ad1bd67d1338/436b9590788dd3df98e73d4c5379c711/aspnetcore-runtime-8.0.6-osx-x64.tar.gz",
+          "hash": "61786ecd784b83eacfe4dd901bdd55474e52d9da85806b3d52184e8e35a3065b476e574c939f3af491a925bf7f04fdf376c53a25c103a187a7939f4736158297"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ee1b10d3-aca1-4ae0-b74a-97bd30fa6d2d/87e7a62e9f5438342b66e673d422cd57/aspnetcore-runtime-8.0.6-win-arm64.exe",
+          "hash": "894e98cfdd9cc7f6beb1f68c756eb474f8004a3e4020de9033d93d7d804c1273f0af77008ace9e972d133c461eabaa7a0502ed545f785a80c590c07ec243bb46"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/879b35cf-65fe-4072-9bc9-2aff035ed1e1/ecf45be70b47c7e53917237fad886bda/aspnetcore-runtime-8.0.6-win-arm64.zip",
+          "hash": "4ee96bbba7308e672a6087e9f37da462c9fa30ff7288ff5e2c852d0af56a5592d3c947ac4072bb48f35064b63e265f4e3e377117b69b72c8345714ff640c1970"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/38b32fc8-8070-4f14-bd52-65505fddc5ff/50e6cf3b7505eee02c3b3db8ea46ffe3/aspnetcore-runtime-8.0.6-win-x64.exe",
+          "hash": "7bdd420d03e92d8e05a8467649f5a0e64910341e945f3ae6f0ce26dc513b121ce00d4bd8889b043fddd4c6eadffd52a69cd12edb62a661b2b23a886174e4dfc1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/520cd61e-9682-4051-8d92-865ab45f76ec/98078349ce015c3252baa8e8a8c65132/aspnetcore-runtime-8.0.6-win-x64.zip",
+          "hash": "64eb92e0fa015de55df849d93b8a0afbfa0573cf5b7d5ebb81499aeb586eb2a82d86eee34c7b5bd555a8f819f92e6e1366d7bf98c2aba26d3d6fe8daf875cd67"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/88a7d3f3-615e-4771-8709-1e16873645b3/a36f311385df553e54201137f53d041e/aspnetcore-runtime-8.0.6-win-x86.exe",
+          "hash": "b311bd4ae0a87fbce391005edb1c6b55d4e630e59fa15a7ed510947aaa6bf3ffc2970e833d3a9f9063f5f8af3ffa4cdd5c2da3e0d808990977c0ce6e262f15fa"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/efe7c4fa-23d7-45b4-843e-ac8a466f18b9/178f4917f6b29edc149ebf404018b14d/aspnetcore-runtime-8.0.6-win-x86.zip",
+          "hash": "9e5ae375d1e7e6d58f62419285a8b087053ccbd997a670538fe11122febcc80a318814cec459044964fae78de95af21e188338ddebc5fb1e35addfcf788b5f2a"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/23223793-f03f-4b30-a0f7-07fcdb687be8/01a4fb13a8360fcc208e172f8aa197d1/aspnetcore-runtime-composite-8.0.6-linux-arm.tar.gz",
+          "hash": "f7fccfe2b4bde2317efc4954884d780bb9486a5e55bdbb50dadd65eea59681abbe9fdb9565a5ff13935b21fddeda2b2efb380811dbe0974cb39335e04f94d494"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/933fe1c2-c361-4893-b187-06122ee95e52/20e0d984ff8be88ccdb6587c29fc8c3b/aspnetcore-runtime-composite-8.0.6-linux-arm64.tar.gz",
+          "hash": "2ac853990b44bc1ebfa7ed31c599150f5c7f43b4a84ab7b7a96312ced78222dda93728d42b94b3be4acf763e6d95702b7d27186b51b56db25d39bb8bc745aeec"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6cee00e7-81ab-40d9-bfe8-c54d9aee20a5/3f7980778d3bdb550d9fe1f301c5016b/aspnetcore-runtime-composite-8.0.6-linux-musl-arm.tar.gz",
+          "hash": "bb91187b837739a7317a946e459bd2fcbe61f0763a196f867c3cb6b9d967cdf6ef30953b43a9bdcc298545dbc88c7a565d0006113f425e08f8d9fbe296de07e8"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7d2289a3-6d52-4b79-8577-245dcaf61e54/3531b11b9a71e0fea86683226d2f3eef/aspnetcore-runtime-composite-8.0.6-linux-musl-arm64.tar.gz",
+          "hash": "1ac399561d4c5056ecf9dd8b36ef64704c7de9e8bf92f3c45c54c2cf1fe794421edf18e663d39643746e4abe3fe9a5376578a2887198b166f49155c0d0ced6b6"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1fe40625-1390-487a-a739-b78505215e95/a5e64f42110cfa77153011677703b1fa/aspnetcore-runtime-composite-8.0.6-linux-musl-x64.tar.gz",
+          "hash": "8a8336c331327fdb480a27a45825a1d798733d766bf090b0f9af9ba611d91d73a54ca754c5a5654f860eaaccb8cd8708007576f1da35c32f00bca6a9ed7b308f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/23defc47-8cd4-4ada-901b-9bb942e3cde9/9c386c008a3dccc23c70de3dbbbbb1a2/aspnetcore-runtime-composite-8.0.6-linux-x64.tar.gz",
+          "hash": "bffc08fb0ec63251d06cf69c95844d19924b139f0417d1a79f729c856fda89610e03b3ed49844f7dd15401c447137f6daf5b26550269a2c0eb0bff253ab234ec"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/751d3fcd-72db-4da2-b8d0-709c19442225/33cc492bde704bfd6d70a2b9109005a0/dotnet-hosting-8.0.6-win.exe",
+          "hash": "01c4d06e0bb10e69581b67fba6618f003fdbdd6043bab4c58c47b7f8ac25e52ab7bd3e39404f733821fe6083e2462dbca20b2ff948a7abe8fbb4fd2f26956584",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.6",
+      "version-display": "8.0.6",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3bee8b48-dd89-48c4-bb3c-1d786600a924/7a811fe983a4c5a61d79192e37c38e13/windowsdesktop-runtime-8.0.6-win-arm64.exe",
+          "hash": "26752fac8a17d9c78968fed741faaf364b17815bad2d74d2ba0cd29444fe2f86ed0f85d8e40744b82155a7763c43ab5f399fad426cd7f17a0a6775b5e8a6ec36"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1d50d496-fb15-4bf6-957a-c340c0a9a81e/cb7ec8cb099ee10bad57254f1736e4f0/windowsdesktop-runtime-8.0.6-win-arm64.zip",
+          "hash": "e24e53c2bf2fff89f66c66211b4da8718d3ba72eee9f361d47ce79e953c95a5f1edb0939b2bddc1ebc3794a7fff4ff0f1673797e75798742aece9f23b63ecc16"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/76e5dbb2-6ae3-4629-9a84-527f8feb709c/09002599b32d5d01dc3aa5dcdffcc984/windowsdesktop-runtime-8.0.6-win-x64.exe",
+          "hash": "91bec94f32609fd194ac47a893cea1466e6ad25a16bbaf39cd6989fa9f09e865ba87669aabfe26cd3c8f2a57296170cc021dc762e238a6c5cb5e843d3df3169f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c33ca75f-f47c-4eb2-9b35-0d3a0d39d986/40080ba5834b05fc4ff059f7a60e7033/windowsdesktop-runtime-8.0.6-win-x64.zip",
+          "hash": "ff7dbe5c53a99b755fb702f24f9a63f7c6fb6d3451cac3f8984632bcd4012072b4a0198535084560ab829271623d31834b7c7e64e051726b1778d9fb6e3070fe"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fb4a2e70-0c24-42f8-a549-4ea2b6e16831/e7bf08360f9c96ad3a90b0eb2edf96c0/windowsdesktop-runtime-8.0.6-win-x86.exe",
+          "hash": "8cd87203979b7ca6c191bb5f46f71ade8f00439a564fbe73caa48c8bc0d33701893fff51d0e1c58fcb9cd83cdc420748fb30f4daa221e7417012d136bbd2310f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bc38d8f3-ed1a-46ec-8f8f-19544085fc7f/0c2070145654146d4ca8f9e9f9a4601d/windowsdesktop-runtime-8.0.6-win-x86.zip",
+          "hash": "6628d2a82bb69adc698afa52214c5b456b3b4e8ae6a5d45d6f3bd6e67224349b86531fb9d055180608d47f591c331c13c7586dc5ac41571b834bc37335a9ea51"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.7/release.json
+++ b/release-notes/8.0/8.0.7/release.json
@@ -1,0 +1,634 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-07-09",
+  "release-version": "8.0.7",
+  "security": true,
+  "release": {
+    "release-date": "2024-07-09",
+    "release-version": "8.0.7",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-38095",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38095"
+      },
+      {
+        "cve-id": "CVE-2024-35264",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-35264"
+      },
+      {
+        "cve-id": "CVE-2024-30105",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-30105"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.7/8.0.7.md",
+    "runtime": {
+      "version": "8.0.7",
+      "version-display": "8.0.7",
+      "vs-version": "17.8.12, 17.10.3",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1dc20d39-a5c4-4e23-a70b-842fcd6d603a/814d37d9c67811d9d2837905e4330eab/dotnet-runtime-8.0.7-linux-arm.tar.gz",
+          "hash": "ccfe95a95be3c64d568c6f79df391daf73304fa2c2aedf4616cd9981efe11cac698c157d8375da3afda691b78124cc6672fde7353b0fea4d45da15e003040a2a"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/710337b9-9cb6-4bc8-8d13-daeab2578a08/b3ec8c17f85e340820a0ab36a3870168/dotnet-runtime-8.0.7-linux-arm64.tar.gz",
+          "hash": "99e6959a1156d5abc8f0c73b3d493fc1e10a42d48a573226ebcfbdf96bb6fb1c8701db5b3582a4303ce26a4f784e74eb402cb6e5e4bcdbb5dfab8fea221cfe02"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2bb39900-40fb-4a9b-8c6c-17a46d2022ca/8fa92b782e35d1799e987487b06da37e/dotnet-runtime-8.0.7-linux-musl-arm.tar.gz",
+          "hash": "03aecb348a99d0afc9b90006e14a0c75ed69f7ef6cb8689fac171edf0f88aaa928a395ce433a390cee1ca4255560511c89d8d827a575b21876e2e7f94d5bceef"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/131bbb56-05f0-42f5-bcd0-7f34519c3987/88bfa5e29ea09629c1e62857402cd466/dotnet-runtime-8.0.7-linux-musl-arm64.tar.gz",
+          "hash": "249246082498d3f6b5a3a0347527ac5a98ecd0fde235d6bb48bb18e4bb031eda6833526035279e99e97fbb5dc58fba132c9bed5f33442c47e571a91f648fa863"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/938cbaf9-8ed5-44c4-bbb3-fa982add0482/29c59ec494a4349190c29b2d03d8957b/dotnet-runtime-8.0.7-linux-musl-x64.tar.gz",
+          "hash": "31386a3af6cbeea3e1b0e2f109d10222c5ad41057540fd5c626959ec7d2a542b859c9699cb86a1ac812eb7fed139dcab0c53ecb8adf678fe0ad04c62cf6c1f8d"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cf3418ca-0e14-4b76-b615-ac2f2497f8ec/2583028ea52460cb1534d929dc7970fe/dotnet-runtime-8.0.7-linux-x64.tar.gz",
+          "hash": "88e9ac34ad5ac76eec5499f2eb8d1aa35076518c842854ec1053953d34969c7bf1c5b2dbce245dbace3a18c3b8a4c79d2ef2d2ff105ce9d17cbbdbe813d8b16f"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ae4430fd-26d6-4bd3-838a-314ffd356c78/24147e9a69b371bea66a1789bda6a1d5/dotnet-runtime-8.0.7-osx-arm64.pkg",
+          "hash": "6fe0c208a7fe6a2b93a64a9d0cd30f7f162849fc9e71bd012e5f1305b27103721f403689f1ccce8b45b038027d892d125f842e280d680c831f09dd5ff400b998"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ccacebeb-3dda-4887-9a98-e2dc9a9d9dc2/0ecac27f49c0111f4877cac54ff873a0/dotnet-runtime-8.0.7-osx-arm64.tar.gz",
+          "hash": "8af655573350f6be0b47223ae7272ca8d49fb3c74f6fc167e7249267c1616842eea09709205a07acd3b86a5ac862026ed1269ece5e681c3fd50ada8351c5dfdc"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f7ffd35-2e7a-4a42-b096-7b344ddbb514/bb2e3a4af76ab0f3c39fd01bb0b51e6f/dotnet-runtime-8.0.7-osx-x64.pkg",
+          "hash": "9bbdd3a4f2792083a51d47ca2e854e392bbf64c4c6995e4d6833a2998f4549dbf5aeeca2d84c335965f48857b7813d860fb980d7a254704dc43b72fe8f512952"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c0e3a3f4-d235-4531-a1f2-1ff969cac1ab/837430d708532d74b7296108a681b9bb/dotnet-runtime-8.0.7-osx-x64.tar.gz",
+          "hash": "09107de04c6748fb3d98d72296e3470a6d3551a66bfcc310d2be0f678dd1cb8cb13a886b1b7e1e3856e12c0766cd5007f9922625653a6e284f5ab8fc80ee04ad"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/68d0360d-462a-44db-baa9-53fd5d67c05b/6b2c172c219ef4d083c3f4b7f69ae97b/dotnet-runtime-8.0.7-win-arm64.exe",
+          "hash": "098e27604a181888ce901eca1cc2e55af60a540e813be554eae39fcb2569b5e74b8ae2c7ed37a7ed9ef1048d50b8a0bcbd33ad94803a7d2e4b724a64e87a0db7"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/12a17ef1-071d-489e-b138-1fd5249ac7f9/4e6030ef34957f9120171a74932f4fb5/dotnet-runtime-8.0.7-win-arm64.zip",
+          "hash": "4b2dd24aa09efa1438bea7f7d8e973117f4901f94aaed785f12a3e15fc705bb4ca068c5c81ca6f7751ab9d1ec2a277a11430a3c9171a297d628190e250c96c1c"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3980ab0a-379f-44a0-9be6-eaf74c07a3b3/bd1cc6107ff3d8fe0104d30f01339b74/dotnet-runtime-8.0.7-win-x64.exe",
+          "hash": "e016b47ff8f179f1edf641cca20130e04951509f0f69f564f290bfb0ad81d7db83541fb00c4ddd8364e71c1120bcc227fa0e7e8e142bbee2c4d329674ed0b155"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0f2e2c47-3e38-45be-aa3b-f382c5e73ff8/c7890b45dbd8306b4d89daa55abe49f6/dotnet-runtime-8.0.7-win-x64.zip",
+          "hash": "abe510a4e57bb115698bbfc1c49fe2414cd5696ebeffc7c8803d4d0278a40010dff36b3c347651e5a87301a4472bc610019ea281499d5c351e25e60caa18195e"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b1dc2db4-3337-4ee1-a1e9-91768860af9e/78fafd2bcbd8937fae5ba1bb97071138/dotnet-runtime-8.0.7-win-x86.exe",
+          "hash": "32290e42a0a0b082eec4e70352d9777c9cbcc97296df98904a8b8e309dd1fc196433a1a3c62d1f60cd0939b4948237a3ff5f154c577729b7154a627e3d56c1bd"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3e0c1889-b4f7-414c-9ac9-cdc82938563d/daed61ae792654223bcac886ff3725ba/dotnet-runtime-8.0.7-win-x86.zip",
+          "hash": "1bd64825ace6fbde84c8f0d42f18df57c1a570464ff65767842797f3b54f86486288084687bdd8d1da0f83ef2eb76b05af14d386b6c52e4c9ff072bd71f58a32"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.303",
+      "version-display": "8.0.303",
+      "runtime-version": "8.0.7",
+      "vs-version": "17.10.3",
+      "vs-support": "Visual Studio 2022 (v17.10)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9e0bdcde-1878-4351-883a-c0adbb570bba/156df738634f710dad131e993fc0f48a/dotnet-sdk-8.0.303-linux-arm.tar.gz",
+          "hash": "03b3730d1fd5e1955b8a23e69695c975e88e781513b1f47027ce4ed96a8743ba2560ca87ae2e937ebd89ef69a3aa05c4ca2f39eede5a27bd937775f372b9feba"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4bfdbe1a-e1f9-4535-8da6-6e1e7ea0994c/b110641d008b36dded561ff2bdb0f793/dotnet-sdk-8.0.303-linux-arm64.tar.gz",
+          "hash": "09cb6b12770febe186e36971afdbcea6e8bf5fb34b7701cd8c416f597d3b7e930d05e51ccef1985e5598291540ef2d721187904587469300bb39772317e2be5c"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2ff544fc-a1c1-4dc8-b489-aa43117f314c/228b6791886d5243f29d17390c8661ae/dotnet-sdk-8.0.303-linux-musl-arm.tar.gz",
+          "hash": "5e119bf1496bebd3b62d0c0c837bb8e8695784c91f9042771b01b47953d82e59605d7c04f2b821340792ace2966587a10d980bebeb8f9a39f1e8e4588ab59a6c"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cc4a53e2-53e4-4d13-8b19-6bb5df78eeaa/1989589954758fa2883080f290da47b4/dotnet-sdk-8.0.303-linux-musl-arm64.tar.gz",
+          "hash": "88a42a0a9f0b6981eeb0d2cdbde0fd98631d57c09ddca566bc1b4d4b99a9165e276a3434f6804bd54628387edae99c8f0025e889c0e06ade0defaf2fa5858d65"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c75c7461-fe0f-4483-9e1b-b5f629dbd51b/da8d9a8dbfd6e6bc144ef930259bf346/dotnet-sdk-8.0.303-linux-musl-x64.tar.gz",
+          "hash": "5696332dcfa1dd16f897f68dd190e45f6604fd8228d563394ef9da09f2ff99214ba23b80fa416b7748a5c34912eb42523ba83138d5cbc4468e1efc15b747630a"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/60218cc4-13eb-41d5-aa0b-5fd5a3fb03b8/6c42bee7c3651b1317b709a27a741362/dotnet-sdk-8.0.303-linux-x64.tar.gz",
+          "hash": "814ff07ccdfc8160c4a24adfda6c815e7feace88c59722f827a5a27041719067538754911fc15cb46978e16566fe0938695891723d182055190e876131faedda"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/763ab233-7f0e-481c-8b8a-c432328330a5/8a1d8bed9188f553e1cd3ea2b615a93a/dotnet-sdk-8.0.303-osx-arm64.pkg",
+          "hash": "3084ad0cce453937b22912ae6b882fcca3d680c3103964ee7859a2ad55816e3188b98d186df0a7c4e5e2a411806a72686392e646c3d34c85bb4e40d525f0f12f"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d81d84cf-4bb8-4371-a4d2-88699a38a83b/9bddfe1952bedc37e4130ff12abc698d/dotnet-sdk-8.0.303-osx-arm64.tar.gz",
+          "hash": "c1c2935ac0b6654805e8112ff88d31ca9aae7f345218c9a9d9e512c98d73e2bccdfdb006537832e4f20fd3a9ce4defaad537e5cb98deb538e95b54a2c76a9110"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/827eac3c-729c-4416-bdf4-0fae6ec6492f/40ccf2187797de61688d354da3e43090/dotnet-sdk-8.0.303-osx-x64.pkg",
+          "hash": "3a65f25e7bf4af09403776fe058b990cc7ee43e59ec7312d18429d1da929c5e9564d9ac89ee68775817b814b47137e1f4ab93e233635467ba8f48cb42b447b9c"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/295f5e51-4d26-4706-90c1-25b745cd2abf/ef976bfc166782e519036ee7670eac36/dotnet-sdk-8.0.303-osx-x64.tar.gz",
+          "hash": "5676b8c0497adcc9543b5f4dd57c54451ea66e79ce6f656647bff54619785a05f5c52cb22483bf14b1f3eb85cd3fb19c2ce4352e7b8482fbc1998a1e7043c377"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a141a071-019c-4fb3-9611-30bf2015704f/1542d3366480dbf57f1d98e3debde994/dotnet-sdk-8.0.303-win-arm64.exe",
+          "hash": "a2f26a8b816bb27fda3d0b5bfc32af0714543ab08cc1261261dd4487605fe89de85a77d646e2c514e1b54ba0d0f5e06b93c3d81a7a81cc711654e6c1237d5cd7"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/047ba9ae-13be-47a6-aafc-f95935068573/ba7ab57972d76fae909506a2cde85b9f/dotnet-sdk-8.0.303-win-arm64.zip",
+          "hash": "3ec3f0a3d5cdd3cd0b33be9b09166ed0dfc1e83bcae38170b60085fd8a95b557bfa9bd0583abe576156845998e356cdd43afc95428a1d093546a3bdbfdf97f43"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d1adccfa-62de-4306-9410-178eafb4eeeb/48e3746867707de33ef01036f6afc2c6/dotnet-sdk-8.0.303-win-x64.exe",
+          "hash": "69c7195d859b3ca0757fa1bf367e839c050996ba8e46568130b722d987177d3d3e025dfb9be6ba3da3e83d3c1e7a4ebba6cdaebd31ee4677a8fd4a74971ca0a1"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/93d39941-31b3-4c50-b124-0de50d464fe5/93a0dddb827811ff50586cb361f613b0/dotnet-sdk-8.0.303-win-x64.zip",
+          "hash": "be8a71f8819ceb35937c158107a34a77d0ee4f7ad761241d1a5a49842288f280b1f521dc3dcbcd2fa8a571de740d873e40b80615c2b345e2501e1875844b0350"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ce6d94a-13c1-4102-bb1b-b0f7ea5afb6e/0764c80c81c16ab927c0a7321f7c07cf/dotnet-sdk-8.0.303-win-x86.exe",
+          "hash": "af52649a05bb3c8ba494291234d67f3385446a8a08eaefcbe9fbc4e766ae97a6a13253060a798ce076511fa59086b1d9fa638b51a5e748bcfc79d36ddc7991ca"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/351df7c4-0671-45da-9eb9-dfb165486ce3/4526c9497d5fe8a68886010f0d298b0a/dotnet-sdk-8.0.303-win-x86.zip",
+          "hash": "1a2e7f7c0c7ca9e1bf453459490e8a496c673135f4e285ed9dc3b205cb999c0fe686d74bd3f1d1dd5293b943b14d41d1d2b61e3f8dc7dda9d6c524cea8b30c8b"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.303",
+        "version-display": "8.0.303",
+        "runtime-version": "8.0.7",
+        "vs-version": "17.10.3",
+        "vs-support": "Visual Studio 2022 (v17.10)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9e0bdcde-1878-4351-883a-c0adbb570bba/156df738634f710dad131e993fc0f48a/dotnet-sdk-8.0.303-linux-arm.tar.gz",
+            "hash": "03b3730d1fd5e1955b8a23e69695c975e88e781513b1f47027ce4ed96a8743ba2560ca87ae2e937ebd89ef69a3aa05c4ca2f39eede5a27bd937775f372b9feba"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4bfdbe1a-e1f9-4535-8da6-6e1e7ea0994c/b110641d008b36dded561ff2bdb0f793/dotnet-sdk-8.0.303-linux-arm64.tar.gz",
+            "hash": "09cb6b12770febe186e36971afdbcea6e8bf5fb34b7701cd8c416f597d3b7e930d05e51ccef1985e5598291540ef2d721187904587469300bb39772317e2be5c"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2ff544fc-a1c1-4dc8-b489-aa43117f314c/228b6791886d5243f29d17390c8661ae/dotnet-sdk-8.0.303-linux-musl-arm.tar.gz",
+            "hash": "5e119bf1496bebd3b62d0c0c837bb8e8695784c91f9042771b01b47953d82e59605d7c04f2b821340792ace2966587a10d980bebeb8f9a39f1e8e4588ab59a6c"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cc4a53e2-53e4-4d13-8b19-6bb5df78eeaa/1989589954758fa2883080f290da47b4/dotnet-sdk-8.0.303-linux-musl-arm64.tar.gz",
+            "hash": "88a42a0a9f0b6981eeb0d2cdbde0fd98631d57c09ddca566bc1b4d4b99a9165e276a3434f6804bd54628387edae99c8f0025e889c0e06ade0defaf2fa5858d65"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c75c7461-fe0f-4483-9e1b-b5f629dbd51b/da8d9a8dbfd6e6bc144ef930259bf346/dotnet-sdk-8.0.303-linux-musl-x64.tar.gz",
+            "hash": "5696332dcfa1dd16f897f68dd190e45f6604fd8228d563394ef9da09f2ff99214ba23b80fa416b7748a5c34912eb42523ba83138d5cbc4468e1efc15b747630a"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/60218cc4-13eb-41d5-aa0b-5fd5a3fb03b8/6c42bee7c3651b1317b709a27a741362/dotnet-sdk-8.0.303-linux-x64.tar.gz",
+            "hash": "814ff07ccdfc8160c4a24adfda6c815e7feace88c59722f827a5a27041719067538754911fc15cb46978e16566fe0938695891723d182055190e876131faedda"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/763ab233-7f0e-481c-8b8a-c432328330a5/8a1d8bed9188f553e1cd3ea2b615a93a/dotnet-sdk-8.0.303-osx-arm64.pkg",
+            "hash": "3084ad0cce453937b22912ae6b882fcca3d680c3103964ee7859a2ad55816e3188b98d186df0a7c4e5e2a411806a72686392e646c3d34c85bb4e40d525f0f12f"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d81d84cf-4bb8-4371-a4d2-88699a38a83b/9bddfe1952bedc37e4130ff12abc698d/dotnet-sdk-8.0.303-osx-arm64.tar.gz",
+            "hash": "c1c2935ac0b6654805e8112ff88d31ca9aae7f345218c9a9d9e512c98d73e2bccdfdb006537832e4f20fd3a9ce4defaad537e5cb98deb538e95b54a2c76a9110"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/827eac3c-729c-4416-bdf4-0fae6ec6492f/40ccf2187797de61688d354da3e43090/dotnet-sdk-8.0.303-osx-x64.pkg",
+            "hash": "3a65f25e7bf4af09403776fe058b990cc7ee43e59ec7312d18429d1da929c5e9564d9ac89ee68775817b814b47137e1f4ab93e233635467ba8f48cb42b447b9c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/295f5e51-4d26-4706-90c1-25b745cd2abf/ef976bfc166782e519036ee7670eac36/dotnet-sdk-8.0.303-osx-x64.tar.gz",
+            "hash": "5676b8c0497adcc9543b5f4dd57c54451ea66e79ce6f656647bff54619785a05f5c52cb22483bf14b1f3eb85cd3fb19c2ce4352e7b8482fbc1998a1e7043c377"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a141a071-019c-4fb3-9611-30bf2015704f/1542d3366480dbf57f1d98e3debde994/dotnet-sdk-8.0.303-win-arm64.exe",
+            "hash": "a2f26a8b816bb27fda3d0b5bfc32af0714543ab08cc1261261dd4487605fe89de85a77d646e2c514e1b54ba0d0f5e06b93c3d81a7a81cc711654e6c1237d5cd7"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/047ba9ae-13be-47a6-aafc-f95935068573/ba7ab57972d76fae909506a2cde85b9f/dotnet-sdk-8.0.303-win-arm64.zip",
+            "hash": "3ec3f0a3d5cdd3cd0b33be9b09166ed0dfc1e83bcae38170b60085fd8a95b557bfa9bd0583abe576156845998e356cdd43afc95428a1d093546a3bdbfdf97f43"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d1adccfa-62de-4306-9410-178eafb4eeeb/48e3746867707de33ef01036f6afc2c6/dotnet-sdk-8.0.303-win-x64.exe",
+            "hash": "69c7195d859b3ca0757fa1bf367e839c050996ba8e46568130b722d987177d3d3e025dfb9be6ba3da3e83d3c1e7a4ebba6cdaebd31ee4677a8fd4a74971ca0a1"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93d39941-31b3-4c50-b124-0de50d464fe5/93a0dddb827811ff50586cb361f613b0/dotnet-sdk-8.0.303-win-x64.zip",
+            "hash": "be8a71f8819ceb35937c158107a34a77d0ee4f7ad761241d1a5a49842288f280b1f521dc3dcbcd2fa8a571de740d873e40b80615c2b345e2501e1875844b0350"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ce6d94a-13c1-4102-bb1b-b0f7ea5afb6e/0764c80c81c16ab927c0a7321f7c07cf/dotnet-sdk-8.0.303-win-x86.exe",
+            "hash": "af52649a05bb3c8ba494291234d67f3385446a8a08eaefcbe9fbc4e766ae97a6a13253060a798ce076511fa59086b1d9fa638b51a5e748bcfc79d36ddc7991ca"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/351df7c4-0671-45da-9eb9-dfb165486ce3/4526c9497d5fe8a68886010f0d298b0a/dotnet-sdk-8.0.303-win-x86.zip",
+            "hash": "1a2e7f7c0c7ca9e1bf453459490e8a496c673135f4e285ed9dc3b205cb999c0fe686d74bd3f1d1dd5293b943b14d41d1d2b61e3f8dc7dda9d6c524cea8b30c8b"
+          }
+        ]
+      },
+      {
+        "version": "8.0.107",
+        "version-display": "8.0.107",
+        "runtime-version": "8.0.7",
+        "vs-version": "17.8.12",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/020bb759-11a7-49be-89f1-b2935c8fea05/c2df282e9aeabab835159e8a368b04da/dotnet-sdk-8.0.107-linux-arm.tar.gz",
+            "hash": "782065b4bf96901c91448412bb22fba27958e8812caba0a02cf8dbf2333f7320ba2c1eecbef4859f4034eb80d04bdb853a1836e1d284bdf5f623c7416dfc9861"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8d60cad9-ce0f-43de-8dd3-fa3fd39fae11/ce3bd2ec1177f519b45fe30c6e9bb74a/dotnet-sdk-8.0.107-linux-arm64.tar.gz",
+            "hash": "ab487873827677f44efe4372e0c325a48f339008d00307876e1e56795bc006be1770e8b1f9581c7197ea1bf857eae525aca18934591f603363f8fe9e021e7b2a"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/17620b9e-7cbc-44b5-ad52-7b93845b5480/277f76f99f6e33d6ca273c5647c5e61e/dotnet-sdk-8.0.107-linux-musl-arm.tar.gz",
+            "hash": "e6e6325c6292bf435a0771c33eaf330dc132a11372ea6d12427f5a6c24cb6db260d95b1dfbba3c232cf9d5166f61192a05c7e3be4210a05a6687634fb0a887c6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/119a72b4-47c5-4c7d-afb1-1116f25bf03b/39b9016420f86e19dec95a08d8a7c4c9/dotnet-sdk-8.0.107-linux-musl-arm64.tar.gz",
+            "hash": "5b99a07607cae652e4b392c17a7856ffb5df939e95d741d07c385d422e5511394567b5102213da1dc65183680d0e908d83c43c95b14bfabec305ca7731d9d676"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/10822ebb-400d-4ebc-80eb-f81fefb5b126/f18a8a171534bc6c28dde71bf1dbe8a2/dotnet-sdk-8.0.107-linux-musl-x64.tar.gz",
+            "hash": "f25c95f9acff4db16593541fda517c32477eb618dc9ad5b3983a4ab5bd62fdd3c03c7d9f56afe1132aff5137bbdc4161e0b83f7c8101cb1766b82ed4072becef"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7280c125-4555-41e5-8060-cd69e4e325a4/34e25b09d2c92b71215f8974a4eeded3/dotnet-sdk-8.0.107-linux-x64.tar.gz",
+            "hash": "10e0fbdc589e5e0de4fb0fe0e9c839bb2257c51948037a224d4358b8328b6791014ab4cb164beb617c83531a6ed774acb37b08e4a1b53f165e3eb853fd41a959"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0d87e4b-fe91-494b-a514-1ac57f1a8bf7/df4e34911dce10259cc62e755c52ef02/dotnet-sdk-8.0.107-osx-arm64.pkg",
+            "hash": "15049070340e2ed4481df808fd922d19e9ef2287702feb5b4a5785e2a20204108274869f3376dc8ff4b2cb4e5e43fbb9fae6a430a684539bb4c2451d2f33eb32"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2bb0f88b-19ab-48f3-b0ff-146629c3ead8/8e59918475c54fe4d881ce8f5bbde2bc/dotnet-sdk-8.0.107-osx-arm64.tar.gz",
+            "hash": "b293f8e3cad20278ee85e30b4b1baa615c30b0e7aba557b1d0248d9e5c4557e323b726afdde0386c0227d6cbc6f95c8ef5493e209cb5a42b64e8c7f6e495224e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2cc7d177-7dbc-4e7e-825d-c5b546b7c295/6a8b21c1108782b7e13dcda1dd1f2346/dotnet-sdk-8.0.107-osx-x64.pkg",
+            "hash": "9b63206c36ff3b64d222fea1c143741a813d099616e5c90665484b966f82e26b38addc7f4712a705287b12534319b517ac377b14d30c4310fe7d695676f7b4a6"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c26fc34d-c784-4c4a-a2b1-43bf3599d4e6/c3ebead0223edb028c7e53eecf37048e/dotnet-sdk-8.0.107-osx-x64.tar.gz",
+            "hash": "9bc62515220f924cadf02e5be880fa813b6d0b0cf8c2199a7e930e25e81576ff3e88894e5a0b691d8b0a1e32fe1ab4499ff47d80cd004f07af61d6d362efb654"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1d411b6e-8138-4ee8-b592-81b020839cc2/8eb7170c83b693cc47f50d6f12d04c14/dotnet-sdk-8.0.107-win-arm64.exe",
+            "hash": "df5c9f9d4298bbeb5430e793d1735ecd17bd8bd18ec5547c3a9593ee4cd09688dd6eccfaf312156a161336fff830382261ed970bdd767f8dcc8404bad1b316a1"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a5ea5b30-001d-4438-ad5f-3318d601c9c0/08b9ba76a5a94dae385914d769ec6dbf/dotnet-sdk-8.0.107-win-arm64.zip",
+            "hash": "088753c813432bbd94e13f45b7db4366730a832ce603efd5f60499c4d414575bca805c066ba5743d5639c5e427d9f4501640da7c0eef437d411382e0c17dfcc5"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9c40a009-d059-4e8b-bdef-83daa6f3fff2/b806aad8cb92c64f30e8c39d813bb2ba/dotnet-sdk-8.0.107-win-x64.exe",
+            "hash": "98413082e4d7df181904053f481f3d172d6d62fc546c004d0e8301b882cee72508c0d69afa514b6ec060ffcd6e4b02b239eaf9e2c804009bf5b99dfaa29ee41c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c1b355f8-c828-4d2d-a0f5-a0695834be68/2c7a7983c02bebffc071648658b33b73/dotnet-sdk-8.0.107-win-x64.zip",
+            "hash": "9d26be45d25a7b13861e4beb95c78e73425c5c210bdf8c3b23b29813caaa314195b928df38eddf5bb561bd2767e607dd2b863d09283ed7d5f96dd4fa6a35434a"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f596f9b6-943f-4606-b332-dcef8069803b/673eeb3661e6c1530b050cfbfb63053c/dotnet-sdk-8.0.107-win-x86.exe",
+            "hash": "969d63a0747103bd4bec05a891d0e2c900e12ffdda504123f2de4c4025c4904f516e55b8edd84003e08e414c05256c5cc0df2ca6527c61684be59791c071abca"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ac14ad95-7937-45ef-8497-d0df69b6e478/a537c1abef6bf6a4ce4b33098f9acb5a/dotnet-sdk-8.0.107-win-x86.zip",
+            "hash": "8500a6e40d28de34881ea9f2679d2559d6192a4deb16bf2fad7bed91d10ef0726da294b6f362be0fb89524622d246bf0fd3aa2a4dab97e671f5bcecaaedb67ed"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.7",
+      "version-display": "8.0.7",
+      "version-aspnetcoremodule": [
+        "18.0.24166.7"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d37fc703-70c6-46f2-a5a1-b60f45fd71d0/6a74aa0bb89feb7f795df1ea92d030bf/aspnetcore-runtime-8.0.7-linux-arm.tar.gz",
+          "hash": "d0107441223a44f1c4d9fa08c2d66b1875d20917fb1dacab7f80a42f0da1428570dd1cb86bc1f6e4eef3414e1770768fc8f17b836d0f7ab9b890848bc18ce8b0"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/421d499f-85cb-43dd-97b2-8ebfd06dda8a/61b03be4662125e4af044c7881e66f0e/aspnetcore-runtime-8.0.7-linux-arm64.tar.gz",
+          "hash": "5f1d31b0efc793655abf4289f8f1c7e8cd1ffabfd65b385b49e3f5232277c62ccfbbdad2a51731a8a88594a06c2c9774e38865cb3f7e19c9925a12b25b40b485"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3898e56-a160-4817-b6a2-712c5cb64266/1a465710acd917f8002548f426deebd0/aspnetcore-runtime-8.0.7-linux-musl-arm.tar.gz",
+          "hash": "9acc8bc8c5fde692def85b1dffaa8648fcc6a2a482c252882660ecdc4ca8b4be8d59274891bfb9b106cca62849a705b482ef5b4c539014e284dc2309234ffe22"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d7c07119-b207-4ded-b41f-2f3fca16099b/4463b6690425cf7faa37519dfbe89a46/aspnetcore-runtime-8.0.7-linux-musl-arm64.tar.gz",
+          "hash": "ca5b8d9fbdbe3c38f560d662705be00174885fc7abd875ac056c97788410329af9017ec6052a146b9414d26ff956accdfdc6ef315aaf7c6936b0520a9320493f"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7fb2c473-d403-4347-83c8-243b9840d7f1/2aeb8220ea65ee119627f6145102599e/aspnetcore-runtime-8.0.7-linux-musl-x64.tar.gz",
+          "hash": "a60d470dee1a1da34ce4d9e84a6dca1e7df2bbbc8b3b0fce36543f712b8a3da78a3ddf59b4ac231986f49a6fb44f59a270a184fabbda6a0e098d018d3e2afa46"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/06cbb934-ef54-4627-8848-a24a879f2130/52d4247944cee754ec8f4fd617d502a6/aspnetcore-runtime-8.0.7-linux-x64.tar.gz",
+          "hash": "c7479dc008fce77c2bfcaa1ac1c9fe6f64ef7e59609fff6707da14975aade73e3cb22b97f2b3922a2642fa8d843a3caf714ab3a2b357abeda486b9d0f8bebb18"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f8909467-b187-4651-86ab-6edbbc21f6e8/f07e4a0141b3907f83079c0dd44188ca/aspnetcore-runtime-8.0.7-osx-arm64.tar.gz",
+          "hash": "f02e3b3a4ec366a2be7ef596f728914fb7c3810ed507ebcade27b09ff62e7cb84cd4b24c8438cada72b99e60fc7477d868a6cb57083a39387f7900874faa35f7"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e2410d8b-380c-400f-ae85-c0451afc35e1/cf601795432ee94bf55f03f8fef08e6d/aspnetcore-runtime-8.0.7-osx-x64.tar.gz",
+          "hash": "867765250c5ab0431023d59b9fd04ac0ac868797e2ea1b4257e44d93033d653e48d8776bb7e7cbbdec094a5a60002d2833c5a58094fe54c2b6402b1ce2882c49"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/21fa80b8-7132-497e-a44b-f25b6790ac37/512c8a433fcb462de3ff06dac0f651c7/aspnetcore-runtime-8.0.7-win-arm64.exe",
+          "hash": "d54d9a1f344adc9f31d3bc4085fe977c55fde9e5c65c59a9ae3475ddf53ae4a15e0a6eea7dbcc211e02297530035f55f879dc777ad499e25b61b5be29d51e09d"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c9015caa-2f1c-4eb3-a0c7-69fdca47bb7b/2d5d3957612f18c92f806fc73c999346/aspnetcore-runtime-8.0.7-win-arm64.zip",
+          "hash": "e4443dec8f8c50ff61bb607447c662c48c05890946afe1a7dcddb956b94056d14bed60f455d0854b273c938c078c0b67f6cc3744216f7d4f199218a7898170ab"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7cd032b-21b3-4a9d-82cc-5249dd7fe092/00af1c24dd391c81df9d89cb737c9954/aspnetcore-runtime-8.0.7-win-x64.exe",
+          "hash": "0a6b57b7bf939dacd3b90f7da9ee4696993c1f736e8e4d61feb97c9061e78cad023e0efa94c5c6bbb4c25272acd4ac89e555dfff39a44fc65b9d5ad0bb1e6019"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/66352bdb-4385-424b-bdfd-7b86ff004efd/9688194ae6987d772b703ae025cd1548/aspnetcore-runtime-8.0.7-win-x64.zip",
+          "hash": "e745cd0eb11ff4f5dbfcea2966542dbfec57cb0d6025e1fd0a8f0d500c1246d9636f780b72586a55a3c8bac657a07443e4073eb9503b9f4eefa7aab336b6000c"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fae41b37-b28e-48d7-8582-8a68fe782c17/bdf588c806eb1316eab1aeade3b511fa/aspnetcore-runtime-8.0.7-win-x86.exe",
+          "hash": "5d887a491c58210abd3015099f80dc626c59bb832d36becebe619e729332daafa3aa030ca6af06ef7135805905c6ec79bc0fa2ab6d02d4ce066406a1441c7960"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/168ffae8-e7c4-494c-9a2f-47e13c8ce5a4/01361017da1145dd454f12813d534768/aspnetcore-runtime-8.0.7-win-x86.zip",
+          "hash": "504f3738ba8c626477d22462d832e2f68f2ead4da66454a1c0dbe90af5c16411b01d8fc653d83879c20c837f2f44c406fb8a108ea88c24af7cdaa42710d6f176"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1a3a7b22-e1a4-49c0-b54a-2d86c4d65190/45d081b0224e9c9155085dce92758ff8/aspnetcore-runtime-composite-8.0.7-linux-arm.tar.gz",
+          "hash": "72f95a217994b8bcc0dc4a195cd8ebee8b532e6ab668fbb3621a36651e44ba1862fabf9c9374773be22a5d94ced81811b4c0c9fdb2543aa8220cefb182070b09"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/22c5ff01-2f30-4dae-a415-ccabc5a08982/8db4ea4303f68c207c4e0e0316d0c952/aspnetcore-runtime-composite-8.0.7-linux-arm64.tar.gz",
+          "hash": "37a7380ea8466fafbf3e36f3ba3102ea9cd5add99ace485fe4b612f3e75481a3cb721dd0425380840ad641d559bd0fddfc73bb7ad4b452d4be50a4ff8c286935"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/39b3562d-dc87-4d32-bfaa-dc79764d6106/748a05efe11178c0f60acf7be736611e/aspnetcore-runtime-composite-8.0.7-linux-musl-arm.tar.gz",
+          "hash": "ba4cd631dc1f88cd8bc7fd8e5c3924758a81585d5f8d1e3ed97bf2efc8bb25d740d0a5d38bfcb67a9454c642f7b6d2b5b2e4faa2d4447687973c2c3584a365a4"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a9bc830a-a4ea-4883-ad4f-81bf9fdca20e/f3e33897a16e90b49a775ef220c34a56/aspnetcore-runtime-composite-8.0.7-linux-musl-arm64.tar.gz",
+          "hash": "d6da2d256622ac7733ee3b21573f59411854c7ce702a459e84ab1d830f172cf07250d7b9ee14b898bb18e414658f25e90ab9b1bfd21c02d5f0d1610e4d4dd9b8"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1f1e9fd5-c98d-46be-a4b2-904a68af7db4/ddef01f271e583354cfd891f975a4b41/aspnetcore-runtime-composite-8.0.7-linux-musl-x64.tar.gz",
+          "hash": "c1e303f0ba0cf584157b2e830dfa237fad8a67c8e699737f6f4ba701fcf101afbe639dc15dc12cf69be6c9b4f947ca8b9043374247cededce891a1cf6987516f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53cd4d8d-c54a-49e8-bcc3-9892e3f885b9/db1f8704e2e7cc7540aaf9e06b381d43/aspnetcore-runtime-composite-8.0.7-linux-x64.tar.gz",
+          "hash": "206786d755c85ff253e2b9a08c9df0793301656d91e6539554dba8d119484e8684cf0c83a75773608a64a109d1e94c4f966bf5e4636fb4e438f01dde3f769814"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7d169ca8-2755-4870-b45c-bfc651013a77/46639ef8e327f00ab1a941288dd28abe/dotnet-hosting-8.0.7-win.exe",
+          "hash": "53395e0042b1a2d473589cb8d4522d2fb2087831b26589d4269f4774b461bcfd753f70199459e8b6c3423b32e43672f3a76cb373a0fe63463a558f10c264c1fb",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.7",
+      "version-display": "8.0.7",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/93f3856a-ba9e-4fd2-9a6e-abd7cad44c27/3f70ef9e35cc7225199321e70af12d20/windowsdesktop-runtime-8.0.7-win-arm64.exe",
+          "hash": "bfd5a8bdd87d9c010fc9cbd058f071e832b7d515c2550e0ca43b6da23dc5c108f9d8065ad89fa33bc5fab7c814eee7531e07cb58d09a4e69073a880137affe41"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cd3562da-babb-4500-862c-69a73491ba86/c8f403b2ade8a420ba1f0a2f7634394a/windowsdesktop-runtime-8.0.7-win-arm64.zip",
+          "hash": "2569af5ddd639dae21a132db89fab22e1346261f477d47980f6a4f876cd0cf8d0533f3c96b9b6b977bb0e85ce9ca50b3feda486d88ae4a333b562ab7f8ec8212"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bb581716-4cca-466e-9857-512e2371734b/5fe261422a7305171866fd7812d0976f/windowsdesktop-runtime-8.0.7-win-x64.exe",
+          "hash": "391ca05d7540c58f25047ae07b8c5656829f7fd32f6e88a4e34c5337525f574e5714657e1c4f4f4d48e006087f573f8c03f1fc8eab8c9b9dab4d5ca5c8ea1fd4"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c96053c9-c748-460a-a74f-934c0318c219/6f235374716b2edda4cfb2bbb931a923/windowsdesktop-runtime-8.0.7-win-x64.zip",
+          "hash": "d26210d317cd108ec08d075fd646d0b6412aa666d53674fe76f988bfe669e1a7cfd6e3332948aa5d0dbd1edfce643713ddfc841bbdc76b3fed72e8393960cfce"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/853ca8b3-f0d0-4aac-a33b-d93bb1c991e9/9664c41e36cffd82b4f04471020116a7/windowsdesktop-runtime-8.0.7-win-x86.exe",
+          "hash": "5adf46498caa1f4ae10ea6327f5c89f424665e1fc471cc8ca18c43779058a37aa5441ce89f82d9b2a5a4b877ab7f448fb5c48193e628eb038956f82d71880942"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b51c48b6-5d6e-4972-aff6-6670a6e78aad/349941bf042167a212b7041bcbb269f7/windowsdesktop-runtime-8.0.7-win-x86.zip",
+          "hash": "14908d8e3b67ad7df164e4c2e68c31e02d982b345c025a32595d052dba6d1220becde6d4c8060a521603c9e8cca806bebf0e8e7dfe8cbf8a153597de12efc5e5"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/8.0.8/release.json
+++ b/release-notes/8.0/8.0.8/release.json
@@ -1,0 +1,846 @@
+{
+  "channel-version": "8.0",
+  "release-date": "2024-08-15",
+  "release-version": "8.0.8",
+  "security": true,
+  "release": {
+    "release-date": "2024-08-15",
+    "release-version": "8.0.8",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-38167",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38167"
+      },
+      {
+        "cve-id": "CVE-2024-38168",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38168"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.8/8.0.8.md",
+    "runtime": {
+      "version": "8.0.8",
+      "version-display": "8.0.8",
+      "vs-version": "17.8.13, 17.10.6, 17.11.0",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e427de4-981a-481e-9fec-fa77b02a7edb/0d156acae55ca1329b6b9a8de70f398f/dotnet-runtime-8.0.8-linux-arm.tar.gz",
+          "hash": "c87af5aaaf32e18ccdc2965179c65aabae5e0e9e8ea209f6c364270ce2e4afffea979ca22e143de4674e36a2b12c66b575588ae219f16636aca7121440240288"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ac04b123-0542-4e80-9216-93f51a6814b3/d110733c152d34ab4eedb435ccfdab4d/dotnet-runtime-8.0.8-linux-arm64.tar.gz",
+          "hash": "246fb7e5edb51db93421c6bb7420f7a358430b98b224a71fb70e71a2bce0bc91f853aa89109f2188b0ab28532a245c3d52baac163463e01a02019dea37fd39f2"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2f4507aa-972d-429c-9129-cfe95c1279eb/60dd9afc3f4786a568b01119c2280c63/dotnet-runtime-8.0.8-linux-musl-arm.tar.gz",
+          "hash": "8a6f920d93d7d5527dc289f472521e2a671afb4e663aaacfd82c32658c2ea39eab43a5c97d3d3d7ba58403ebfbf6cb96fc73ff5b7ccc1a9447d13bf41eeb80c9"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8d78f160-0833-4db5-bd62-947f8bc2d571/25638f47211018a7bd8fd9d314763196/dotnet-runtime-8.0.8-linux-musl-arm64.tar.gz",
+          "hash": "26f35e1c6074a7d99a40ea48f6c02db78f4e2c743cbc74463a094da014e126e9379d09b4e56809ac9829b26b6ba0a901adc47adfc3c5d35a97e9ead5a6931489"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9c4e4e4-bb2d-4f1a-9ded-bff5e354bd5a/0c6dbc5f68bea36a65fdf80e6aa4d55f/dotnet-runtime-8.0.8-linux-musl-x64.tar.gz",
+          "hash": "ca2ff32145506513253f80ecd72b5c24d8bda28f44ae83c988c39ebfa75e737d5510bcb84bc27a149d2e6995761f8b124d7701522ae9bbcac17fc32667217eb6"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/68c87f8a-862c-4870-a792-9c89b3c8aa2d/2319ebfb46d3a903341966586e8b0898/dotnet-runtime-8.0.8-linux-x64.tar.gz",
+          "hash": "8f5220098c562fa3490417748eb9f4f9ca1551f7155728b9ebb1924359c63c18dedef643bcd89ec67b59cb5b1b9de7283ee156ef381ffb16801b516dba9b1b0f"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/454e6d99-5836-4c51-947e-b75220eebd09/fcbaecbeaa1f95a8ac80aae62e8718b0/dotnet-runtime-8.0.8-osx-arm64.pkg",
+          "hash": "3c53474ad1ae8549a24bb6c11d8dc0c2d4fa6b67bde9d01d676162097352070fe65585101264d7ba8a725b5c1c4a1901f3a625be26d10481a3ba6a66a0a3fe41"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e9ded115-7a30-4952-bb72-ff101583f20b/5a7628261b98d095d2c97ec3fe5267be/dotnet-runtime-8.0.8-osx-arm64.tar.gz",
+          "hash": "88b06dd051819bd9e8ce2c340b2516dc0e4a77d565eff145d8e957b2552a641e235a5ce7e8db3607475887bc766f1530d01d0e7efd80d10cd652a299954398b4"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/13a441ce-6908-4f4d-9615-0fcb80e2b41d/b9309626d2013d4e21bd6b0fe405e5f6/dotnet-runtime-8.0.8-osx-x64.pkg",
+          "hash": "00e76af7982ad1da51241d13b5cff379cb2eedccdf7bd09c2923e4610e232ef35c9e8d34b58435f5ed66c52ca3ab6e68c7d89fbb0caaa53487c4882e00b01865"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0159972b-a4d6-4683-b32a-9da824d5689e/ffb0784119abf49015be375b5a016413/dotnet-runtime-8.0.8-osx-x64.tar.gz",
+          "hash": "8029986c1f8bbf1b0e8d0929756156fe41d46d2df6ebe1ab1c66fbcea2add47c35b934573c6198797cf60d2b372cd463e70326c0a35b0926dab4d5c157a357f3"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b0574522-b0b6-4075-b7e4-3c3d6f1c83d4/43d3e0e551de10faf0ddd1664e2ab4be/dotnet-runtime-8.0.8-win-arm64.exe",
+          "hash": "a4ed101b343495708462e96860d4e20542117988186aea96d7ad014e52571f9bcc6d730891b5245e70cef98ca0944b6dd45703dc261e7a28d9e4673392e45928"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3c1da0a1-c405-48d0-99d7-273dab3b0083/240aa566253cbd5f86be31a55c1a0f30/dotnet-runtime-8.0.8-win-arm64.zip",
+          "hash": "36ac8eb458e3a31d02de10ce1855bf189b85ac2e88020430c6f6cfb7b92fffb04463bcfbf0d5a2146862102be922b182d230f51dc2e34a5fe7133abdc201ede9"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cc913baa-9bce-482e-bdfc-56c4b6fafd10/e3f24f2ab2fc02b395c1b67f5193b8d1/dotnet-runtime-8.0.8-win-x64.exe",
+          "hash": "57f2a276176661a340b96991b584bcb81ba3c0150e3684cb109b29cc3a8ebe6fdf1e586d948d498e7aaf22f7401c1cc94062c13cffd20999771ecc5dfc2e917e"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d9d43c59-b9f4-47b7-a520-da3a7fa255dc/95b26e342a1ecfa29c527faebdc272e4/dotnet-runtime-8.0.8-win-x64.zip",
+          "hash": "cca24d8c1d8a8af7496fd29bf8fa1750f438207181bd3add128aa5083e6ddb159d5d7de8f3bed3b30618c8886b4380dc55ee15b03e71feb345011c48a08d27bd"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2083daf-6d33-404f-a7d6-dd3bb012a945/e241d0aff000f63ef8a49c3c7da08087/dotnet-runtime-8.0.8-win-x86.exe",
+          "hash": "fa542b8d3ae98e020b66f0bfa33c44a4ea166ab9cfb7b3cbe3034f9c38318464db8c767af9eb3a6fe9829aa67cff96beb49e2c1cb9e6081e5657ee4f75544bf3"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e9b87eb9-a673-4b3e-bf22-95ade61bedeb/d9d83b7c82a86c3e35da7454f71bfb58/dotnet-runtime-8.0.8-win-x86.zip",
+          "hash": "c36c90dd056aabeef40615113941144381e45f831c71b129802bad04b6db4a95561d8552aba1cb75ff85e8f0820d2d3887660ce7113bd449f3653801128eaed4"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "8.0.401",
+      "version-display": "8.0.401",
+      "runtime-version": "8.0.8",
+      "vs-version": "17.11.0",
+      "vs-support": "Visual Studio 2022 (v17.11)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/788ca4e7-c3ea-405d-9f82-2d362d4a08f6/d54b1aefd4048bcf4eebb24edfc6aeb9/dotnet-sdk-8.0.401-linux-arm.tar.gz",
+          "hash": "fb90a8e52f5dd29e5953e4662cc9d57caa96dc6a8f6ff6cfae17947aa8a3f53b5fef1bb35b8c05815fa1cafbdc73179f7296ce846bf5769ee12c9daf5bd27941"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/14742499-fc32-461e-bdb8-67b147763eee/c14113944f734526153f1aaac38ddfca/dotnet-sdk-8.0.401-linux-arm64.tar.gz",
+          "hash": "e8738b21351d030a83be644571f3674c8dda9e6fbd360b221907a7108fab02becd18e1331907535a1294d8c4d0f608519674c27c77dc2c2803cc53cce3e10e0d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f9eed98d-5e19-4822-85d6-c59c62376bad/52ba188eabe759516711f14247c57f7a/dotnet-sdk-8.0.401-linux-musl-arm.tar.gz",
+          "hash": "c5c547eb301dc965eef1d9bcc64231678e209591b80197a78249d35d1655a5469f39ce6de65436375f6e42d22d159c3dc487be17f6dbe7634040095fc988db21"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8f3dec03-a016-4c06-a4b0-04efcffbe521/e0e94170cbed0aa9312be63e43a69932/dotnet-sdk-8.0.401-linux-musl-arm64.tar.gz",
+          "hash": "2faab93dd38a49386032083a0f4a3a5a5661d6ecff4a98f068ed7aa07b201233804fa0e5efa4911b6eebedc9994d59c4d5d843deb773e7e2627b2aa97e634a82"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3ce68ecc-a007-4d15-9196-79ced76a154a/6a45f69bb5c24576abeea048cea09987/dotnet-sdk-8.0.401-linux-musl-x64.tar.gz",
+          "hash": "e711b74832269463e27f98b049c442d3684cdc213115133285a2b189ef4564b65127747cdd3a900de53581019bdf8f47426f2cfc9bfc1c0c3a83106f9bb54ea5"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/db901b0a-3144-4d07-b8ab-6e7a43e7a791/4d9d1b39b879ad969c6c0ceb6d052381/dotnet-sdk-8.0.401-linux-x64.tar.gz",
+          "hash": "4d2180e82c963318863476cf61c035bd3d82165e7b70751ba231225b5575df24d30c0789d5748c3a379e1e6896b57e59286218cacd440ffb0075c9355094fd8c"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1764cd94-29ac-46b2-b308-77d02b47486d/8397cdc3d842a60f062f1a08199a4974/dotnet-sdk-8.0.401-osx-arm64.pkg",
+          "hash": "3b9305c3b5b5853221bf4c3f53cd1143bef02249a81a98ba7d6ac9f4a750860bb0880cf908a6061f6be4cafd38a00c9143f3d014f6ec2a206ddb4182a9aa3005"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/29ef2c29-154a-4c44-9450-071ae664767a/4ce00627f3eaee13874b54f033a9a27a/dotnet-sdk-8.0.401-osx-arm64.tar.gz",
+          "hash": "a3232c0693b41ee6b18dc3c8b26d82dd9116132bd7871dc9c0a0acc5e7995f352e760869fe91a08828417ea7b91fc27859aeea449b9efabc17c136a57737c93e"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/62d5b0f6-e67e-4d89-9758-e285c407eb6c/38cd1ca749bffd444fe4fc1cedf3b692/dotnet-sdk-8.0.401-osx-x64.pkg",
+          "hash": "61b12de01153f8f878a975052ea7a398eb1e43a6ce7b170ac2e6051ca0a6fbc4d56ab157b4e9414263bf7b6d975300591be70f43427bde567f148021af373a08"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b266f183-c677-4f93-a729-abe0334401ea/ca0ce4f684c4cfea2d372223f9c67cbd/dotnet-sdk-8.0.401-osx-x64.tar.gz",
+          "hash": "063aeaf4e949b96d501b77873279f0286cde46f9212b59181c6db21630401fd6a352e3259848cee8e127e4ceac85a25e0bce36699a2fb6f6e2a91997c6f61eae"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f4f3c82d-4d24-4e01-87fe-67b6d9213f42/d33ef29315ad07d303993695f7b93479/dotnet-sdk-8.0.401-win-arm64.exe",
+          "hash": "e48f571d524ad369aa0dc523ac53860fc2143f2e0a1da48e0c0ac16e373d617f427bba703abef8b0f68df1c7b456ff2ee44dc3df0f6e8d5f47d51b602a19d219"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b4b805f3-83f7-4b1c-9e0d-e9871e08a672/56f43b9c6c18a9bdcf508c06361bab88/dotnet-sdk-8.0.401-win-arm64.zip",
+          "hash": "5e4ab2b0d4623796a5aa9d209084b9bd19a5d5db2c9165b9be0cd8dc2953a73a26e681c7c7f5816e0b96a771f91995d7ee9949ff578da8f43990f3bd9c203195"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f5f1c28d-7bc9-431e-98da-3e2c1bbd1228/864e152e374b5c9ca6d58ee953c5a6ed/dotnet-sdk-8.0.401-win-x64.exe",
+          "hash": "47080f5378ab4ce22d572f11eec19d65151508c41f5c5245e481e6b22bd14d1d84ac197459c0d68717298657c3b752ed5a1d87b26d499f78ef41c2d04582ba9e"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/346fb097-97c0-4c83-9af8-ab245644f9da/bf2c626621422428a7e09e0ead5b0747/dotnet-sdk-8.0.401-win-x64.zip",
+          "hash": "384c473811118f47d50e937e29bb4f03413a07dc859c30486b1129d99ac80a61527c77baceafcf1ce42533ab307d65b476e5d0d7c503f930440456a0f75b92dd"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/523db424-b1cc-425d-97f5-bd0e9b0c7440/f04171a6d597780662d809107a13f44e/dotnet-sdk-8.0.401-win-x86.exe",
+          "hash": "38c0e76da9c2e90aaed7adba596b2c3801f7ab76909cf2d8d67f3e7ad16a3fe5d30cf2ef1ce2bbb5222c6c43d001822193a694ece3c5e381189c108f72470098"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0e57db61-8501-4486-a9f3-5587bcbc0430/4cddcc8b2d7eb4393d955d229eb16614/dotnet-sdk-8.0.401-win-x86.zip",
+          "hash": "ee5e467d9285843cf4b68913c1dffc40ee0f828aa39b75e60cd9514d08d7c1a0c809e282ea4d0cd2a18376f80298fc05680f26a96d11247f7abf1347c8fa4671"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "8.0.401",
+        "version-display": "8.0.401",
+        "runtime-version": "8.0.8",
+        "vs-version": "17.11.0",
+        "vs-support": "Visual Studio 2022 (v17.11)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/788ca4e7-c3ea-405d-9f82-2d362d4a08f6/d54b1aefd4048bcf4eebb24edfc6aeb9/dotnet-sdk-8.0.401-linux-arm.tar.gz",
+            "hash": "fb90a8e52f5dd29e5953e4662cc9d57caa96dc6a8f6ff6cfae17947aa8a3f53b5fef1bb35b8c05815fa1cafbdc73179f7296ce846bf5769ee12c9daf5bd27941"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/14742499-fc32-461e-bdb8-67b147763eee/c14113944f734526153f1aaac38ddfca/dotnet-sdk-8.0.401-linux-arm64.tar.gz",
+            "hash": "e8738b21351d030a83be644571f3674c8dda9e6fbd360b221907a7108fab02becd18e1331907535a1294d8c4d0f608519674c27c77dc2c2803cc53cce3e10e0d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f9eed98d-5e19-4822-85d6-c59c62376bad/52ba188eabe759516711f14247c57f7a/dotnet-sdk-8.0.401-linux-musl-arm.tar.gz",
+            "hash": "c5c547eb301dc965eef1d9bcc64231678e209591b80197a78249d35d1655a5469f39ce6de65436375f6e42d22d159c3dc487be17f6dbe7634040095fc988db21"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8f3dec03-a016-4c06-a4b0-04efcffbe521/e0e94170cbed0aa9312be63e43a69932/dotnet-sdk-8.0.401-linux-musl-arm64.tar.gz",
+            "hash": "2faab93dd38a49386032083a0f4a3a5a5661d6ecff4a98f068ed7aa07b201233804fa0e5efa4911b6eebedc9994d59c4d5d843deb773e7e2627b2aa97e634a82"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3ce68ecc-a007-4d15-9196-79ced76a154a/6a45f69bb5c24576abeea048cea09987/dotnet-sdk-8.0.401-linux-musl-x64.tar.gz",
+            "hash": "e711b74832269463e27f98b049c442d3684cdc213115133285a2b189ef4564b65127747cdd3a900de53581019bdf8f47426f2cfc9bfc1c0c3a83106f9bb54ea5"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db901b0a-3144-4d07-b8ab-6e7a43e7a791/4d9d1b39b879ad969c6c0ceb6d052381/dotnet-sdk-8.0.401-linux-x64.tar.gz",
+            "hash": "4d2180e82c963318863476cf61c035bd3d82165e7b70751ba231225b5575df24d30c0789d5748c3a379e1e6896b57e59286218cacd440ffb0075c9355094fd8c"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1764cd94-29ac-46b2-b308-77d02b47486d/8397cdc3d842a60f062f1a08199a4974/dotnet-sdk-8.0.401-osx-arm64.pkg",
+            "hash": "3b9305c3b5b5853221bf4c3f53cd1143bef02249a81a98ba7d6ac9f4a750860bb0880cf908a6061f6be4cafd38a00c9143f3d014f6ec2a206ddb4182a9aa3005"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/29ef2c29-154a-4c44-9450-071ae664767a/4ce00627f3eaee13874b54f033a9a27a/dotnet-sdk-8.0.401-osx-arm64.tar.gz",
+            "hash": "a3232c0693b41ee6b18dc3c8b26d82dd9116132bd7871dc9c0a0acc5e7995f352e760869fe91a08828417ea7b91fc27859aeea449b9efabc17c136a57737c93e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/62d5b0f6-e67e-4d89-9758-e285c407eb6c/38cd1ca749bffd444fe4fc1cedf3b692/dotnet-sdk-8.0.401-osx-x64.pkg",
+            "hash": "61b12de01153f8f878a975052ea7a398eb1e43a6ce7b170ac2e6051ca0a6fbc4d56ab157b4e9414263bf7b6d975300591be70f43427bde567f148021af373a08"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b266f183-c677-4f93-a729-abe0334401ea/ca0ce4f684c4cfea2d372223f9c67cbd/dotnet-sdk-8.0.401-osx-x64.tar.gz",
+            "hash": "063aeaf4e949b96d501b77873279f0286cde46f9212b59181c6db21630401fd6a352e3259848cee8e127e4ceac85a25e0bce36699a2fb6f6e2a91997c6f61eae"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f4f3c82d-4d24-4e01-87fe-67b6d9213f42/d33ef29315ad07d303993695f7b93479/dotnet-sdk-8.0.401-win-arm64.exe",
+            "hash": "e48f571d524ad369aa0dc523ac53860fc2143f2e0a1da48e0c0ac16e373d617f427bba703abef8b0f68df1c7b456ff2ee44dc3df0f6e8d5f47d51b602a19d219"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b4b805f3-83f7-4b1c-9e0d-e9871e08a672/56f43b9c6c18a9bdcf508c06361bab88/dotnet-sdk-8.0.401-win-arm64.zip",
+            "hash": "5e4ab2b0d4623796a5aa9d209084b9bd19a5d5db2c9165b9be0cd8dc2953a73a26e681c7c7f5816e0b96a771f91995d7ee9949ff578da8f43990f3bd9c203195"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f5f1c28d-7bc9-431e-98da-3e2c1bbd1228/864e152e374b5c9ca6d58ee953c5a6ed/dotnet-sdk-8.0.401-win-x64.exe",
+            "hash": "47080f5378ab4ce22d572f11eec19d65151508c41f5c5245e481e6b22bd14d1d84ac197459c0d68717298657c3b752ed5a1d87b26d499f78ef41c2d04582ba9e"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/346fb097-97c0-4c83-9af8-ab245644f9da/bf2c626621422428a7e09e0ead5b0747/dotnet-sdk-8.0.401-win-x64.zip",
+            "hash": "384c473811118f47d50e937e29bb4f03413a07dc859c30486b1129d99ac80a61527c77baceafcf1ce42533ab307d65b476e5d0d7c503f930440456a0f75b92dd"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/523db424-b1cc-425d-97f5-bd0e9b0c7440/f04171a6d597780662d809107a13f44e/dotnet-sdk-8.0.401-win-x86.exe",
+            "hash": "38c0e76da9c2e90aaed7adba596b2c3801f7ab76909cf2d8d67f3e7ad16a3fe5d30cf2ef1ce2bbb5222c6c43d001822193a694ece3c5e381189c108f72470098"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0e57db61-8501-4486-a9f3-5587bcbc0430/4cddcc8b2d7eb4393d955d229eb16614/dotnet-sdk-8.0.401-win-x86.zip",
+            "hash": "ee5e467d9285843cf4b68913c1dffc40ee0f828aa39b75e60cd9514d08d7c1a0c809e282ea4d0cd2a18376f80298fc05680f26a96d11247f7abf1347c8fa4671"
+          }
+        ]
+      },
+      {
+        "version": "8.0.400",
+        "version-display": "8.0.400",
+        "runtime-version": "8.0.8",
+        "vs-version": "17.11.0",
+        "vs-support": "Visual Studio 2022 (v17.11)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a388927-c8b0-4411-a211-8a37a9f8876c/1b2fd1d36ee22f2c35cbc04ade46bc7e/dotnet-sdk-8.0.400-linux-arm.tar.gz",
+            "hash": "caad292647790023a41a9b728b70994ffa2adbdc08099a768870806b16b53a4b3e4b6cc0aa79974aabf8d9adc61e2f9a2b662c829dc9c72b0fc509fe06119265"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0fcf170f-0f4f-420d-92d4-b2c8e54bb901/9e14c42736ee429407ac6b14bff3c7e9/dotnet-sdk-8.0.400-linux-arm64.tar.gz",
+            "hash": "d27b4ddd864478fc4655485cef0773411fb934c816fb3dcdafb18f670212c5389661a8255ca8a54562613815712f5ea23e5d8ad1cce4e00a3f8a82c9b4a6b127"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/11fcd2ef-81fb-461c-9cab-f6c22ee12ea2/3a6a4fd8e4865c77ecd9de9d8c9aa5c4/dotnet-sdk-8.0.400-linux-musl-arm.tar.gz",
+            "hash": "5588f18a3bd654bd7aa8b57574b83b40174992772e53baa80041eacde35382cfa6a1c658d979fe082d1e42fccad2af93b8e311dc2d0cd06b5385e712d5275f44"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/73dde17f-f2fa-4f11-86bb-e4e9488267a4/7ca5cc43af6130207e545faf97a57d07/dotnet-sdk-8.0.400-linux-musl-arm64.tar.gz",
+            "hash": "5120d8134b2f638b3c33d7e5506cb16a980adf6bbff54c278b5de64acb8c55e034f20ceb2db12b2b61b823778823cec51089819b5d1f7cb893360ac5cc60b6d3"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/910f7e06-6178-4d2e-ba0a-dd8f1baa25cd/254f03846baa009e09a5146cc5ccc18c/dotnet-sdk-8.0.400-linux-musl-x64.tar.gz",
+            "hash": "c92dd3284d0070f22a4b488884e06b3bfc8e42b3932c9db20cf77368a528f295d4e09e813b709cfecc01a82f8c95c8a0b9d66840073f2a352d850d5ede14c859"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/14951030-5b4e-45ce-af0b-3d4aa613a70b/25acaeb050bbba6950a55960c5d3ad73/dotnet-sdk-8.0.400-linux-x64.tar.gz",
+            "hash": "8a4c637746177c4da6ceec63e23a1f499d61d050aa72bc599841550557ff7b1a15a034044c3987b230fdca4e5113de12b1676f5a2366e9946bd94aec1e51a42b"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/06edb9e2-e2bc-4692-a26f-df48c67d9292/2058cb632932d3c63fb78cd54692bc88/dotnet-sdk-8.0.400-osx-arm64.pkg",
+            "hash": "98046617de9a6e4128e2afdf85c8f404aa155c9875f5fd564e7f5fc742ead304f0893162b65470e16891f506e70d58f5ceaa1adaae700eb8aa0244cdaf3a2f46"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cfa04712-231b-4ef4-83f0-476c856774f2/9f852a73d183f63cbd50a3e58a4e7306/dotnet-sdk-8.0.400-osx-arm64.tar.gz",
+            "hash": "29656a362ed6d74eec08d48aef930e5098c7456faa1bcaf178f9421f8423178838071b4ff81c0429155f1f834014cbdef8121eefe002a079443ff7a3193b4ee0"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3bb8bc8-66dc-402e-9ced-a53241c4c15e/fc855e95c2e04813fa1efd64cc17ce86/dotnet-sdk-8.0.400-osx-x64.pkg",
+            "hash": "7003adb0fef54264f7a2124113a8be75fb2b5f5fab33fa31af648bd02f2556f34858931dbaea06608e83084f2308c4b373573167308e24efa562fb34c8b69470"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3187bf57-a0f4-46f3-9021-2c8bc9217859/25930e64d1f3be622e5571118b0daa01/dotnet-sdk-8.0.400-osx-x64.tar.gz",
+            "hash": "d7963a28de862605ff3c52f42155a3400aa37d7a2c01374f278bb18f0daa7a8206856cd9114bc2b94fcb8f9010ec02ab31e043e7f564038de4dd5811f943a331"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a91eb253-6568-45bc-a74a-15946e2708a6/75498a48c01018e9a1ce2a8f25f2b208/dotnet-sdk-8.0.400-win-arm64.exe",
+            "hash": "fc7a4e0f08c3fc623151b0ff3d1b40a1afed94bd97caf1e71820f638fec1f5e112dbb3a37d1f5af6c367132d522caa0232f9c28098edd2aae702cdc75fa4ff36"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1788607d-b711-4c2c-9492-e081d7ac4f27/c0c21b90236c2a3119471d003c2167b5/dotnet-sdk-8.0.400-win-arm64.zip",
+            "hash": "f9d5a82d27fa5054bf1b38c65085d8cf4974fb8b69e646656c95114eeead163ce69ff42752266797407353759ccd9d26ad936bff830111d1b8df7f6e78e5937a"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/57ffff70-1b2b-44fe-aa9b-209e30f79c6f/cc24e73a485140d3a32ce93f63acf4e2/dotnet-sdk-8.0.400-win-x64.exe",
+            "hash": "466906bdd41ff425e4e759ec4ca827e79f4c2aebd593032191b7a0bcf554f2a43c333c606ee3ed0da9af55c2b449ed368d224751665ec0af51bbe71e27a4fbff"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cfccc24b-46eb-4515-b696-161ec8652b39/9fb1edaba0f12a56446fa6716a1789ca/dotnet-sdk-8.0.400-win-x64.zip",
+            "hash": "3b3b402f9402af4b80ba12d04787a083d1950c741fb64b06b3e215f6e5b3db2f86aee8014848c955ea17f9b699d302271a934ab2d5db1b35dfbb9d22405032dc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/53a96c28-cd09-48fa-a68b-5fdd2a79dc37/5bcc92ce87327b43fa369045a8e8d932/dotnet-sdk-8.0.400-win-x86.exe",
+            "hash": "718b917e3575e487dd7f3bb5b5cc89491a2b203ec38bc1f93de004abeb486a9ce3e72e8cf460f89916ec8c6854b013cdf170eee1c4f39b42fefad9da217097ed"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4bc6c939-8cb1-45c4-afde-a1b0715eec7d/c3835988860504c59187049089ca2466/dotnet-sdk-8.0.400-win-x86.zip",
+            "hash": "d6102dde8550c0c77617eb19ef7c8e5e6beaacff5527ac024e7dc06acad97e2b099d570a371daf295db107a4deaa41d6d11db13b2f9fb8512ad8f8a2278c6201"
+          }
+        ]
+      },
+      {
+        "version": "8.0.304",
+        "version-display": "8.0.304",
+        "runtime-version": "8.0.8",
+        "vs-version": "17.10.6",
+        "vs-support": "Visual Studio 2022 (v17.10)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c73041ed-e684-4dc9-981a-2db502409dd7/0e24c20b4b1d0a728e20982de0b8790f/dotnet-sdk-8.0.304-linux-arm.tar.gz",
+            "hash": "31b48574ee763b0d41820c1f496b3e05536c6b69fd6e7641244b1cd65dcc3b2ed5efb483d7bfcc3c2fced2fe4e946589a58e244ddc5a131cb2654822018c0d2e"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/be9572a5-bcd5-46a0-b10d-0d00229ad57c/b80d3adb25c20fec467bd33f29f9a1be/dotnet-sdk-8.0.304-linux-arm64.tar.gz",
+            "hash": "6ce93ba330848b4045b6c63f96ad0a91c474361cb0a208bd4128d418fd6da04695559add63df9a0acf283a32e6e781328d3979af900e0b2382cf006c9982806d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/21dcf586-94e5-44f2-8407-bd409d73f59a/ec99c395aae24f38dd5cf91c8dc06fd3/dotnet-sdk-8.0.304-linux-musl-arm.tar.gz",
+            "hash": "d2d1071c674664a8fe96f61a6204c56f9e2c6598d2a11e34eac9165ff30d1cd33119e10e79499a9a354ec461e3063e407772b362f3640e64114cdcd2a4ef0f6a"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8083f186-347d-43ff-ac05-575f63a1c692/dfbfb3ee9943b880472ccb8e5517a881/dotnet-sdk-8.0.304-linux-musl-arm64.tar.gz",
+            "hash": "f266f2c8c405377d84c4f1917a0c4a7493097cc853940ee1290eefc8777331935a80002a9c6c7c03198ff3661bc8aba2e933415d8a778949ff901da8bfda8d1a"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5cf9b56c-0da6-4229-9e30-44547aba8be6/20d2e5353050b04d3272aa5c4a1b689c/dotnet-sdk-8.0.304-linux-musl-x64.tar.gz",
+            "hash": "41da6d47972a7ca676ebc071861fa3c56f311f63ee09f7fe03cc09cef1e4771e4efe73c5fc6b02ab84f007c2e7044d7ee16c658971fa856d53f15f43e6a61d9b"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52cedf32-8a92-4966-b184-18404ea1c5a4/cc399fff1b152b822776514ad247df50/dotnet-sdk-8.0.304-linux-x64.tar.gz",
+            "hash": "971c344379240ec4bfaaf1eca69c6667e594cdd0dfdcde6e8962cb7a41d669dff91c644e48eed3573d841b7b3e60ce02e0c27a7ce37b66cdec27bf3457087c4a"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/057be84a-7404-4c14-960c-2d1e8184f308/5565f0821ac7a70da5983bbe711d859d/dotnet-sdk-8.0.304-osx-arm64.pkg",
+            "hash": "2a8c0b6413f98eea57fcd79e0af7e8e5e42e0e122df25c19d25d61c57cd4544770379e0a5283a13031715b637a99a16c916cc87c55fa4d922652cdfeac39f6c4"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5ba638c9-0721-42c5-8bf8-9706c0f9c033/f8dbde51758bd9e734a9c932b60e12bc/dotnet-sdk-8.0.304-osx-arm64.tar.gz",
+            "hash": "6993a950bc5bff0efe762ba2562a88761e93c61024d93633209950cbb68aeb5ff189fcbfe9247a1cdebbe37e738136123c7d4eda1050708608bb1ff0408eff4d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50c51c87-f2f7-4f24-8c51-e0ba6d776d82/8d6e2ec35f9bdf4eda32e12127e2afa9/dotnet-sdk-8.0.304-osx-x64.pkg",
+            "hash": "6d75cd899b0eba8a19a25665abf518a87a8eab9e1d96167a498cd35625ada0acf5c80a282b1bb2f05dff044baa9d2691a6bf1a7d566515baa2ef2b4760b98f82"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8b5c27ce-6c82-4a06-8960-15ebd5434595/508572144872e190e7f00ba6583011d4/dotnet-sdk-8.0.304-osx-x64.tar.gz",
+            "hash": "50f0265436e8c3d756ba00ab7fcd606cb5d452d7bede4daf97e4c02cc97dbbafc00b76f37ec4f07bbed4bee643a433849ddbd363ad2d916aa5965ee74ba317d6"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d872774c-eec6-4dfe-afba-d817ac5353e0/f6fbbbc8fbd4fe56614cb5f5d63dd601/dotnet-sdk-8.0.304-win-arm64.exe",
+            "hash": "dd08ba99c3d9b8381177b549afcce1602abccd5048aedaf41c189655f2f8ccfd6fc7b7c218175f8e7aec41d1442cfc70f47ffc20864c970422c5a0f579556872"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0949a9e4-474d-4284-bb1c-484d2f491f33/9dbb4df9af15c020589cade8ef001bd6/dotnet-sdk-8.0.304-win-arm64.zip",
+            "hash": "252dbfca1c0d581f7ed108fc9da7716af795d7778585ff1cf631846e6782f3bf3300397741fbd0b0dab22c7a6456b990199e8232c9fc10c2d8dd4a11f3786d80"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2d0373a6-cd0f-468c-ad58-7aa8d39486f7/bc6dd4c6ab074dcf1550b573708b03e0/dotnet-sdk-8.0.304-win-x64.exe",
+            "hash": "2a76b25cb072c10807b096e7dc118ec2bbf484d529f782344fdaf694744dbe45941c7c54a4aafe2175bd0b066e5faa4ac5c4144c4cf5f1753b3368ad73fef8af"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/58147e38-33df-4d74-b402-af113cf8eba2/4b290b246f093aa17ca65afe91757b6e/dotnet-sdk-8.0.304-win-x64.zip",
+            "hash": "7e987e30c8739b3785e7ae5f17e56f991d62d5ef9e7b721b7b19998b9b4c314c662a5fa50c299c4ff7e2b40cd706b390866a4988e0096e93448950b9710b4101"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/835e3f90-77fc-43a6-9e30-edfbbbed9181/34ff227d9611496c86f427fc2023e410/dotnet-sdk-8.0.304-win-x86.exe",
+            "hash": "afcf14628b32f04fe7f4fdfdd16256e1cddfc35b857a6cfbfd0d46cf6791c5a42a428495e51c27aeaa1980f1f69d8a89a5c41c812ed750e27c944bd999d116de"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef70b261-a0d9-4b99-8ee2-f6ba83571579/d9dc41d344cb8d8df3dbc2d71804c9ee/dotnet-sdk-8.0.304-win-x86.zip",
+            "hash": "9eed5301d98ac2b644dce118ca56c89e302424893fd6b2c015bf00b2c0552d3fefe1774653ce955a7a99661f41f372d3e7530007f84753493d6abe6445882daf"
+          }
+        ]
+      },
+      {
+        "version": "8.0.108",
+        "version-display": "8.0.108",
+        "runtime-version": "8.0.8",
+        "vs-version": "17.8.13",
+        "vs-support": "Visual Studio 2022 (v17.8)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/27228a4b-1ae9-4c1f-8a21-eecd21d6c7b8/c0500c9fac6db54f68c04956b828e8ea/dotnet-sdk-8.0.108-linux-arm.tar.gz",
+            "hash": "fafa8564b34b524b4209e1047ce7cf1190a5d42e7ba1b13524f5de602b075e630cdd229567f14eb2f0ae6c96ac910ae9dbb4fc4e528df958c9d31471341eedca"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/07df5bfc-98ae-4335-91c4-c95ec5f99a58/48a310e5d1bde3e77c53a51c99bdfc08/dotnet-sdk-8.0.108-linux-arm64.tar.gz",
+            "hash": "6cc723f2b139d19b2e17da5936698d388a5b64638b75ef78c40c407ed3cfd3dea745c2916f03efc9e66479fc55d608eb3a89305727ecdb1c999b183b58de258d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/24ef2f24-ca8e-4c3d-8466-2311550147d4/acbf2877ab4b8a611a3b63a9b9853dfc/dotnet-sdk-8.0.108-linux-musl-arm.tar.gz",
+            "hash": "efb308d81ac1020962f14d03e7ca9419a2901a0846120e07cd95c65407fe2981a26360c2ffea141d80581aac6d2c36a7379c76c07b2fb37d4efb836905f8ff68"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63bf0f75-e962-46b3-b7c3-12aa20129d46/071514943265037c423e6f5e40df7ace/dotnet-sdk-8.0.108-linux-musl-arm64.tar.gz",
+            "hash": "e7009ba373b043ccb469557271ac8ae518ab9c9b5b364e9841d8b97305b6036f33240e672e7c483798616a233429748d5038fdfd336352b82060afd645747045"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cab77c39-2e16-4f29-a9cb-e490d7fff442/ee37bc88e34e082a64d834ed5041bcee/dotnet-sdk-8.0.108-linux-musl-x64.tar.gz",
+            "hash": "744715501de3946f06cd316f35cabc0e363e0af651044c976708c0d48d4eb0d09489d92cceb283c751b2eed0e293ceaaabddcbabf7c25e21d658ebff9dc304aa"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95a365b4-ac3b-4300-ab6b-54cbc73220f4/4aabad928064af8761315ef34b08c24b/dotnet-sdk-8.0.108-linux-x64.tar.gz",
+            "hash": "5666ddf6fa9b65deaba4d7c5fcc2e2d56f631c4f5f6fb2a9f5919af0616ab2b420b12a828becc2e4b8628a76ac3dae824b55abde5c6d5ac59ee131d7eceae7c2"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b19671fb-4f1b-4770-bbf9-18069a1528ba/3792352e12df44e417da0fa15a7f5550/dotnet-sdk-8.0.108-osx-arm64.pkg",
+            "hash": "df4453447ec2180ffeb7d08826e296992c966467ef95982d9e57ad861ea03b6b93af1b26b7e7657c797cf071b9380550c9c5ec8ea9659e4b7bf09a0c7e419605"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64a3d858-c2e3-48d1-8236-7c6702efc1f8/191bed6c7f89244eb998b0f186db57d7/dotnet-sdk-8.0.108-osx-arm64.tar.gz",
+            "hash": "83b01276474b4b62bf0a282fbe11d2353a2191d90becd403b373cd6dfc95264442a907117ad8f615765b13969267b887d26a9f24dbd5f88d8b55daa94412d13c"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/162bce75-f162-4e62-be2c-18029b6ca689/909caafac67300888615d8a82443501c/dotnet-sdk-8.0.108-osx-x64.pkg",
+            "hash": "45a977e7cf5fd9fe2c7b471692646212f25ac4bde7c991a0ec13a0de3ea143b08acb295bb4da6cb3ee489004bca2744e734b87bc558245135795904fc736a943"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5ea78b09-65a7-4b08-ac65-bfae17afb322/7416ecc76a30ae4c77e71aade36e037f/dotnet-sdk-8.0.108-osx-x64.tar.gz",
+            "hash": "a80fee279abfeb558a5540ca2a969a11bb3dbeade8c39d8c47be8a2d622ef1c2bedb22c874598ad41dbff2b95d5a43197bd9f55fc933ab4ede5edcb6a76cf6cb"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/69b65d0f-b944-4f58-8fa3-fc6ebea04433/46f33c9c88dc19a42c891ce1982319ea/dotnet-sdk-8.0.108-win-arm64.exe",
+            "hash": "699591071f80944e81b46d783fcc124f9c5095fc5b97bfc620c012d7eba4e222251f60e3a6d21d26d58eca505edc0f113ffb67def0a35a6f61de347b914d146c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9024c669-0137-46a6-ac9f-44022bc05245/16e8250ab13fdb16f848db888385ece3/dotnet-sdk-8.0.108-win-arm64.zip",
+            "hash": "ae0495f030e8cbfd278912bd30ebf764007eeb31352c5a1700cb2d3aacdc1e0cea43dfc048f6da72441ed2c507b2b918297df0fc942a652c309b0070c53b7577"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a72eff3c-aafb-4af1-9f11-84f27cd07836/8249dcfd41cae96595a83d9cc5c345b1/dotnet-sdk-8.0.108-win-x64.exe",
+            "hash": "a2506216679e4d04767a6a92151a660545461a5c4a658f51c97b0e2fafc61d05abb1c143f43e05691f9d6d9c3342280111e94121583fac0adbc836d6a15d0ef9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/547b5a93-8197-415c-b131-356c44fa9240/a91b74ec9bb4c58687a9d82373f64417/dotnet-sdk-8.0.108-win-x64.zip",
+            "hash": "9ab4a1fd0e593dfdac8834ff614f7d1d39022fe3cb3b70c500b07afe77ba7e1214b531a557303b8d3f667a3b22b88df12d4c9e2020427f5a3526a2a394740922"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8dab9fa4-da17-4fe1-a17f-45d3bc0ce862/8a99e9bd38ea5120f4e7e781a4ddfc09/dotnet-sdk-8.0.108-win-x86.exe",
+            "hash": "e76849c5604c1f061d963d4254078211b866851645a4217644aad9c5e611c8fd1341a4ed406e9595696000902442026103dd3446615e57d84371918c890d73a4"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bc1e7fcb-f271-477e-b0f2-ebcc646dd3b8/4f978c9bcf20fc427238d3cd02f84f50/dotnet-sdk-8.0.108-win-x86.zip",
+            "hash": "bc18424167a9978097918ada0ec8510d592ac3567966321b21ee651e73d50ca4dcd90b11dbed6410d722551a7de2bb02b4de0f7644d58213e585d6b9051bf4fa"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "8.0.8",
+      "version-display": "8.0.8",
+      "version-aspnetcoremodule": [
+        "18.0.24201.8"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/26f16795-9928-4ddd-96f4-666e6e256715/bf797e4f997c965aeb0183b467fcf71a/aspnetcore-runtime-8.0.8-linux-arm.tar.gz",
+          "hash": "d0feedd91bb4028069d8cff1726191e9f09920e756405de0d2bbf6f43116277cc93ebe2483f405baa4972b54ffe89b09cbe172a639e60397ae7138df5ef48c4e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f6fcf2c9-39ad-49c7-80b5-92306309e796/3cac9217f55528cb60c95702ba92d78b/aspnetcore-runtime-8.0.8-linux-arm64.tar.gz",
+          "hash": "c3dc9d71fca0a48eda96074cbcef4c9a265c1c4e10cbff38614dd74d79443ae9d1ccd10714764cd041291f81d83c0ed1c307abf89249ab4b6f58a5de952fcffd"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9255e487-cdf2-4690-9840-74712503e37d/40be3d122db1d1ffa53a9843321c3979/aspnetcore-runtime-8.0.8-linux-musl-arm.tar.gz",
+          "hash": "5d9f609e72dcfcc16b6bb63d49e7fd47c3e2d77913d9de14864417fb2a534b2f7db56530db165acc63633641c706d0faba95db985b09844677d8cb41039a0c67"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/95f358cf-86b5-4789-8ee8-063067081c8b/e50e603b2453d7dc65eeb26dd4cfb398/aspnetcore-runtime-8.0.8-linux-musl-arm64.tar.gz",
+          "hash": "6028c29306d4969ee404c459dca3130f1e9614d1954e8ed4400140b35ad8a1e66a0a8b3ae02155df6bd046cd9309074220487a1c2625c39f081bdc6c8ed62005"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7d2ac05d-2bef-4069-9513-bb2ef7fab48d/4f3d2d3fec003a65513dc1f70c126ab7/aspnetcore-runtime-8.0.8-linux-musl-x64.tar.gz",
+          "hash": "822f2e1716dc2d2aa46ff08f4d2d9bb9ea8c82332785d0aba5f4f33e5eb60bdcd84e899cd2a13ca93032226710b5f0ca5c7159beda17027f84efa285278b5798"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/648de803-0b0c-46bc-9601-42a94dae0b41/241fd17cee8d473a78675e30681979bb/aspnetcore-runtime-8.0.8-linux-x64.tar.gz",
+          "hash": "d6c0cc2aac79fbacbf81b597f286763599f66278c17ddb448ce0b93d499bad8f88777d425854e68602945ab18af8a61f1ee59d431d5503006137f86113faa8b2"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a7080974-fac8-446c-ba20-313f6f323fbe/f907c126c9bcd394939a7cdf86b85f4b/aspnetcore-runtime-8.0.8-osx-arm64.tar.gz",
+          "hash": "a196c62b14e9136362073826a03e76e0a147027f03655529426e594f7e44eb8dd036daea80997876047171c1793c7edcfa5146bd55a01b591d9405fb1646eb00"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/465bdf6e-407d-4512-a222-32dafb225ad8/c22004de330d10a06141dee0f42b5d12/aspnetcore-runtime-8.0.8-osx-x64.tar.gz",
+          "hash": "d3ba8dcfaddcd6d50fd434911fe3eb8309666939a8a1ede800d7da2dd814efbd781d1449a42b71d1c71d9593465e9e97205025eb432808ef9a3ba0dcbdba0e3e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/21fe7f94-d40e-4890-9b53-91c9982388f8/7b3bb07fcb21549de69ad6848e66a2f9/aspnetcore-runtime-8.0.8-win-arm64.exe",
+          "hash": "3cb44ec35bc7f6fff4d6879ff0fc07abe1f2cd192ef9950c8f95aeae4c9023189710941583ae22bb7c56e5c3357ee80dd9fde1a9ba35452a46d133d2970604f3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3202aa8-e732-4807-90eb-b0cccae3e21c/6b53dccfe94032a084d279d6df48ebac/aspnetcore-runtime-8.0.8-win-arm64.zip",
+          "hash": "cf1aae298dd82dd3f23f30ed2cd045eec71fb3d6714bb4d0ebb4d7adf3597096106c2beb753398a82875012910215b7ba3b901c307c2a8109a7a65b67ff165a1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b336ee1f-b26c-4a03-958e-1e8a0b3cbf3e/afdfe9f8130098cb759ea933c66806bb/aspnetcore-runtime-8.0.8-win-x64.exe",
+          "hash": "908a9e973b052ebf564f2b693bc004ef968079ff2a325cce2912d6d20dd8a74411ba6e6e98ae6e9cb0098eb1cd3878c7cbece8af62ba0e1926c89ba5408799aa"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/020128a3-35b6-4f0c-b007-daf912a939a7/d9970e40d5f5b743bc7b041bfc75d318/aspnetcore-runtime-8.0.8-win-x64.zip",
+          "hash": "c5ad87fdf6cac37234317109fcbc6649aeb0adef3ffc2583af6e044e8934862aa37d17a6071d5383917ca92c01691c8c0680270fa5b6f1aeb43a0fb1d6cab4f6"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bc6a4cfd-be25-4dc0-90e9-2000f740a66b/6c5e6422aec7a09a8cebc1dbe8e37971/aspnetcore-runtime-8.0.8-win-x86.exe",
+          "hash": "45b4cfb383fc9541423547807229bbd8477bf7f1c30af84cc4f4a41506fba0b54a06f28d83aafe7ce2a0014ae581813c4f4e60a3f08c23bd7e013fa947bd6995"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/43d7268b-e704-4a36-9c1b-d3091f482471/d6ac5259b0d751532a03a0f943c672dc/aspnetcore-runtime-8.0.8-win-x86.zip",
+          "hash": "7f1f69cdb6ad0d1ba784cf827c122a1e77084c98d824936ce2d9c5a611818899f4bf27fe5d1a62678e78dc9cf987cb5aa6abd51c03874d046964a88ec7f80061"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/979c1823-ee43-4fbf-b9e0-f17411627b00/8e3b9cb3b2f6e1e3b03e38be20b37f07/aspnetcore-runtime-composite-8.0.8-linux-arm.tar.gz",
+          "hash": "0b4273d059bd57c7473b80f548fc519a674542d18403d46416e7005dc6e5b984828f1c3c125d19af8752712936c2e49e2e574d8534002980aa298a159bc89698"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5d24db42-a622-40ec-9f92-32fa9b319446/220f5807d7a803e9afe88c360460b803/aspnetcore-runtime-composite-8.0.8-linux-arm64.tar.gz",
+          "hash": "6385460af9f0e0377fa92f737dd0c76aaac60c8602c0a872467909738ab95dca67d9f75e10077610a3a7ea52f4abef5a86f50f25eee1c8587426011441d1abfc"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9850633c-fb83-42c4-8a73-e6e3a1c59993/d94ed365a5855270c7555a757753efc2/aspnetcore-runtime-composite-8.0.8-linux-musl-arm.tar.gz",
+          "hash": "f115d139bbd635eb83818d78caa85b68725a1c35404985c077a1a0c696698cf4e6068635a25b053251139ddf80738acbe97168c109fc890f1dea4fcf9df86cdc"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8ca98cac-c013-4e69-bdac-d8f7662e3c13/af7705d765641174b760af47701e502a/aspnetcore-runtime-composite-8.0.8-linux-musl-arm64.tar.gz",
+          "hash": "02e92e451ecfa4fe2e6c9483323fd60b974c62f24e7f6910ca28a977233315029566e440f44acbb8beb23bf7691c9a7812a0e2670be3446158362279a08be752"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a6e31eb-47e6-4d2a-b771-a6bd91cbada0/53b59a92b7e2db9aea8cc492edfe9e84/aspnetcore-runtime-composite-8.0.8-linux-musl-x64.tar.gz",
+          "hash": "7f3ad22abca4d43a46c11ffcdfedf8cf51a297ea83e53ece11e131cc9afceb67a8d4cd8aa0e35ae53c2bad0fdaf866936ba4c670fdfc9c9f57f832d2cd1d0c62"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/22051276-9045-4a93-b8b5-57d89e8ab627/0d579b69f59a222d05fa7ee4e65d8d8a/aspnetcore-runtime-composite-8.0.8-linux-x64.tar.gz",
+          "hash": "7f5c9df8a36f900021cdd6c3e8aa7e1583b1dd413de52d0ee109f44f101479110828f8840082020b86e06301789f075a6ce0018b86af26bf9544fe4f6fc165f2"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ef1366bd-3111-468b-93da-17e6ccb057e1/1fac364775c1accb09b9ac5314179004/dotnet-hosting-8.0.8-win.exe",
+          "hash": "f3f388d24050d4071a8564fbd22c23d3ef86912be48ead0854ea4fe37e2416d8a255031bf85208b6d39c87105ab41442025366aa42b35337357cdd74b423506f",
+          "akams": "https://aka.ms/dotnetcore-8-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "8.0.8",
+      "version-display": "8.0.8",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2603d3c8-f891-4121-b84c-54b4c566929d/5f534746507ee61be351289e23680ed7/windowsdesktop-runtime-8.0.8-win-arm64.exe",
+          "hash": "6c8d48681b18c403e1daf1eff2d141d98a2c538d26f49dde6dc02701c0300bfc5e101dfd47e9eb54f2d9328e5eeebb44366a08d99c48efa3eb1c6f71c98b78c2"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eeb4582f-f809-4d44-aecf-24f73e03e9a0/729e189727ba9abdcfb695dc163d8336/windowsdesktop-runtime-8.0.8-win-arm64.zip",
+          "hash": "eb881af017d58baa63d96d93da551503b7abe503e1a5e1fdd0e9f253d70e40607808a3b0ad68988f6683927b6301a65dc2ec020e8dea0239bac4c24923fb6f2a"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/907765b0-2bf8-494e-93aa-5ef9553c5d68/a9308dc010617e6716c0e6abd53b05ce/windowsdesktop-runtime-8.0.8-win-x64.exe",
+          "hash": "27484ffb1e9ce5e6290cda8f5f49563cf4a9e2692aa57429fcd0d3de4f30fc2fce204b1b120349ed50712e95d3fa51037ebaf9b7fd60c41856857b1372e0eac7"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/65b56aa4-0132-412e-86c0-8bf8decb0d6d/c9df1ca4ab97a2526af9d8388fbce537/windowsdesktop-runtime-8.0.8-win-x64.zip",
+          "hash": "955db393694978a237f2e16a70057a3a4b74e0de15e18e1021f411ee9913fdf63aedada8d71974c6bb8b609c6d9296fa8770018bf582a76a46c4e403651c7fa0"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bd1c2e28-44dd-47bb-a55c-aedd1f3e8cc4/0a15fac821e64cf7b8ec6d99e54e0997/windowsdesktop-runtime-8.0.8-win-x86.exe",
+          "hash": "3101e64ab772cef8081ca5f441f599d1906c9a3869e7ff20ee1725e121a54dd0569e55dfd842e748a0dd6bff902562834922681c9bb43ede6760aed1206c7966"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a24ff6c3-0466-4205-a8f6-4ace56b05b04/dd3c9d2b9dc4d8c6d4c73cf49d826bda/windowsdesktop-runtime-8.0.8-win-x86.zip",
+          "hash": "37b580145dcd37bcbc2c9def7f3f0e51b63e1210219712b9828b403b0805a6fdfaf1f2f6e42196084726575e27a0edd1cf7c40647c92c53fabdebe5d89664ccb"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/8.0/patch-releases-index.json
+++ b/release-notes/8.0/patch-releases-index.json
@@ -8,55 +8,55 @@
       "release-version": "8.0.8",
       "release-date": "2024-08-15",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.8/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.8/release.json"
     },
     {
       "release-version": "8.0.7",
       "release-date": "2024-07-09",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.7/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.7/release.json"
     },
     {
       "release-version": "8.0.6",
       "release-date": "2024-06-11",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.6/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.6/release.json"
     },
     {
       "release-version": "8.0.5",
       "release-date": "2024-05-14",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.5/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.5/release.json"
     },
     {
       "release-version": "8.0.4",
       "release-date": "2024-04-09",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.4/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.4/release.json"
     },
     {
       "release-version": "8.0.3",
       "release-date": "2024-03-12",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.3/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.3/release.json"
     },
     {
       "release-version": "8.0.2",
       "release-date": "2024-02-13",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.2/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.2/release.json"
     },
     {
       "release-version": "8.0.1",
       "release-date": "2024-01-09",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.1/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.1/release.json"
     },
     {
       "release-version": "8.0.0",
       "release-date": "2023-11-14",
       "security": true,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.0/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/8.0/8.0.0/release.json"
     }
   ]
 }

--- a/release-notes/8.0/patch-releases-index.json
+++ b/release-notes/8.0/patch-releases-index.json
@@ -1,0 +1,62 @@
+{
+  "channel-version": "8.0",
+  "latest-release": "8.0.8",
+  "latest-release-date": "2024-08-15",
+  "latest-release-security": true,
+  "releases": [
+    {
+      "release-version": "8.0.8",
+      "release-date": "2024-08-15",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.8/release.json"
+    },
+    {
+      "release-version": "8.0.7",
+      "release-date": "2024-07-09",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.7/release.json"
+    },
+    {
+      "release-version": "8.0.6",
+      "release-date": "2024-06-11",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.6/release.json"
+    },
+    {
+      "release-version": "8.0.5",
+      "release-date": "2024-05-14",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.5/release.json"
+    },
+    {
+      "release-version": "8.0.4",
+      "release-date": "2024-04-09",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.4/release.json"
+    },
+    {
+      "release-version": "8.0.3",
+      "release-date": "2024-03-12",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.3/release.json"
+    },
+    {
+      "release-version": "8.0.2",
+      "release-date": "2024-02-13",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.2/release.json"
+    },
+    {
+      "release-version": "8.0.1",
+      "release-date": "2024-01-09",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.1/release.json"
+    },
+    {
+      "release-version": "8.0.0",
+      "release-date": "2023-11-14",
+      "security": true,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/8.0.0/release.json"
+    }
+  ]
+}

--- a/release-notes/9.0/patch-releases-index.json
+++ b/release-notes/9.0/patch-releases-index.json
@@ -8,43 +8,43 @@
       "release-version": "9.0.0-preview.7",
       "release-date": "2024-08-13",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview7/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview7/release.json"
     },
     {
       "release-version": "9.0.0-preview.6",
       "release-date": "2024-07-09",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview6/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview6/release.json"
     },
     {
       "release-version": "9.0.0-preview.5",
       "release-date": "2024-06-11",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview5/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview5/release.json"
     },
     {
       "release-version": "9.0.0-preview.4",
       "release-date": "2024-05-21",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview4/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview4/release.json"
     },
     {
       "release-version": "9.0.0-preview.3",
       "release-date": "2024-04-11",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview3/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview3/release.json"
     },
     {
       "release-version": "9.0.0-preview.2",
       "release-date": "2024-03-12",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview2/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview2/release.json"
     },
     {
       "release-version": "9.0.0-preview.1",
       "release-date": "2024-02-13",
       "security": false,
-      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview1/release.json"
+      "release-info-uri": "https://raw.githubusercontent.com/dotnet/core/main/release-notes/9.0/preview/preview1/release.json"
     }
   ]
 }

--- a/release-notes/9.0/patch-releases-index.json
+++ b/release-notes/9.0/patch-releases-index.json
@@ -1,0 +1,50 @@
+{
+  "channel-version": "9.0",
+  "latest-release": "9.0.0-preview.7",
+  "latest-release-date": "2024-08-13",
+  "latest-release-security": false,
+  "releases": [
+    {
+      "release-version": "9.0.0-preview.7",
+      "release-date": "2024-08-13",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview7/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.6",
+      "release-date": "2024-07-09",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview6/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.5",
+      "release-date": "2024-06-11",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview5/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.4",
+      "release-date": "2024-05-21",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview4/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.3",
+      "release-date": "2024-04-11",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview3/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.2",
+      "release-date": "2024-03-12",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview2/release.json"
+    },
+    {
+      "release-version": "9.0.0-preview.1",
+      "release-date": "2024-02-13",
+      "security": false,
+      "release-info-uri": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/preview/preview1/release.json"
+    }
+  ]
+}

--- a/release-notes/9.0/preview/preview1/release.json
+++ b/release-notes/9.0/preview/preview1/release.json
@@ -1,0 +1,507 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-02-13",
+  "release-version": "9.0.0-preview.1",
+  "security": false,
+  "release": {
+    "release-date": "2024-02-13",
+    "release-version": "9.0.0-preview.1",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview1/9.0.0-preview.1.md",
+    "runtime": {
+      "version": "9.0.0-preview.1.24080.9",
+      "version-display": "9.0.0-preview.1",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f59acd9f-cbed-4483-acde-2b42d1abac59/b6edd8e417a12e04849dded2c6143869/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm.tar.gz",
+          "hash": "8f5e104562dd8ecbe87433896ba7bdd48400f28f41d0ffebe39d160adb6f0f600dcd327acd653d6c8a6dd13f3b375784290f17fd129e2f20bf307ccdbc4ba285"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7d911f96-acdc-4f5f-b283-cae6d6439bfd/f9e1c8d283ffd1d2e40346926a9c37bc/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm64.tar.gz",
+          "hash": "265b7bf094730be765bdaadec3215c1a7c51bff6fb18bb51cff383473e32d1ba821b6d046e0f7fa864400dc5cb68e35943057f5b6ae6e8c411375fc15fdbaf3c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d4e427bc-0a0f-4bd1-ae1f-79dfcb59ca8e/2c2ea76fdbbe8eb67029013741abc7c8/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm.tar.gz",
+          "hash": "7e8d46ae5668cc13011b9b579f71f27fa5c5feb93be2f6ee3541e75a163bb9f82d5e7b41cd5290e964d1ce7644ffdb9832d1570d7d795821cfd8c12f029e5d74"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d8daea8a-5a9d-4570-a860-cc9512946d66/bec3eb14bf7e22a3f99e21f6de8f5a7d/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm64.tar.gz",
+          "hash": "9e5a8dac01bc070758fb07788ec693a2b1c98be2d8aa1036d70e778c024df93d5a9299a4198514b7a8712143de47af6ce830d059350ba8686c760c6a37a8811d"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fe51f8fc-c30d-42ee-ae0b-e4866193c392/c8cecc468809fb235223f77dd19a0bfc/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-x64.tar.gz",
+          "hash": "f6a42522f3bbf59e58e28f3b5ce0bdd2b81e5f0aa9634ea4be7221145853925c221bdf04988e9e7364efd578c665f5136af55edc2eb9e2b276877ccd92235d80"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5bcb417b-0de3-461c-9ce2-a9ddd5df1aff/73e36aaa7c2e381724a2adac149eb376/dotnet-runtime-9.0.0-preview.1.24080.9-linux-x64.tar.gz",
+          "hash": "68f0b89227c8e0b3239477409708c1b0c5cc7d80afd6661dc2150946c66e2130cf560c2471609f0fd063f01ca1d8e72f74beec45ecb519cf58f1cdc434615054"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/00b22eac-00df-4aaa-9d9c-cb709afc7727/30b1bd396e681d1e7a5e0a2d034243a7/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.pkg",
+          "hash": "011963caf28e5fdd3a92b11732dffddf532f6c97ac5525682c32fc8ed3cb542f82aafdaa4020eef673f1b466533e2fdb133dab9334cff51840f45601c27a1a77"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/079214b6-0ce6-4d6f-a0ac-9bd9072dad0f/14b558eb20224c345f78ea80f7029e11/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.tar.gz",
+          "hash": "63bf6a57f61c4dcf4e0cdcedb8ff6c76cb702a95d4e0033f17b4cd2a3e800e73ab16c401fb098416404ea5716c725c175f9422250b2a8816c08eed2702cd38e5"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a33892b-8d4c-4a35-831d-537ae7361c96/381e7d9f93758fbe2ffbda88927fdda5/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.pkg",
+          "hash": "d4cc85c39b4c287471784a61410458bc2078f44cf07146ea24ae11a8e96944297133802972de80623ac7aff10e57289628e1cd5cc9a64ac2fa3effec2b369418"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0307fdd7-b398-4e90-a88b-574d853b769b/ab8938a35b03d8308a7a16331fa65cfa/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.tar.gz",
+          "hash": "f644ce6ee158bd86a4aba21bdd955a3aebb0367b5af618b6e77dc85922bc790b9c33b572606a15f566b2729a90923f66a933159124e803494105a695c890b775"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/57abc76c-46c8-4a76-b28d-108a097203dd/5796bd89648367c97adab3dbbc1ed1c2/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.exe",
+          "hash": "6027f09e7bd4612fe9cd1ac2550d0663cb80d63cec1a41cbd4a9f502d14c77ed83f83e3e47b87da28ce0820e894a0539624939d09e9363d52f2218696dc685e5"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6714615d-e422-4037-845a-c51a7cb7fd1c/f2efed74b142bcb681209cd5ca1f333b/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.zip",
+          "hash": "3a800156e1680f46a0cdeeb60b780ee56e3150c52f1c6e9b440eb30529f2bc36dd928c51afd495396f8f4a7c1998e52168fedd2a1205ca0f7ccda2d880d12a4d"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a160565d-c481-4d36-b6df-e708b3273914/b31aaffa739731821684023da81c3b06/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.exe",
+          "hash": "a535447c840aa27e21b69de7172f225ae5e3bea3ed632b81372a4cd20919a2ca4c6ae7c3963648bdb98d458fb204c5c5af3e85e0b44c8b5b803c1b3e4d8e791e"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f93597e-2697-4e50-a232-aa4d7c025ee4/4f35240f9b922d5b77f5c426e52c6e70/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.zip",
+          "hash": "a417238c10646dac5ff47663b34d05ed51e96e224aa1f29dc2de03a96c273d72dbd3c890a36b728fc01d0a3d6ae50804ade78c9f29310cdab49dcecf8e0e6ad8"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/292f3bdc-8f10-43cc-9f54-a2740ea4f8e3/3aaa99d7befd139d2e5ac8c4b1fa6707/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.exe",
+          "hash": "70f677e2171a2773a0b0dafd0deffce9bdbf97692e34d2032163ea21645394becb71afdeda332edd0f558dc7e7080ed4e4a695f2ee32aa3866e8d7b81ef919a2"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ae7b1529-8508-4202-be55-911ff8373186/b657e9299262515b194ecd8e95948b4d/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.zip",
+          "hash": "be777abcd6300a3628ea3a154d0c62fae0c4142f3a5e9c4eda5d315d4716014dd42cddc9cac25c2fccddb106bade516f30805584e07c086f2d3fc9a171135dfb"
+        }
+      ],
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)"
+    },
+    "sdk": {
+      "version": "9.0.100-preview.1.24101.2",
+      "version-display": "9.0.100-preview.1",
+      "runtime-version": "9.0.0-preview.1.24080.9",
+      "vs-version": "",
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f5e9fc40-e56c-4276-bcf8-3ecf80f7c1a7/94900c87e4529a89ac71d164665088c7/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
+          "hash": "fa14b4545688097f490b9730a9063a3f7e7b779fd57a4bee43e61ef6f61c6aa5ba33ae5e1c8e0bc13dd060709d3eebbd04b044e06a9a70eecc73243db4107086"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e8743929-2c7b-4410-88f5-5f247040b498/ff454c589dc8d5dd9cb42e0950f34a69/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
+          "hash": "b7c29e4e4baf2d2ba7b29fc5a080df708c5a915e6fb1ce2ff93ffc8f18e7725fae5d569ab1349ef4b067d05d00886a17c8d1a95e211602db1ee5da820b5edefd"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4cf1722b-252e-4b66-a292-8aa97fdd0fec/7bc384770059a0348e4024d8b6489f3f/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
+          "hash": "821f7e1387a50b27c9fcad1e1955cc6aeb4012a0d1cef7273f882409ca18a42d97fe3fcad18eb141e8dd91afc16fa698a720763e4be6d7054af9c4e9104b43fd"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9fba65ff-def6-44cf-9230-1973c6a150a4/230b5ce3ae290ce5b10ed748b4f16dfc/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
+          "hash": "93a0126c76bcd054a7119fb5e51b64980b130f55850d006d77ed4dd3a5f9ec79bfe49c0160c2c4dd58a01226c7264081f36b594e4b2d5c8d18a400ab57b86460"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/744e137c-6902-426e-a494-1ec7bc71a8eb/c5a6d2c3d3c4e57c10da28992e34617a/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
+          "hash": "7b44faba92fcc228477dce2ecd3311f0d6b68c30f082ff020472b07fc2615aa0e591da9185667a172a6f708192c6610e6c20594f79cee8e1a046515ffbb8e26b"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f51b05d4-bc43-4290-9b33-aaa212edbba6/e10559d91242409faf5c37cb529de8f3/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
+          "hash": "e176126d9a12075d91a0ad2b4dd50021a564258742d86560bd216ac36482c763087bd8affc68fe9a8d3c46f61f864bc2c7c2e455739d21614516c4f73fd281fd"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5f6fd-0b74-407c-a3cf-52792d76415f/53c4911d66ce7a8757c9d10c2c4d6414/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
+          "hash": "5375987c0a02eb33d820802ec9c76acb14ccecf1a35df1f894bf7e362e1400a8b48dad628267b65d8bda29850f1a70ff4cc0960cd57cd61dc7f155e155bc9de6"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cd991bbf-8952-4bd1-83d4-33eb1a810939/3662095e14f91f43c2b3a7e6c55666fa/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
+          "hash": "901835cfc277c626d38c7a2bc1a6704115d240812631cd32f4b51833b41ddcd3a4a169a1bbda42a9446eb33b2337f6a8c6410bc3d1bae557c8898d427e2fc8c1"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5c78b512-56ef-49a1-b181-96ca60917c06/f6ad92dac6791efabedd862a495e7d4b/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
+          "hash": "8254d65d65ef1bc038255e651ad962bc15249b2f5a760c31e628fa342f3a2bfd2dfd2aa96f1125cf8318d60e8ec99cb7a51dab1d780e606b4f3d47c2b7159f96"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9956af63-be37-43be-a854-01f3a95e12fe/60d97a3f4f53b33376b8df055a14cf39/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
+          "hash": "90c6709c54c0f9f4d7100bbf9c3b8136b6468617034c23f6a60dc17092e311539d54b741e149b70f1b6a6e2c6be0aacc948d4c72abac724f47d5ea05e02a2939"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/224503be-904d-4735-a447-b180b5a90c88/c267d21bd55b3108a226b0b458f02ab7/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
+          "hash": "99c61acc8bf757793fa2a08eb29afcf3e365bf285fde929c58ce774424294570c26609468cc94f89d891f0c42769041d6ad9c6c759a0665727dba16288dd2f64"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/019706df-7545-4e5c-a8e0-1cd8ed308eca/eb7fe6847f4d9be5870ee0ea172d5025/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
+          "hash": "38bc46731201d5796d7a7ee30446fc35f2c225a75c978b896e7b6b09c7d537b22f991acbd413f6352df39cb8e69d94634b085968256377d83843527e55268d0d"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bb120bd7-6656-4ebf-9efc-87dbbbd2f344/ef7cb2cf73d9a740c2af0b4ca9c2266e/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
+          "hash": "82dfbbe479df411c0a177459ed9af55c373561e5b23dfcd09eb1ba713764e0800519dc2b50138108520bb772c8aec696c31f99c85674cb7c7d7b999292668d31"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4c55bc67-e478-4fdc-abe3-08b8dd64f4e4/9cf46c3018f477a93a8498850e6c122b/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
+          "hash": "a993f0a23dee43f43e51509094f385379183ae916ee04f891927bc2398fd3645bfd866d0960c9d0ccf11f7878856dd7317298a6e5ec6a17dd7f32fb3890855a9"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/351f70a4-7eda-44e7-9e3b-44ee92e2b678/92d69c8dc447e2870f95ec535c3edf83/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
+          "hash": "9ee4c1da97526bffda9c1ad58e609bbbcad324dcb4e24b1cdd30f1feb0b37333e326b95ae08706e56f52c12ee20556151b13d7d5c04a0283f3420659c706ac63"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a5790bb-b57d-4c34-bbf9-d93a589bc065/0456e1a4bd06579fccf6fb776dfa5dc6/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
+          "hash": "1ea49121eebc8ad47dae4148bdda7ee9ca17f65f49af9a0ce39d42dfa3916ac4d8430d7d0c0c7f466f15fc0fdd844b891635e743ca4782571cdde76828f7d236"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.1.24101.2",
+        "version-display": "9.0.100-preview.1",
+        "runtime-version": "9.0.0-preview.1.24080.9",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2022 (v17.10 Preview 1)",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f5e9fc40-e56c-4276-bcf8-3ecf80f7c1a7/94900c87e4529a89ac71d164665088c7/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
+            "hash": "fa14b4545688097f490b9730a9063a3f7e7b779fd57a4bee43e61ef6f61c6aa5ba33ae5e1c8e0bc13dd060709d3eebbd04b044e06a9a70eecc73243db4107086"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e8743929-2c7b-4410-88f5-5f247040b498/ff454c589dc8d5dd9cb42e0950f34a69/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
+            "hash": "b7c29e4e4baf2d2ba7b29fc5a080df708c5a915e6fb1ce2ff93ffc8f18e7725fae5d569ab1349ef4b067d05d00886a17c8d1a95e211602db1ee5da820b5edefd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4cf1722b-252e-4b66-a292-8aa97fdd0fec/7bc384770059a0348e4024d8b6489f3f/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
+            "hash": "821f7e1387a50b27c9fcad1e1955cc6aeb4012a0d1cef7273f882409ca18a42d97fe3fcad18eb141e8dd91afc16fa698a720763e4be6d7054af9c4e9104b43fd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9fba65ff-def6-44cf-9230-1973c6a150a4/230b5ce3ae290ce5b10ed748b4f16dfc/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
+            "hash": "93a0126c76bcd054a7119fb5e51b64980b130f55850d006d77ed4dd3a5f9ec79bfe49c0160c2c4dd58a01226c7264081f36b594e4b2d5c8d18a400ab57b86460"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/744e137c-6902-426e-a494-1ec7bc71a8eb/c5a6d2c3d3c4e57c10da28992e34617a/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
+            "hash": "7b44faba92fcc228477dce2ecd3311f0d6b68c30f082ff020472b07fc2615aa0e591da9185667a172a6f708192c6610e6c20594f79cee8e1a046515ffbb8e26b"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f51b05d4-bc43-4290-9b33-aaa212edbba6/e10559d91242409faf5c37cb529de8f3/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
+            "hash": "e176126d9a12075d91a0ad2b4dd50021a564258742d86560bd216ac36482c763087bd8affc68fe9a8d3c46f61f864bc2c7c2e455739d21614516c4f73fd281fd"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5f6fd-0b74-407c-a3cf-52792d76415f/53c4911d66ce7a8757c9d10c2c4d6414/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
+            "hash": "5375987c0a02eb33d820802ec9c76acb14ccecf1a35df1f894bf7e362e1400a8b48dad628267b65d8bda29850f1a70ff4cc0960cd57cd61dc7f155e155bc9de6"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cd991bbf-8952-4bd1-83d4-33eb1a810939/3662095e14f91f43c2b3a7e6c55666fa/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
+            "hash": "901835cfc277c626d38c7a2bc1a6704115d240812631cd32f4b51833b41ddcd3a4a169a1bbda42a9446eb33b2337f6a8c6410bc3d1bae557c8898d427e2fc8c1"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5c78b512-56ef-49a1-b181-96ca60917c06/f6ad92dac6791efabedd862a495e7d4b/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
+            "hash": "8254d65d65ef1bc038255e651ad962bc15249b2f5a760c31e628fa342f3a2bfd2dfd2aa96f1125cf8318d60e8ec99cb7a51dab1d780e606b4f3d47c2b7159f96"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9956af63-be37-43be-a854-01f3a95e12fe/60d97a3f4f53b33376b8df055a14cf39/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
+            "hash": "90c6709c54c0f9f4d7100bbf9c3b8136b6468617034c23f6a60dc17092e311539d54b741e149b70f1b6a6e2c6be0aacc948d4c72abac724f47d5ea05e02a2939"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/224503be-904d-4735-a447-b180b5a90c88/c267d21bd55b3108a226b0b458f02ab7/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
+            "hash": "99c61acc8bf757793fa2a08eb29afcf3e365bf285fde929c58ce774424294570c26609468cc94f89d891f0c42769041d6ad9c6c759a0665727dba16288dd2f64"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/019706df-7545-4e5c-a8e0-1cd8ed308eca/eb7fe6847f4d9be5870ee0ea172d5025/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
+            "hash": "38bc46731201d5796d7a7ee30446fc35f2c225a75c978b896e7b6b09c7d537b22f991acbd413f6352df39cb8e69d94634b085968256377d83843527e55268d0d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bb120bd7-6656-4ebf-9efc-87dbbbd2f344/ef7cb2cf73d9a740c2af0b4ca9c2266e/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
+            "hash": "82dfbbe479df411c0a177459ed9af55c373561e5b23dfcd09eb1ba713764e0800519dc2b50138108520bb772c8aec696c31f99c85674cb7c7d7b999292668d31"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c55bc67-e478-4fdc-abe3-08b8dd64f4e4/9cf46c3018f477a93a8498850e6c122b/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
+            "hash": "a993f0a23dee43f43e51509094f385379183ae916ee04f891927bc2398fd3645bfd866d0960c9d0ccf11f7878856dd7317298a6e5ec6a17dd7f32fb3890855a9"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/351f70a4-7eda-44e7-9e3b-44ee92e2b678/92d69c8dc447e2870f95ec535c3edf83/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
+            "hash": "9ee4c1da97526bffda9c1ad58e609bbbcad324dcb4e24b1cdd30f1feb0b37333e326b95ae08706e56f52c12ee20556151b13d7d5c04a0283f3420659c706ac63"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a5790bb-b57d-4c34-bbf9-d93a589bc065/0456e1a4bd06579fccf6fb776dfa5dc6/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
+            "hash": "1ea49121eebc8ad47dae4148bdda7ee9ca17f65f49af9a0ce39d42dfa3916ac4d8430d7d0c0c7f466f15fc0fdd844b891635e743ca4782571cdde76828f7d236"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.1.24081.5",
+      "version-display": "9.0.0-preview.1",
+      "version-aspnetcoremodule": [
+        "19.0.24031.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/27ce8ce5-a12e-47d5-b075-5c6034c86c40/6280dfd63195eeb410c4b70dff2d6ba9/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
+          "hash": "688c07f9d896db90a1ea863b008fff5187d50b2aef352298f3e4c16522812f3dc9be22f8bdee89abde8554e7668bb9f35d0aa4746b1fd9c42ea0aa8ef84f1f83"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3f2586f3-89fd-44ad-aae2-4c241f72996f/f973c7140305733792dd25b466e37606/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
+          "hash": "118967e64995d7c242738bf806928ecc52cfae3b0e0429a6951047eaf37d27bdde0adc0c6dc74e32d61b69565f7666cbfd4658396c37988e5d343debcc15bdf6"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7783447-29c2-4866-bd77-fcc207fe2d73/a1d3af0e7af02e478e7f748011af1c48/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
+          "hash": "1d322b98cb039938a735267b29f49d1bb5b024fe2fda96608de725c2419d2da3cae8f6e3e7fa2594d0d7768180ced2bc1c2da20582380aa66954e34fe0ed01ea"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/df69432f-27c5-450b-8afc-b7c9e35630d0/b5bc58a367875a214cf0c2c11ad174a9/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
+          "hash": "b297d9cfa88fbd879f4e36a567b17109d5a0ac32102afdc5243c181f469f5c9beac0ec2ac776b68b7419ad9b9ddb932ef0c8f79a7cc14e6d62a491959685969c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d3f3a6eb-ef34-474b-944e-bed7bdb040cc/bccb1d80864eaaf576c25444525f9224/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
+          "hash": "5ddef8928f7db38a3bc9fdad0d7cf8bddd8dee698ce8b72e7e7eedca5d769b70eab79ed161576ea8a5eb65806f80b27f6668f200ddd6c9425ab724074c543b03"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/14b2b268-4d58-4f7b-9708-46c5a0a5b868/3cfbd27c7e2aabc0ca70f474709a4767/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
+          "hash": "29bfe0b5b72608eba97151909308a67a47dc299902a46bf1a22d67bb5f8a0c87c6f4533c0c2d4679f9440f9ccccf549c434a4280c101f7633bdbdcf049c95817"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a407f4d8-183b-45c9-8153-c889c10630b9/2388fbcc5171e20d05abeb301027df2e/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-arm64.tar.gz",
+          "hash": "09746054c291b10bacf3fba8ad147443fd41f42b6b04d9559281bc7d919ddc56ebe7402021997f6f24b745b3292368719cc2142d0eebba76226c5603545b6743"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2e9a9af2-f1dd-467a-85f3-430f5142bf0b/6ce0853ee69a127bb767270a737f6467/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-x64.tar.gz",
+          "hash": "3ed80631a3ca0a4684a70fc0f17d46257a63cc71c7497c958accb4d329eff4a7c832a29c028b608798fbed0b82e2c5b7d5533c57dff2188d4142559b57341192"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f942b1be-4e32-43cd-914f-24bd19b7e583/262944dd0604ab13fc39d5387c59d53d/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-arm64.zip",
+          "hash": "4ef745d883f519a3949ff7479950945a6952de6c0ab10aa0d9320dc9c6578221bf7551788f17d62a2c287f5a662ea81c3b747d1a1b28184a32f7cce47f0ef4cb"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/427d2f8c-58f0-4ebb-b3c2-8960b88d03a2/354461a9a09d96678505e964f829df42/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.exe",
+          "hash": "1644a3474e01a3b5805b341881b4450af885b043d7578360a7a0bfecb13158305d878c9624d697774e10ed5c84c976c1a7f541ecd585bd6d3d53084f6d9fb880"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/188d9bb7-2cd9-48b0-ae5f-c1919ebb0750/c1c4b6c669863c4f6fb5bbe9b6498ca8/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.zip",
+          "hash": "e8ebffbc89b516aedfab48fa8cfd9ec529437df21724b6e7f0a8b8b97eba29d274499a37fca0aaa0f7bd84ab3fb839a2ff09c6042f3abe568d4ec8191becbbd7"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cf9d5773-4262-4135-b8cd-10bdb1d64cf3/2999b27d44b816b58a966d74d43ca2f6/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.exe",
+          "hash": "219addc5b3fc08f3e9c650171cb2804161c9a4c3a70f5367a32a2ef368a7850a8b18d232f27d5c265b323c4ccc7034f21d820558e2f05c59f8fd6f444e7c44ac"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d5423ff0-60fe-4e91-b083-5aefca88610a/962fb47ce2b483795e7eb33f08a4bc46/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.zip",
+          "hash": "6e7730207fdfef400edac61ec142dd7440376699e25675d13fe05b347264f69b9a7cc3b047a8051b14c7862d144a465fe63fc9ff2a6d3c3c7a2a3cb46d1f6657"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fbb4cdaa-f4de-4297-bce0-5af6e8a8148f/90c097d5618d4dd81d8d489abce1645b/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
+          "hash": "2310efa27939af7f28ff3869a640a182a3fca6374b06db98fc9cdc6a5b49b75de9904bb47bb3e15334620357662ede933b08994b35d5bc1dd5c859ca73530602"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/42ca6325-0b0c-4ee6-96c4-ac46affd2c64/20f5fc2ee183de3450cd33e06e5c8bf2/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
+          "hash": "1ea9bc90557a4196eecc51f8965994c6feb446c671b19236b6593a8996641410cc15f2ed6b2a7be73217ae89683664cee2af68594e3a0164306b770778d96295"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5a23389-0099-4b0c-adde-6acbee4412b9/10a484a2160790fb695c8e2eb6d34d53/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
+          "hash": "6f070ba486fdc59d1717c2089f322329d28a4996d5e165ac55f7ed07dc4f014fa18efc2ab36e50fbe0959d10960a346476fede4ef4115e8972ee105fc7b777a5"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c165e81b-e915-4c10-9fd1-86e1a3eaabf6/184c4299dc0fcf3b18a8e18f989a3d6b/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
+          "hash": "5ef4134b9ecdc4b80bb402209fd2adba4c219d235e0f3a4d196c8d7ac0366c9fd40c6a515d1f585b3f9b3bcbeaf7bb9c41a64643ef2f065305abdd47014879c0"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bede20f1-0e70-4a08-a1d8-df9613e7ddf3/aa55cc5fa325b264eb1cbda8eb45d8b7/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
+          "hash": "d5740881123b148f0e9b3d990f2407da9b0a4cb61e6e853c9eb709a52196dccc2e2cb8b9ee5c778fc6022fb5a45a076436020a4817089dbb67e2e126f717b342"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f7492292-937e-4ed2-aac1-1e1aee31c19b/f345f6bc48f5c073b048e2946d504041/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
+          "hash": "8022e4a1d37089242905ca9c4fd5f37a22136f377a170a677f1005fc8ce32d5bbc6341c0b80236d8287022533d908a4d91120bac894ab418b20a056de2e45b61"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6728a941-7b39-44af-b75c-91769681007d/0f062452057e1f17bcf2e1af7e2a5414/dotnet-hosting-9.0.0-preview.1.24081.5-win.exe",
+          "hash": "67a972f36f9e31417e6746b9ea69fc033e945708c2e43be665239ac16f561e92960240f789d942ae886b4d4a38a49e1ed226e5b92f0eeb1e66d178c760cd4960",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.1.24081.3",
+      "version-display": "9.0.0-preview.1",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5bcc6b35-e7e7-48b5-8cf2-277a60fc03e1/d5c4319efbf8e734f9dd11a358c03bd4/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.exe",
+          "hash": "bf252da538951cce59469e1d2074d34c4b8bb04de33421c9b594c447c8d3b9e2e2cacd28e4f515ba1a2e430db18d11c70bffb07cdcb518a3d035cf88f777a768"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dc0ae26f-121d-4f63-a066-2333861699b7/45bb105bf0b9756495fe8d217f20c397/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.zip",
+          "hash": "2df2ba1949621525b70767bd1230928d8d82255e58a0f28a131ae4345d32e62ceeac41f42bac119c7b60eef0f9731d4920e522a4555e5d64a34ef361ef5128de"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0c804185-7f86-4167-8703-8365d4939d72/02935dd20c741d36acb2c4eb2f2d5a21/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.exe",
+          "hash": "ef2731f34d6d2e732deaa5dff36e4fc04d6c2d6f600d0faf0a8f4f662e731fb6eeb778efa2dbc287dc04bdc00fda257f194ffb7821958cd4137683feaabe9d12"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9a297cbf-b641-4026-bca8-c68293c4fa8f/05b5d48d0ab2dc0cea2271f85c027c87/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.zip",
+          "hash": "15f93de63a9144e01528bafd169d62a0e7fa1fc5a85c4e7422a1553b79ddbbc7213488facc38d677b8fca90778c608d623f49ada121a16664d675a1d7e225d9e"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e3264b5f-c04b-427b-bf87-f9a264f53b0d/9f564a10f3af50fda2ec7ef2365b10d5/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.exe",
+          "hash": "0288cddb418da54bbc09fdf9640eaa8ea0c236e4cec8613b70c10f6a2e2f831104d68d0bbe11138ba51bf51861cfdb6fba532394e3e58a7ce255f28f7f71a474"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f0788f54-28b1-4a6d-ae86-1ead236dda97/37a05b2928ca436d0424aeb3d5ce4e4f/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.zip",
+          "hash": "e47ae91d7bf992e9dda09519551dc2dc9f5cec7b61542961c3b8c9ca67606204ed2f212934bed8a34bf6331d095683f018bb4418fed442e5b3ead1a11b479f28"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview2/release.json
+++ b/release-notes/9.0/preview/preview2/release.json
@@ -1,0 +1,507 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-03-12",
+  "release-version": "9.0.0-preview.2",
+  "security": false,
+  "release": {
+    "release-date": "2024-03-12",
+    "release-version": "9.0.0-preview.2",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview2/9.0.0-preview.2.md",
+    "runtime": {
+      "version": "9.0.0-preview.2.24128.5",
+      "version-display": "9.0.0-preview.2",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b8a2b8f8-4499-450c-81e6-a54654e3e8c4/4c148cdfdce492949538fdcf478b72a5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm.tar.gz",
+          "hash": "845b0a1eb3ba18637cecbe4105e6f7a26cf5e0c482177feb1570e1ec85eecb717d59ae5e189788bc4a4a4db23081c21369b8c462991fc4a426b52ddcca34b4bc"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ab7bbaf3-c61e-481d-8dbf-b0dc2bcc80f6/0467f280265fe3b33ddcd345b04cdfa1/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm64.tar.gz",
+          "hash": "5ae4c5f4acf1465c8aba29a90aa3ee99ab47ffece9f932e9fb4de8937d05feace4c5d3b53d4b8bf226eb99de16a0aad0e71f091827651f0722261513c8a8a2e7"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/95ae0189-d474-4d1e-b47b-32999c6c9b96/aef82d9a69aa8ba7563eee2b64324dde/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm.tar.gz",
+          "hash": "31ce6e4af959df846383b8ff5d7912b6f16bb8244dca675b1109153ff13298ac033b4675319eb30bbaea6dda8172cf87d0f4f5e1f3680086374fff97c41110d7"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ec450edb-1042-432e-9a15-211c3aa63f73/99dea9857c948437ebc0d18c0466f596/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm64.tar.gz",
+          "hash": "3384c37ae4dd0b0f9eda8a4b7bbdc24ab8fd82a9fba9977408b93ef2a49c4aeca7808faf6c28fa970cd07959c6883045cd0408d3c96f52d1bfe9282dd6cf06eb"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5ee7ee86-0913-4a6e-886c-287b5c315645/49775cbe375d6544da49676b68595ad4/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-x64.tar.gz",
+          "hash": "192faff21e221e1211acc087a759925205ced69d47641df46495cdb508b2e9a6276b24da54c6046c6cdf5e82ca5fc3eef1febc05cdfe3459018b7c63bd764e2a"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3d7900df-fefb-4aba-8dbc-e3d755111a85/c849ddf0290aeae485414ba46ad961c3/dotnet-runtime-9.0.0-preview.2.24128.5-linux-x64.tar.gz",
+          "hash": "6433959a75103f2f1108bbc16cfe348f9ba04fec1c8f9b6895019241bfcb7b21fab675cc13971f2c1a66b46b044a95f91e1e2b46e6e8bdd893d277906f82545a"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/943e433f-88c2-4e0b-a56d-44fba4946e1e/809ebff77cf2e17f2d9146df174fddeb/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.pkg",
+          "hash": "08e482abe56ca8282f53a32ef30f078397e16118fa1fcc83eda0a08b67e052668a111cad6b9f7245db8c27051a5d26ed70b3428964f593d1cb54b754022204b8"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6401083b-8213-431e-94b3-bb1bba37d792/551aca92ab4da13513ead1e7865d57e2/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.tar.gz",
+          "hash": "cc7b8626cdec48427ef79f14c0919a09a3500bdc1c2933c6b5cf80886cc590ab20ccbd07bdb3a6081e47b80f372db3b4887b5276a12252887b7360a7f23e9901"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/018b25f2-3017-4750-b7d4-aa5feac985d0/46eec7638b52e3179eafe00d17e8c448/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.pkg",
+          "hash": "975279950f5644c9c7889ba5b1c6c4fb836a3561b68d1a6024ceb028860350c480a53e451f7317e0cbc3ea88813319c5108a2a99a04bb61731417d81b486aa37"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8ccc8b00-80b0-48c4-9948-9adfa67f42e3/b93918f628eee154b3400fe05774d1be/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.tar.gz",
+          "hash": "9f83d1d7dbfb8c8df1c7530fed3ddbb1571e60100954051bf07b8ee758edc600d1d988819c91711cd8b4baa05dd97f9900d1edf2ae5035ac74930a920951f380"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e34ab999-b734-4d28-9811-c850e7efa475/e8ee49da3fe00f64d7974e2a9229bdf9/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.exe",
+          "hash": "e9f0e707f54b1dde058a7c47a29f3b02d2119814b3a7c752e6ef295a00ca3130e8c3d6b7a58b753c2148818d0ddf0baa335d98d0500602695a35ae16f76068a1"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1b52f101-5fc6-4de8-b929-79c152dd976d/b332a49ecbffbfecf6c175d9d0c28d2d/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.zip",
+          "hash": "3f284a3ae3e14566788edf0d093f4da83e7c0024931e32b04620b73c2739bded2061e3268caf36af6490b31dc257d26f1fceac5c53b88921217f3588cb870c43"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c00df4a5-6d92-4704-ac31-ae10be42083a/41aa5cd5ebe827a4138ab662c31da899/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.exe",
+          "hash": "dcb1fbdcc439c81dab9d17e60ec226bb0307e3a68c5e28683408b9b8900f6e81e9c457e6a5ff65d177e538e02514841a9d979cf017f1ff24c98513916a089c29"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/148ff15b-93e9-43a5-b9a0-19be5f5918c0/c2793ee38f227acac267234877e0bcac/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.zip",
+          "hash": "701283ab4dde1f23b621ae712b66e117b4d87f9dfe4aacfee0d1a0622e7b9135b54a940f132e3a59add88bae69ffad790b1acacfa03cc30f55d16572c34fd932"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cbb27466-67aa-4847-aea5-6c81d1d16dc7/a302106d0792a83c1fdfec62466fdffa/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.exe",
+          "hash": "4b64d2d82c53e6f7e541c589eacbe273e4d71d22b538b4caa57a52de302613e32a1ae1d6f3312a4529ecd8ecf378411b0262e1902ae929f58ac09942894f8ec4"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7101e9b8-6446-42a8-8ef6-2a9806db83cc/338af40210ac0a98c56ddcc904f09862/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.zip",
+          "hash": "b472c78b3eb5d3762bf2cf2690efe0379a79958e34986a939f5f07b0c78950e9cbc423d072b99b31db8bf063b739434a9dc6cdae874ce64601e351474c9bd85a"
+        }
+      ],
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)"
+    },
+    "sdk": {
+      "version": "9.0.100-preview.2.24157.14",
+      "version-display": "9.0.100-preview.2",
+      "runtime-version": "9.0.0-preview.2.24128.5",
+      "vs-version": "",
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2602262-2aba-4921-81f0-640ec8200c5e/7eac075f28a6817086891867c5058ae2/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
+          "hash": "51dde68d8cbe20e8e77fef7b940ae55158e8dbc31d219696228e82b2e4223b55a43dd2797c70101d3fcf2ca56bfd7370ff08daba5f0e457f54dbd8e171503f31"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b64ba1b3-ad10-40a2-b588-73db9ed9d99d/f772743c20f55a5a8aea3da2e1480676/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
+          "hash": "1d591e504352f765a35092394719451c024a628c69efb6a10d0a5d57947c466a004243e799b46147fdf6316a23b4335b1e8fb1fc5513def1dec9f96c6c845dc7"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/daa714fa-cd09-40ef-94ef-7f7785e312d3/a0a4d29f8508ce756185f682ff1acb47/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
+          "hash": "a0547586a2e1c04b1ac030637901c113abb7bcf3bfb4bb6e017d6c11ee6f5fc114dea4da57cf4f702765a0a0e5c19391623c73e9a3500d5f6713a000a9c14058"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/48c6b988-5bb3-431d-b8d8-f03a1607ae06/6d0fb991e397020332cd09deb21fee15/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
+          "hash": "a56d724d388576e8e6db78c67004a7296ae33a7c2ab00d8af132d3df12398cce3f81b08a50f9094942cbab6ffa66efdd805359a5ee9189dfacbafd7478d34285"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e9eeb6eb-889b-46f6-a5b5-63d985747b66/a7aab27d12efd89d1d387727a32bc2f3/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
+          "hash": "51fd7da5986f7776a602d8aa3dee1952e86ba0676c1fdb392f7d13c642bc608489a897347707267fa030355042f6873024c92583a6bb8080397427bee35f087a"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/911f82cf-0f87-46c2-8d70-44fab9a0f3c9/137ec23686722b8119bd62def8d7b117/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
+          "hash": "c44df5e11791e4b22720834ed7f28102e33ab475670fa8e132d73d5dd03d8f4ed3f4a548deac67a79e06db6f776c9f632eda4503b6fdc9eef7ffb001cc9963c0"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ea918db8-961f-4b46-9457-00eddc6289e7/8c9b1472a0dd4d12702f598ac017617d/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
+          "hash": "61e5819cfe28beab99b3a75425c9c0dd0afb01390170e21fdc0fc0ecd9518d20ce24d07048012e522b53d727f7bc94639f257cc6021fd1b39b57405ae6adaeb2"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/30628efc-01f0-468d-baf1-fc487e55093a/4c2bf86dbebb6c522d4d667516dc5930/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
+          "hash": "1c7166a594ba6c07d0233aac44428e561e2131f1f1812cdfee75807d19f1fe53f40f9d93e88d4a478c885993424ec2ec7b9aaf8f174332f587e6ff10813680ec"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/077d24e5-df1c-40fa-8204-cd601e0b3465/44de36d04f570e120f4f47debe33b839/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
+          "hash": "16d6a5e48cdce9e5e529c5572032d02213136b5b028a06a86c72c32765a87b30aaa62381bdde4f810e5b1ad7ab07103386002b6447bb8186888604794da7faed"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5d2259a0-cb6e-4079-96fa-e0de6f0448c5/9b299e3cc15adf6153c28c24cba35fef/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
+          "hash": "a5a02f596e3976e65650d6a780903a755d4d700491c670b4f3c2f167224da632b98ad03ab7a087dc18561c5cc3ae6a3be78d5c6ca2f7312c7d7c417d909a481a"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b9e31f8c-0bf0-4895-9c79-8baffc8530ef/b2db38465ee04fecbad4a970422681c2/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
+          "hash": "86ec1715eb1373d22ea3ea49021c537484b481c03ce6a82df9ae81d911f5de28a8878f78871db66bc407d65bb84cc1ffe0099928a177ebab50910b6f6bbe1290"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41c79f6f-30d8-4b2f-a15a-c098084dc78b/e46437cd6d1bca934eeba50a70a33bf7/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
+          "hash": "c8d0ff7e90b6799f352ea69cbff376e7efd201ae5593d6199145225afb2caa920480191be2bdff1c364ade02e89fc157e06cd944f761ff3af0b08b4009b1c28f"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e120265e-8b49-4faf-ae33-7828bbec8375/8d607b56fb4d92f8c456eff315d3d687/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
+          "hash": "7ea7ea590d222d84ab7326ff120a40b45364a01c386c881ea7efabfb869237b789743b0829b791895613d7f4f2584c411f38150f319bdc5fa3f2b9ee7e5b3bd2"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1e952733-b58e-4d72-808b-4b6cafec490e/04fbd6374d14a95bebdf500b47e12098/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
+          "hash": "83dcc6aee85e332993ad57b041e22c09c1ca946fc7befed54bc451ae0c2d2ec16b818d2323589a8a150cd2ef90239e990bbb2390d5ded458a4904be0052fa364"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/af6eaf7a-e53e-4787-a61d-74cdb048b2c0/81cdad4a45ebaebf4881ae1a5a944c49/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
+          "hash": "1ff5e7be6fe1a1a436be343553d12066ea8e94b1d80b5ed7d2979f3d2eadf3c5c7e2da5727be2d12cc6ad1d831562172fae4dc55d5a84075b00891ce8395126c"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/db55584c-9ba6-42d4-a946-545993e2ec07/a5ccf36a2217b8476337d2ad5f547b87/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
+          "hash": "5c1b310ff5543d7416850d2044c4584f4a2286676b7cd05c32f505b95959bc66968f334cae1b35c852937cf289160f97f4129e15f5e5e220ab1d6c5bf61f1fd2"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.2.24157.14",
+        "version-display": "9.0.100-preview.2",
+        "runtime-version": "9.0.0-preview.2.24128.5",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c2602262-2aba-4921-81f0-640ec8200c5e/7eac075f28a6817086891867c5058ae2/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
+            "hash": "51dde68d8cbe20e8e77fef7b940ae55158e8dbc31d219696228e82b2e4223b55a43dd2797c70101d3fcf2ca56bfd7370ff08daba5f0e457f54dbd8e171503f31"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b64ba1b3-ad10-40a2-b588-73db9ed9d99d/f772743c20f55a5a8aea3da2e1480676/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
+            "hash": "1d591e504352f765a35092394719451c024a628c69efb6a10d0a5d57947c466a004243e799b46147fdf6316a23b4335b1e8fb1fc5513def1dec9f96c6c845dc7"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/daa714fa-cd09-40ef-94ef-7f7785e312d3/a0a4d29f8508ce756185f682ff1acb47/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
+            "hash": "a0547586a2e1c04b1ac030637901c113abb7bcf3bfb4bb6e017d6c11ee6f5fc114dea4da57cf4f702765a0a0e5c19391623c73e9a3500d5f6713a000a9c14058"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/48c6b988-5bb3-431d-b8d8-f03a1607ae06/6d0fb991e397020332cd09deb21fee15/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
+            "hash": "a56d724d388576e8e6db78c67004a7296ae33a7c2ab00d8af132d3df12398cce3f81b08a50f9094942cbab6ffa66efdd805359a5ee9189dfacbafd7478d34285"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e9eeb6eb-889b-46f6-a5b5-63d985747b66/a7aab27d12efd89d1d387727a32bc2f3/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
+            "hash": "51fd7da5986f7776a602d8aa3dee1952e86ba0676c1fdb392f7d13c642bc608489a897347707267fa030355042f6873024c92583a6bb8080397427bee35f087a"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/911f82cf-0f87-46c2-8d70-44fab9a0f3c9/137ec23686722b8119bd62def8d7b117/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
+            "hash": "c44df5e11791e4b22720834ed7f28102e33ab475670fa8e132d73d5dd03d8f4ed3f4a548deac67a79e06db6f776c9f632eda4503b6fdc9eef7ffb001cc9963c0"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ea918db8-961f-4b46-9457-00eddc6289e7/8c9b1472a0dd4d12702f598ac017617d/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
+            "hash": "61e5819cfe28beab99b3a75425c9c0dd0afb01390170e21fdc0fc0ecd9518d20ce24d07048012e522b53d727f7bc94639f257cc6021fd1b39b57405ae6adaeb2"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30628efc-01f0-468d-baf1-fc487e55093a/4c2bf86dbebb6c522d4d667516dc5930/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
+            "hash": "1c7166a594ba6c07d0233aac44428e561e2131f1f1812cdfee75807d19f1fe53f40f9d93e88d4a478c885993424ec2ec7b9aaf8f174332f587e6ff10813680ec"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/077d24e5-df1c-40fa-8204-cd601e0b3465/44de36d04f570e120f4f47debe33b839/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
+            "hash": "16d6a5e48cdce9e5e529c5572032d02213136b5b028a06a86c72c32765a87b30aaa62381bdde4f810e5b1ad7ab07103386002b6447bb8186888604794da7faed"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d2259a0-cb6e-4079-96fa-e0de6f0448c5/9b299e3cc15adf6153c28c24cba35fef/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
+            "hash": "a5a02f596e3976e65650d6a780903a755d4d700491c670b4f3c2f167224da632b98ad03ab7a087dc18561c5cc3ae6a3be78d5c6ca2f7312c7d7c417d909a481a"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b9e31f8c-0bf0-4895-9c79-8baffc8530ef/b2db38465ee04fecbad4a970422681c2/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
+            "hash": "86ec1715eb1373d22ea3ea49021c537484b481c03ce6a82df9ae81d911f5de28a8878f78871db66bc407d65bb84cc1ffe0099928a177ebab50910b6f6bbe1290"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/41c79f6f-30d8-4b2f-a15a-c098084dc78b/e46437cd6d1bca934eeba50a70a33bf7/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
+            "hash": "c8d0ff7e90b6799f352ea69cbff376e7efd201ae5593d6199145225afb2caa920480191be2bdff1c364ade02e89fc157e06cd944f761ff3af0b08b4009b1c28f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e120265e-8b49-4faf-ae33-7828bbec8375/8d607b56fb4d92f8c456eff315d3d687/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
+            "hash": "7ea7ea590d222d84ab7326ff120a40b45364a01c386c881ea7efabfb869237b789743b0829b791895613d7f4f2584c411f38150f319bdc5fa3f2b9ee7e5b3bd2"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1e952733-b58e-4d72-808b-4b6cafec490e/04fbd6374d14a95bebdf500b47e12098/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
+            "hash": "83dcc6aee85e332993ad57b041e22c09c1ca946fc7befed54bc451ae0c2d2ec16b818d2323589a8a150cd2ef90239e990bbb2390d5ded458a4904be0052fa364"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af6eaf7a-e53e-4787-a61d-74cdb048b2c0/81cdad4a45ebaebf4881ae1a5a944c49/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
+            "hash": "1ff5e7be6fe1a1a436be343553d12066ea8e94b1d80b5ed7d2979f3d2eadf3c5c7e2da5727be2d12cc6ad1d831562172fae4dc55d5a84075b00891ce8395126c"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db55584c-9ba6-42d4-a946-545993e2ec07/a5ccf36a2217b8476337d2ad5f547b87/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
+            "hash": "5c1b310ff5543d7416850d2044c4584f4a2286676b7cd05c32f505b95959bc66968f334cae1b35c852937cf289160f97f4129e15f5e5e220ab1d6c5bf61f1fd2"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.2.24128.4",
+      "version-display": "9.0.0-preview.2",
+      "version-aspnetcoremodule": [
+        "19.0.24060.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/69ca0164-e58a-4777-b1e9-0bd15a372b40/51284f988bdd4dc653eea820484a071c/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
+          "hash": "f1dd7f9d7a9faa408c081e869804f7b2a54d8a03d8cb3ac4378e0a015ce87e05ad0963684fb9f8369ba0860eceb9f8cd2774e92740564e96858a62b2a5d62b03"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cb8d7d43-e403-44b3-9ee8-477a947f3e6b/3e38a543b6b9144e0fed12cf18eae7f9/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
+          "hash": "6f7a5575d02197f1908c56d580f0a9049f393ae68a4ad4b73935e981d9c6766e028463d2828d3ba0aeb4049237516fee2e116196e790948fefd65436ea804f35"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/97bcbe77-6b0f-44f7-9a01-a3110308bcf8/469574afbddd9432bf1f4b9f9078c919/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
+          "hash": "db34cb136e1bd5e3722e9dae9029cbb5bcaeb8f563e02e39ff51daa5b51ef4435cac60d77197da30753b79af45e2efd6aba7f75a02fe766859ecd863fe7da2c1"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/948610d8-af3c-4c0c-84f1-65cf3b9bfbad/226982b96d52f4147bcd36d9a2133cad/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
+          "hash": "1158514625f2284a38a528b6182d98137ae7228512995723015d57c3a3e1e81436f87d18eb2b9d864398b609373bf4212a20943db97d5fb1acb29b0fcbc9b8e3"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/59a764e6-bc1a-4aba-95d3-15e94a3aba0b/18f5fd10635db63df24fc2592f7cf65b/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
+          "hash": "6454787598b68f4402012057d1019d21f16df83b763c56b55557c0d45d2dc66a161dc41aa46a1b6324950315484fea5b7a5c8089f08cd69501d79c5f5fbf961c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e3e81a61-4493-433a-ac40-ce2bceb3370d/ce1c59a7054d200dd24a7e4987666b8c/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
+          "hash": "9d836edc539ace64ef8fa883bdfc881d89f4cf30d048640246dae9d54e46e79f2e82ebcdf366c1b69017d86d1bf1496acef5d56c3133297ea0bddb2df2eb4523"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9f27cd5d-334b-4dfe-8876-33186210815a/2752edc7662b603b734219e4fee20ba0/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-arm64.tar.gz",
+          "hash": "81b5860e68e9e660a535568f96d8058ab6f98dd6b0a8305e3e3358ee721da610c08baf0b59a52d7e30184c39784ab18544f9328a55d8490d400d07be734059a4"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dbbdbf43-8860-4aae-b1aa-57d44f976cc8/f4f6c6c4a740de95a332ed2c693d1d6f/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-x64.tar.gz",
+          "hash": "c0c37a504f8c3113c90b8108f1f784fbb61387475e3eab37d303c49f627e06034ef6e917ee9c780e910cbf565c20050173f240f215fdead4fabb1f3795f3ac08"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/049903fc-4c2d-4236-85cd-87951ea9de7f/0f0aec1fb155fa09f61ed86cd26b6b6e/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-arm64.zip",
+          "hash": "513afe42770fbab74e7d5746587d5f4859f95ed801954e6a16fad6b5e6cc681d1fb40822764f38140ba7b74aa71ef42c502f0fe65abe0a5010d8d5b3b8d73e4e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2a880ed-96d2-4060-9132-5343b8fdb539/dda51332250362edb5c59047e925f556/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.exe",
+          "hash": "0b55ba24806ba6337aa95e26b64ee5d3d4b1feb00ba0993dbcaadb03e17e0544ceeec0a4cfad82b97ec0b9454219d421d5ba12b1e4cfaeac12ddbee81f59091d"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/872b0c60-bd0a-4fed-a744-b265f13fff25/160c69de96951aed473bdb0570352322/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.zip",
+          "hash": "cdb4a42761d729bf68ca94414f85c9543bd46e8954680b37b66db15c26135def215933a2fbd38b231302f7ea4f6407a4290d00a25c5f8d7d58e780e55052c3dd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cbf688a5-c777-476d-a47d-6b532848fd71/5034e38cef71b22c4d0a6fcd19db9840/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.exe",
+          "hash": "b9b8bbf176c545fa2b1e2765c8eb6ea632c9acf27d15f6e54f22451b3982c115af027a5a957fa37a9e762c41dc2fdc9c0a3ec22933dfc7effa5c468cb9e29e84"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9f46c914-c6ec-437e-8769-81a5c7d372e4/e3e5847261a6b71742a74fb47331d20f/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.zip",
+          "hash": "8f6e89659b3d641f3fe64f417023d8c3bd587eebc343c8cf478a44d945e79a039c2fef828484764ab43cfd30e5b3bc50c17b81590b2f6f1000b3ccf4e8a15ab3"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a1b3ae66-ed5f-46db-a1da-a3aa6f379a10/449d2758801ca01a21baa296edebf9d4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
+          "hash": "725a370e508db4b4be0b4e6cb1ba1070316877a6950bbfcbe0fad76dfcc8bf12cbe987a4ce3787a48eeeccd37c04189d3fa517f1ceeb78ad92fbb30e326819ce"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3651a71-c7b5-445c-aa96-fbb473513f68/d23dc7326deba60db789acec02afd4b2/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
+          "hash": "ae20e3cabb39e4cb91cd3678f85290e89162d2007316719ca408093b9c8d5772a443926abac1cd909405d6a58b81ec0e96b8d00fc076c699081965e1d1e90b4f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dd404332-ec4e-4d97-9cd9-007d9d185904/3e1e4ce502178d132adf8f68904c9002/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
+          "hash": "de45c5866d477bc2685f3a9d6ebdd08e3cb7effc37df896fb1a10c5ab9dd95cc120e49e9d95930c078f9f8b7262ed567b85cb752ee93b236193eb3e90fc49657"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f59418a-e794-4cbd-83ba-28caf49ffab6/895663c4eb1a594f37015a79d5a6c57a/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
+          "hash": "4030c12b8efd49a254a53454bae20407f3fdfba39c8ecf637ef9581b8cdb98b792d904d0be641561237b47f7daf83281b15e473b81a43c0f1052e6f42011f92a"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f8b9b876-af92-4182-9eeb-075f9c10903b/780b103d20efe7b3aa0b5baea30c93c5/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
+          "hash": "18987fc174b6f52c65537e91a60d9590af3fee05c3f83b248abcbd17b8988996d79eeaefedbc0c42a2b9a815ce28c6babf4dbf3d3202fcf30bff28262ae22514"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/285f7beb-77ed-41d2-88df-9b13831a8a6e/5ec67e65df1f9c869af24fdcbe43bd60/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
+          "hash": "80e47ec27e40c11cce232b033c0fa961f3262eed9cb6743768d164af7fb5243e10464a7607fa1fffb4217446f5716382dfd836e7c8c5a118df6da4ac6203e689"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bab2ec4f-c930-44be-9b7d-38b9f837b3af/5ad4812b54c7588622b9eb10fd0de616/dotnet-hosting-9.0.0-preview.2.24128.4-win.exe",
+          "hash": "a959ade3fa01e191bf8b03adc89247a1a45374d354e3c27db06927e8e692d8368974e918ecf27a1a0bcd2020f2f11212d878d64a389f907345d053aa79b65449",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.2.24128.10",
+      "version-display": "9.0.0-preview.2",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7636b226-87e1-4d09-b758-c71b375b1bcc/ae993e6825615dfe90ec796c3fea0bad/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.exe",
+          "hash": "9bc150443a0358f44a9891c23d8dde0f05717291d91ef1458093426023621122cb23cafb3543d8969a99dd02dbd16238816034517dc9aa0c9ccf5d4164a447b2"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5b6ce66b-ad59-445d-a46d-b94fc74e665d/90a22ecdb847711b7b765310b63e01ad/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.zip",
+          "hash": "8cb6cb9edf27ea32bd67164d108d8ce15e9850e5e1d9cadef427e273fc895a84484a081f5162c6ea693bf94d5ac751432ab78c25be4ea09cfda30335d6f8838f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/860c2219-3f1f-4948-925a-1d463ae23801/092fdd99190bf61c37eaea1b5b034305/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.exe",
+          "hash": "5cd41db47e7e52f62b8f2f0f312224117ec83c4fb27af08e5bdb9d560efaa58863c36a0c5a46d3acfe971bcb983a14af659579503cf53c9b4900054b5c3c2f70"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cc5408ce-a9da-458c-ba58-65fd4dfb47ea/57a22113ce6b45f0880f391efb953cdd/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.zip",
+          "hash": "faf7c80e268b50d6eb36b27e4c3f0bc85361bfdcb6f58bb4d421c319f65e648c8960b3f501c968e0b321b83b84658faa311117ca20ff5756525cb5a056c0f6a5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9914baa5-6682-45df-8dfd-6098376d0ee6/4b7d697197ddb6929f00778759f09275/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.exe",
+          "hash": "c7bd9a824c7594099d4d26759dbb181d49698cee8b35bb46d72fc88a09989b3b49d110058a40c1fc237f925a98e47b071e29396b68fb67a09c61a9fe4e391003"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2d3eae09-04af-41ad-8072-ba414988dd87/a725bb2c98fd8a56412e4c1a9e61fa98/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.zip",
+          "hash": "559103fd16447f5f279d3174cfe2efb1d31215c175134a099df3653c5debeb37781fb98000444f918840bd3273fb0eabba58b5f1b172310e2078b4a7b213a710"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview3/release.json
+++ b/release-notes/9.0/preview/preview3/release.json
@@ -1,0 +1,507 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-04-11",
+  "release-version": "9.0.0-preview.3",
+  "security": false,
+  "release": {
+    "release-date": "2024-04-11",
+    "release-version": "9.0.0-preview.3",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview3/9.0.0-preview.3.md",
+    "runtime": {
+      "version": "9.0.0-preview.3.24172.9",
+      "version-display": "9.0.0-preview.3",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/34bb1d7f-d98c-4f07-b659-d51fcfe82e40/b755a48d351c45c04645be8616dc2e2c/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm.tar.gz",
+          "hash": "ccbda0ce6e8220ec83bf9fd7eba030a96d2e9567bd4bf162e4b0ccc3ce8c08b855c6ec20b15f401e6b4341464d12dae219f3716102a001672fc441a4358e3445"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41f0b5d2-d224-49ef-baba-d4f75e495f17/dbd1b290ff250e51fd5daa4f639c8e8e/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm64.tar.gz",
+          "hash": "3f8bd80a03a63019d0c2038119a0bccfa5b1b700fc7c22565bff2e0af425fc0ca475c13b03a666aca2f954db9e53d7505db9cf984482d4a6be1d8019986324ab"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/97ddafb5-67fc-4af9-8458-8af7fb3f74b8/896be16550d107cc0e6ba54d614d760e/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm.tar.gz",
+          "hash": "c5638c562451f2c2d591e51e014edb15111ab49b8a71016bca3d4095a74d9064184a3f5bdeb236fda59ad98dd730221038628c5ac6105d9a4eae6664a98abf16"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/463ffd08-51fe-4d29-b267-119349e3658b/0212b77c93920c7a6a8e688bd8b106df/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm64.tar.gz",
+          "hash": "c8777c446cad3a37012e47625031552d517e27d32198ccb746b1544135abcf60bfc3ff7e801cfcfb72d2d8563604345e2da011fa0aa8939bacb13d8b619bea5d"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/124b82e6-f328-4c78-a3b4-f039dbf5bd70/6ac2746137c3ddefdbf5e45400d3e781/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-x64.tar.gz",
+          "hash": "adace7cff420fcf0e437bdfc90b6a39b703c53301b95d2fbdaab15fb4a7acc6d8a40ce6107a8c0f30230c6c8145c28e8c0f33c2ab604c6d1946d80dd8d350c48"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/28946a74-4cba-4b0d-a080-3c84b4be668e/651cbebe71762ec64bf342805e48e85f/dotnet-runtime-9.0.0-preview.3.24172.9-linux-x64.tar.gz",
+          "hash": "244963004ced27054eb1c5473adfa7a0e249cca4def0305e81136e39d00319e5be2c77f687034df7e1f026bf92321332d8904ce93851e215e9c213da105d37db"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9e33acd8-adc5-4359-a4a9-e7c538b6ab1f/dde8a2b81d4d6beb63e201781f65f19b/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.pkg",
+          "hash": "15576674976f8927fc0fb277382d536692c4426a6483189ff192a082128b9c43d03eff1a6bd7de859e991bdb8fe75421ab3c45163552ef9e7c45441a483793de"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f2a01607-d9fc-45eb-87d9-190f178f1945/2655017d0a043d97dfe292fc4e986ef0/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.tar.gz",
+          "hash": "20ac79faf78b8e95e73778ab8f8c238aa282d2a6ab844406968f68e946a4a8258e8f01458794a4c77ebf7c0a1e9dcc76169ecc84dabcd1fe983209f968367887"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c78a2485-5638-4936-9c47-f7811c1bc8c2/0bc4ad7a2a12f347931f29df84fd4da0/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.pkg",
+          "hash": "dce9a57df606ed6b3e142aab69ac482c160ebd4be776552881ff80843ae777e13f25f160289bc1ddfa19e04446f85552de59e9d700bbc0354aa070bd99eda4e6"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3b5e0ed2-6c44-4e1d-a790-0a9b6a9cdc59/af989e13e8da69501c6ae95b9d12a1a1/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.tar.gz",
+          "hash": "873078a50675fa576df27867231b37c7a09511893bb2f7c91f4cc1069e88ac4b6fa7c4eb439b6b39ba2522b7a3e2d2cc9fbec4e700e49402672e6358fdeaaf07"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4d2de3d-abf3-4884-b6ff-aeaa13aa12f2/930bb09dfba48658bf899d14c09c3c86/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.exe",
+          "hash": "77b0ea1bc5b722858e269ee0c61509729a3419b7da3ad6210d85e10e18d07ed2d46ef2311a1eadd077b1997f28d2cf483e3e6d34a6f56c8c4a871cdd27f77706"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d1ce7d03-9718-4b84-8c37-34730b224fc5/d58f7cbbf1fde8914d7fac169305c04d/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.zip",
+          "hash": "7c51a32dc7dec38e9f923ebc43ad9d587d3bb209589124bfbd8102a2a6d155bac6cd1758bb35f6290a3e95a0abee98a83c383900fe6765f57871652d28f5691e"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c5fa8322-30ed-4a4e-8685-91bd51d5dee2/729372cb9f417afc136e4d65099103b1/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.exe",
+          "hash": "9cecf9017cec09d32bed0d26e43ae00c2122380a25ef1426dc0ad3fa16f4e43e7ba071910ef56940d32540bd5053faa0a219aaa83be3b62c273f6216c3c7ab84"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f239997-f134-489b-be36-ecc855324592/ee1ee9d2b19682384cd8d17ac9aaba19/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.zip",
+          "hash": "4b46ec7849a78d73ca71cb55f259bec2d320e26029b64b398bf16ea2ef14bdff2096a35fbabe929f21b5b97ae865688c5722b2b761babc09a0d53b8921434d91"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/474968ad-0fd5-4d18-884f-4122d1d01210/278c3572b1194e5d1c11732d82c5d4c1/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.exe",
+          "hash": "b73bb3c6ac46fbbfb3e536f1579abaa0cf86e97001e049226dd60e3dc1be2ead8f9d825ac8775a8fa7a57786316e0c13a63931b2c2b66363da9e033e4c3b9047"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/68781d98-413c-4722-ae18-25ff088d5f34/dca7d9075327516c817df2f5ae2f428b/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.zip",
+          "hash": "5c70d0844fbd6b0178a8820f4a0f9c9204e35216ae3de5a121e29fbfbd53f23dd82978f6bdd551907578869984242c61a7dbea57bca3b6bea59c7af7ee7b7546"
+        }
+      ],
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)"
+    },
+    "sdk": {
+      "version": "9.0.100-preview.3.24204.13",
+      "version-display": "9.0.100-preview.3",
+      "runtime-version": "9.0.0-preview.3.24172.9",
+      "vs-version": "",
+      "vs-support": "Visual Studio 2022 (v17.10 Preview 1)",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c5268ba0-1e77-4d0c-aeea-44e91f1ee161/e9ce85b34c7477cba722f397fe1271e2/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
+          "hash": "76e53d9b288ed800b9087d2a3bde25481642d84f133955f57ec69a35f2ef65237c937fc1f0f60b3c2190cd6e34f3bccc71b85fb2c37a08976e82e2d761ec40d0"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/793717c7-d418-4972-b9f1-1df9bc7f9a59/f37654f223b95c31b5baa92599b72118/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
+          "hash": "83c6fc2cdb8aba6d72661f2fc360147482dda7c22b69b3f0df9912efe7e0499f3c7b1d1a8577b3667ec3faf6cca99bfa887c663904847356c93e6f1e6f9917b9"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7a43093-48b9-4ced-bf6a-3923de4b08e9/08786ae87bbb7eaa7ff4c8216194fa07/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
+          "hash": "772b2af66459b4ad7cd8005a02799f7446fe7fdac97f488d7575b1d1ed2079af539420b01609da6caf0addc86bbca72e53949ba4979c31853a9d724f80756492"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dd82f0d6-9181-4f73-a0aa-c8fa9df4d5fd/dcf5c9923fd4daff0a836a2b2a84bd96/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
+          "hash": "8f19023e96760e397261b1d0c765a789c01a7377b782ab8254b5f85c01048c305f8e627d796c8b6040a23ed12eefdd544200167bcb32871efe0c627359f3e7d4"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/944ea319-8239-427a-a7aa-948cfa852c8a/ac946e77eac62fc4130f79d182952c89/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
+          "hash": "e72027ffbeb7d5c9b8796620226ab410510ff57ad93f5e24f7a2ee281fd733daabff74a15f3dcbe04413fbd4bff0713fd298cac732eb0f71ee6c6dadf334e972"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/34c1f43d-2d16-4a44-870d-1e333148e4fd/10ee0406a349070f4e120fdef056216f/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
+          "hash": "7f487d92ee3b28061ef28e013295ebdf6703721b5e2e55ae2d7b18f1ff4fa4e3e01b6a8b508723ffb22dbc8437f0693d7c07f4dd8ef113d5da8a51b3645b3422"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/788839e8-1e23-4ed2-b176-534d3c4d5899/d80c58a63108090e803c06d0b05a1b73/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
+          "hash": "43d167bea8ab900ff67674bd378ba09228f105be8d8b0c4866e867611072169a7ee1aca67cd04f06294d01fba2ae2c0427553e5552de10c41fc1096df4db9e54"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0872ec6f-0e73-4caf-8381-c8004cf508a9/009b50364d70ddb4f892392593659d86/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
+          "hash": "69452e7266bbccebc7acb9cec7b328f8fa1bca4b0720a27450b67c19d41ac9e8b5ca23f3da762c37769dadd0c65fcb1068b32c98b507d19cb9c5619b301f6860"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9794b13e-14f8-4fd8-baa9-265adc2c7f31/605ec6e450a81e1acfeedc06444450f9/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
+          "hash": "7ae365e863a76a52b2c646bf34ca444b6ec08118edb4f52391d013c22f2fe9df1ceab75156b3c48d16d564baa02c71093b9b9e0edac01a6e2a0b311182bbe561"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f11c0612-bf78-41ae-836b-2b3c8765fdfb/feac36e69a3ca718c3c0d12dec3661b5/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
+          "hash": "1c0d5a8751f36b4e2f0d2971600a6f870155dd12e0a0669951d99b1d50b8021c51a5c9df447ecd8bb53c3ceaa6f4467edc0eb357bcc8d26e272b5ea121f170f7"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b790cf13-8249-4fba-95ea-4e730138457a/c59c22cc546b7d1bac832c1000e9e9e7/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
+          "hash": "ad7114b1a961db4797a733cd2823aa6a5735103290b282f1b0a3bf0917d360d8fac931d629d94ecc3f8ffac50cb6bcf4c0afdcb48b1dbc621fc59348abccf524"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8d18eaf5-8c36-4485-83e8-6c9569e25bf6/167d5db5b84f7080d1ba9098d464efea/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
+          "hash": "1fb88185859896b2fc6e0e6f867b6a27cdea13aa414c8c6b606ce72b48148fd938209fb49c073316689a5bcc739443a647fa60b98b6ffedb0fd508886096b7e9"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/509db05f-a1fa-4420-a8e8-20249073f3fa/a699c2bd1b7bd10346a175117877d455/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
+          "hash": "d8f49442160a7a92b617a59eaf8fdc4ca776739429f79a7dfd5da4486629a8b6df1999cf2adb3d06ae715a31a8fc3aa355329a87d2780724874afa5028688898"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b50c34cf-e50a-4e64-9bdc-cbd984d44acb/9cba57d4130ef9451e2a9ec218d2c83d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
+          "hash": "55114bd014d2613aa35e91148bad263cfe0fd8499995c9641bdfff1b7c2f10c70add06c1d9c016f60fe7c4d144725154187a7c0ad4b1296f1ec32e876ae3ceed"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cb5b922d-65ac-4829-b035-2a2df6cd88f7/7623d8b2c846c77dc1dc9c2d19e1214d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
+          "hash": "24bc29abc7c11988648584adbd17d9d3f8694b7b2ed622f860709a680f7eee97b12de34470c78a9718383cc33ee8934d19e3193475a6a7f304b65cdb02468f33"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5ff67d85-1737-499a-b12d-274b4d7ae73e/5b3dba505826bcff95607e5b0185770f/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
+          "hash": "e240c2ebfa0089b95077f297748988b9c1cfd662fc39616b225c479f810dbe7ffafc91c5c3faf7cdf633be2660e1aee3d201209122cc30a9a66be21273197741"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.3.24204.13",
+        "version-display": "9.0.100-preview.3",
+        "runtime-version": "9.0.0-preview.3.24172.9",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c5268ba0-1e77-4d0c-aeea-44e91f1ee161/e9ce85b34c7477cba722f397fe1271e2/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
+            "hash": "76e53d9b288ed800b9087d2a3bde25481642d84f133955f57ec69a35f2ef65237c937fc1f0f60b3c2190cd6e34f3bccc71b85fb2c37a08976e82e2d761ec40d0"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/793717c7-d418-4972-b9f1-1df9bc7f9a59/f37654f223b95c31b5baa92599b72118/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
+            "hash": "83c6fc2cdb8aba6d72661f2fc360147482dda7c22b69b3f0df9912efe7e0499f3c7b1d1a8577b3667ec3faf6cca99bfa887c663904847356c93e6f1e6f9917b9"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e7a43093-48b9-4ced-bf6a-3923de4b08e9/08786ae87bbb7eaa7ff4c8216194fa07/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
+            "hash": "772b2af66459b4ad7cd8005a02799f7446fe7fdac97f488d7575b1d1ed2079af539420b01609da6caf0addc86bbca72e53949ba4979c31853a9d724f80756492"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dd82f0d6-9181-4f73-a0aa-c8fa9df4d5fd/dcf5c9923fd4daff0a836a2b2a84bd96/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
+            "hash": "8f19023e96760e397261b1d0c765a789c01a7377b782ab8254b5f85c01048c305f8e627d796c8b6040a23ed12eefdd544200167bcb32871efe0c627359f3e7d4"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/944ea319-8239-427a-a7aa-948cfa852c8a/ac946e77eac62fc4130f79d182952c89/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
+            "hash": "e72027ffbeb7d5c9b8796620226ab410510ff57ad93f5e24f7a2ee281fd733daabff74a15f3dcbe04413fbd4bff0713fd298cac732eb0f71ee6c6dadf334e972"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34c1f43d-2d16-4a44-870d-1e333148e4fd/10ee0406a349070f4e120fdef056216f/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
+            "hash": "7f487d92ee3b28061ef28e013295ebdf6703721b5e2e55ae2d7b18f1ff4fa4e3e01b6a8b508723ffb22dbc8437f0693d7c07f4dd8ef113d5da8a51b3645b3422"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/788839e8-1e23-4ed2-b176-534d3c4d5899/d80c58a63108090e803c06d0b05a1b73/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
+            "hash": "43d167bea8ab900ff67674bd378ba09228f105be8d8b0c4866e867611072169a7ee1aca67cd04f06294d01fba2ae2c0427553e5552de10c41fc1096df4db9e54"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0872ec6f-0e73-4caf-8381-c8004cf508a9/009b50364d70ddb4f892392593659d86/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
+            "hash": "69452e7266bbccebc7acb9cec7b328f8fa1bca4b0720a27450b67c19d41ac9e8b5ca23f3da762c37769dadd0c65fcb1068b32c98b507d19cb9c5619b301f6860"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9794b13e-14f8-4fd8-baa9-265adc2c7f31/605ec6e450a81e1acfeedc06444450f9/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
+            "hash": "7ae365e863a76a52b2c646bf34ca444b6ec08118edb4f52391d013c22f2fe9df1ceab75156b3c48d16d564baa02c71093b9b9e0edac01a6e2a0b311182bbe561"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f11c0612-bf78-41ae-836b-2b3c8765fdfb/feac36e69a3ca718c3c0d12dec3661b5/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
+            "hash": "1c0d5a8751f36b4e2f0d2971600a6f870155dd12e0a0669951d99b1d50b8021c51a5c9df447ecd8bb53c3ceaa6f4467edc0eb357bcc8d26e272b5ea121f170f7"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b790cf13-8249-4fba-95ea-4e730138457a/c59c22cc546b7d1bac832c1000e9e9e7/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
+            "hash": "ad7114b1a961db4797a733cd2823aa6a5735103290b282f1b0a3bf0917d360d8fac931d629d94ecc3f8ffac50cb6bcf4c0afdcb48b1dbc621fc59348abccf524"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8d18eaf5-8c36-4485-83e8-6c9569e25bf6/167d5db5b84f7080d1ba9098d464efea/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
+            "hash": "1fb88185859896b2fc6e0e6f867b6a27cdea13aa414c8c6b606ce72b48148fd938209fb49c073316689a5bcc739443a647fa60b98b6ffedb0fd508886096b7e9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/509db05f-a1fa-4420-a8e8-20249073f3fa/a699c2bd1b7bd10346a175117877d455/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
+            "hash": "d8f49442160a7a92b617a59eaf8fdc4ca776739429f79a7dfd5da4486629a8b6df1999cf2adb3d06ae715a31a8fc3aa355329a87d2780724874afa5028688898"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b50c34cf-e50a-4e64-9bdc-cbd984d44acb/9cba57d4130ef9451e2a9ec218d2c83d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
+            "hash": "55114bd014d2613aa35e91148bad263cfe0fd8499995c9641bdfff1b7c2f10c70add06c1d9c016f60fe7c4d144725154187a7c0ad4b1296f1ec32e876ae3ceed"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cb5b922d-65ac-4829-b035-2a2df6cd88f7/7623d8b2c846c77dc1dc9c2d19e1214d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
+            "hash": "24bc29abc7c11988648584adbd17d9d3f8694b7b2ed622f860709a680f7eee97b12de34470c78a9718383cc33ee8934d19e3193475a6a7f304b65cdb02468f33"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5ff67d85-1737-499a-b12d-274b4d7ae73e/5b3dba505826bcff95607e5b0185770f/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
+            "hash": "e240c2ebfa0089b95077f297748988b9c1cfd662fc39616b225c479f810dbe7ffafc91c5c3faf7cdf633be2660e1aee3d201209122cc30a9a66be21273197741"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.3.24172.13",
+      "version-display": "9.0.0-preview.3",
+      "version-aspnetcoremodule": [
+        "19.0.24083.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/889f7855-0c73-459e-a02f-eafa99a8e500/586101e88960a4424001143dc71b5d90/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
+          "hash": "ad4540890752e278406a7a731705251e9e803100ea8784f3ea9ab499ae24bdf3fa09456b324834953775f5edea019a3e80c608d9ebfc7de0cb2ff430a0234e3c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b7eb8865-5ff1-493d-b2f2-add90226b29d/901cff3eca56382d9bd7ca0f7e0087e7/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
+          "hash": "e484d1530bb8462f5956d50b0055407a5b697f176f43a8e97b26d80c0507f9373b950f962a5144f7876e4c699b2fd29a63eeda71b090fb80c4885750d73cc42a"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d568896f-9f13-4dfa-a486-20e54d717c16/8daa58ccb02ea0003b54c10f6c0a3785/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
+          "hash": "70700a6ac11a4a4e192e8d536d7dbe746aa2b209fbe5522a9bb6b09988b1d40019d03327a1e79917f04a8008581b685f7b6fc925750ffc6e0de4877955ebbad8"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ca2b4853-a3a8-4b0b-be76-f3f9dfb7e34d/7574a7679a38e6dadf61a0c5e4bf5ce3/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
+          "hash": "6011b173f4f31ad942f4911623b1b0175e03c160ea55b2d50c454bc0a921ab3f35a5ad2f822590ccab5ea3470ba0f5ac9a617386e4538f82b235ff68e46ab6a9"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/382eb79b-f802-4b3f-b6c0-7efcefff5aab/ed7c9079ae9a02d84c126c4ebf5097f4/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
+          "hash": "8e6c42872a062f50e25432e0945a18ff4508d708983f004bfcb619c76d5e13b5dd0653cffc5931ec7834d1d7db174566b4d9d00016c838f98b351d821e012334"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/37747dcd-c967-4c91-8928-959b32b706bc/2cb1cf0735fcea5d7eadda52bd5a6cc2/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
+          "hash": "319f2700c3a954a1e6e0dd01b45c18dfe7d3728fe175b82cbdbdd928c2f64c5fc6f53b7c44f753cf59fb7c32649fab95f0245e5077ae3f607b8f59b5e9cd417d"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5b68ce5e-aea0-47de-bdfd-5a0eb0e9b1a8/67b0d4863b14455f45b2ff1a916bcd6c/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-arm64.tar.gz",
+          "hash": "c216b72b3ed028cc49ac5e6c50612b77eaadb7834e21a4ef89bce346c7eb1e55bcaced48131ba68ed00d381ea0321501e9b9a0cddff088dd6ff96d5b04be6e6c"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0b4dddc0-6afc-47c6-a878-4ef939e4f46e/70f229cbcc2f968e7dd3cf53bc7132be/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-x64.tar.gz",
+          "hash": "6f2f4b7ad18311259864f1fe2b2ab4b78e60e035213951eed77f9fcd41488bd9f1a6360bad348af130e3984cffb7e7d7b16406c5ae2bdbd4e75a6eb28924cb68"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/daccd7a8-ee29-4398-9c0f-53ee52a8348e/dff56958bb98da605699647134b3fa60/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-arm64.zip",
+          "hash": "023e2058f0f036c07ae383505305b4e46ea1be75bc5204be9d0ac864f88fa6d126e7ffeb158635c717e98a1b1f7e42b69dd44a5fe8ad4f17a332141ca91f1c8f"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0dd6eca2-4194-4784-b60e-5def59f82a53/7c5bbe6d6c403261ed81c9a0fbe8354f/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.exe",
+          "hash": "3e2949483b1453bf0edea37eda3395f8c582c56fab65a4a315ed84e53b6ab9acda27764332911abbb16cf49c3b7844024a7235cba58f3c12f44643dccf45f768"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3982a9e-ef26-4506-a03e-b7f492df4e5f/677debf2487991af87442a9b07ae2466/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.zip",
+          "hash": "6e3d9ff40c04eb382ce4d3603892733e43c58c47472c571efdc12e8be7f52a338fa46659137c9320fecaae4288ce81ca6f41a5bec32e73511b9014ebca7a4c99"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5c3f1910-1f0b-49ef-917f-e438af26f069/658cc32133053424f78e9cf4c2ac8475/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.exe",
+          "hash": "b1e8df9ed48bdc53c03a309ffd58c5aa91f999067258f7e905573011a57f93b3b406a829dfe2f760d6fe68fb5cc8b347812b9a01b3e9722de08a2cda0bda94fc"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fb3609f3-44c7-4591-9095-db37485716c3/49c7db163acfaac6cf65884ab93a5ddd/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.zip",
+          "hash": "501f5353a720e0e4a976c4cae5875da7ccb7a5cc9c93343f732bc182ac0a457f6cea8ba2edc33a7665849d558c213e3ffbb16b85110c61d47b776487da4b35b0"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/97290bb1-9a86-47e0-ad8a-8027c080999e/ac2621ad5bced59e859c6a4b1468a87f/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
+          "hash": "a6958b10bb735875670bb280b6187f963b65fa2a02f49848096b2a6c06526a39accefbf362394d6cb82d5cce65eb1819762365c7114cd7b7748908f814fdebca"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f787be98-8e32-4356-94cf-afdbfc89807c/908078a68902b7db3419cdfe66aa28cc/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
+          "hash": "88edee0dbe7c16409674db0442b5098a92d9d22f2d6e4d8bf27e44a6415f38023bab96174d45a33a9bfdcb88bf896ba6acfb36b6f7fec7323dbb18e472bebdc1"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e5c76b43-b251-4796-9ca7-a060e73372a4/da95c6e26f9c56ea5dd9a0ffeb45d986/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
+          "hash": "370274b311ae9671f2aeb38b313b05cdbc6b04eeb96146ad82ab7b3b9e65fa2d2fbc03f4343026c4fb81106fa97fbfaaaf933127c8ae9bfc9c91fe6aa3c6786a"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/55bdb213-5027-4ef3-b23f-4833298c2312/896cd4a98a5b29100519c5f8bac55ad9/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
+          "hash": "cf1432c021e7e639d1eefc18f7feeb0c2a11ebec19dddf3e101903d7a3171b1b9415270e8b4086a19f86ffe2a1cb6ec4e73c391ac3040caaf9dd32b2f8d06136"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d86383e0-8ba1-4bbc-b79a-b51906336d40/ae0a563e8efd2a8f73eaf2985909565b/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
+          "hash": "f6861aa3ef052d5a4140ce771cee2cd62c07256043581ff06e601d8d4f95a344bf90c86fbf22ec55d9a130e4b205b18e7711af3dba7a03e1741f2abd02f74f58"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/35d8c84e-43ba-4a6d-8151-ca2b2cefdbeb/46e265a8e72808dc3f82990d13beb955/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
+          "hash": "7a4b00241a2a91cf7dd3ca391b4f64edefc4179c351eeb0aa260c27680510be71b4fbc1f07ac7682208c73e879a40fdf3943b5cdf58456d7a4763665e46e8258"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f28df469-8a85-4d55-9c4c-957b8c79a7d0/902f993af8ee3aaaf646bc55c4cf668f/dotnet-hosting-9.0.0-preview.3.24172.13-win.exe",
+          "hash": "bf6f9cbe3dea1e45f7fe831d9a8ccbb46f744c479f22449908e328a388d8517f5f38caac5cd8345166279b79f653a040399a85f18f75da63d983199ddd1ca340",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.3.24175.3",
+      "version-display": "9.0.0-preview.3",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/505f54ed-7158-4708-8111-b3cac859e452/28d77d115e8c3179b0752d7a1fe89dcc/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.exe",
+          "hash": "4b15257cd6b655483677a1b842b011ca6cc3937ae6ee3ee7873fdc99197911618d7049480ebf43642ca4eb65a43edc322f6ec62f0c20759406b0f95376d586b5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b4dbf836-975c-4413-9319-b3e40f633fd1/668ed496071d38cf29863e60a8f5a263/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.zip",
+          "hash": "0552d7553ec1a44d215d41bace840366e93530ff352a51988c297bd13bac4dfb09759473878de199e92aa8dda6323cf93b74dec1570f72b77cdec87e2b3448f6"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/678121c1-dd28-4eb9-9389-139d270d0f8c/4bc7282a6ebd29714ff7767871308a71/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.exe",
+          "hash": "a0dcd0adbf301165d90085be2ef05cfdcc100224c6097a98ad056df70351f974bdf8dbc129e8927f5f473b6ccd0932288be0467d629f932c7db43a45e2b14af0"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/27d8d431-11d7-47fb-9510-2e2419f80561/e7d7a221ec27b3274b981782893fd2dc/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.zip",
+          "hash": "58024d2eb7284a46d8393000e8d93083699fef472d9a9eedcecd17a98ad45b81636ac67fa6cda2e62c34e8a27038ff75d07de0fe5f8bc7d6e58da879777615c7"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2dbf9b41-0a0c-4ca5-8b64-e3d7f9f74048/7d5eb210b81b7357cbdf8bc7b5d54754/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.exe",
+          "hash": "2e2faa1c23a40a2459670a1af10b802e6e295dc3c3ac6e5f593fcb5de756912707009bb3e8a98f2f3e07b089b984083158417a5d3d383becbc0a0aaa33ffb3b5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ad07edbf-1cff-4e61-8273-847688e323e3/b7a65770015e2c1b7a8a4927e537f8e1/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.zip",
+          "hash": "4032a8bac5d08289dcc4b124ef1e5922ed3133f5ba9ec5bdfb86203fc93787f2fe68b1231ad1ba238341ba5bdc47e0eb6309c6bab3d0d56be9bca8d135e462e6"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview4/release.json
+++ b/release-notes/9.0/preview/preview4/release.json
@@ -1,0 +1,513 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-05-21",
+  "release-version": "9.0.0-preview.4",
+  "security": false,
+  "release": {
+    "release-date": "2024-05-21",
+    "release-version": "9.0.0-preview.4",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview4/9.0.0-preview.4.md",
+    "runtime": {
+      "version": "9.0.0-preview.4.24266.19",
+      "version-display": "9.0.0-preview.4",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a99b6e0-105d-432e-8df1-9f881aab7d86/4018c96b74950f6943e9102b99baec58/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm.tar.gz",
+          "hash": "9ecc3c6afdc445b0008d8f6bc7a0635ba6abc00ed0e5b66be3bc2e4a4da2579d0c1cce848635a5046a086f2c7154e3befeb9176219af7c8feadeb41a78b1ea5a"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/18801fdd-b1f5-4856-8288-c306b11f0f43/5c62f28b9a269b1a840cfb310a9a9f86/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm64.tar.gz",
+          "hash": "ce8c21b6c854b6772578e84d42e2df5f5144d5a15aff3e6d48953feb1aad517215b6349c20fc22542364a9c439fe19a562f070f88eabf14b5d95ab50fe1ecc00"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/35dd9b11-2055-4d52-9169-1b6c3dd11594/a35d42236e89f7e0bea13545138e170e/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm.tar.gz",
+          "hash": "cd38668eb106653c9ce2ec62e8b0443f3c7c90105302afdf790153b19b677af6b931af5b2a836b226c54ab8b7f8609265f81c37653697ac15d2688cfb2261902"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/242ea287-a11a-4248-8c85-bfca8d2057e0/c0da08d4b4f8b07c966d9169ec56ed1d/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm64.tar.gz",
+          "hash": "969aa069d1719e7dc0c5f1abfd13d3960e58111ecfd61cf557979ec4f3e30cfb2b9082250041bee49841ac5b40eef3f80caf921b63ea148825289ccfde582f6e"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5139dd2b-c1a7-4be5-9913-18e09aed94f3/f9a8615238ec30073a7c1bcb3c7ae247/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-x64.tar.gz",
+          "hash": "964110b4637ada5eb605aa035c30f4cde754a5ffbe26cb11b63d10cb6e0f3287e746662fb85c421c4c3b9b3a334755f59c123b65799b461d22e1d53c42ad496c"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bd635e31-a279-4078-ac0d-f82ad8940f84/2e9b04bbe40e28507e8483c73eafdd7c/dotnet-runtime-9.0.0-preview.4.24266.19-linux-x64.tar.gz",
+          "hash": "b366a4f19f25281c5b325e737f8c9fe0fa97ca4e19e0e8f00cd42cac84f4134469d02558b07412c66cde62e53f1cb1a7efd68357713ce4d3e816c19ee538e9b6"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7e461d11-8e26-429b-a35e-6f67c84d5b3f/0d7cfe48dcbfaa6a8284850793c984d7/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.pkg",
+          "hash": "247fca6bd0fcdb80cc4fdfee87520b2ae12c54eb8399bb625ba226cb845971d562037b37c2d507d4d7405976410929e41ab7f9bb02c17c66e080aaf99f0867ea"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c53cab87-a771-422e-be8e-f33a8a6ca637/6e72c3d16f517c6e692572a5cc9546c2/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.tar.gz",
+          "hash": "f9e8188c71ab47631c28d3fb9314b382eec31ae5592a73eaf8c944fcdc240147ac23ef4530a871e9a5deaf311b84ac5b0d5a1f4b6ff22134a8f4eda4555c43a2"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/73f4cbbe-9a84-4403-ab5a-4ea15abe6890/95fb54f4ccd9024e7d41cee510cf3fa6/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.pkg",
+          "hash": "7efa0a175811039994d605e6ddc0aa007f28e17516230d335ee1a3af469515aff8ae681aed56a7fcaafecf52f17cd93d07bb7d0d4e219d14afd9e659b0e6358c"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6bd91ad7-ac3c-4027-8674-239367730906/007b8c98680c550fb801c34dea28bc9f/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.tar.gz",
+          "hash": "9e7364e1448d98df03922bd315f788ce564dfcbec1a9e83c9e1437c22d8d52f72f061750de2f9e149e7662c168b7a781e7450d2c1e8b7f048cb62b360f12d6f6"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e377474e-7847-4bca-a032-07a50104e7f5/97851ebb43ff0e3dce49a0ca9d0fb0d1/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.exe",
+          "hash": "6c3695d936ebfde747f5d656afe764fe2bcde551f2808e4018be4358f1a98e63cc91f340af6ec2f2370165a068eb12bb45f81e4e2d4d6c7ab916fa0c491e42e2"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/28a070f2-adb7-4d2a-8363-6c4e285a8e63/9156f37f7cdcf63739881a80d8dbc050/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.zip",
+          "hash": "47e92441bdb222b3c69dab181504de00a1c89c75d9b42cc6b093c1ae81dc184fb962319c6cd3e6fc78835b27257e5799f04c6c8481ceee30af9163d97bb9f93a"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/62b4e83e-1346-4c01-986e-33047bc2a6d3/852c4d4ff7a7517a5edbd896e4796e15/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.exe",
+          "hash": "5b6865c131836c1bfb2b9e78c515b3ad5aab5fa5a7317d2024d216de8964b9e749a6878a43cbf8e1b8ed587ba4641011d5250c95f6b15c5e0a2c4a0bdf78bbfd"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/676e985a-6242-426e-84dc-caa80beac6be/576a6d8e8f74c9520c8e7942c4d5278f/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.zip",
+          "hash": "61ec667e4c6394ba21748a3529969e54ca514c37c42b5acca2a87dbf7f816d6c7c4add8962efa51db7b99a7177546ad439121c53053b5fe6e01763f77f42daf5"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4415bda1-d266-4128-b194-0d4d280128c4/685282429a7c7affd9134fd5d2d9a2c0/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.exe",
+          "hash": "5226d35e6325443448e2897a05394212a4b475025b5bf1e3702093f00daa05bb1a64be3a986114c528b1cbf7a50a3d358f8bbb5020451ca4e56aa61f6f977d76"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/284b822f-4ff7-409b-90ef-9b37eb487dcc/26719d69cfcc500a1493bb9d4de6fd7f/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.zip",
+          "hash": "df01e6fae6ec5aebda2ece30617bf9c4e04e105b4ccd8f3da8e790650e22c1333e5080a949f43814033fe60a2e8061be53c2923d17b2a31e61c6a0c77b726bab"
+        }
+      ],
+      "vs-support": "Visual Studio 2022 (v17.11 Preview 1)"
+    },
+    "sdk": {
+      "version": "9.0.100-preview.4.24267.66",
+      "version-display": "9.0.100-preview.4",
+      "runtime-version": "9.0.0-preview.4.24266.19",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eb98063a-61bc-443b-b51d-0bc82cfa10bb/ef920311f783df4ade75298fcd45c9f7/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
+          "hash": "3728477aaba64f03f28b4690caffcc90852960d7bb573cda142a49decc394ba38cd1090e7c00275d3f8e5af0ffd0cbbde04c27102cad72814d8503281bf1fe65"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/098a764a-8756-47c5-97e9-118431c31b9f/2e1b737cb4750deadb0136283346c7ed/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
+          "hash": "519d529c74a972484af49ea72053466e09fbfaec0142cd924705dddc117dc40901ac22ddcb11c05caf7b43ef8cf44ec8a0a9dd4c56fbd329b0f750513ae3100c"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/42b4a871-aa76-4e76-81d8-4de3adc015b7/1e6a598bb1c74ca1bd0f97701c1beec9/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
+          "hash": "952735f8b305ecf67f644acde4e5176a17399c4616a51a9a279d84763cb30ed67bac6b64caf2ed359f103794de5d4082d72da79f5fe5486b2f32a22e78893f32"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5970728d-630b-4a98-b92e-c7411094995d/97319be6b9b617c0e5529a89476d4431/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
+          "hash": "85e8caab9e74882fe4959f7078d7e4f736c0c2109b6167aeacec1518348945e093839774baf2a90163f8868ae5593912caf8477f5ac8ce20e0cca1bead066da8"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/42143563-4bb7-456d-b3ce-698869c0feee/129e62b28eb216976385ddb095159013/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
+          "hash": "5861ccc9b1670a134c6d76be3ba0aa3606c8c3c110cc8415d2015c921c86bc19cc6363e64f7a2f9a3dd261e042956e55d0c9c2e5410bcce2dcefe309dae631d1"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/87f2eabb-8ba2-4677-9f91-526672f51857/9ed7fb997d40a369c038269a514fc4e4/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
+          "hash": "28b63633a1e6f4078ccc60218b9f7b6663eb960f0ab1c41069ed8f7f67757fa22ce9f4c04d88b9015c417aad34a7a57986451682bd7aa7b966eda45ace23d283"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/343689ab-65e1-4633-b85a-ca1bb8a0e5d1/e04cf1a20a665f377e2ea45d3a9734c5/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
+          "hash": "7d3ccf857593bfc53a60d6085d41b9e6afcb57c8e18e7e79bfc9d61bd269466c7c69cab4f3801496b1314bbaa134d6226b37493b01b70b20a8b4b7c6fa0bace6"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e003d2d1-abfd-45f6-aca2-e3f2199e3633/dcefd0cccdfb48a3fbb20b14fd2fe22c/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
+          "hash": "3791e2134f7cae53c430ae5306f325eecb84058da07d90f276f8d4045701c6c85567472ffc2c535002bb3066817683c0a8e82d23ba6ce32a52f7217867db30d2"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f0858498-9230-46ee-9cf4-fb68aec0e37d/58e82c5b5705f0fd9efb2d4ecc74c02b/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
+          "hash": "a672acfbec52b2f636614a2cff682ddde5ecd8c82eab884608af1bb7ef508ef5bd202c25e31ecece7d81766ffae6c96b518841f215bb6361bbf66f45ca6c0a1b"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c3cee1ac-1bb3-48b0-8a35-813e511d1d41/dbcba8b2e6d28886d07bec53ab509225/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
+          "hash": "da35a51180e75a238b7a4b5d1a5b7e3e33f1a1c179b40957deee98c8e01a9bfade62e2c909d2e5b377f43cf2dc78687b34b349b27b2f8f841165c3c05b3fe443"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/29c1ff6f-0156-43d4-b86c-9e7d3d99676d/d6097b452228be86bc95b995688685c2/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
+          "hash": "b855a6a68dd1e4fe93348d20a7940685ab46540a4037512d99e30269a9a941c8a740f71984876b876441597e2830aff4bc2940666043a3ba565016c491f982ee"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7b9dad11-8a62-4521-9984-3a099d9ce61d/a0a1fe27a63ac76480db3281577edcef/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
+          "hash": "611c04fe90746c82c4902eb75a98e6219222cd82733388b79cc81fe3c9401ed261474e92993439e06efa6eec6230604bbb05a77a0894f030ea75dc22808d1edb"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1515bcb1-1862-43c5-a86c-180b1ec9049d/c4049cf3b8eb87e40dff823573cf563d/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
+          "hash": "32eee5f12a564098fe19253a50260bffaad34fd92d7a2d10612993eeef0a78fc7aee051dff9c72738091f3c38029d4579886a626541f656e090497080ffce22d"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5bb0c9db-5ddb-44e7-90d1-bf34c1ac688f/8ba52405d812250c4b31e81e94c62334/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
+          "hash": "5abe780d515bf82692752d3defe6317bdd17171ddbd5aa9b769ba8f63edd713868c26b8735ba427c9f193ac0daac28c2cd87c4321565c3b2c4545b906f5c3587"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bb1317f1-6c8d-4287-b10e-618e67cff2ff/d7537c37617a5d5d56b87079a24a2a66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
+          "hash": "2c3ad59a9e57b9a56aaf825f4eb23f90caffc1508c9bb5ef511865455e051fb65e2834f3ceb829931d6ee74ab81c52885c2c862d02c23a015593d6fc182030f7"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ce78ba3f-c369-408e-8026-a2318844db65/d1636d07dd075acfdaad4d80d69b6262/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
+          "hash": "ea8617ced22a2b4e0e048f3560e350cd720d5529776bd5cd5e165b139bf287624178870cdaad68e613a18122f3d2ca5e917c46ff8390a8a92631787e21a39243"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.4.24267.66",
+        "version-display": "9.0.100-preview.4",
+        "runtime-version": "9.0.0-preview.4.24266.19",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eb98063a-61bc-443b-b51d-0bc82cfa10bb/ef920311f783df4ade75298fcd45c9f7/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
+            "hash": "3728477aaba64f03f28b4690caffcc90852960d7bb573cda142a49decc394ba38cd1090e7c00275d3f8e5af0ffd0cbbde04c27102cad72814d8503281bf1fe65"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/098a764a-8756-47c5-97e9-118431c31b9f/2e1b737cb4750deadb0136283346c7ed/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
+            "hash": "519d529c74a972484af49ea72053466e09fbfaec0142cd924705dddc117dc40901ac22ddcb11c05caf7b43ef8cf44ec8a0a9dd4c56fbd329b0f750513ae3100c"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/42b4a871-aa76-4e76-81d8-4de3adc015b7/1e6a598bb1c74ca1bd0f97701c1beec9/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
+            "hash": "952735f8b305ecf67f644acde4e5176a17399c4616a51a9a279d84763cb30ed67bac6b64caf2ed359f103794de5d4082d72da79f5fe5486b2f32a22e78893f32"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5970728d-630b-4a98-b92e-c7411094995d/97319be6b9b617c0e5529a89476d4431/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
+            "hash": "85e8caab9e74882fe4959f7078d7e4f736c0c2109b6167aeacec1518348945e093839774baf2a90163f8868ae5593912caf8477f5ac8ce20e0cca1bead066da8"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/42143563-4bb7-456d-b3ce-698869c0feee/129e62b28eb216976385ddb095159013/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
+            "hash": "5861ccc9b1670a134c6d76be3ba0aa3606c8c3c110cc8415d2015c921c86bc19cc6363e64f7a2f9a3dd261e042956e55d0c9c2e5410bcce2dcefe309dae631d1"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/87f2eabb-8ba2-4677-9f91-526672f51857/9ed7fb997d40a369c038269a514fc4e4/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
+            "hash": "28b63633a1e6f4078ccc60218b9f7b6663eb960f0ab1c41069ed8f7f67757fa22ce9f4c04d88b9015c417aad34a7a57986451682bd7aa7b966eda45ace23d283"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/343689ab-65e1-4633-b85a-ca1bb8a0e5d1/e04cf1a20a665f377e2ea45d3a9734c5/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
+            "hash": "7d3ccf857593bfc53a60d6085d41b9e6afcb57c8e18e7e79bfc9d61bd269466c7c69cab4f3801496b1314bbaa134d6226b37493b01b70b20a8b4b7c6fa0bace6"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e003d2d1-abfd-45f6-aca2-e3f2199e3633/dcefd0cccdfb48a3fbb20b14fd2fe22c/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
+            "hash": "3791e2134f7cae53c430ae5306f325eecb84058da07d90f276f8d4045701c6c85567472ffc2c535002bb3066817683c0a8e82d23ba6ce32a52f7217867db30d2"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f0858498-9230-46ee-9cf4-fb68aec0e37d/58e82c5b5705f0fd9efb2d4ecc74c02b/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
+            "hash": "a672acfbec52b2f636614a2cff682ddde5ecd8c82eab884608af1bb7ef508ef5bd202c25e31ecece7d81766ffae6c96b518841f215bb6361bbf66f45ca6c0a1b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c3cee1ac-1bb3-48b0-8a35-813e511d1d41/dbcba8b2e6d28886d07bec53ab509225/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
+            "hash": "da35a51180e75a238b7a4b5d1a5b7e3e33f1a1c179b40957deee98c8e01a9bfade62e2c909d2e5b377f43cf2dc78687b34b349b27b2f8f841165c3c05b3fe443"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/29c1ff6f-0156-43d4-b86c-9e7d3d99676d/d6097b452228be86bc95b995688685c2/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
+            "hash": "b855a6a68dd1e4fe93348d20a7940685ab46540a4037512d99e30269a9a941c8a740f71984876b876441597e2830aff4bc2940666043a3ba565016c491f982ee"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7b9dad11-8a62-4521-9984-3a099d9ce61d/a0a1fe27a63ac76480db3281577edcef/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
+            "hash": "611c04fe90746c82c4902eb75a98e6219222cd82733388b79cc81fe3c9401ed261474e92993439e06efa6eec6230604bbb05a77a0894f030ea75dc22808d1edb"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1515bcb1-1862-43c5-a86c-180b1ec9049d/c4049cf3b8eb87e40dff823573cf563d/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
+            "hash": "32eee5f12a564098fe19253a50260bffaad34fd92d7a2d10612993eeef0a78fc7aee051dff9c72738091f3c38029d4579886a626541f656e090497080ffce22d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5bb0c9db-5ddb-44e7-90d1-bf34c1ac688f/8ba52405d812250c4b31e81e94c62334/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
+            "hash": "5abe780d515bf82692752d3defe6317bdd17171ddbd5aa9b769ba8f63edd713868c26b8735ba427c9f193ac0daac28c2cd87c4321565c3b2c4545b906f5c3587"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bb1317f1-6c8d-4287-b10e-618e67cff2ff/d7537c37617a5d5d56b87079a24a2a66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
+            "hash": "2c3ad59a9e57b9a56aaf825f4eb23f90caffc1508c9bb5ef511865455e051fb65e2834f3ceb829931d6ee74ab81c52885c2c862d02c23a015593d6fc182030f7"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ce78ba3f-c369-408e-8026-a2318844db65/d1636d07dd075acfdaad4d80d69b6262/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
+            "hash": "ea8617ced22a2b4e0e048f3560e350cd720d5529776bd5cd5e165b139bf287624178870cdaad68e613a18122f3d2ca5e917c46ff8390a8a92631787e21a39243"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.4.24267.6",
+      "version-display": "9.0.0-preview.4",
+      "version-aspnetcoremodule": [
+        "19.0.24138.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/992c2b62-6318-4dc7-b7c3-994fd9f29e35/37e65e34cbe93b5389f8b779bded70f2/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
+          "hash": "e156c79c3e064e0d4ba2f2cb2fe53d2d427b2c5d62641e350278b31abe53e67ecd955de296b5e35f2e5fe491082fba8e09be67e1392874756be97487ab5a7994"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bc6ae1a6-a98c-446f-8aa9-fe4bdd18412d/569b1a10883293eaa5aae3275d8a4e2f/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
+          "hash": "6f457cfc870a8ea3a8f9e5cbc6b4554dd98c7380ced6f4c6f05bf918545e22937b1c446cc696125e08f964f78dacb2215c0d9e42fdd86ea1c3a4a57af199dac1"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/833d8170-3991-4523-8601-e7ff36cf254f/ff7f1cf297f4af74acadda36affcfac9/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
+          "hash": "2cc4b0babc021c5cfa87ca25c1259485626b71834614f40468c6e1dac6468bba7585f2f0b373a42741be109653911fbebbac9036ace4e1f79e5b6eb8ca75b1d0"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/02b13c1e-b263-4ab2-add3-963137022042/9d5fe5a6b63936a143047fc6a466eb17/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
+          "hash": "02a4e69d6a627e80b76fa6d24d5f631420a92c83763bb65392a3b34d6bb24d24e24e49cedbaaa1b835c9815da8c01d64bb17b87aea8dd9771d80c6d99d5f1ecf"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f6caec80-aaf5-494d-bf71-10761428ff24/e062b54765e468699ab0588c092cce18/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
+          "hash": "ac7c5caefd2285bf9e3d6d5afb6fd99e6fc23e534635cd3300acd043c042d21e0936670515a4e5d30bb58ef9503f9765787e4ff7bda675975dec5c9d46097677"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f889c70-8c50-44d0-9877-0d0376c031ab/d73ca2ec30f5fc3e537b16f37c029daa/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
+          "hash": "ee65f640c894ac6e67589c40682b2fc215f2ab7037695589b9f92801073a0f8a8d071c3caf4608679f61e10830f02d21e916107f77b68c58e59b1f191ec8039a"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/57b0954f-d550-42af-b1b5-8c9ef5da0d58/a4c7f9677ac41fa3421050bf9822c56a/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-arm64.tar.gz",
+          "hash": "2440f43ec72f5298679126527af6c1c410cc542a98ab4e0c5aca0ffda40d29b7dc52e1f1aaa869b2d5b86b7bcd80579bada8fe20d0ba9e48a64ea147ed3b4c0c"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ccc886e-61cc-475e-9ab4-b1723078e7e4/093617db718ce4669b6a93f2d8934b1f/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-x64.tar.gz",
+          "hash": "614fc10a69d3c78a1b1478b1d49d1e5d7dcadb02b6edd1ece510b81075e19f6267a53c7252ee4cdba1c5df1353f17ad64a54a08459d3a3a8a4baf707e4bef7f2"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/92b6f660-9ac3-4f16-85ff-28e623f6d1d8/cc4895fbe24aeca773a1c1ad991c2d0a/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.exe",
+          "hash": "6e1aa5c31257030364e9140a6626e818f18f71f6cb3f14b7ae37f72200984069ad60020029bf3824ee46d1fbbe55d97b90f6e68cbac3d4060aed972c007ff536"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/accb26be-44e1-4940-8add-d51e6c3dfdb8/6514f378b6921d8cf43deaa94d803197/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.zip",
+          "hash": "412daab92de5b9eb2a27c2b2146ec4e56f422b512b4b61cba0d96e34059f59116715e4eeaae30c59c8c6c57562262ccda353a589f47e969a5d61c0d0b6119e3e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c4862573-61c6-491e-82c5-851c6e68e50b/6685d83ef28ca605014610d2302db83d/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.exe",
+          "hash": "8864e666cf561f6ad1127d1add213293e4448fa83cdd589b2ae019346f29294d1ea12cd22f4939d0989435ab3f09c7493bd2466bf99179c2693bde9be4569c3a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a97e2ca1-2463-480b-a8d9-1ef74cbeb1b8/a817f2e44eefb42f8859ce34d4ab4d05/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.zip",
+          "hash": "f57273459e202bf2ac7a1a2cefe7075a6400d6c8baf4da2426d76b488a5f935eb2b8ae6178c69d4b3fa252aed8b02453c2200d8f996555ac849fcb26839d8984"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c041c63a-938d-4c08-95a5-d019b64af27e/1ed28254f2a8d92e934968b77b90701a/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.exe",
+          "hash": "78f5e5f81f1e5af7f89dc608c0937498f23544627e97d443b6614e982ff707ae9276f64b2aa6213f09a5efa6e103a480df3477272df8b5ff0683a5d91ed603cd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/51f63e30-95a8-4c1e-81b7-4da3b8d66c22/d56ec056ada0081cad7ffa34bc7461e7/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.zip",
+          "hash": "abd9d4c26dc916b8009d628bcb7d05d7688fd5ee2183adfca5323241b3b1a6bb299f383179659755c30197d14a33e1fb443e4acc26e0cdc79ace6e14f79dd8c7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4345184c-9cb3-447b-8515-f577a4f80082/15e68b416144285b265fc84e11e6b54d/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
+          "hash": "45bd8e7829d00f37867fbd74e3801fdf69104db7c45e8a2e579059ef02e77ba96152a1073c7ce76ec33f2d88ddbaae92ad90dc21c741ec94ffaed8ecfcea3f1b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3241265e-62d8-4a77-aed5-ec07d829a4f9/c3beb873fd6733a0e17741681220fe1b/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
+          "hash": "29acf67b87c29ea9e02ba05a48052ea323494d91c6c07cda8c82cca4704b60b12683fc05e8fde803fcbf00a2810d1e9581bd90125eb748a6b556b05b55f2e236"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c4601543-9425-4a65-a7dc-890fc5031fd1/ee9980fb39cd686314d2ce281d57e9c8/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
+          "hash": "016b9e5efb3dd65fdd4a27b256cee6d10ae8541e26e5446dfec5c603f585555ac49e343dbf04db44efeb6ab5f973a2fb8ec253b6331bce3f6d5ff96c9ac80e60"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e0785796-d1f1-4224-b951-be51959d2422/cb7309f3f96bb1d6c87e003f5bea97a0/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
+          "hash": "e7b353d80a12e91cab47d74e9d9624db5455a8cbaaf39c26e16d1f19dfda235a7598534c828c1c7d1ec8db85585aa8ee902267e9406e938bcb05eb1c97a5c81f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5b89c4c9-b798-4eb3-a7cb-4b84f5cfccba/9cc25a4b4e004197ec7d99c53406f266/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
+          "hash": "bd6900bebedbc02cad6793f0ce25361591562118c205035821355522d1b0dd70143949377c02131d65a1bea536dc1ebcf310e4a441187b4159ac54e4be419158"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/75d03b48-e892-4ecc-bac2-94b361ec9f15/8c345c3075ad13ec8c9013e7f1d08d85/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
+          "hash": "4fbd2ff0a650bfc46fca485886aa53b17e78f1e4ea28ac2933429724a409b1739132d07be4da7c163a3713b73ec2448426921bf8ba8b3901d5b05998cc5a3f47"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dc7f36ba-c8ca-4dbb-9fc6-ba10ec01c36f/fd73f2c002241fec538305a8cf26c203/dotnet-hosting-9.0.0-preview.4.24267.6-win.exe",
+          "hash": "19885f297d2f01e20b46b69c48b8a1fd02aaaa9bf44ab7ca8b7a8ae961b0147bfdff8b8a63cf2766fb6bbb8ffe3d5dac80b1efe2a12bc4a91cd798abcb09ae4d",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.4.24267.11",
+      "version-display": "9.0.0-preview.4",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cfbeca90-42aa-4cac-bdb6-96cd4613e5c2/4ff431cf779a7892ffb899c27c76d7e5/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.exe",
+          "hash": "432e3d142eedb2a67eeeadb8d5aea906085d06540ed12cef9d3c6fdf55661024bf8b220ed8dbbefba3fbb6d23ed38916260e0ed935d97c39e92b941a74869367"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9db2ef93-4e2e-47a6-9574-f8de141e8469/57ed42a750224dc5e501833f23df7f51/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.zip",
+          "hash": "18ecaf2ac89462b371e1e281c4336b00d8b1cf72ac0f7534cacd9f184423a57c330834293506c2f649df833e15c2ff7948f9e8befb8644512f962b71c0ff0f75"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3420930-6bca-4552-9c40-adaf4abec571/5a6243eda5d7e9645afe9b6145213ec5/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.exe",
+          "hash": "0f46daf2f73ad038dec2b333c5b921148102622c2897a6651d76bba8a782f0bf6e29b20139c446eddf9bcfd31106eaf42832c48db7411587988fd772f486fa9b"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d8f00-2cf0-47d5-b763-a534a8cb77b5/f4043682c3e2f1bab5c2ebf5507ed4cc/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.zip",
+          "hash": "3f54ad4b62953d2438c1d9d55116ada0f1f98d41698a2f3b9d6baaac2e17a32186825935a4f83dc973f0c229396ecf82c2dbb255381343db3488c722f46d0eee"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53c1b7b1-1a61-43a7-8344-1c66d8238f03/592ed2c250de13ad82ec1c34d96a6b68/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.exe",
+          "hash": "d34b5653e4ccfc370a2667e5c8718a93b154e5f06e85f605b33d95186e067aad788a817ecf02858e7bf06c6f034868d89dc5974cf70f55756bded3a20cc9a549"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/43216cd1-dd9c-4dcf-b05c-9591125f0cd7/91dabb962aaf27fddc388b20dd80dc10/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.zip",
+          "hash": "a5a15087e024beb729b2382af8c47ad38b08de2375eb4d49f9f5ab853725ff80325641f5bae0fa31ff9e62abb2194d648df36603c06c623d24216bd6cfbd93cc"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview5/release.json
+++ b/release-notes/9.0/preview/preview5/release.json
@@ -1,0 +1,513 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-06-11",
+  "release-version": "9.0.0-preview.5",
+  "security": false,
+  "release": {
+    "release-date": "2024-06-11",
+    "release-version": "9.0.0-preview.5",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview5/9.0.0-preview.5.md",
+    "runtime": {
+      "version": "9.0.0-preview.5.24306.7",
+      "version-display": "9.0.0-preview.5",
+      "vs-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/31e7d9fb-9414-40f5-a12a-bee1649c4402/09ca8c548f4492c664ab654a225bc1cc/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm.tar.gz",
+          "hash": "0aafb3386223e1d06e6e2e92255a198a10780f9be82fe430f3a0ae450a145f8b266e1075825a9b20392d0741a226d6552ba3c06acaca11f4d223285e3794a651"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ac3c308-bdeb-4fff-98b8-b22ff6c479aa/31e3d32e7732b17506d41cb6cd7a51b2/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm64.tar.gz",
+          "hash": "8e49eb2e279684c665031e04c915d63c19e617bf44194655374c957bb13d7f22c8c0e233196711c029653958f98788732e1bbf200d22fad27f76523d7506a91e"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/76b19839-edc8-47ce-9d60-72aa67ff8c41/6d659b8e3ff0b7bd76e2f79b82d6cdf2/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm.tar.gz",
+          "hash": "62aa5ac3fb049900dceb7eda01fc6d0392291ce15a26435c5ce502c0dac607d1d38c29864c3042838bf82da0294b10ff245211bac51f1c3a21e05eed8ec5a290"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9dfae8d9-9567-49de-8872-3f8a1f218380/6ce317e891b4426f435cf5189d1ea925/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm64.tar.gz",
+          "hash": "d81305d5715c84ea1c424102714198f974e977ba24b5f40ed38288c38b3b0d2ff55f0c4803a9535f8b4f2c1bc3456fdce94a30b9ba49dd02ebf4c259a80fe48e"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/36b2f309-949b-4366-be8f-cdcf152c617e/8ea218ed0b23fc78a351cab9b1ed1f0c/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-x64.tar.gz",
+          "hash": "8c41a36a84bfed4b74a20329566146558bb3cf4ba6b9aec56e93a1c7c2439a7a3c54dc7b152b1c822a6067cc7806557958c6f6389d535a83205651d9ed80ba51"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/acc83ac1-a75a-453d-beb1-ab0eef7544b6/fc1c9260c812441c5c51370aa57ea1f9/dotnet-runtime-9.0.0-preview.5.24306.7-linux-x64.tar.gz",
+          "hash": "6d5a313eb3213bca2ac209021218d978a7d8291041f4572780dfb48b5ccb7efe9ace509c75dad1db8e6a427c0bd5e4b2596c3e9f66eec5df4e717a66f8c3d7fa"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/127371ea-846e-4a3a-9f2b-9d9f4058caba/9fdf695f9a388cef6a0af6a92dc18c18/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.pkg",
+          "hash": "e1eb051ebf5e909c89dd24409a7ea888661f59600f97de0835aa01a4f443f21b7b9cd103c64f659778c4d5396582f4ecefce7b4fea91921f0f3d9b3e6a40f121"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/42df8bc2-3414-4253-99f0-50d52d4b0c36/a9b0b1664e2dcba0622b9dc6c6a8a8e8/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.tar.gz",
+          "hash": "7c61293b719016dc8212e5564a80a3686a6947d220e2243438616559995c2d415629bf583148513d0691325ebdac91b6a13cbf4d37d7328426b73989edd8ef7c"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/509552cc-02e8-438f-8c88-dd82b3775550/382bb36a28229b8c5f9798c91822a2b9/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.pkg",
+          "hash": "c07849bc1360081e99c76b389bddede1a590ab0cedef5f53eba70c65a8eb6eab4e25ad5f0596ecd65ae1d55361164b2c04c57c22964e60ffe7b1cbb034c7dcf2"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4a7db5f1-a6b4-4232-ba81-f848a8f6dde7/20b9502eb9b73e2f7ae047ae53cd1f21/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.tar.gz",
+          "hash": "617847ec35016e4c51359fb8585563a432b8a9ff2c6656d6c10f2e3db70c20dada36509a73b31622c91ccfd5246f51c1c0df79852035f65521ac3f78943f37ca"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4933af57-6528-4320-bd0a-6ff672c6aaa7/1b7989cd8590fe25af0b915cb61cf100/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.exe",
+          "hash": "1ba7123b16b25b6b04c8fde6b0c1e8298453cdd60c0a43b43374c8612071fd4939cc0ff62b6179b28dac654bbdcf2e81da3e249893718d41145b0d7d62f9f4d7"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5a8db69-0aed-41ea-b6e2-18f59b74e8a3/f241e4b6b0e8b837fcfd4c0c320cb6eb/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.zip",
+          "hash": "d29287f4fef0999a5bc8aacbe327e374b83720d0f4c97fd9886e7e2f1f298b41d9ec3ba0d98f866ec63b6a25644a74a77eb291397a6d8f51b0e0a5920e98ded2"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/aa73bf2d-5bdf-4c20-b673-9bb003e6fa1c/0c0fab1e7c74c74bdef199ac814a13d1/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.exe",
+          "hash": "9f8e928c896edc6807639286eb4d064ffa931a4a9c4cf166e6e3969ec5f3f2325a376810a8842376d9ef22fd832ab94b95772faf438593c37730b23316cce290"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d4578076-c2c1-4083-931e-4bdfc0545d3d/c153c8ea28930c65a3247e24c18d85fc/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.zip",
+          "hash": "078864a20e4efe15aa1008bcd1696474dcbeca721e1c2d13dd8f11652630cc1b7adca74591fe910424c56e565fa499785eb882ce3889b87d476de0181dc71e83"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6bf7d5fa-0998-4ed1-b595-7fa89efe5782/5f52d09fff08eb17ccb7586174b67471/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.exe",
+          "hash": "49a755ac3c9ae403290856a2255f5574d180f29a5c3b6d5def899fd1f72adf886b0f051e7c73c02f56c021259b3d02d416d4f5531f87bf8f7adc2da58d6ff1e0"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b169201c-2a05-4555-a923-7054c5f3f912/3b53906e9a1b455e09edb80e0e7d3428/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.zip",
+          "hash": "7b23fa2374bc68a2288e410a0a2c96e9b69c814f0f801b3ef68f8f49aadad26cebf20a1199dd415ac73670891124b5ac354131c03ac3b1f4921fa6c48706c86b"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "9.0.100-preview.5.24307.3",
+      "version-display": "9.0.100-preview.5",
+      "runtime-version": "9.0.0-preview.5.24306.7",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ff4f1830-f8bb-4be5-a065-ca27005ee25b/ab73d8a64752e5f94ca5de8e45871e5d/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
+          "hash": "39b94bed670ffe0abe0482222cef8d706995ee00531e077b856c6cc600cecc81bfe34c1d0cea3172796b694fecd150f350e08d2884e237dfc024d942667b1676"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/25f41d0d-d27c-4dc5-8884-6c49897d89d1/c51387b8bde1d278a0982b03c3e8c1b1/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
+          "hash": "3c6f7e6f2f56e86bc8a9633f50129cfa992c52c287dc89551b23cd62fa471199e90392eba7414659c8ff8eecf1dad04016615a98cf85f6c2045d61f6f14c9e73"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a31f873-8093-4c63-8481-1d3cdc8f6f0a/c305f1ca9f40bad90c380fbb5f0de559/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
+          "hash": "347dc481e1c752e1560ac856d3dfe53b78c42e5c70d7eaeae820329a03a46b2ae9aacfa150fe8a8e141b82ee79373cd417c99f75166ee036cc5943fcb358db5d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9281b5de-3ec7-4452-8e0c-5b18d02f0203/76790fd16370719461f1ee565fdf1142/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
+          "hash": "4a98db47ab702ad98b647cdb4db2e429d41a8759c174c0b8ff16b98644feadb9b094d268701b4b8a0651e795d63971715231d36caeee197a24d7298081a20cd2"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/26ae7803-8ea9-4fb3-8b86-fc7218e5f57b/18b08c66b2a5872ba0b71078f0a80a80/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
+          "hash": "085a930d44dc9c8048af4bd3cd0b370b4b8a8abc10393d118fa9594812d23cc37cd3ca56c5bbe35bac17c83885c411e32179fd689c350d59de09a8c8724b8bba"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/96e19e8f-579e-4a1d-a18e-6773a44d7cd1/092cfc588686cc698c449998b7d5ae35/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
+          "hash": "13b9934b3e7b736ab802a8c580aad95ed4dff6b8f31047c71ce9ffcf4d07e55105d4b0170d309551707b9d232d297cb305c67ed5b5f7026f47ec072ee1bbc121"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4138605e-d1df-4672-b024-862b8b1bc4dc/bbf19075238cb836aa0483014f8174e3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
+          "hash": "c578766dc35c61bafeb6ab07e70b6e6664504d2e5560bc37aa50fc75690dac485bb635c86d9264670717a04514787a0344561ce428e30e25e17f820fc2cd8d09"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/090175ff-fe42-4064-98fe-b6d90e08162d/bc72a57ada79f0ee7b71d74f5deb66a0/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
+          "hash": "8c1a13d14f2502d3897871f82abd2c2df8cb41ff9d754e79693b99d0780deb910dad7486e05ec065c4a38490de00d251c64b0b2a734863e0a452f0ed23b1e1a0"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f4139839-15fa-4ef6-a1b0-fb77ee467b2e/7529958cc121871a79d3da1a0f851333/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
+          "hash": "c82ca4055e7d2d8cae3f9a9924a9fc05392f3b58a5bf4b690efc233d61c061e185f2b125967733bf69936d5db8b1a4d06dcbc3c1d28d3bd131edcedf780a2697"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a6731f1c-ffd0-4cca-a309-89576e55552c/3000f43ca4b3b51bb034bd7daa514841/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
+          "hash": "ebb84f920a7bb663238a10007d784a7c90f66d073089371fc2c9d5556cba945918fd8b193e02eb3d889676952b79616398aa2555d7d46d080088f01f67ede43e"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f58d46d-3ff2-4ad5-9e25-6abaf2a98699/d96c5e7e2b2f7bba1f56b73875a2f764/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
+          "hash": "a8e398611736c4a5a20402b2cb9de2b3320319e03b0904182f258d095523299c7c2ff6774df9301baf1d8bb4e1f5ae0985992ef21c89ef668f291db3f1dafb77"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2c38b883-86fd-4970-b5fc-3486740fcb4e/17024f80e99c45f74ef69700c982d214/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
+          "hash": "137ae59e968091bca5316452d4345830b5743578a65167d493d3b12242f54d6cf40181471236060803a3e29e51bed254b86dc436582bece8915666dd0193cc0a"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ad4f7358-9797-4301-bb3f-2bbaeffb1aea/7e740c0f41c8dd1e2282e5b88a65e727/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
+          "hash": "911abd43eb7b7b49eed69304dfe2e0fab3360bf7e72d5e421b2954e1f6dc33e9db7dd4bf357382e57d71b663c3bf242284592a4130c9141d9c782e602edb6779"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b08c26a7-83de-4d9a-b4d7-d87942b6d35e/d6d973d0cfe914189692af1154690935/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
+          "hash": "297797f709933f435021be0068bdf9e7051e493d60212c29a9746cb5e6672ee8f2f6a2b2c214f1d4753e87e449faf712f60edc7c4eb32d34e555dee07c8a04a2"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/99dfb394-02cb-4ab6-82ee-b15c7b5bb69a/cf6e482460f5237237f9232e9f9afedc/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
+          "hash": "2223918e2b3bdc3623a7ff323ae5c930da47408c1276035c10408de80a65c9220d9bcab79435690f9d0473e60939935bd5ce77a532486deb89b26b9e9b4417f3"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7e6cadfb-b694-4d94-9f0c-55b3a72e6089/11c7bbd8d2f072e483e274fec5e8654d/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
+          "hash": "8d167c0926d6d3aaa7739c7417039b9be27aefa4b7f52fef3c6503173d3580dbda6e688bd68716e07441aa072d9bc94faaa34651c2ff0b57a06fec65a8a81260"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.5.24307.3",
+        "version-display": "9.0.100-preview.5",
+        "runtime-version": "9.0.0-preview.5.24306.7",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ff4f1830-f8bb-4be5-a065-ca27005ee25b/ab73d8a64752e5f94ca5de8e45871e5d/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
+            "hash": "39b94bed670ffe0abe0482222cef8d706995ee00531e077b856c6cc600cecc81bfe34c1d0cea3172796b694fecd150f350e08d2884e237dfc024d942667b1676"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/25f41d0d-d27c-4dc5-8884-6c49897d89d1/c51387b8bde1d278a0982b03c3e8c1b1/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
+            "hash": "3c6f7e6f2f56e86bc8a9633f50129cfa992c52c287dc89551b23cd62fa471199e90392eba7414659c8ff8eecf1dad04016615a98cf85f6c2045d61f6f14c9e73"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a31f873-8093-4c63-8481-1d3cdc8f6f0a/c305f1ca9f40bad90c380fbb5f0de559/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
+            "hash": "347dc481e1c752e1560ac856d3dfe53b78c42e5c70d7eaeae820329a03a46b2ae9aacfa150fe8a8e141b82ee79373cd417c99f75166ee036cc5943fcb358db5d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9281b5de-3ec7-4452-8e0c-5b18d02f0203/76790fd16370719461f1ee565fdf1142/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
+            "hash": "4a98db47ab702ad98b647cdb4db2e429d41a8759c174c0b8ff16b98644feadb9b094d268701b4b8a0651e795d63971715231d36caeee197a24d7298081a20cd2"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/26ae7803-8ea9-4fb3-8b86-fc7218e5f57b/18b08c66b2a5872ba0b71078f0a80a80/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
+            "hash": "085a930d44dc9c8048af4bd3cd0b370b4b8a8abc10393d118fa9594812d23cc37cd3ca56c5bbe35bac17c83885c411e32179fd689c350d59de09a8c8724b8bba"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/96e19e8f-579e-4a1d-a18e-6773a44d7cd1/092cfc588686cc698c449998b7d5ae35/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
+            "hash": "13b9934b3e7b736ab802a8c580aad95ed4dff6b8f31047c71ce9ffcf4d07e55105d4b0170d309551707b9d232d297cb305c67ed5b5f7026f47ec072ee1bbc121"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4138605e-d1df-4672-b024-862b8b1bc4dc/bbf19075238cb836aa0483014f8174e3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
+            "hash": "c578766dc35c61bafeb6ab07e70b6e6664504d2e5560bc37aa50fc75690dac485bb635c86d9264670717a04514787a0344561ce428e30e25e17f820fc2cd8d09"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/090175ff-fe42-4064-98fe-b6d90e08162d/bc72a57ada79f0ee7b71d74f5deb66a0/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
+            "hash": "8c1a13d14f2502d3897871f82abd2c2df8cb41ff9d754e79693b99d0780deb910dad7486e05ec065c4a38490de00d251c64b0b2a734863e0a452f0ed23b1e1a0"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f4139839-15fa-4ef6-a1b0-fb77ee467b2e/7529958cc121871a79d3da1a0f851333/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
+            "hash": "c82ca4055e7d2d8cae3f9a9924a9fc05392f3b58a5bf4b690efc233d61c061e185f2b125967733bf69936d5db8b1a4d06dcbc3c1d28d3bd131edcedf780a2697"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a6731f1c-ffd0-4cca-a309-89576e55552c/3000f43ca4b3b51bb034bd7daa514841/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
+            "hash": "ebb84f920a7bb663238a10007d784a7c90f66d073089371fc2c9d5556cba945918fd8b193e02eb3d889676952b79616398aa2555d7d46d080088f01f67ede43e"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4f58d46d-3ff2-4ad5-9e25-6abaf2a98699/d96c5e7e2b2f7bba1f56b73875a2f764/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
+            "hash": "a8e398611736c4a5a20402b2cb9de2b3320319e03b0904182f258d095523299c7c2ff6774df9301baf1d8bb4e1f5ae0985992ef21c89ef668f291db3f1dafb77"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2c38b883-86fd-4970-b5fc-3486740fcb4e/17024f80e99c45f74ef69700c982d214/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
+            "hash": "137ae59e968091bca5316452d4345830b5743578a65167d493d3b12242f54d6cf40181471236060803a3e29e51bed254b86dc436582bece8915666dd0193cc0a"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad4f7358-9797-4301-bb3f-2bbaeffb1aea/7e740c0f41c8dd1e2282e5b88a65e727/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
+            "hash": "911abd43eb7b7b49eed69304dfe2e0fab3360bf7e72d5e421b2954e1f6dc33e9db7dd4bf357382e57d71b663c3bf242284592a4130c9141d9c782e602edb6779"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b08c26a7-83de-4d9a-b4d7-d87942b6d35e/d6d973d0cfe914189692af1154690935/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
+            "hash": "297797f709933f435021be0068bdf9e7051e493d60212c29a9746cb5e6672ee8f2f6a2b2c214f1d4753e87e449faf712f60edc7c4eb32d34e555dee07c8a04a2"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/99dfb394-02cb-4ab6-82ee-b15c7b5bb69a/cf6e482460f5237237f9232e9f9afedc/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
+            "hash": "2223918e2b3bdc3623a7ff323ae5c930da47408c1276035c10408de80a65c9220d9bcab79435690f9d0473e60939935bd5ce77a532486deb89b26b9e9b4417f3"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7e6cadfb-b694-4d94-9f0c-55b3a72e6089/11c7bbd8d2f072e483e274fec5e8654d/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
+            "hash": "8d167c0926d6d3aaa7739c7417039b9be27aefa4b7f52fef3c6503173d3580dbda6e688bd68716e07441aa072d9bc94faaa34651c2ff0b57a06fec65a8a81260"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.5.24306.11",
+      "version-display": "9.0.0-preview.5",
+      "version-aspnetcoremodule": [
+        "19.0.24159.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9885e829-9401-4f84-8948-33bfbec4a486/40b414d190c0c85614c18f42f6c4d1a9/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
+          "hash": "5f41868ee89d47b391968d7f01772e6c223ae12d7d86461d38972f56de8e6278ea0aaf723d736bb2f03ddfb7ba0627f1ce7f0447c62aa6b48854b5434b33da9b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e8849fb4-309b-4008-b697-4b5af127cc8e/285762b4db9cfb18abad4e005b37f2cb/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
+          "hash": "6e6198d26b16ebae7bf7f7a428b0026d3c7edb20fa0acf844670a98cdb78a8b0d37cad5df22f35dc3379de8069fdc95318f5eeebcd5b03ad99cf595699116abb"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0ac17d7b-df82-4c78-8be8-cedd92c28f23/f80b29a59db088239e19970058cd6c49/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
+          "hash": "44628326e3efb241ee24e9a39abf6f4318d415d1977655d8fcdbdb8c61aa05f4b4c058dd8c0c52cf206c3979e5b5b2cad86cdb9f56e0a2b10bf2d9994ae8ebde"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d1c32044-fdd8-49b9-90ee-87531de750e8/8c2d4018226292cebbe470335614f9e3/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
+          "hash": "dfc4e8f082214ff796ca6b3c548b38b1e61221faa90eb96e1f19771f14197e2e4ee616057cd29b37addeba91098ba151859be8eb51015b1bc38113fe2d3c41b6"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f6f9b71c-095a-4aeb-8eb7-fada01704860/117e89d575a73207194a9cffdbec78b9/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
+          "hash": "f82ec65e016c0996b74c144c1a11de7d2f3bc8bf7a51f217d697fc8a019039995df23c7e64df1e98950ff5cb3a8f3c815735102288bd73efd1192a20f21761c2"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f43de71b-3bf6-49ae-99ec-66499bfa6990/438e1533bbb47d3d7e1f58983677a4f6/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
+          "hash": "b4358041bfc42bf614644e7f3c38a4fb73185a8d3541065bfd6758622860b0d0addff6a7ab6e7439d029b0b54238864279d19f1b5096b5d7c0fd10c0435e652e"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b4c5eec1-4026-4e58-adfd-64dbf4426b1e/1f05059da0484ade0ba1ce6a3e8f6bd5/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-arm64.tar.gz",
+          "hash": "f6ed6cc22e20e986cf54ddd0c8868b524efcf84ccbcd5335bdb4ac44fbb08641850448aed5d85bcfd2d403b3a89a73cb932d73db1b590cfc704a58aa8ec79d5f"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f07ad200-6654-4341-a594-9a1eb1ca66f9/929c2533f6fe9c402fcb5fee99ee1103/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-x64.tar.gz",
+          "hash": "104b0b8f216bd36710ee912c92c89c4a5be97774eb21cf090c5c12acbe3ff8a8ec22a2b2bca56feda8aa21690c734d5a4b8293569cbf45172ead6b587d3858fd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c78c4ab8-5fad-4d72-b5c5-6edd4c51fa2d/2154d7e93cc29caa92df1f8d990a8ea8/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.exe",
+          "hash": "93c04f3dfd446180cf143d8839abba89f389b3def23489b249636cba3a7a032406066a0e6db67adb3f9a87897778ec11117599a6524b5e0b69b470edfee10314"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8d13b17d-912a-4f52-bc64-05113d585ab3/40cab8f4d7efdf30ea9d5178e8f16de3/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.zip",
+          "hash": "6f49d789c314b1f3ead17d2c9870f5255cfe53871418ba626946b4128bde87d24c7427bc9176d98c528f458a69aa11ec016bd0e4a23a8f129351dde43a84de5b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/33d48eed-15df-40b1-86db-86cfd602b8a9/f68eedd88c935d4e73028861f95f001b/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.exe",
+          "hash": "0a1f2b3d84864c543fb1882eca2409730bdb8f661422e13d53f664d90b9133d1a651d095467e6881491f8326fd31ab533cff480352af2468e4369fa12fec5d23"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b341e7de-2607-407e-a539-744dc7c0af3a/2a78d3e9a34f4e5f23150554921cdf6c/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.zip",
+          "hash": "b5d2160fb4af420ee73cb9205372518d9401333b91a1852758288b7fe9f198092ae4e029e4b49164d5c8303ca4c8fd0845280d70e2c79d5679ba6cec6c6045b0"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9b5c5c65-532f-4498-93a9-5b38449f577a/3369bf02ce5d8b74a109cb221baf5c2d/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.exe",
+          "hash": "1a209d3bcc4e29dc7afb0bb0aecc66e0762640030d89a32ecd61387c9eeb84f48147a095dfaef4b79c27d3b682a250e3f3de7776e7d0c95570d18f8bef41cdf1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/86db0409-ec32-4dc6-bcc9-d5534ec20220/b5ed337c859e403f4b33a31891e1cd22/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.zip",
+          "hash": "19d750ac6418996ae9bece2198ea576cba161bf5e4670f256ba2f17972f7bacbae35463bfbb40a32887739fa8b2dda906df395df150b356f2350e00279ad20bc"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e04de0f4-59e6-42a8-9530-16af0bf369cc/c66a4ec5be50872a6606a8f8b2f78404/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
+          "hash": "2b80333b0c8513ed18adfa715121290575c71e0101f920b8bc105d3d81ce3ba104a823d36a8ad5c871b6db42d1078b19f72979ca4e1225ff0f15980ab5aac5d7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b0f62525-01d8-4ed4-a091-086fd0210846/00a6b88fc1c125bde4a47b3ba9d6b209/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
+          "hash": "441abcf355a94f02929f3bb16899180ce3e253daebd7591696dd7f934e5d2033b341a1cb1944b06e0b205afabc3189432fdca26d89bd80f82db132d5589262dc"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a1d24de4-4253-4689-b74c-49200f858bb2/302418f944d071fc5add18730a928c9f/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
+          "hash": "976d8f04c387a42f107fd4a0c1ecef798cf1d3a3e961aa4f06bd9ddf08b15155cead38876d4cda60ec68664562d7883f03e642aadec32693c6a42265cfad4463"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/060552c1-2c74-40d7-b625-b35a7e41f827/c5b91c025b6ef6bf62b6fd1050fa67d2/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
+          "hash": "ce547b2e4249f0028fb12b5d2f16560c959263874b63983797128ecc091099f374c89dd2386aaa8db9ac559114255932ccca9511378bc0a43db05e99408d333e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e1b305a5-cee3-47c6-919e-8772e5dd76ff/8dba7a53c74a331a667de203b2d2191f/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
+          "hash": "abf43f18b74bca8a7e6e4c2faf136eae844012f6a1e77e886e2d5a414c0bfd450de6d0916a78951218e39f8c162ea5803a061e833fb73763e9c56ef821b684f9"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/44d88b11-6c78-407c-8f2b-c1c08065afc1/1e62a37ac72e089926415447b1989f8e/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
+          "hash": "5273644b48020ae3cfddd4035f17b0499d9cb0bc253bf53b6332bba0e8460b1994f0a4d3ad7d644533d84fea481cc521294f91e9e28608b815d9b332de7fc075"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1eb7f78f-c605-4e38-b5b0-33b58ccb8460/c7421e8b5616b751a9a66c0c5abba81d/dotnet-hosting-9.0.0-preview.5.24306.11-win.exe",
+          "hash": "04a1299e7fbf65ad6587f58013c03cb557e34790193aeb98af95a29e26bf836649730d76060042b0a99566d85b02f4aa69a5558aa777865b087bd59cb6f8d836",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.5.24306.8",
+      "version-display": "9.0.0-preview.5",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fabdb881-9c52-4744-ae24-b529aca98806/c5b048d0f5d46b66ddec6643b3b8bbb7/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.exe",
+          "hash": "483b81fbada3d60b94c7bdd6163c04449243aadaf5805d0135ab732b9a2a7aaf1a271e6de37b0704b1586523751a30131ac42415bd841ffb4cf77d5eee9d63ed"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2ed957d2-54c3-479c-a17b-e4c721d25a86/0f56cbf7a7454a15de16fe20273ed8cb/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.zip",
+          "hash": "d4b865cdcaf3e346b16eaabff77c4f2a911a408c37439dfdd4f632170dec2900b8745d0fc80fe8463ef25b768031c2b741663a8e02bdc930de56d14076996cc5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6c481981-dc6b-4e69-9c60-7f0c3ce64e0d/0b5a8d18e2014143af7faed2e2c5e251/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.exe",
+          "hash": "c294acd9d6b022193f12605adbb1cf8609990455990d46ed307a5b9cae2d0977b4e81dacbaa7539386059307b83e7f4de07c22644689f7df109346970bd569bf"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2790489a-2b90-47f5-a281-353a05c4cdd9/0833d5448b6481a29d8a58b6db98feca/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.zip",
+          "hash": "85e7a9465091f4bbe63c47938f042404e40ccf6b1f217713994fc67404a95607cb0664543cabc54b3aa017233243299139a1ac90570e36a0a3020bf9c15f141a"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/976bdb90-8f89-49f0-871d-8aafcc1337c6/67bf6ba2ff55915f3c99dd88b0bbb6c0/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.exe",
+          "hash": "0d406c96f0c38eb1a887bd7327c0bb4c75c456003098203b34100a7c64e06072e2d7b913714a9cd64f9fd727203f1b30f6aa51a99f40503b9da6d0a70a7fe1e9"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4dea813a-bc32-49f9-96c3-09b1762b4034/0b3bac88273cbce4e1d939114801c396/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.zip",
+          "hash": "d3b44cdad9da672e4cd4480e2092f2492455b3e36f25782e323af9b79d29bd57997164c0395bbd10e4cbe8a8bcde63e021b8e64ef6a1fa8a3b137d276ec55d5f"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview6/release.json
+++ b/release-notes/9.0/preview/preview6/release.json
@@ -1,0 +1,513 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-07-09",
+  "release-version": "9.0.0-preview.6",
+  "security": false,
+  "release": {
+    "release-date": "2024-07-09",
+    "release-version": "9.0.0-preview.6",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview6/9.0.0-preview.6.md",
+    "runtime": {
+      "version": "9.0.0-preview.6.24327.7",
+      "version-display": "9.0.0-preview.6",
+      "vs-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a5921e58-68b9-4436-a410-59ef6182c029/ea09e5cc7ef7e81ab04339de9817b1f6/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm.tar.gz",
+          "hash": "8a3d23bdd25b69599c9ac6009c76bbb66af2b1312121da4951266630ffd3a31e91b6479ec1324814a1dcd850d145d47f03f3debea9e6b6d1292573824c239f6a"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c19fa925-faec-409e-8a8d-2c106581014a/ad8f61c688682647a6a2daa4fac8fdd3/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm64.tar.gz",
+          "hash": "755961903291c262a1f5f7b70543016c8f85f6993e861a6f83f8509fd2a828f4a34f4161a3b9f15114663e8073b37937748befeef9ea9818d513aea1b27f944c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dadb9bfc-0b55-45be-9ca9-9231555136b4/cd84e333aa8a6907f45c358c9ab5ef3c/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm.tar.gz",
+          "hash": "cd49793061602577d7d1017c2e0f43c205bc48eff50b9234ff8a56d2a873ffb1167429f5f132e5ac201a460efeed83c82c404e47ae87fe336970fd04b3cff697"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8619f9c1-40fd-4762-bf82-e913e6fe74a4/8ede733c84d21905ed757adc9ed7d62f/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm64.tar.gz",
+          "hash": "643fcc319138f31bb2cc7e7896e14caead677e16fa79b2d5031f339103f2bb5dbb9994485ed24281c93ecd32bea179861330c69e75d03db30a58d46fc932dad6"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41574d6b-f1ca-4455-87c3-622cb06fe292/1172197d3202e6ab7ba0b92eac740cc9/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-x64.tar.gz",
+          "hash": "7c477a29faed51ea6bc01a1314b3c8d5907d41b2bebce28b52db453722bee703e3edf167e3143b316eca572a1e976619f3925cfd965953376cda38157e9395c1"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/484c439d-3a87-4eb9-9a08-683a1c2bb334/0edb0aa500ff6bfa446940e1773ff203/dotnet-runtime-9.0.0-preview.6.24327.7-linux-x64.tar.gz",
+          "hash": "09aa8c4e6ae3ada1a265a5cd2b46779a763163e4dd9a1892b44606b89cf147339e10b7c584dbcaf5404af0553f0ef6c5801436c217f4fe1a5d3bdb6d74aef1d1"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/95fc5ad6-2935-4afb-aaa9-6e3a85096c9b/df3060250716bf7813aa2e6258dbabf1/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.pkg",
+          "hash": "6c04ea05763dedf173f374d7aac7b12749880e6c5e3e4b08dbfacc5b3a94000d409912875b5fcbe9b8b3e4e8dade7bfd2c81cff5469154e8aadf28abe70fcdd9"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/866edb84-2362-4941-b63c-8480b2133c5f/2750c6b8cdf26e9214f040c86b040d33/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.tar.gz",
+          "hash": "9f038f1ddf51a6fdb96081932c889d63d9ee818de8b5e71af905ede052c17bb22293599baaf9295f42e560d8073d41785507f752fbba316b446664fb762a60f7"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5e90a5c-5ac5-4a74-8066-afb3f9616737/3aba6bd3250ea5f6a537be3c0a982c6a/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.pkg",
+          "hash": "b15a5a018dfcea34ccf1999826a16a6fab2688402bca889e5a19b57985f48bdcb1bb552908a98b14fb589ce7536e19ff7dfb98a6c05f31ec3a24d39bf2f38697"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0bee7cca-fd9f-4769-8409-30bfea40aa07/e6e565aa83cbf8fc8a27cb054e83d45d/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.tar.gz",
+          "hash": "53d7fd172cc4bfd0a380847b7d38cfdab03f469579458e3c7ab26dbad82b54a663261b60ebc35009f232509e486657ebc4b8516866016510f66e9a3fbec53eb2"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/25bd95c6-6b8a-44ef-b324-b5bebe70d532/5cd96a6c69d278fa0c1a43499a0f5c52/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.exe",
+          "hash": "bc144ecf6a370c4885663513571ec865aeffac1ceb91f4b089bf5e6c39819c27577f9fb1dce5991952e2fc38d2a29eaddb851e14b4aa7b670934f6f9fefda39f"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c452b715-ed66-48d7-acd8-0db06f7b06aa/5bbb3d458b9f8c60cfc390d457bf2934/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.zip",
+          "hash": "0fea090b348df52be11c7053429fd82227e5d5093ab758c756f091ebb2c1f6e47086bbb8a23ed1d6eb97b6b4960b0b67639ea6025b2d516e1e30f7cb458b3ead"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b9378c8d-7415-4d91-b116-02ee0abcb536/49e294d54fbc2aaef4135625d51b30d8/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.exe",
+          "hash": "3610d07f38263fb7a3f107b0c7a3b859f08103ec3eec7c9256e90f68313de9d88f306041e2eb79fcb4085152b86d8a6ca100e56aa7cb7a8e87b8c3cc08f12032"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8cca5125-0359-4dcd-b88c-e7bc0e14f7cf/764aeec7baeb3aedde755a45059eb5d1/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.zip",
+          "hash": "0f54db8195bc2082feb9895be1effe9e5beaef9158f18570dac752877177ced94bc8b2da12468dd3076d8ca5c573aed032bd47de589d52841adbdd27eb9c3b2f"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a409bd1-1ea7-4b64-8e5d-bd84660cf1a6/46da365616d4dbaf68dd7c16ab9238fc/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.exe",
+          "hash": "bfbbbd3ff343b621a573a237468ae93e0ce186347b9147470c40dc938ec675fc6c16483753317062d17c404efb226d22a924e72d67bdcb649346453d36a063ba"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/618fe300-8cd6-4029-bd30-5624ffc092da/dafb4244931a312cfded7332ffd68ffb/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.zip",
+          "hash": "09cc78ee9c8fa1da7415d007e541ad674b1a103349ff7467fdeb18483791fca6268411646ee1df030a136dc66f73473ccb020a65d48186ff557f701ef11bbdf0"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "9.0.100-preview.6.24328.19",
+      "version-display": "9.0.100-preview.6",
+      "runtime-version": "9.0.0-preview.6.24327.7",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b0b225be-9431-4098-a3d9-f7ed8b2435e3/2dff72be21a0da2e9a82ddbb47e3e521/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
+          "hash": "9e57776a5fbb257e39318d485d02ec7a0b07c680cc6cf9dfc8a6cbebd98c6eb70f39131c3bdc1ea1a34a4df2c9cc9ed4f512ee4be8156f3ecd9f36c32e371e77"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4129d95b-c724-43cc-b1f5-f394c6fddf5d/24f44d474f12d33f4f74f6913d9b233e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
+          "hash": "f4822637ed89f856736bb947cfc1fd4f1c81452016884cdf10ca9ac97c36d5bf810316d534263b3219843096fd5ffc15972714041f85caab243efb5fb910d7fe"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7c1dc66f-1d62-4996-9a96-90f9d7a86660/fb956c6fc95f73a98c530a7518363cc8/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
+          "hash": "b3e1bfb0f46c5d49fb44a38bd1725cf6cf2660f34ee3457fea7b73d477f41b686e34b363ebd5000e2d8e16e49f9fb800721106cf5546fc6c4f5fefccaa2ad955"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dda0d54d-9ee3-4410-9cc6-007718fed183/b2ad0ff295895c56f7e353d4bff57c0e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
+          "hash": "49c15fb243534f54bf2711bc10b5e233acd2d76459110f87e9e756fb312f63a6ac61bba106028a73a9f76563230eabe66fc0c03a8dc8e82922231c333e8ab87e"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/270d6741-6525-4811-b378-2194408cc835/54b6ef775ad1679752a35e9a8016a26c/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
+          "hash": "6e57001dac6b78de5976529543709b05d5cf57790a72904c72ad35215646a03c9f1219aeb6c4e979a7a86d6ca20f65b4febfe87f12291f61b52704291d40ff87"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a01db0ce-d997-41c7-83de-08ddbb1bad67/49da8a4fae2e0e803854738e5098d89e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
+          "hash": "ff040c456b096aeac707053517d5f9f5f0df92b6754a4af6b6fe635fd8f4a569589b8241cbad0c5db998dc5bc54682b2f1e4dc4f3d88024a3ef56c1ecc9f4c97"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c0231fde-8a62-4e17-b396-25a4f8d6cf1e/753d07aa1f5d1652e6f69dab4fb588c5/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
+          "hash": "a323f9856ca9ac447d0a34f7aa23fa8d3360b8db2ac63bc882227eb1bccb927f001879dd77dfa61ee9b5a188569f98c3f4139e7dfc2bcf0cf33b6d8db0bdf8ef"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4dec7038-6ff5-4490-a383-4e98596b3265/671e5c37c62486c331a3c2cea7c8572a/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
+          "hash": "0aee16fc9a8e9729a5016d12e656ea2f8f0703116a778d3e33cc05c7f2d9870239fb3a0f4e5d7152cd7d6942c41853855fced70f777cbb7d40b5a3e03da2b4c8"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c7132bf0-f591-4bbc-877e-bb881008c442/12a5262ac08f9d3d6e0cfabfc8806611/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
+          "hash": "ae2437e7450a2f001e380ef61bb2dff22ffaf087452dae2191122c5a3621b92751c8eed7a7a3d231d3ef7ca3189bffec6637e6f9b675ddb097c98b928445fd45"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a856c115-c1e0-4050-bcc2-5a2e8840a60d/dd16b2fd886ab6e66ce56f6e7c08beb3/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
+          "hash": "db4e9122cb0ba6d4560a6396cef194735ad41c22ee8cebbfedd41c7b8eca049209e9eedb5013927d6a1f76fea134b78e637c0b3d02523fa7f7a7d4311a059c18"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e42cda14-704a-44fb-b565-9ce82673b41d/f08d42872a41a6d98025b62fa3fa9536/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
+          "hash": "9ce4ef04fa4d9e4e7872adc104f54060761c2ced3f6c2a866f345cf2f36fd8ef5b044025afea64534b5faaa8ab5a3d81724b81ddcba6141818977a40c906b39d"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/06126587-13d7-4a76-a80b-d0353fca10be/e146117dcb49deb82efa6f94fed18607/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
+          "hash": "d67792819626d5292fce195e57a541078e604f012d706f71b0eb3414249d32c8ab8e85ee46065c5503fc3d31601705d30543883876c862e95c2c31c032474eac"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fe2ada54-887a-4bf6-8872-d91a6b201b3c/5cd457720c0d17b1efab4989dfdea6bb/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
+          "hash": "c13e4012dccb0037bcd7d48593947765a5faa05a2181bd2a3a7e32a5acfc74fecb251f602652d82410fb10b8f7174bf444e5a50dc226f137f0b1ced6a31976e5"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a889b484-004a-4cc2-844d-d5040cea4193/292354e7dec9e3a55932afdb66719c80/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
+          "hash": "cc4a5ecb76cbb5efbe229f8154451d6866e2157f4124fedf7588706b8a356babb0c1f1007317336803bf9674a988f2f6ac7e359d6390521ce4bd355fcb6831c0"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a3070acf-317a-4a8d-bf40-48049d215cc3/ec90f6a7803b646000d96fa6c0b96ef2/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
+          "hash": "9ff4057a1c5e7b5fc088415244ea795462f708ba6fff4d68bd6cc0e2cb7d10ecfd7ad2b6157999e1a815cc6ba01fc816c9ab5a15976eccc2f5adbd7c815ef8bc"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/089a937d-6e0c-4cca-803e-6aaab0c6360c/26b6fd99102654de3fa064a25c0d635f/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
+          "hash": "50587f8d0f40cbebc6a56eb5045a458e4f78f26a76c9a98313832ac6aa623120e72eb3028b39babeb635efc9518716bbe246f08339a5c75ff8b2453a32e22b7a"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.6.24328.19",
+        "version-display": "9.0.100-preview.6",
+        "runtime-version": "9.0.0-preview.6.24327.7",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b0b225be-9431-4098-a3d9-f7ed8b2435e3/2dff72be21a0da2e9a82ddbb47e3e521/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
+            "hash": "9e57776a5fbb257e39318d485d02ec7a0b07c680cc6cf9dfc8a6cbebd98c6eb70f39131c3bdc1ea1a34a4df2c9cc9ed4f512ee4be8156f3ecd9f36c32e371e77"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4129d95b-c724-43cc-b1f5-f394c6fddf5d/24f44d474f12d33f4f74f6913d9b233e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
+            "hash": "f4822637ed89f856736bb947cfc1fd4f1c81452016884cdf10ca9ac97c36d5bf810316d534263b3219843096fd5ffc15972714041f85caab243efb5fb910d7fe"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c1dc66f-1d62-4996-9a96-90f9d7a86660/fb956c6fc95f73a98c530a7518363cc8/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
+            "hash": "b3e1bfb0f46c5d49fb44a38bd1725cf6cf2660f34ee3457fea7b73d477f41b686e34b363ebd5000e2d8e16e49f9fb800721106cf5546fc6c4f5fefccaa2ad955"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dda0d54d-9ee3-4410-9cc6-007718fed183/b2ad0ff295895c56f7e353d4bff57c0e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
+            "hash": "49c15fb243534f54bf2711bc10b5e233acd2d76459110f87e9e756fb312f63a6ac61bba106028a73a9f76563230eabe66fc0c03a8dc8e82922231c333e8ab87e"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/270d6741-6525-4811-b378-2194408cc835/54b6ef775ad1679752a35e9a8016a26c/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
+            "hash": "6e57001dac6b78de5976529543709b05d5cf57790a72904c72ad35215646a03c9f1219aeb6c4e979a7a86d6ca20f65b4febfe87f12291f61b52704291d40ff87"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a01db0ce-d997-41c7-83de-08ddbb1bad67/49da8a4fae2e0e803854738e5098d89e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
+            "hash": "ff040c456b096aeac707053517d5f9f5f0df92b6754a4af6b6fe635fd8f4a569589b8241cbad0c5db998dc5bc54682b2f1e4dc4f3d88024a3ef56c1ecc9f4c97"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0231fde-8a62-4e17-b396-25a4f8d6cf1e/753d07aa1f5d1652e6f69dab4fb588c5/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
+            "hash": "a323f9856ca9ac447d0a34f7aa23fa8d3360b8db2ac63bc882227eb1bccb927f001879dd77dfa61ee9b5a188569f98c3f4139e7dfc2bcf0cf33b6d8db0bdf8ef"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4dec7038-6ff5-4490-a383-4e98596b3265/671e5c37c62486c331a3c2cea7c8572a/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
+            "hash": "0aee16fc9a8e9729a5016d12e656ea2f8f0703116a778d3e33cc05c7f2d9870239fb3a0f4e5d7152cd7d6942c41853855fced70f777cbb7d40b5a3e03da2b4c8"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c7132bf0-f591-4bbc-877e-bb881008c442/12a5262ac08f9d3d6e0cfabfc8806611/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
+            "hash": "ae2437e7450a2f001e380ef61bb2dff22ffaf087452dae2191122c5a3621b92751c8eed7a7a3d231d3ef7ca3189bffec6637e6f9b675ddb097c98b928445fd45"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a856c115-c1e0-4050-bcc2-5a2e8840a60d/dd16b2fd886ab6e66ce56f6e7c08beb3/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
+            "hash": "db4e9122cb0ba6d4560a6396cef194735ad41c22ee8cebbfedd41c7b8eca049209e9eedb5013927d6a1f76fea134b78e637c0b3d02523fa7f7a7d4311a059c18"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e42cda14-704a-44fb-b565-9ce82673b41d/f08d42872a41a6d98025b62fa3fa9536/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
+            "hash": "9ce4ef04fa4d9e4e7872adc104f54060761c2ced3f6c2a866f345cf2f36fd8ef5b044025afea64534b5faaa8ab5a3d81724b81ddcba6141818977a40c906b39d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/06126587-13d7-4a76-a80b-d0353fca10be/e146117dcb49deb82efa6f94fed18607/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
+            "hash": "d67792819626d5292fce195e57a541078e604f012d706f71b0eb3414249d32c8ab8e85ee46065c5503fc3d31601705d30543883876c862e95c2c31c032474eac"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fe2ada54-887a-4bf6-8872-d91a6b201b3c/5cd457720c0d17b1efab4989dfdea6bb/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
+            "hash": "c13e4012dccb0037bcd7d48593947765a5faa05a2181bd2a3a7e32a5acfc74fecb251f602652d82410fb10b8f7174bf444e5a50dc226f137f0b1ced6a31976e5"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a889b484-004a-4cc2-844d-d5040cea4193/292354e7dec9e3a55932afdb66719c80/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
+            "hash": "cc4a5ecb76cbb5efbe229f8154451d6866e2157f4124fedf7588706b8a356babb0c1f1007317336803bf9674a988f2f6ac7e359d6390521ce4bd355fcb6831c0"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3070acf-317a-4a8d-bf40-48049d215cc3/ec90f6a7803b646000d96fa6c0b96ef2/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
+            "hash": "9ff4057a1c5e7b5fc088415244ea795462f708ba6fff4d68bd6cc0e2cb7d10ecfd7ad2b6157999e1a815cc6ba01fc816c9ab5a15976eccc2f5adbd7c815ef8bc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/089a937d-6e0c-4cca-803e-6aaab0c6360c/26b6fd99102654de3fa064a25c0d635f/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
+            "hash": "50587f8d0f40cbebc6a56eb5045a458e4f78f26a76c9a98313832ac6aa623120e72eb3028b39babeb635efc9518716bbe246f08339a5c75ff8b2453a32e22b7a"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.6.24328.4",
+      "version-display": "9.0.0-preview.6",
+      "version-aspnetcoremodule": [
+        "19.0.24180.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0d850aa0-1aab-41b6-8659-bf780e19a699/5bedc9ef82acdf760d1a976e470569f2/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
+          "hash": "592961f315d2ec54687c5c4f2a6a15eceea2f5eb7b4e3614adf777c395f611a280b454f43f98f528a1b4a96cc8514b2dcdf22bb30ba6cc182c40fd07f50ae7b5"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9c7b5592-95fd-4d00-8515-3d6a5c24264f/59f528496c3ab6576bac71982f2dcd98/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
+          "hash": "55e5ea839ddf9cb40d538af961e26959a2dbeaa2dac5de3c85ea50b15927fd5f132ce614e2e4abeb2c8f46f13902cc5f04591f4d12196ae0f8761822e107972e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/59484924-72aa-45dc-82ad-0c546a659270/1d3c62f9a09fb6b421596583b2b222d3/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
+          "hash": "836212e6c83f790096bcbc131f7bea1175a0ab17898c8e872e88bcb0e27b52e5f94cf27dcde815e54e102610cf2d002ffed4f325da815d3b6be416d2425f0d46"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e2db14f2-5366-4965-8af2-1a030b731742/b620ee26104d3dab57ecaac499b9746d/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
+          "hash": "f7e0e8c258d4199c3e79fbdfd12f2ccd02cf57afa9bd53add921f40e05bf300c29dde18589eb446e1a13fb0833eabecf46fe15ce04fe5cba915fcab6ad1091ac"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b2391445-7b08-42a7-a249-d8593eff2da3/91cbb8a4248f5a502aaf740836d4b0ac/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
+          "hash": "c95601ea6775f229a7de6daf8ae92b947ae7942b134de7cb7073eab22114c940738b44273f6ddaafbabc5363c9f4cde1eff7423781b5a821eb9b0aa2535a3952"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2ca1c5cb-12bd-49f5-8924-b1ca8031a856/ed898523c59ab06231f833b15b46006d/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
+          "hash": "4e178bbd26c70a3f1690c2b84b01c5a43cbf546adc878617fdf4c39d10e8063684420126261aacabcaa7f72c697290c1c06d3e93d9f3babe57c72d5fe98346fb"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/62ec355f-dbe5-4674-a3c8-a745079e11cc/f50999d4b748511662feb80dc3950f3e/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-arm64.tar.gz",
+          "hash": "181c501df6e92ecf85d4c81df755eb06b1734d1814653818164175977a40ac94044341d97c8d40b185dd70685eb55212e9fbb93c4538dbc48529433a336d6af2"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b37e6088-911d-48ae-9bb1-920c5c784e44/eec60edf24e317a9df244a48a73f6ba3/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-x64.tar.gz",
+          "hash": "b80a2ab4ed45878a7817fb0a60da2e1a0f1a4f4477e8e15a6245e5b94fd4cf4fb57dc57a6daa9c8256648e42f1d33a7680a4b8b8eeb41a0d4fcd020b0e216e06"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/068d4d44-7491-47c0-8323-93af5e4a9670/bdc53f3b1471062a6228bca376a5b2f9/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.exe",
+          "hash": "17d77898cc0dbe726ed9db15903e1698f6a768b20a44409fb2f3527d5604f57b500fa5185bdc18932ce578406a887ee3fab9668866ff548ee8ad3a07d4c3c9cd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dffbe139-0a56-478f-85d9-72621e0cc3cc/9ca1aaeecc2fc48a2e55062ca7a3ab00/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.zip",
+          "hash": "87db6953ae3919633447cf598b449b1bfac80c7a1ca8be1cd573076a90de0e67e312180804a27b487737fd75b42a77bedac0232c5e399b1a5c5acddbea834d7a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a516941-84be-4bbe-9fdb-3b9ad784acdd/eaed3af65bda0067f26fd8f1a1ebbccd/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.exe",
+          "hash": "27b9c3e84415ecb777d1bd8e2521825f9983a35ae1f3f0f17b9178d3012c805f65d9789644c3bb1a18731b33e5d760ab433984268d07c7b5b20dee42d65971ca"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f987ce84-daa7-4a09-8537-683568ee838d/cd3cdb3e26e71103014fcd4d7645d24b/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.zip",
+          "hash": "6fbb3aee8c4844b0d578edadb4f4120b4ddeaaee1f5925a7c986746227a50a7586993879b338e93e932c7bc2145285e096e67cab374a71b5617e1ad1111453c1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9d0959fb-bdfd-41b4-b3ec-9c360bd60092/1560ab71035697b2767c68b06d730d8b/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.exe",
+          "hash": "fd935802e478dcf3bd539b41b280d008a06c605887d6515f8a659291a592a003cd0b9c19349e5b96da36c8eabb6b2e2b9b7cabd3c12b0d3f44df1d7d05b063b1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e669318f-279a-4c59-9460-18c6dae7b637/884c1aabe8ca5a5d2b0d07f993904008/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.zip",
+          "hash": "c6ef82bbb4cd033183bc4e7938590ff595721e59cb80ec38a5b9d3985822972a027e1b18cf880161830a78e6b5cb3faff29ea71439fe4db6385002fdb4e5589c"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/45d67589-b962-46c8-8497-c79eee46e2de/f38f3b6cf4d8d60001b1aa489fb2cb2c/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
+          "hash": "7ba1c3965913cc462dd18e6076b0bd5b2060afcaa87da015036c4a855fd49a651c32c230963a610c5142a2d6a3d845b1d766df5273cfee78b20550c9d35ba61d"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1b813ae4-d5d0-40a3-b890-f29b0cd0d481/42bc9c6998a3fed0fce51970043d151c/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
+          "hash": "4f400682bfdbb8644462ef49ed267142fca9b0823b80bddac759285b3eaa5e71a03d79e3d7bb1fd2264dfe68e40e9e647e619e0d4cdab24e18fd1bf7d8914c36"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/48ade329-ab4b-4497-94e6-62519ac6e0da/dd58fc59e31176c0656edf54e42682ba/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
+          "hash": "bd2d95e485d363156931c7fd451937e88fab482aa1fab8d2425bd2b02192afb1513289ee7b121850f82ab19aaa66a952aeea69deb5e5806321f02ef22ca338ee"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1ac4709d-f5cb-48c5-a763-ff4eb4dee8d6/b81f5456163a9eda99ccab797a69a1b4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
+          "hash": "bbe4754055920ecbe0dc4f16347834be3b5cc4fc8903e4ca9b520dd166dd02696a03ad6dd0a266f836d2cc437eed3c4cc372497f8321deea49733f7a690c13f8"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b1c56531-dbcc-43ec-aa72-835f59806e7f/17c4a08883877e0139455b5a87c2e599/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
+          "hash": "519569f665d13409fdc9444d17ff9cf77275ebc4f0a6b29c290b70c51ca1be60ab557962b4ed118567956b0aa29c6bf84e74845b62ebf47e579174c44143b4b0"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a40d0b31-f3cb-4e49-aa3f-dd24c4be148f/ba028e5db90d6b2166f78551a82f39e8/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
+          "hash": "30249d6228d37f5a76ea75a130afedc71c62b7e7618474dd25aaf87734bdf39758bf4ba318924e74e3d955cf511e6b537f016cb88a30685fcd00e783aeb0ecef"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d1bd32e-b91d-47dd-adde-e9871ff54127/b47f402aca31e6c2093f3f55c069f84f/dotnet-hosting-9.0.0-preview.6.24328.4-win.exe",
+          "hash": "5820ce5df0099855ce078b8f7c2039f6680afa9f3a7374d20d33624a0774026533b98cfa48b9d846257a8c1b17fb5e843476d23c6b49687b412270a4b670ca04",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.6.24327.6",
+      "version-display": "9.0.0-preview.6",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7fcc2e2e-536f-487c-9606-fa46a5dbc11b/fe46f091471d88a46222a125280975e3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.exe",
+          "hash": "8f5d4d070541105ec838e79ec36e097e281ebc7f947fdada663ce8f91ea1733f4c25b711bdf90ace632135ff1b44c6ab4d06fd19b5ce5c860a2f36f33a0562ec"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/970fb36e-b8fa-4cbb-a4a1-0a50bb403be2/37ec1a3f29546faac9b0029c1cfaf8f3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.zip",
+          "hash": "8c263fc12fc160eccced8069fff1e8d12d96a25dffd3402b35de7bd5ddab7591562445e4f05f82f49d7b989777e5b4496fa7593faa96e6ad9095cf79431831df"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/32b2d8fc-5f11-4773-bb42-953c09def1da/dc794fff482d2d89db656e4e139943fd/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.exe",
+          "hash": "88a39af22ef1e01e9161db019daf35edc2ea8a9bd359a4e10f9b9053bcd81babdf8867f2cffb43508914991648605646a3ad9c7d6e23e08d6010e9d64e573d28"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/33bf60f8-51e6-4224-bd19-c6f4e653e0a4/a42f1c6c3dd70817651ec6349d2de723/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.zip",
+          "hash": "e16afec8e8615de42d766e3ba1c4318458c6cb1c9a08e60cd21eab32f36a7cd10acd942c05733e29a1997355155f7f188913da39cb4646e2d2205dc0b36a06cf"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3ab0f618-276c-4f8b-a25c-50b1fc43ba7c/805a32b93762155832111503300120d3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.exe",
+          "hash": "79b565fed3bcc8eed6e430dfd162ed59a8c6d9d8e860cb3ce9ed9237a2cf654310527d7667fee891cd1cc9c103e81fb6bceb23e08e8512c0dae7edf57d49a277"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6eda409d-742d-4241-887f-31501b4c88d0/1c686614a0b2302b07d982d231bbc134/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.zip",
+          "hash": "076f7760efdb5c9123dea168bdebfb714b541b817f93b8ca73f6b91137ac90b71110c954721b1fae004de685c75eed4b50973b304b873b997d0698516c5ee91d"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/9.0/preview/preview7/release.json
+++ b/release-notes/9.0/preview/preview7/release.json
@@ -1,0 +1,513 @@
+{
+  "channel-version": "9.0",
+  "release-date": "2024-08-13",
+  "release-version": "9.0.0-preview.7",
+  "security": false,
+  "release": {
+    "release-date": "2024-08-13",
+    "release-version": "9.0.0-preview.7",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview7/9.0.0-preview.7.md",
+    "runtime": {
+      "version": "9.0.0-preview.7.24405.7",
+      "version-display": "9.0.0-preview.7",
+      "vs-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/074a9718-7e48-46ad-99c2-1de78504111f/23e4f1e407d3c7f019156e633a59f753/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm.tar.gz",
+          "hash": "6bf40d4e837f74f0ac92ce504c187b33ee1d6ba653dee8006bbaf5a6f923eeffba2cb9c2f938207856c84bb9e41d5c3f42d0a0b1dd62bbd9997e885beab6a3af"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/248e66b8-594d-4738-8b01-2aa045faf3fd/686e989ba0365848fb4f81f8d780812c/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm64.tar.gz",
+          "hash": "f7440b679315c6d35b12d839a1cf52c961784d56524f52e96a7834bbda7bf4e5bfd726081148cf71fb19b3107c7b1f39681a2fae7e87f1d9fa0634b70a47f4b2"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4c4efbb5-befb-41fd-aab2-7b1a0d0b4921/69e5daec0c5b967f7f27abbc49343c06/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm.tar.gz",
+          "hash": "d627507d36e0ee3e8a6253d0488bb2c85458ba124016b32c8a481ec3d603f4393b700f1cd08c5640aad1971546526898ffb049e9590cbd655dda4375b7d7757e"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d680fd8e-6530-4da3-85d9-9c76c56cc737/c4d4b30f592e8a374f86c7f261886207/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm64.tar.gz",
+          "hash": "57bb109d2bd66c6e273b54d4bbb4836a53375f1cb13bed1139c6bc950f85de774070014fd19ddb8b43588fa32f6de60811b43cbff5d29b1f537cb8206561fc5c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0c5ee877-7142-41e4-bca9-244fa4fa129f/46a54128a24c0a2c75ca2d4e8aca5f28/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-x64.tar.gz",
+          "hash": "343d911894ff3b61cf6ee560b5a5da14a8b84e9dffa2211529d885e81314a6b0e88b6018b3a116f05b0bcd6e80b2a1e8cb45547f193a49a3aafcdf3992b580e7"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41a47c9d-c08b-4abe-a2d1-920b51fe16b0/f6af3aa0615cc1625bfc77cd38e16d02/dotnet-runtime-9.0.0-preview.7.24405.7-linux-x64.tar.gz",
+          "hash": "9ede46bc2e6f87a9f592f888562a4cdda6ffa01ca9822f6d4ae586a7c478d3e4fe6c70758a4e9ecbba86445978c68f805d1d6d6f4d37fc653a2b7510309dd5dc"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f79b68ef-768b-462d-a96a-33d7a8129021/94bcf8b454c20f901564223fcc5b4e76/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.pkg",
+          "hash": "b6d520b49da68a823a0279ab93f5aef4f8381fe8fb45ea3e0998eccd111300331f1196d95e22f9d7bb64e74cc5f0dde2c33b63a4db3b56da60b3e0cf8c9e4cbb"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a71e7742-36b6-4f68-a573-b3437fc53a77/571d8fff000e17abd5d820cafc600b63/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.tar.gz",
+          "hash": "ade75303e39c33af6d7ea10369bb87d5d446619d2ffa630db1e8342b1577efe6831d8f32316fb0e0536e56e0adb7978c4e1b75ddef9a2d1cda8657b8fc457356"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/117d87f9-aa46-4ca0-b884-a04580c7edac/3cdfbfd89b544c9726aedd7b32e00d3d/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.pkg",
+          "hash": "1be6f9be0cab72e50a99350b4a8517a428c468b83e9c69eb0fe3253ae62586507f1600173efacc049dafae5252721120a27611c68854104d3f737ec3d87f47c7"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dc29a044-d48d-43cd-a56c-2b8cba456df2/888138574a36ee8c2fe1af2e33c1119d/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.tar.gz",
+          "hash": "17352746d1b780272766c6ea20bdb0961f8004bafc529877644fa536bc0e7441eb48d65cd05c4eb9017249651361c773d89b1ec1c1720bd4fce0fe965614d48a"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/89f9e7e7-67fd-4524-8dde-9b89ca1ca74a/7a5880589767e7270561fc544143493e/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.exe",
+          "hash": "cf8b6518c1daf0d5c25d42c7ed5370a6f853b496903822cb254af9064bc91578ce8476d75c8373ad3492d182c3db4459a933afb28f134059937ab5b7c27b7dd6"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/151ce0ec-b807-4a23-9ae4-ba674d45b29b/3853e079685484b17d9e38b17e3b2e10/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.zip",
+          "hash": "5f45a3ccde7dd587451d45eaf70756877df4646f4b9411948e2b71bd7da2d48d513c54f0642e44d306d75e969a01f4d2931eb980de3c71cb1172604c89838432"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7ed661b8-ac50-444b-9540-5ee529b2e4aa/8780dd90140b747748e1ec15705c64e2/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.exe",
+          "hash": "7246da48251745c46acba6c3cf0c53e66eed0c17c8579e167a0cec928190e7a38ecc905dd1dcefc7e9e3baaf633186858b6dc7d4b8d52218192bc3580fabd05b"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7391d24-2880-452a-8fd0-5b72cf81049c/fdd37234b82b7e50a8a1575680246df4/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.zip",
+          "hash": "063c60a61ef96c06be677f9a418e807134563b8cd03be861924ab13325051070a570457a1e32ac676e8e70158a5fcf5e652b4484f15b517086e34faaee1071ee"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/98c838c8-d2c9-4660-9bb0-2e4587a8e016/d1fc3857e4914f991bf3ef769972ee0e/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.exe",
+          "hash": "e3292dfa9b747f15d7a928b2f09cc0e1e3662276303aea0535f96018d9ea58bfd36d5353638438bab611e491551fea8bf38773351065b13a3ef69d7f19ab9ea6"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bf90ebe8-dd13-49c1-9945-c62c742739f7/dc34e583261c1acb3de46c36e3837572/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.zip",
+          "hash": "545d98b9757995faff8222e18a918519ca0e4fe4ecfd3216d622bf380a5b1a49109b07957b22f7069b8aa2d1bc89e0d0be6dc1c079e7d95d481b77d164125923"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "9.0.100-preview.7.24407.12",
+      "version-display": "9.0.100-preview.7",
+      "runtime-version": "9.0.0-preview.7.24405.7",
+      "vs-version": "",
+      "vs-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d684965c-26a1-4ad9-964e-eba707075cb2/a76775d98eb7565314c7061881ebda5e/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
+          "hash": "b97c357cf8a2e129b222748e23b59343c4264b6dc9dbe00c5a01bf2d3f57c1a6bc61e5ec053b75ce0d17434977e1616d3efb7c4642aca18d8bb5fe7b6c0f906d"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9dce0bb1-16ab-4670-9af4-57b6bd1c0c21/ba6055b1ad714158742dd1b2373adaed/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
+          "hash": "c8ae08858c9ccf16d7b4879b7201ea22bd59e97f1924d4ff2b25079168c906d88a2864e6796244b67db612a36170969fef212879aa3b2232418795c7e7e6d526"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ad7426e9-3acf-402b-a2d4-de7046d67137/8c596827e70ab0960dad22502e17d7fc/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
+          "hash": "cd27cfd56483c51f48d12c204e3de0bd490b081d2add0d3db9f1ae905cef7470613727beb5213c6e68a9dacd2c46ccab8e4bf2b37eb5a8ea19a5d30447c42918"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dbf65449-bd68-4127-b39e-0a63b7807d01/107d0ef2ea0f771da9922f9bde0f04c4/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
+          "hash": "1ccb6b8ad6e2d32f3d27b234783cde01e25e5c319ca8c5f90320e1ea2cf4f2a3cc58841a9d781c3a63d8a03b458391dd45a16c96d20a0c4f80e570d6decd80f9"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0499097c-376a-4e66-b011-fe4996c96795/c3e842772e3edaedfd3410467b789519/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
+          "hash": "f558d4d3e8ae430ce544a8157197f9084849998f8788e26b9a20f742761ac1ab09c12423e0d1eed1d3bed7a25788b717e3525586b10977f9bec414ae76ac3515"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/84a39cad-2147-4a3e-b8fd-ec6fca0f80dd/d86fc06f750e758770f5a2237e01f5c5/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
+          "hash": "3bc1bddb8bebbfa9e256487871c3984ebe2c9bc77b644dd25e4660f12c76042f500931135a080a97f265bc4c5504433150bde0a3ca19c3f7ad7127835076fc8e"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1f851fbf-f9d3-4b2a-9189-a1686bcb4853/8f8c50e3186b29bfc0a65f9a0ba7c31d/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
+          "hash": "43667fec64adddd6b61628a047c0cea2c4c14b4958a5e6589ba0df7a56727416d293c559c6a9089a8d703a8444ebf929df2db6f3362f40c96cee14aebcd6a815"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/49e6076a-438d-44de-a34d-6ad47af02423/f20bca6b909e3bd42679c14c8288fd0f/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
+          "hash": "0af77ffeb27e44b2e695caabfa85254f94c77807be6d96fc6abdda1d71be266857320c5dc02d5df968da8963a52cd2aea4b4cad6dfc6540ad26b7b532bf83fd9"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8fe9315f-284a-400c-8e09-6f8ad474ad46/8ebb620e266c23d064f2cb7f0de1e635/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
+          "hash": "ff9d18978e2e6b18baeb5b731a52f39458fa65fe2f6ff758e5b1b31b831817ca27149ce9231840ba39a88e2ec5f649b734097129cd8dbfef7f96bf21ec8a23d7"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4a7fc24d-481e-4202-8654-06cf5fba0ebd/a4084481acd9aa803ad1ebf3cd668646/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
+          "hash": "b410a65d69f991ea55c81e5f7ea58c98ceef309d63ddd21a7689848a4a4516cdb898f8e36702a554a51fc22420cfbffe7a662a785175bbc1ebe1c33fcf6ffbf8"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1b2a7758-984e-43f4-9277-bf33de3b3c87/af83a9dc52a935e10e80f9584d8cfdb1/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
+          "hash": "0d6db7e772809f87bd70c6b5468f37ff14b466c59f3f3c0f85848b2cb7e938f550768b0a8a70ddb3dae0f900a6abe69dd6c641393e772d857a5160167c4b76cc"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/017ef318-d4b0-407a-8850-255a96480d9a/90cea33924e1ae3ddab243fb4c25ce41/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
+          "hash": "69c9b7fd4772509a343907a3cc386660caff5295fda42e64ae62c52147ba2adbd9511fa976dd9738df0643a3596a5c7eaa3e51a0f8bc8ffd4101eea706a5dd2b"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7f691a3a-ddc2-4d1e-b447-7e87da162f9f/b320579c671f8f08ed6979bb93f23ff4/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
+          "hash": "53a429eec91b4335d2ff1822bd2b41c826b06a53d187d24645a991066f28498d93f06557bd1c471a9334dc02bcdb3b6d075cfa9d6c894bdfc0f29c0b6e0d7a02"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dee149e6-a8bd-4290-ac01-ca2740fde18a/bffedcce6bab8b98bdbc75201cfbc9ad/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
+          "hash": "99ed1ff4207b8e465b0a483649be860164fb9d4003ee08b1758d0db0df194dda523be4896572c21bfc6ca333f3408b48c14872cf5748a5af7c4d2682f29d8d3b"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c25296ec-5287-4386-9a05-d45536f34943/0050fe9eaf6e3c4bbaa150a179d01829/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
+          "hash": "fd527045869746eb27acde707a054618f5f9757ea44333d1088013de9d5efef0c398ebfc911127a6a1a3ea292572db4e1f5d0e687f3e3e44bf45a3aa7816595c"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/acffccad-e120-49de-b2a7-f02883a53063/6dbe2a464e389c3d2a57bf069538c44f/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
+          "hash": "ba3b33dc34e811e9d740e9af00844a5cc67372718e45226b859812b917ac50b9249397752c8b0b63ce87339df5530f1e27d8863bfd2690834e51c38cb3bf4be7"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "9.0.100-preview.7.24407.12",
+        "version-display": "9.0.100-preview.7",
+        "runtime-version": "9.0.0-preview.7.24405.7",
+        "vs-version": "",
+        "vs-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d684965c-26a1-4ad9-964e-eba707075cb2/a76775d98eb7565314c7061881ebda5e/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
+            "hash": "b97c357cf8a2e129b222748e23b59343c4264b6dc9dbe00c5a01bf2d3f57c1a6bc61e5ec053b75ce0d17434977e1616d3efb7c4642aca18d8bb5fe7b6c0f906d"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9dce0bb1-16ab-4670-9af4-57b6bd1c0c21/ba6055b1ad714158742dd1b2373adaed/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
+            "hash": "c8ae08858c9ccf16d7b4879b7201ea22bd59e97f1924d4ff2b25079168c906d88a2864e6796244b67db612a36170969fef212879aa3b2232418795c7e7e6d526"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad7426e9-3acf-402b-a2d4-de7046d67137/8c596827e70ab0960dad22502e17d7fc/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
+            "hash": "cd27cfd56483c51f48d12c204e3de0bd490b081d2add0d3db9f1ae905cef7470613727beb5213c6e68a9dacd2c46ccab8e4bf2b37eb5a8ea19a5d30447c42918"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dbf65449-bd68-4127-b39e-0a63b7807d01/107d0ef2ea0f771da9922f9bde0f04c4/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
+            "hash": "1ccb6b8ad6e2d32f3d27b234783cde01e25e5c319ca8c5f90320e1ea2cf4f2a3cc58841a9d781c3a63d8a03b458391dd45a16c96d20a0c4f80e570d6decd80f9"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0499097c-376a-4e66-b011-fe4996c96795/c3e842772e3edaedfd3410467b789519/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
+            "hash": "f558d4d3e8ae430ce544a8157197f9084849998f8788e26b9a20f742761ac1ab09c12423e0d1eed1d3bed7a25788b717e3525586b10977f9bec414ae76ac3515"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/84a39cad-2147-4a3e-b8fd-ec6fca0f80dd/d86fc06f750e758770f5a2237e01f5c5/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
+            "hash": "3bc1bddb8bebbfa9e256487871c3984ebe2c9bc77b644dd25e4660f12c76042f500931135a080a97f265bc4c5504433150bde0a3ca19c3f7ad7127835076fc8e"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f851fbf-f9d3-4b2a-9189-a1686bcb4853/8f8c50e3186b29bfc0a65f9a0ba7c31d/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
+            "hash": "43667fec64adddd6b61628a047c0cea2c4c14b4958a5e6589ba0df7a56727416d293c559c6a9089a8d703a8444ebf929df2db6f3362f40c96cee14aebcd6a815"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/49e6076a-438d-44de-a34d-6ad47af02423/f20bca6b909e3bd42679c14c8288fd0f/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
+            "hash": "0af77ffeb27e44b2e695caabfa85254f94c77807be6d96fc6abdda1d71be266857320c5dc02d5df968da8963a52cd2aea4b4cad6dfc6540ad26b7b532bf83fd9"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8fe9315f-284a-400c-8e09-6f8ad474ad46/8ebb620e266c23d064f2cb7f0de1e635/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
+            "hash": "ff9d18978e2e6b18baeb5b731a52f39458fa65fe2f6ff758e5b1b31b831817ca27149ce9231840ba39a88e2ec5f649b734097129cd8dbfef7f96bf21ec8a23d7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4a7fc24d-481e-4202-8654-06cf5fba0ebd/a4084481acd9aa803ad1ebf3cd668646/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
+            "hash": "b410a65d69f991ea55c81e5f7ea58c98ceef309d63ddd21a7689848a4a4516cdb898f8e36702a554a51fc22420cfbffe7a662a785175bbc1ebe1c33fcf6ffbf8"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1b2a7758-984e-43f4-9277-bf33de3b3c87/af83a9dc52a935e10e80f9584d8cfdb1/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
+            "hash": "0d6db7e772809f87bd70c6b5468f37ff14b466c59f3f3c0f85848b2cb7e938f550768b0a8a70ddb3dae0f900a6abe69dd6c641393e772d857a5160167c4b76cc"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/017ef318-d4b0-407a-8850-255a96480d9a/90cea33924e1ae3ddab243fb4c25ce41/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
+            "hash": "69c9b7fd4772509a343907a3cc386660caff5295fda42e64ae62c52147ba2adbd9511fa976dd9738df0643a3596a5c7eaa3e51a0f8bc8ffd4101eea706a5dd2b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7f691a3a-ddc2-4d1e-b447-7e87da162f9f/b320579c671f8f08ed6979bb93f23ff4/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
+            "hash": "53a429eec91b4335d2ff1822bd2b41c826b06a53d187d24645a991066f28498d93f06557bd1c471a9334dc02bcdb3b6d075cfa9d6c894bdfc0f29c0b6e0d7a02"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dee149e6-a8bd-4290-ac01-ca2740fde18a/bffedcce6bab8b98bdbc75201cfbc9ad/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
+            "hash": "99ed1ff4207b8e465b0a483649be860164fb9d4003ee08b1758d0db0df194dda523be4896572c21bfc6ca333f3408b48c14872cf5748a5af7c4d2682f29d8d3b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c25296ec-5287-4386-9a05-d45536f34943/0050fe9eaf6e3c4bbaa150a179d01829/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
+            "hash": "fd527045869746eb27acde707a054618f5f9757ea44333d1088013de9d5efef0c398ebfc911127a6a1a3ea292572db4e1f5d0e687f3e3e44bf45a3aa7816595c"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/acffccad-e120-49de-b2a7-f02883a53063/6dbe2a464e389c3d2a57bf069538c44f/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
+            "hash": "ba3b33dc34e811e9d740e9af00844a5cc67372718e45226b859812b917ac50b9249397752c8b0b63ce87339df5530f1e27d8863bfd2690834e51c38cb3bf4be7"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0-preview.7.24406.2",
+      "version-display": "9.0.0-preview.7",
+      "version-aspnetcoremodule": [
+        "19.0.24219.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e16d860-eacd-48cb-9d3b-a29894cf74fc/f1e9a698798f7325b1e28588c7075cfb/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
+          "hash": "c5a60fc24cfd9ccb27c022938a93668a344f1f3f1bdb41e01f4740bb798ad04341b5b30fd4aef129d936c909ad8473cf6072a76f999ec626221df9696c73dcc5"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/28370706-3338-4dd5-9992-6cd1d86ba666/354c9434538f587c3198fe57fa0d2e00/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
+          "hash": "706925fde5bb93b98e347540fe0983ce0819a2ca2520ed2d5bfc4515cb6852587a30f29852b512509b660daf8ee76ff3c8bb2d2fd78e47c6ae156e6f00cde918"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/058d32bd-03e3-4867-8c62-79e88b5b9b69/784891ca110016d0afa902cc4176e46f/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
+          "hash": "08b67ca34122f063370d0f24606174026d3e67f8767ac2e4c4393c214e608d47d82dad177a97c5e6e28d089412403f75012c00cdaabb109e461e266ad6a620c5"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/94ac38de-a00b-45a1-a37a-c7b4d8a52ddf/135aa93213a5f87c7feaf267e305a3b3/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
+          "hash": "df15606e28e68162739d6b5f3a3852664cbd8d78ff8e8ebed07e2f78c8699d0dd4bd2a3c3b5c98b63bfdae1106720fd4069d349d0d4e32037deea77a4e97efed"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/60441f64-edc5-4c33-8022-107be30d728b/a3375f19b72b8e23d5394e3a1e2a1806/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
+          "hash": "bddb66623e26d391d4587b46f6b7be5280788eb0355c558044016c1a12062005f2627bd3fdf51cb271f85eaa91fb920532ef235edd764e4ca63931595e1fb52b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bdb8a419-432c-4f1c-b5ad-ae6e27617b5c/65b26a64e3dda62c456a7a45df73dc1e/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
+          "hash": "44f86c407b501a700aaeae2ce95cf544d85c08b41cdd12cee22bfcfdd03c4f6a16e495d9f8315f5e56a66b7e6187a4fc39d899f967a65f73883e40172343275c"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b2836c76-8c1d-4030-b7f6-0cd5ec1b640b/ea922caf251b0245b96ba2afd7ebb2b4/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-arm64.tar.gz",
+          "hash": "8200af559c76f5bf12f5e0495c285a837dbe29c7ac2d6c562540f7077aa68fa65dc05205b4b219e72f78d55c20a75a514f6ccf3f53d6ecf34fd2cea0817a7ede"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d0813855-fdde-47df-8d71-119af034e409/40989f36db96de19bc682d62cbadd8e3/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-x64.tar.gz",
+          "hash": "0f309d6b849ccec8e13812de9ff70fac5cc78785b71f356fc63e5070296305766892a3dfd74bae9b4775ec4449335d03d046494a416304f56e5ba7746f3316ca"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d56241f9-9411-4ee7-b656-872d5666bb99/5015011e1f74c0be2e3e88ec842112d2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.exe",
+          "hash": "c3acd624e17bf532bc7c3a1045d551e94a1cc70b8c126c816c64dc788db0152c6737cb703bc76a04a84cf6a11dc589f46e38c1c825860d5f32514bb2fa41e54b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/18014125-ce33-4c3b-94d1-365b12e16aee/c0981da139aa9fbb392cf9d88b8b3da6/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.zip",
+          "hash": "aa0fcb2d6f74856e9e65d13504c313d4237cb98e55b122c3a2fd89bb4c4307b65bd6386f7350e264d6e4499eaf55ff79766218a2708bb556a66502c62ecf6a7e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e085306-10ef-4184-a5ef-113ccadcd55f/ac63196a2fcccbbcb41a7e73de73caca/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.exe",
+          "hash": "a1b17cbe3b028f41c8d8b3c9608112692004259a62ce45efe658ff9506016b8c16e7482708b0f1a861bac21fed19205bed880c790d58c3d1cfd62b81933953ae"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/150e0d3c-4bca-4c0c-acc2-09ac93f32a6c/0ad15ba162c80b92f5bea820c6b646e4/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.zip",
+          "hash": "ce32f77bfb17c15c85968bd3062d6d628ce5d7b1b1bc5d1cab1c7b659253ad869c264b6e98773a57ce80cb818c22db5da79ed6b32affe6f8be0f1952069c7714"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b4aa5307-82ed-462f-aeb2-b461c4eeb6f6/875b2ae1460fff14911a6ae9ee723c15/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.exe",
+          "hash": "3b3bdf4c59fea2035881a95d611f06f64d468e57c85f1c4c04566e6286bfebe1f35837f61c28504697856a782dbcf3b613b51fac41003b3f5bec0ac816894971"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fb394383-000b-4ec1-a995-6270b205201f/74866e7e6391f5fa17c479ee0cd4b9e6/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.zip",
+          "hash": "42c04862e239e07b698dfdc1f39633c42ff196e84569660a1dc2f74ea910a705c91cd1f2453efbc8243de883c89452ede139647c272552e29fb9e57c7dacd494"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1c178b77-927a-4852-9637-6dc401a290a3/3c485a7d5ebd8e80d73d3d6c693e0f88/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
+          "hash": "7839fa20a2a6459f2c4ba41844ac6c57a0eff6ffd8eaef0463ca44918405a0ab3d1b80e7d3943d7c14db21d0d2cf5490a44d1bdfbc9492138d80dbe228910960"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ff3b69c9-f76f-4a7b-af13-123d491c0861/baf999495f1dd404918562f079db60fc/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
+          "hash": "9805dfd4167cf7d67153044265921df12883d67812342779f26b7f400658a117a25b54e29e83bbc8757899d6c96af52d7b35226ebaf2b7a9524b1114d580a741"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6201b645-6b36-41ff-911a-3a2807b8ff22/efaabeb363f451008341297b8a500c53/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
+          "hash": "ada585f833f0d4617d36df8ccdf716553e275cb7b49bae3e44945fd3826d3152eef1830339d069cdc0d60f3947f031647929c7580c97ad768e8b32b7f06274ef"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/21b93eac-4fd9-4606-a87e-4c9e5ab2383f/f72967bdefbc4c75379a477bfbd10f02/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
+          "hash": "d4ec9d402d78a5da914642622a47da05e6c0b55c80ccbd1ba0c1a6c336e38f8598b0b30b986e5d0d296d1ff1783f53cb369d9a7a3c4da25b94c8c6ed4cf67291"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1a9130ec-0085-4a3e-8a24-1f8378108e84/a3d8bbd3d85578085cc5a3583f63d371/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
+          "hash": "2edd041b05b65e35464d7941bd1453f97d510408f51ea6e08dadcc81a76529e3500f4c62c48249b68ac2662a42bf8b00d4bcc6f998d3bdf594929914a9d5deed"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9c538089-9dc0-44bd-9872-34881002e6f9/6690bcaed6d067f6599420052968a9d0/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
+          "hash": "5a580a89c144a268ceeaf2171f2a60f31ab99c3c1879d043920cf4a0a70eb5d3aa0419029408f64ddb1930ebf830e4988d9356dd7dd7819fde570622aeeab7b5"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fdd84cd2-f012-47c1-bf90-df245aef7fdc/04161e728311f32a1ec0f9f973a9d606/dotnet-hosting-9.0.0-preview.7.24406.2-win.exe",
+          "hash": "84426e1c134c0bf6227ed9610a252c562470b65c76a10153e5123b2939f3daaa2e7e067f65de9629ed8542b480ba8549dd0301b58ad94380b8b35cf096882b56",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0-preview.7.24405.2",
+      "version-display": "9.0.0-preview.7",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b0080098-a31b-49e1-9624-2864c4d2c4f1/843fbd5a038f44630b0e007da84a2ac1/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.exe",
+          "hash": "c559f8c488d2b94e12e5fe7e61c89eb28ef74b7fe0f52b991e52361d417385521e60384b7db8b7ade2b81cd5f8e905bb31b2d1574e16c506bc998e81171ed0e1"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1a4c7151-99b9-4601-b160-01d09cd8ed4c/893ed6327a2f1367c0d59d30121b0fc7/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.zip",
+          "hash": "463b8ac6e5b9f62eddec20009ff2517b2a5f90cc1d6047cc005fb446a344c1337cbf0f59ced2749e1b569ef44942c5c7150dbeb10e0ce1f9a76e9c45a1d1bbe4"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ef26a963-0101-4288-900e-71c17f210316/99d1cccde7fffb997ee4af1cf024ae54/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.exe",
+          "hash": "77ffd490b614126debd79a3984df39cacfaa11049e4d209ccbde0e37e48f8169183b369c294b2f5b4e51ed1bee78ae56b4fcb794a663b6c4515248346f838ea3"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dbecfc4d-1b43-4fe1-833c-6fc188f7b7eb/99b15fbc905fdf2343bc6813c8d4c6b7/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.zip",
+          "hash": "296cf946d83670772dc6794f1019549f59987cfc50cdfa4d04e756fc16174381249b15fc0dd2b154f17be0df2fc4e2b25f95601a238765cf29ad103033125b2a"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3373f83-b929-4d53-bf74-c0095ad6c900/e7f11b0a8e2a617fbbd55bba7dc15007/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.exe",
+          "hash": "7eb2c020a8849ff267e6bbe441913773d5a1e8cdb4bcd81bccc73d424a55f398ca4228fcbbd48e191d333d4a6a0b37ed7a4db03edecdd19262dc3f0cbec77d03"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/86a1653f-b9ca-4bc1-8b75-07d31812de15/de93ce0c63d3ff059f1e147ed3618680/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.zip",
+          "hash": "d29732075a45d16dfde9c02957ab2532053721c9cf3e41f37cd59afe866ed06138d82b1aa94668f0f0697abd07c983a309e6f79aac9f0b17a8470cff6be8e281"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I generated patch-release files for 8.0+. That was a choice. We can make a different choice.

There are links to blob storage. We can copy the files before merging or we make these GH links (it's just a code change) while we're getting this all figured out. Either works for me.

https://github.com/dotnet/core/pull/9480/files#diff-4792c8566cd38c9a12d0f0d06b0c9fc272aa7c941324a18da65dc9223b05955bR11

Contributes to https://github.com/dotnet/core/issues/9417 and borrows from https://github.com/dotnet/core/pull/9427.

@Falco20019 @leecow 