### PR TITLE
Fix supported-os.{md,json}

### DIFF
--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "6.0",
-    "last-updated": "2024-07-11",
+    "last-updated": "2024-08-23",
     "families": [
         {
             "name": "Android",
@@ -184,10 +184,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12",
-                        "11"
+                        "12"
                     ],
                     "unsupported-versions": [
+                        "11",
                         "10"
                     ]
                 },
@@ -244,7 +244,9 @@
                     ],
                     "supported-versions": [
                         "9",
-                        "8",
+                        "8"
+                    ],
+                    "unsupported-versions": [
                         "7"
                     ],
                     "notes": [
@@ -261,6 +263,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "15.6",
                         "15.5",
                         "12.5"
                     ],
@@ -285,11 +288,11 @@
                     ],
                     "supported-versions": [
                         "24.04",
-                        "23.10",
                         "22.04",
                         "20.04"
                     ],
                     "unsupported-versions": [
+                        "23.10",
                         "23.04",
                         "22.10",
                         "21.10",

--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "6.0",
-    "last-updated": "2024-08-23",
+    "last-updated": "2024-08-26",
     "families": [
         {
             "name": "Android",
@@ -184,10 +184,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12"
+                        "12",
+                        "11"
                     ],
                     "unsupported-versions": [
-                        "11",
                         "10"
                     ]
                 },

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 6 - Supported OS versions
 
-Last updated: 2024-08-23
+Last updated: 2024-08-26
 
 [.NET 6](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -47,7 +47,7 @@ OS                              | Versions                    | Architectures   
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
 [CentOS][8]                     | [None][None]                | x64                   | [Lifecycle][9]
 [CentOS Stream][8]              | 9                           | Arm64, s390x, x64     | [Lifecycle][10]
-[Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
+[Debian][11]                    | 12, 11                      | Arm32, Arm64, x64     | [Lifecycle][12]
 [Fedora][13]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][14]
 [openSUSE Leap][15]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][16]
 [Red Hat Enterprise Linux][17]  | 9, 8                        | Arm64, x64            | [Lifecycle][18]
@@ -130,7 +130,6 @@ Android                 | 9             | [2022-01-01](https://developer.android
 CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
 CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
 CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
-Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
 Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 6 - Supported OS versions
 
-Last updated: 2024-07-11
+Last updated: 2024-08-23
 
 [.NET 6](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                     | Architectures      |
---------------------------------|------------------------------|--------------------|
-[iOS][2]                        | 17, 16, 15                   | Arm64              |
-[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
-[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | 17, 16, 15                   | Arm64              |
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 17, 16, 15                  | Arm64
+[iPadOS][3]                     | 17, 16, 15                  | Arm64
+[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[tvOS][5]                       | 17, 16, 15                  | Arm64
 
 Notes:
 
@@ -42,17 +42,17 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
-[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
-[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
-[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
-[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
-[SUSE Enterprise Linux][20]     | 15.5, 12.5                   | Arm64, x64         | [Lifecycle][21]    |
-[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
+[CentOS][8]                     | [None][None]                | x64                   | [Lifecycle][9]
+[CentOS Stream][8]              | 9                           | Arm64, s390x, x64     | [Lifecycle][10]
+[Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
+[Fedora][13]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][14]
+[openSUSE Leap][15]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][16]
+[Red Hat Enterprise Linux][17]  | 9, 8                        | Arm64, x64            | [Lifecycle][18]
+[SUSE Enterprise Linux][19]     | 15.6, 15.5, 12.5            | Arm64, x64            | [Lifecycle][20]
+[Ubuntu][21]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][22]
 
 Notes:
 
@@ -63,53 +63,49 @@ Notes:
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
 [9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
-[10]: https://centos.org/
-[11]: https://www.centos.org/cl-vs-cs/
-[12]: https://www.debian.org/
-[13]: https://wiki.debian.org/DebianReleases
-[14]: https://fedoraproject.org/
-[15]: https://fedoraproject.org/wiki/End_of_life
-[16]: https://www.opensuse.org/
-[17]: https://en.opensuse.org/Lifetime
-[18]: https://access.redhat.com/
-[19]: https://access.redhat.com/support/policy/updates/errata/
-[20]: https://www.suse.com/
-[21]: https://www.suse.com/lifecycle/
-[22]: https://ubuntu.com/
-[23]: https://wiki.ubuntu.com/Releases
+[10]: https://www.centos.org/cl-vs-cs/
+[11]: https://www.debian.org/
+[12]: https://wiki.debian.org/DebianReleases
+[13]: https://fedoraproject.org/
+[14]: https://fedoraproject.org/wiki/End_of_life
+[15]: https://www.opensuse.org/
+[16]: https://en.opensuse.org/Lifetime
+[17]: https://access.redhat.com/
+[18]: https://access.redhat.com/support/policy/updates/errata/
+[19]: https://www.suse.com/
+[20]: https://www.suse.com/lifecycle/
+[21]: https://ubuntu.com/
+[22]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
-[Windows][26]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 20H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
-[Windows Server][28]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][29]    |
-[Windows Server Core][30]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][31]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][23]               | 2022, 2019                  | x64                   | [Lifecycle][24]
+[Windows][25]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26]
+[Windows Server][27]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][24]
+[Windows Server Core][23]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][24]
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://www.microsoft.com/windows/
-[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[28]: https://www.microsoft.com/windows-server
-[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[25]: https://www.microsoft.com/windows/
+[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[27]: https://www.microsoft.com/windows-server
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc                     | Version  | Architectures      | Source             |
--------------------------|----------|--------------------|--------------------|
-glibc                    | 2.17     | x64                | CentOS 7           |
-glibc                    | 2.23     | Arm64, Arm32       | Ubuntu 16.04       |
-musl                     | 1.2.2    | Arm64, x64         | Alpine 3.13        |
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.17    | x64                   | CentOS 7
+glibc           | 2.23    | Arm64, Arm32          | Ubuntu 16.04
+musl            | 1.2.2   | Arm64, x64            | Alpine 3.13
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 incompatible glibc](https://github.com/dotnet/core/discussions/9285) or a Y2038 compatible glibc with [_TIME_BITS](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) set to 32-bit, for example Debian 12, Ubuntu 22.04, and lower versions.
 
@@ -121,61 +117,64 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-OS                              | Version                      | Date               |
---------------------------------|------------------------------|--------------------|
-Alpine                          | 3.16                         | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
-Alpine                          | 3.15                         | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html) |
-Alpine                          | 3.14                         | [2023-05-01](https://alpinelinux.org/posts/Alpine-3.14.10-3.15.8-3.16.5-released.html) |
-Alpine                          | 3.13                         | [2022-11-01](https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html) |
-Alpine                          | 3.12                         | [2022-05-01](https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html) |
-Android                         | 11                           | 2024-02-05         |
-Android                         | 10                           | 2023-03-06         |
-Android                         | 9                            | [2022-01-01](https://developer.android.com/about/versions/pie) |
-CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
-CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
-CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
-Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
-Fedora                          | 38                           | 2024-05-21         |
-Fedora                          | 37                           | 2023-12-05         |
-Fedora                          | 36                           | 2023-05-16         |
-Fedora                          | 35                           | 2022-12-13         |
-Fedora                          | 34                           | 2022-06-07         |
-Fedora                          | 33                           | 2021-11-30         |
-iOS                             | 12                           | [2023-01-23](https://support.apple.com/HT209084) |
-iPadOS                          | 12                           | -                  |
-macOS                           | 11                           | [2023-09-26](https://support.apple.com/HT211896) |
-macOS                           | 10.15                        | [2022-09-12](https://support.apple.com/HT210642) |
-Nano Server                     | 20H2                         | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring) |
-Nano Server                     | 2004                         | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing) |
-openSUSE Leap                   | 15.4                         | 2023-12-07         |
-openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
-openSUSE Leap                   | 15.2                         | [2022-01-04](https://web.archive.org/web/20230529015218/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.2/) |
-SUSE Enterprise Linux           | 15.4                         | 2023-12-31         |
-SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
-SUSE Enterprise Linux           | 15.2                         | 2021-12-31         |
-SUSE Enterprise Linux           | 12.4                         | 2020-06-30         |
-SUSE Enterprise Linux           | 12.3                         | 2019-06-30         |
-SUSE Enterprise Linux           | 12.2                         | 2018-03-31         |
-tvOS                            | 12                           | -                  |
-Ubuntu                          | 23.04                        | 2024-01-20         |
-Ubuntu                          | 22.10                        | 2023-07-20         |
-Ubuntu                          | 18.04                        | 2023-05-31         |
-Ubuntu                          | 21.10                        | 2022-07-14         |
-Ubuntu                          | 21.04                        | 2022-01-20         |
-Windows                         | 10 21H2 (E)                  | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
-Windows                         | 11 21H2 (W)                  | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-Windows                         | 10 21H2 (W)                  | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information) |
-Windows                         | 10 20H2 (E)                  | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2) |
-Windows                         | 8.1                          | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81) |
-Windows                         | 10 21H1                      | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1) |
-Windows                         | 10 20H2 (W)                  | [2022-05-10](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2) |
-Windows                         | 10 1909 (E)                  | [2022-05-10](https://learn.microsoft.com/lifecycle/announcements/windows-10-1909-enterprise-education-eos) |
-Windows                         | 10 2004                      | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-10-version-2004-end-of-servicing) |
-Windows                         | 7 SP1                        | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7) |
-Windows Server                  | 20H2                         | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring) |
-Windows Server                  | 2004                         | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing) |
-Windows Server Core             | 20H2                         | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring) |
-Windows Server Core             | 1607                         | [2022-01-11](https://learn.microsoft.com/virtualization/windowscontainers/deploy-containers/base-image-lifecycle) |
-Windows Server Core             | 2004                         | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing) |
+OS                      | Version       | Date
+----------------------- | ------------- | ----------------------
+Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
+Alpine                  | 3.15          | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html)
+Alpine                  | 3.14          | [2023-05-01](https://alpinelinux.org/posts/Alpine-3.14.10-3.15.8-3.16.5-released.html)
+Alpine                  | 3.13          | [2022-11-01](https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html)
+Alpine                  | 3.12          | [2022-05-01](https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html)
+Android                 | 11            | 2024-02-05
+Android                 | 10            | 2023-03-06
+Android                 | 9             | [2022-01-01](https://developer.android.com/about/versions/pie)
+CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
+CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
+CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
+Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
+Fedora                  | 38            | 2024-05-21
+Fedora                  | 37            | 2023-12-05
+Fedora                  | 36            | 2023-05-16
+Fedora                  | 35            | 2022-12-13
+Fedora                  | 34            | 2022-06-07
+Fedora                  | 33            | 2021-11-30
+iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
+iPadOS                  | 12            | -
+macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
+macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
+Nano Server             | 20H2          | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring)
+Nano Server             | 2004          | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing)
+openSUSE Leap           | 15.4          | 2023-12-07
+openSUSE Leap           | 15.3          | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/)
+openSUSE Leap           | 15.2          | [2022-01-04](https://web.archive.org/web/20230529015218/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.2/)
+Red Hat Enterprise Linux | 7            | 2024-06-30
+SUSE Enterprise Linux   | 15.4          | 2023-12-31
+SUSE Enterprise Linux   | 15.3          | 2022-12-31
+SUSE Enterprise Linux   | 15.2          | 2021-12-31
+SUSE Enterprise Linux   | 12.4          | 2020-06-30
+SUSE Enterprise Linux   | 12.3          | 2019-06-30
+SUSE Enterprise Linux   | 12.2          | 2018-03-31
+tvOS                    | 12            | -
+Ubuntu                  | 23.10         | 2024-07-11
+Ubuntu                  | 23.04         | 2024-01-20
+Ubuntu                  | 22.10         | 2023-07-20
+Ubuntu                  | 18.04         | 2023-05-31
+Ubuntu                  | 21.10         | 2022-07-14
+Ubuntu                  | 21.04         | 2022-01-20
+Windows                 | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)
+Windows                 | 11 21H2 (W)   | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information)
+Windows                 | 10 21H2 (W)   | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information)
+Windows                 | 10 20H2 (E)   | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2)
+Windows                 | 8.1           | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81)
+Windows                 | 10 21H1       | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1)
+Windows                 | 10 20H2 (W)   | [2022-05-10](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2)
+Windows                 | 10 1909 (E)   | [2022-05-10](https://learn.microsoft.com/lifecycle/announcements/windows-10-1909-enterprise-education-eos)
+Windows                 | 10 2004       | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-10-version-2004-end-of-servicing)
+Windows                 | 7 SP1         | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7)
+Windows Server          | 20H2          | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring)
+Windows Server          | 2004          | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing)
+Windows Server Core     | 20H2          | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring)
+Windows Server Core     | 1607          | [2022-01-11](https://learn.microsoft.com/virtualization/windowscontainers/deploy-containers/base-image-lifecycle)
+Windows Server Core     | 2004          | [2021-12-14](https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing)
 
-[OOS]: #out-of-support-os-versions
+[None]: #out-of-support-os-versions

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "7.0",
-    "last-updated": "2024-07-11",
+    "last-updated": "2024-08-23",
     "families": [
         {
             "name": "Android",
@@ -179,10 +179,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12",
-                        "11"
+                        "12"
                     ],
                     "unsupported-versions": [
+                        "11",
                         "10"
                     ]
                 },
@@ -236,7 +236,9 @@
                     ],
                     "supported-versions": [
                         "9",
-                        "8",
+                        "8"
+                    ],
+                    "unsupported-versions": [
                         "7"
                     ],
                     "notes": [
@@ -253,10 +255,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "15.5",
-                        "15.4"
+                        "15.5"
                     ],
                     "unsupported-versions": [
+                        "15.4",
                         "15.3",
                         "12.5",
                         "12.4",
@@ -276,11 +278,11 @@
                     ],
                     "supported-versions": [
                         "24.04",
-                        "23.10",
                         "22.04",
                         "20.04"
                     ],
                     "unsupported-versions": [
+                        "23.10",
                         "23.04",
                         "22.10",
                         "18.04"

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "7.0",
-    "last-updated": "2024-08-23",
+    "last-updated": "2024-07-11",
     "families": [
         {
             "name": "Android",
@@ -179,10 +179,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12"
+                        "12",
+                        "11"
                     ],
                     "unsupported-versions": [
-                        "11",
                         "10"
                     ]
                 },
@@ -236,9 +236,7 @@
                     ],
                     "supported-versions": [
                         "9",
-                        "8"
-                    ],
-                    "unsupported-versions": [
+                        "8",
                         "7"
                     ],
                     "notes": [
@@ -255,10 +253,10 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "15.5"
+                        "15.5",
+                        "15.4"
                     ],
                     "unsupported-versions": [
-                        "15.4",
                         "15.3",
                         "12.5",
                         "12.4",
@@ -278,11 +276,11 @@
                     ],
                     "supported-versions": [
                         "24.04",
+                        "23.10",
                         "22.04",
                         "20.04"
                     ],
                     "unsupported-versions": [
-                        "23.10",
                         "23.04",
                         "22.10",
                         "18.04"

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                     | Architectures      |
---------------------------------|------------------------------|--------------------|
-[iOS][2]                        | 17, 16, 15                   | Arm64              |
-[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
-[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | [None][OOS]                  | Arm64              |
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 17, 16, 15                  | Arm64
+[iPadOS][3]                     | 17, 16, 15                  | Arm64
+[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[tvOS][5]                       | [None][None]                | Arm64
 
 Notes:
 
@@ -42,17 +42,17 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
-[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
-[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
-[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
-[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
-[SUSE Enterprise Linux][20]     | 15.5, 15.4                   | Arm64, x64         | [Lifecycle][21]    |
-[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
+[CentOS][8]                     | [None][None]                | x64                   | [Lifecycle][9]
+[CentOS Stream][8]              | 9                           | Arm64, s390x, x64     | [Lifecycle][10]
+[Debian][11]                    | 12, 11                      | Arm32, Arm64, x64     | [Lifecycle][12]
+[Fedora][13]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][14]
+[openSUSE Leap][15]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][16]
+[Red Hat Enterprise Linux][17]  | 9, 8, 7                     | Arm64, x64            | [Lifecycle][18]
+[SUSE Enterprise Linux][19]     | 15.5, 15.4                  | Arm64, x64            | [Lifecycle][20]
+[Ubuntu][21]                    | 24.04, 23.10, 22.04, 20.04  | Arm32, Arm64, x64     | [Lifecycle][22]
 
 Notes:
 
@@ -63,54 +63,50 @@ Notes:
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
 [9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
-[10]: https://centos.org/
-[11]: https://www.centos.org/cl-vs-cs/
-[12]: https://www.debian.org/
-[13]: https://wiki.debian.org/DebianReleases
-[14]: https://fedoraproject.org/
-[15]: https://fedoraproject.org/wiki/End_of_life
-[16]: https://www.opensuse.org/
-[17]: https://en.opensuse.org/Lifetime
-[18]: https://access.redhat.com/
-[19]: https://access.redhat.com/support/policy/updates/errata/
-[20]: https://www.suse.com/
-[21]: https://www.suse.com/lifecycle/
-[22]: https://ubuntu.com/
-[23]: https://wiki.ubuntu.com/Releases
+[10]: https://www.centos.org/cl-vs-cs/
+[11]: https://www.debian.org/
+[12]: https://wiki.debian.org/DebianReleases
+[13]: https://fedoraproject.org/
+[14]: https://fedoraproject.org/wiki/End_of_life
+[15]: https://www.opensuse.org/
+[16]: https://en.opensuse.org/Lifetime
+[17]: https://access.redhat.com/
+[18]: https://access.redhat.com/support/policy/updates/errata/
+[19]: https://www.suse.com/
+[20]: https://www.suse.com/lifecycle/
+[21]: https://ubuntu.com/
+[22]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
-[Windows][26]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
-[Windows Server][28]            | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
-[Windows Server Core][30]       | 2022, 2019, 2016             | x64, x86           | [Lifecycle][31]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][23]               | 2022, 2019                  | x64                   | [Lifecycle][24]
+[Windows][25]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26]
+[Windows Server][27]            | 23H2, 2022, 2019, 2016      | x64, x86              | [Lifecycle][24]
+[Windows Server Core][23]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][24]
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://www.microsoft.com/windows/
-[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[28]: https://www.microsoft.com/windows-server
-[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[25]: https://www.microsoft.com/windows/
+[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[27]: https://www.microsoft.com/windows-server
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc                     | Version  | Architectures      | Source             |
--------------------------|----------|--------------------|--------------------|
-glibc                    | 2.17     | x64                | CentOS 7           |
-glibc                    | 2.23     | Arm64              | Ubuntu 16.04       |
-glibc                    | 2.27     | Arm32              | Ubuntu 18.04       |
-musl                     | 1.2.2    | Arm64, x64         | Alpine 3.15        |
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.17    | x64                   | CentOS 7
+glibc           | 2.23    | Arm64                 | Ubuntu 16.04
+glibc           | 2.27    | Arm32                 | Ubuntu 18.04
+musl            | 1.2.2   | Arm64, x64            | Alpine 3.15
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 incompatible glibc](https://github.com/dotnet/core/discussions/9285) or a Y2038 compatible glibc with [_TIME_BITS](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) set to 32-bit, for example Debian 12, Ubuntu 22.04, and lower versions.
 
@@ -122,46 +118,46 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-OS                              | Version                      | Date               |
---------------------------------|------------------------------|--------------------|
-Alpine                          | 3.16                         | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
-Alpine                          | 3.15                         | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html) |
-Android                         | 11                           | 2024-02-05         |
-Android                         | 10                           | 2023-03-06         |
-CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
-CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
-CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
-Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
-Fedora                          | 38                           | 2024-05-21         |
-Fedora                          | 37                           | 2023-12-05         |
-Fedora                          | 36                           | 2023-05-16         |
-Fedora                          | 35                           | 2022-12-13         |
-iOS                             | 12                           | [2023-01-23](https://support.apple.com/HT209084) |
-iPadOS                          | 12                           | -                  |
-macOS                           | 11                           | [2023-09-26](https://support.apple.com/HT211896) |
-macOS                           | 10.15                        | [2022-09-12](https://support.apple.com/HT210642) |
-openSUSE Leap                   | 15.4                         | 2023-12-07         |
-openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
-SUSE Enterprise Linux           | 12.5                         | 2024-10-31         |
-SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
-SUSE Enterprise Linux           | 12.4                         | 2020-06-30         |
-SUSE Enterprise Linux           | 12.3                         | 2019-06-30         |
-SUSE Enterprise Linux           | 12.2                         | 2018-03-31         |
-tvOS                            | 17                           | -                  |
-tvOS                            | 16                           | -                  |
-tvOS                            | 15                           | -                  |
-tvOS                            | 12                           | -                  |
-Ubuntu                          | 23.04                        | 2024-01-20         |
-Ubuntu                          | 22.10                        | 2023-07-20         |
-Ubuntu                          | 18.04                        | 2023-05-31         |
-Windows                         | 10 21H2 (E)                  | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
-Windows                         | 11 21H2 (W)                  | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-Windows                         | 10 21H2 (W)                  | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information) |
-Windows                         | 10 20H2 (E)                  | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2) |
-Windows                         | 8.1                          | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81) |
-Windows                         | 10 21H1                      | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1) |
-Windows                         | 7 SP1                        | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7) |
-Windows Server                  | 2012-R2                      | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2) |
-Windows Server                  | 2012                         | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012) |
+OS                      | Version       | Date
+----------------------- | ------------- | ----------------------
+Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
+Alpine                  | 3.15          | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html)
+Android                 | 11            | 2024-02-05
+Android                 | 10            | 2023-03-06
+CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
+CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
+CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
+Fedora                  | 38            | 2024-05-21
+Fedora                  | 37            | 2023-12-05
+Fedora                  | 36            | 2023-05-16
+Fedora                  | 35            | 2022-12-13
+iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
+iPadOS                  | 12            | -
+macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
+macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
+openSUSE Leap           | 15.4          | 2023-12-07
+openSUSE Leap           | 15.3          | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/)
+SUSE Enterprise Linux   | 12.5          | 2024-10-31
+SUSE Enterprise Linux   | 15.3          | 2022-12-31
+SUSE Enterprise Linux   | 12.4          | 2020-06-30
+SUSE Enterprise Linux   | 12.3          | 2019-06-30
+SUSE Enterprise Linux   | 12.2          | 2018-03-31
+tvOS                    | 17            | -
+tvOS                    | 16            | -
+tvOS                    | 15            | -
+tvOS                    | 12            | -
+Ubuntu                  | 23.04         | 2024-01-20
+Ubuntu                  | 22.10         | 2023-07-20
+Ubuntu                  | 18.04         | 2023-05-31
+Windows                 | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)
+Windows                 | 11 21H2 (W)   | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information)
+Windows                 | 10 21H2 (W)   | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information)
+Windows                 | 10 20H2 (E)   | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2)
+Windows                 | 8.1           | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81)
+Windows                 | 10 21H1       | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1)
+Windows                 | 7 SP1         | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7)
+Windows Server          | 2012-R2       | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2)
+Windows Server          | 2012          | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)
 
-[OOS]: #out-of-support-os-versions
+[None]: #out-of-support-os-versions

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 7 - Supported OS versions
 
-Last updated: 2024-07-11
+Last updated: 2024-08-23
 
 [.NET 7](README.md) is a [Standard Term Support (STS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                     | Architectures      |
---------------------------------|------------------------------|--------------------|
-[iOS][2]                        | 17, 16, 15                   | Arm64              |
-[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
-[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | [None][OOS]                  | Arm64              |
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 17, 16, 15                  | Arm64
+[iPadOS][3]                     | 17, 16, 15                  | Arm64
+[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[tvOS][5]                       | [None][None]                | Arm64
 
 Notes:
 
@@ -42,17 +42,17 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
-[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
-[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
-[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
-[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
-[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
-[SUSE Enterprise Linux][20]     | 15.5, 15.4                   | Arm64, x64         | [Lifecycle][21]    |
-[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
+[CentOS][8]                     | [None][None]                | x64                   | [Lifecycle][9]
+[CentOS Stream][8]              | 9                           | Arm64, s390x, x64     | [Lifecycle][10]
+[Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
+[Fedora][13]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][14]
+[openSUSE Leap][15]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][16]
+[Red Hat Enterprise Linux][17]  | 9, 8                        | Arm64, x64            | [Lifecycle][18]
+[SUSE Enterprise Linux][19]     | 15.5                        | Arm64, x64            | [Lifecycle][20]
+[Ubuntu][21]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][22]
 
 Notes:
 
@@ -63,54 +63,50 @@ Notes:
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
 [9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
-[10]: https://centos.org/
-[11]: https://www.centos.org/cl-vs-cs/
-[12]: https://www.debian.org/
-[13]: https://wiki.debian.org/DebianReleases
-[14]: https://fedoraproject.org/
-[15]: https://fedoraproject.org/wiki/End_of_life
-[16]: https://www.opensuse.org/
-[17]: https://en.opensuse.org/Lifetime
-[18]: https://access.redhat.com/
-[19]: https://access.redhat.com/support/policy/updates/errata/
-[20]: https://www.suse.com/
-[21]: https://www.suse.com/lifecycle/
-[22]: https://ubuntu.com/
-[23]: https://wiki.ubuntu.com/Releases
+[10]: https://www.centos.org/cl-vs-cs/
+[11]: https://www.debian.org/
+[12]: https://wiki.debian.org/DebianReleases
+[13]: https://fedoraproject.org/
+[14]: https://fedoraproject.org/wiki/End_of_life
+[15]: https://www.opensuse.org/
+[16]: https://en.opensuse.org/Lifetime
+[17]: https://access.redhat.com/
+[18]: https://access.redhat.com/support/policy/updates/errata/
+[19]: https://www.suse.com/
+[20]: https://www.suse.com/lifecycle/
+[21]: https://ubuntu.com/
+[22]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
-[Windows][26]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
-[Windows Server][28]            | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
-[Windows Server Core][30]       | 2022, 2019, 2016             | x64, x86           | [Lifecycle][31]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][23]               | 2022, 2019                  | x64                   | [Lifecycle][24]
+[Windows][25]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26]
+[Windows Server][27]            | 23H2, 2022, 2019, 2016      | x64, x86              | [Lifecycle][24]
+[Windows Server Core][23]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][24]
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[26]: https://www.microsoft.com/windows/
-[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[28]: https://www.microsoft.com/windows-server
-[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[25]: https://www.microsoft.com/windows/
+[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[27]: https://www.microsoft.com/windows-server
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc                     | Version  | Architectures      | Source             |
--------------------------|----------|--------------------|--------------------|
-glibc                    | 2.17     | x64                | CentOS 7           |
-glibc                    | 2.23     | Arm64              | Ubuntu 16.04       |
-glibc                    | 2.27     | Arm32              | Ubuntu 18.04       |
-musl                     | 1.2.2    | Arm64, x64         | Alpine 3.15        |
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.17    | x64                   | CentOS 7
+glibc           | 2.23    | Arm64                 | Ubuntu 16.04
+glibc           | 2.27    | Arm32                 | Ubuntu 18.04
+musl            | 1.2.2   | Arm64, x64            | Alpine 3.15
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 incompatible glibc](https://github.com/dotnet/core/discussions/9285) or a Y2038 compatible glibc with [_TIME_BITS](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) set to 32-bit, for example Debian 12, Ubuntu 22.04, and lower versions.
 
@@ -122,46 +118,50 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-OS                              | Version                      | Date               |
---------------------------------|------------------------------|--------------------|
-Alpine                          | 3.16                         | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
-Alpine                          | 3.15                         | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html) |
-Android                         | 11                           | 2024-02-05         |
-Android                         | 10                           | 2023-03-06         |
-CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
-CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
-CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
-Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
-Fedora                          | 38                           | 2024-05-21         |
-Fedora                          | 37                           | 2023-12-05         |
-Fedora                          | 36                           | 2023-05-16         |
-Fedora                          | 35                           | 2022-12-13         |
-iOS                             | 12                           | [2023-01-23](https://support.apple.com/HT209084) |
-iPadOS                          | 12                           | -                  |
-macOS                           | 11                           | [2023-09-26](https://support.apple.com/HT211896) |
-macOS                           | 10.15                        | [2022-09-12](https://support.apple.com/HT210642) |
-openSUSE Leap                   | 15.4                         | 2023-12-07         |
-openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
-SUSE Enterprise Linux           | 12.5                         | 2024-10-31         |
-SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
-SUSE Enterprise Linux           | 12.4                         | 2020-06-30         |
-SUSE Enterprise Linux           | 12.3                         | 2019-06-30         |
-SUSE Enterprise Linux           | 12.2                         | 2018-03-31         |
-tvOS                            | 17                           | -                  |
-tvOS                            | 16                           | -                  |
-tvOS                            | 15                           | -                  |
-tvOS                            | 12                           | -                  |
-Ubuntu                          | 23.04                        | 2024-01-20         |
-Ubuntu                          | 22.10                        | 2023-07-20         |
-Ubuntu                          | 18.04                        | 2023-05-31         |
-Windows                         | 10 21H2 (E)                  | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
-Windows                         | 11 21H2 (W)                  | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-Windows                         | 10 21H2 (W)                  | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information) |
-Windows                         | 10 20H2 (E)                  | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2) |
-Windows                         | 8.1                          | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81) |
-Windows                         | 10 21H1                      | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1) |
-Windows                         | 7 SP1                        | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7) |
-Windows Server                  | 2012-R2                      | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2) |
-Windows Server                  | 2012                         | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012) |
+OS                      | Version       | Date
+----------------------- | ------------- | ----------------------
+Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
+Alpine                  | 3.15          | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html)
+Android                 | 11            | 2024-02-05
+Android                 | 10            | 2023-03-06
+CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
+CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
+CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
+Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
+Fedora                  | 38            | 2024-05-21
+Fedora                  | 37            | 2023-12-05
+Fedora                  | 36            | 2023-05-16
+Fedora                  | 35            | 2022-12-13
+iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
+iPadOS                  | 12            | -
+macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
+macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
+openSUSE Leap           | 15.4          | 2023-12-07
+openSUSE Leap           | 15.3          | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/)
+Red Hat Enterprise Linux | 7            | 2024-06-30
+SUSE Enterprise Linux   | 12.5          | 2024-10-31
+SUSE Enterprise Linux   | 15.4          | 2023-12-31
+SUSE Enterprise Linux   | 15.3          | 2022-12-31
+SUSE Enterprise Linux   | 12.4          | 2020-06-30
+SUSE Enterprise Linux   | 12.3          | 2019-06-30
+SUSE Enterprise Linux   | 12.2          | 2018-03-31
+tvOS                    | 17            | -
+tvOS                    | 16            | -
+tvOS                    | 15            | -
+tvOS                    | 12            | -
+Ubuntu                  | 23.10         | 2024-07-11
+Ubuntu                  | 23.04         | 2024-01-20
+Ubuntu                  | 22.10         | 2023-07-20
+Ubuntu                  | 18.04         | 2023-05-31
+Windows                 | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)
+Windows                 | 11 21H2 (W)   | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information)
+Windows                 | 10 21H2 (W)   | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information)
+Windows                 | 10 20H2 (E)   | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2)
+Windows                 | 8.1           | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81)
+Windows                 | 10 21H1       | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1)
+Windows                 | 7 SP1         | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7)
+Windows Server          | 2012-R2       | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2)
+Windows Server          | 2012          | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)
 
-[OOS]: #out-of-support-os-versions
+[None]: #out-of-support-os-versions

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 7 - Supported OS versions
 
-Last updated: 2024-08-23
+Last updated: 2024-07-11
 
 [.NET 7](README.md) is a [Standard Term Support (STS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                    | Architectures         | Lifecycle
-------------------------------- | --------------------------- | --------------------- | ----------------------
-[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
+OS                              | Versions                     | Architectures      | Lifecycle          |
+--------------------------------|------------------------------|--------------------|--------------------|
+[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                    | Architectures
-------------------------------- | --------------------------- | ----------------------
-[iOS][2]                        | 17, 16, 15                  | Arm64
-[iPadOS][3]                     | 17, 16, 15                  | Arm64
-[macOS][4]                      | 14, 13, 12                  | Arm64, x64
-[tvOS][5]                       | [None][None]                | Arm64
+OS                              | Versions                     | Architectures      |
+--------------------------------|------------------------------|--------------------|
+[iOS][2]                        | 17, 16, 15                   | Arm64              |
+[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
+[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
+[tvOS][5]                       | [None][OOS]                  | Arm64              |
 
 Notes:
 
@@ -42,17 +42,17 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                    | Architectures         | Lifecycle
-------------------------------- | --------------------------- | --------------------- | ----------------------
-[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
-[CentOS][8]                     | [None][None]                | x64                   | [Lifecycle][9]
-[CentOS Stream][8]              | 9                           | Arm64, s390x, x64     | [Lifecycle][10]
-[Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
-[Fedora][13]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][14]
-[openSUSE Leap][15]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][16]
-[Red Hat Enterprise Linux][17]  | 9, 8                        | Arm64, x64            | [Lifecycle][18]
-[SUSE Enterprise Linux][19]     | 15.5                        | Arm64, x64            | [Lifecycle][20]
-[Ubuntu][21]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][22]
+OS                              | Versions                     | Architectures      | Lifecycle          |
+--------------------------------|------------------------------|--------------------|--------------------|
+[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
+[CentOS][8]                     | [None][OOS]                  | x64                | [Lifecycle][9]     |
+[CentOS Stream][10]             | 9                            | Arm64, s390x, x64  | [Lifecycle][11]    |
+[Debian][12]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
+[Fedora][14]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][15]    |
+[openSUSE Leap][16]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][17]    |
+[Red Hat Enterprise Linux][18]  | 9, 8, 7                      | Arm64, x64         | [Lifecycle][19]    |
+[SUSE Enterprise Linux][20]     | 15.5, 15.4                   | Arm64, x64         | [Lifecycle][21]    |
+[Ubuntu][22]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][23]    |
 
 Notes:
 
@@ -63,50 +63,54 @@ Notes:
 [7]: https://alpinelinux.org/releases/
 [8]: https://centos.org/
 [9]: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
-[10]: https://www.centos.org/cl-vs-cs/
-[11]: https://www.debian.org/
-[12]: https://wiki.debian.org/DebianReleases
-[13]: https://fedoraproject.org/
-[14]: https://fedoraproject.org/wiki/End_of_life
-[15]: https://www.opensuse.org/
-[16]: https://en.opensuse.org/Lifetime
-[17]: https://access.redhat.com/
-[18]: https://access.redhat.com/support/policy/updates/errata/
-[19]: https://www.suse.com/
-[20]: https://www.suse.com/lifecycle/
-[21]: https://ubuntu.com/
-[22]: https://wiki.ubuntu.com/Releases
+[10]: https://centos.org/
+[11]: https://www.centos.org/cl-vs-cs/
+[12]: https://www.debian.org/
+[13]: https://wiki.debian.org/DebianReleases
+[14]: https://fedoraproject.org/
+[15]: https://fedoraproject.org/wiki/End_of_life
+[16]: https://www.opensuse.org/
+[17]: https://en.opensuse.org/Lifetime
+[18]: https://access.redhat.com/
+[19]: https://access.redhat.com/support/policy/updates/errata/
+[20]: https://www.suse.com/
+[21]: https://www.suse.com/lifecycle/
+[22]: https://ubuntu.com/
+[23]: https://wiki.ubuntu.com/Releases
 
 ## Windows
 
-OS                              | Versions                    | Architectures         | Lifecycle
-------------------------------- | --------------------------- | --------------------- | ----------------------
-[Nano Server][23]               | 2022, 2019                  | x64                   | [Lifecycle][24]
-[Windows][25]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26]
-[Windows Server][27]            | 23H2, 2022, 2019, 2016      | x64, x86              | [Lifecycle][24]
-[Windows Server Core][23]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][24]
+OS                              | Versions                     | Architectures      | Lifecycle          |
+--------------------------------|------------------------------|--------------------|--------------------|
+[Nano Server][24]               | 2022, 2019                   | x64                | [Lifecycle][25]    |
+[Windows][26]                   | 11 23H2, 10 22H2, 11 22H2, 10 21H2 (E), 10 21H2 (IoT), 11 21H2 (E), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][27]    |
+[Windows Server][28]            | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
+[Windows Server Core][30]       | 2022, 2019, 2016             | x64, x86           | [Lifecycle][31]    |
 
 Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
-[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[25]: https://www.microsoft.com/windows/
-[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
-[27]: https://www.microsoft.com/windows-server
+[24]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[25]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[26]: https://www.microsoft.com/windows/
+[27]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[28]: https://www.microsoft.com/windows-server
+[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[30]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[31]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc            | Version | Architectures         | Source
---------------- | ------- | --------------------- | --------------
-glibc           | 2.17    | x64                   | CentOS 7
-glibc           | 2.23    | Arm64                 | Ubuntu 16.04
-glibc           | 2.27    | Arm32                 | Ubuntu 18.04
-musl            | 1.2.2   | Arm64, x64            | Alpine 3.15
+Libc                     | Version  | Architectures      | Source             |
+-------------------------|----------|--------------------|--------------------|
+glibc                    | 2.17     | x64                | CentOS 7           |
+glibc                    | 2.23     | Arm64              | Ubuntu 16.04       |
+glibc                    | 2.27     | Arm32              | Ubuntu 18.04       |
+musl                     | 1.2.2    | Arm64, x64         | Alpine 3.15        |
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 incompatible glibc](https://github.com/dotnet/core/discussions/9285) or a Y2038 compatible glibc with [_TIME_BITS](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) set to 32-bit, for example Debian 12, Ubuntu 22.04, and lower versions.
 
@@ -118,50 +122,46 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-OS                      | Version       | Date
------------------------ | ------------- | ----------------------
-Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
-Alpine                  | 3.15          | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html)
-Android                 | 11            | 2024-02-05
-Android                 | 10            | 2023-03-06
-CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
-CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
-CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
-Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
-Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
-Fedora                  | 38            | 2024-05-21
-Fedora                  | 37            | 2023-12-05
-Fedora                  | 36            | 2023-05-16
-Fedora                  | 35            | 2022-12-13
-iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
-iPadOS                  | 12            | -
-macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
-macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
-openSUSE Leap           | 15.4          | 2023-12-07
-openSUSE Leap           | 15.3          | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/)
-Red Hat Enterprise Linux | 7            | 2024-06-30
-SUSE Enterprise Linux   | 12.5          | 2024-10-31
-SUSE Enterprise Linux   | 15.4          | 2023-12-31
-SUSE Enterprise Linux   | 15.3          | 2022-12-31
-SUSE Enterprise Linux   | 12.4          | 2020-06-30
-SUSE Enterprise Linux   | 12.3          | 2019-06-30
-SUSE Enterprise Linux   | 12.2          | 2018-03-31
-tvOS                    | 17            | -
-tvOS                    | 16            | -
-tvOS                    | 15            | -
-tvOS                    | 12            | -
-Ubuntu                  | 23.10         | 2024-07-11
-Ubuntu                  | 23.04         | 2024-01-20
-Ubuntu                  | 22.10         | 2023-07-20
-Ubuntu                  | 18.04         | 2023-05-31
-Windows                 | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)
-Windows                 | 11 21H2 (W)   | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information)
-Windows                 | 10 21H2 (W)   | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information)
-Windows                 | 10 20H2 (E)   | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2)
-Windows                 | 8.1           | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81)
-Windows                 | 10 21H1       | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1)
-Windows                 | 7 SP1         | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7)
-Windows Server          | 2012-R2       | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2)
-Windows Server          | 2012          | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)
+OS                              | Version                      | Date               |
+--------------------------------|------------------------------|--------------------|
+Alpine                          | 3.16                         | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
+Alpine                          | 3.15                         | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html) |
+Android                         | 11                           | 2024-02-05         |
+Android                         | 10                           | 2023-03-06         |
+CentOS                          | 7                            | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009) |
+CentOS                          | 8                            | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111) |
+CentOS Stream                   | 8                            | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream) |
+Debian                          | 10                           | [2022-09-10](https://www.debian.org/News/2022/20220910) |
+Fedora                          | 38                           | 2024-05-21         |
+Fedora                          | 37                           | 2023-12-05         |
+Fedora                          | 36                           | 2023-05-16         |
+Fedora                          | 35                           | 2022-12-13         |
+iOS                             | 12                           | [2023-01-23](https://support.apple.com/HT209084) |
+iPadOS                          | 12                           | -                  |
+macOS                           | 11                           | [2023-09-26](https://support.apple.com/HT211896) |
+macOS                           | 10.15                        | [2022-09-12](https://support.apple.com/HT210642) |
+openSUSE Leap                   | 15.4                         | 2023-12-07         |
+openSUSE Leap                   | 15.3                         | [2022-12-31](https://web.archive.org/web/20230521063245/https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/) |
+SUSE Enterprise Linux           | 12.5                         | 2024-10-31         |
+SUSE Enterprise Linux           | 15.3                         | 2022-12-31         |
+SUSE Enterprise Linux           | 12.4                         | 2020-06-30         |
+SUSE Enterprise Linux           | 12.3                         | 2019-06-30         |
+SUSE Enterprise Linux           | 12.2                         | 2018-03-31         |
+tvOS                            | 17                           | -                  |
+tvOS                            | 16                           | -                  |
+tvOS                            | 15                           | -                  |
+tvOS                            | 12                           | -                  |
+Ubuntu                          | 23.04                        | 2024-01-20         |
+Ubuntu                          | 22.10                        | 2023-07-20         |
+Ubuntu                          | 18.04                        | 2023-05-31         |
+Windows                         | 10 21H2 (E)                  | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
+Windows                         | 11 21H2 (W)                  | [2023-10-10](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
+Windows                         | 10 21H2 (W)                  | [2023-06-13](https://learn.microsoft.com/windows/release-health/release-information) |
+Windows                         | 10 20H2 (E)                  | [2023-05-09](https://learn.microsoft.com/windows/release-health/status-windows-10-20h2) |
+Windows                         | 8.1                          | [2023-01-10](https://learn.microsoft.com/lifecycle/products/windows-81) |
+Windows                         | 10 21H1                      | [2022-12-13](https://learn.microsoft.com/windows/release-health/status-windows-10-21h1) |
+Windows                         | 7 SP1                        | [2020-01-14](https://learn.microsoft.com/lifecycle/products/windows-7) |
+Windows Server                  | 2012-R2                      | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2) |
+Windows Server                  | 2012                         | [2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012) |
 
-[None]: #out-of-support-os-versions
+[OOS]: #out-of-support-os-versions

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "8.0",
-    "last-updated": "2024-08-23",
+    "last-updated": "2024-08-26",
     "families": [
         {
             "name": "Android",
@@ -149,9 +149,7 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12"
-                    ],
-                    "unsupported-versions": [
+                        "12",
                         "11"
                     ]
                 },

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "8.0",
-    "last-updated": "2024-07-11",
+    "last-updated": "2024-08-23",
     "families": [
         {
             "name": "Android",
@@ -149,7 +149,9 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12",
+                        "12"
+                    ],
+                    "unsupported-versions": [
                         "11"
                     ]
                 },
@@ -184,6 +186,9 @@
                     "supported-versions": [
                         "15.6",
                         "15.5"
+                    ],
+                    "unsupported-versions": [
+                        "15.4"
                     ]
                 },
                 {
@@ -215,7 +220,12 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "15.5"
+                        "15.6",
+                        "15.5",
+                        "12.5"
+                    ],
+                    "unsupported-versions": [
+                        "15.4"
                     ]
                 },
                 {
@@ -230,11 +240,11 @@
                     ],
                     "supported-versions": [
                         "24.04",
-                        "23.10",
                         "22.04",
                         "20.04"
                     ],
                     "unsupported-versions": [
+                        "23.10",
                         "23.04"
                     ]
                 }

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -149,8 +149,11 @@
                         "x64"
                     ],
                     "supported-versions": [
-                        "12",
+                        "12"
+                    ],
+                    "unsupported-versions": [
                         "11"
+                    ],
                     ]
                 },
                 {

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 8 - Supported OS versions
 
-Last updated: 2024-07-11
+Last updated: 2024-08-23
 
 [.NET 8](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                     | Architectures      |
---------------------------------|------------------------------|--------------------|
-[iOS][2]                        | 17, 16, 15                   | Arm64              |
-[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
-[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | 17, 16, 15, 14, 13, 12.2     | Arm64              |
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 17, 16, 15                  | Arm64
+[iPadOS][3]                     | 17, 16, 15                  | Arm64
+[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[tvOS][5]                       | 17, 16, 15, 14, 13, 12.2    | Arm64
 
 Notes:
 
@@ -42,16 +42,16 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17       | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]     |
-[Debian][10]                    | 12, 11                       | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[Fedora][12]                    | 40, 39                       | Arm32, Arm64, x64  | [Lifecycle][13]    |
-[openSUSE Leap][14]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][15]    |
-[Red Hat Enterprise Linux][16]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]    |
-[SUSE Enterprise Linux][18]     | 15.5                         | Arm64, x64         | [Lifecycle][19]    |
-[Ubuntu][20]                    | 24.04, 23.10, 22.04, 20.04   | Arm32, Arm64, x64  | [Lifecycle][21]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
+[CentOS Stream][8]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]
+[Debian][10]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][11]
+[Fedora][12]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][13]
+[openSUSE Leap][14]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][15]
+[Red Hat Enterprise Linux][16]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]
+[SUSE Enterprise Linux][18]     | 15.6, 15.5, 12.5            | Arm64, x64            | [Lifecycle][19]
+[Ubuntu][20]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][21]
 
 Notes:
 
@@ -76,12 +76,12 @@ Notes:
 
 ## Windows
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][22]               | 2022, 2019                   | x64                | [Lifecycle][23]    |
-[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][25]    |
-[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][27]    |
-[Windows Server Core][28]       | 23H2, 2022, 2019, 2016, 2012 | x64, x86           | [Lifecycle][29]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][22]               | 2022, 2019                  | x64                   | [Lifecycle][23]
+[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][25]
+[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][23]
+[Windows Server Core][22]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][23]
 
 Notes:
 
@@ -93,19 +93,16 @@ Notes:
 [24]: https://www.microsoft.com/windows/
 [25]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
 [26]: https://www.microsoft.com/windows-server
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[28]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc                     | Version  | Architectures      | Source             |
--------------------------|----------|--------------------|--------------------|
-glibc                    | 2.23     | Arm64, x64         | Ubuntu 16.04       |
-glibc                    | 2.35     | Arm32              | Ubuntu 22.04       |
-musl                     | 1.2.2    | Arm32, Arm64, x64  | Alpine 3.13        |
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.23    | Arm64, x64            | Ubuntu 16.04
+glibc           | 2.35    | Arm32                 | Ubuntu 22.04
+musl            | 1.2.2   | Arm32, Arm64, x64     | Alpine 3.13
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 incompatible glibc](https://github.com/dotnet/core/discussions/9285) or a Y2038 compatible glibc with [_TIME_BITS](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html) set to 32-bit, for example Debian 12, Ubuntu 22.04, and lower versions.
 
@@ -117,11 +114,15 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-OS                              | Version                      | Date               |
---------------------------------|------------------------------|--------------------|
-Alpine                          | 3.16                         | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
-Android                         | 11                           | 2024-02-05         |
-Fedora                          | 38                           | 2024-05-21         |
-Fedora                          | 37                           | 2023-12-05         |
-Ubuntu                          | 23.04                        | 2024-01-20         |
-Windows                         | 10 21H2 (E)                  | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
+OS                      | Version       | Date
+----------------------- | ------------- | ----------------------
+Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
+Android                 | 11            | 2024-02-05
+Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
+Fedora                  | 38            | 2024-05-21
+Fedora                  | 37            | 2023-12-05
+openSUSE Leap           | 15.4          | 2023-12-07
+SUSE Enterprise Linux   | 15.4          | 2023-12-31
+Ubuntu                  | 23.10         | 2024-07-11
+Ubuntu                  | 23.04         | 2024-01-20
+Windows                 | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 8 - Supported OS versions
 
-Last updated: 2024-08-23
+Last updated: 2024-08-26
 
 [.NET 8](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -46,7 +46,7 @@ OS                              | Versions                    | Architectures   
 ------------------------------- | --------------------------- | --------------------- | ----------------------
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
 [CentOS Stream][8]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]
-[Debian][10]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][11]
+[Debian][10]                    | 12, 11                      | Arm32, Arm64, x64     | [Lifecycle][11]
 [Fedora][12]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][13]
 [openSUSE Leap][14]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][15]
 [Red Hat Enterprise Linux][16]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]
@@ -118,7 +118,6 @@ OS                      | Version       | Date
 ----------------------- | ------------- | ----------------------
 Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
 Android                 | 11            | 2024-02-05
-Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05
 openSUSE Leap           | 15.4          | 2023-12-07

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -46,7 +46,7 @@ OS                              | Versions                    | Architectures   
 ------------------------------- | --------------------------- | --------------------- | ----------------------
 [Alpine][6]                     | 3.20, 3.19, 3.18, 3.17      | Arm32, Arm64, x64     | [Lifecycle][7]
 [CentOS Stream][8]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]
-[Debian][10]                    | 12, 11                      | Arm32, Arm64, x64     | [Lifecycle][11]
+[Debian][10]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][11]
 [Fedora][12]                    | 40, 39                      | Arm32, Arm64, x64     | [Lifecycle][13]
 [openSUSE Leap][14]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][15]
 [Red Hat Enterprise Linux][16]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]
@@ -87,6 +87,7 @@ Notes:
 
 * Windows: The x64 emulator is supported on Windows 11 Arm64.
 * Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
+* Windows Server Core: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
 
 [22]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
 [23]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
@@ -118,6 +119,7 @@ OS                      | Version       | Date
 ----------------------- | ------------- | ----------------------
 Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
 Android                 | 11            | 2024-02-05
+Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05
 openSUSE Leap           | 15.4          | 2023-12-07

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -1,6 +1,6 @@
 {
     "channel-version": "9.0",
-    "last-updated": "2024-07-11",
+    "last-updated": "2024-08-23",
     "families": [
         {
             "name": "Android",
@@ -200,6 +200,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "15.6",
                         "15.5"
                     ]
                 },

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 9 - Supported OS versions
 
-Last updated: 2024-07-11
+Last updated: 2024-08-23
 
 [.NET 9](README.md) is a [Standard Term Support (STS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -8,9 +8,9 @@ This file is generated from [supported-os.json](supported-os.json) and is based 
 
 ## Android
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Android][0]                    | 14, 13, 12.1, 12             | Arm32, Arm64, x64  | [Lifecycle][1]     |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 14, 13, 12.1, 12            | Arm32, Arm64, x64     | [Lifecycle][1]
 
 Notes:
 
@@ -21,12 +21,12 @@ Notes:
 
 ## Apple
 
-OS                              | Versions                     | Architectures      |
---------------------------------|------------------------------|--------------------|
-[iOS][2]                        | 17, 16, 15                   | Arm64              |
-[iPadOS][3]                     | 17, 16, 15                   | Arm64              |
-[macOS][4]                      | 14, 13, 12                   | Arm64, x64         |
-[tvOS][5]                       | 17, 16, 15, 14, 13, 12.2     | Arm64              |
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 17, 16, 15                  | Arm64
+[iPadOS][3]                     | 17, 16, 15                  | Arm64
+[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[tvOS][5]                       | 17, 16, 15, 14, 13, 12.2    | Arm64
 
 Notes:
 
@@ -42,16 +42,16 @@ Notes:
 
 ## Linux
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Alpine][6]                     | 3.20, 3.19                   | Arm32, Arm64, x64  | [Lifecycle][7]     |
-[CentOS Stream][8]              | 9                            | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]     |
-[Debian][10]                    | 12                           | Arm32, Arm64, x64  | [Lifecycle][11]    |
-[Fedora][12]                    | 40                           | Arm32, Arm64, x64  | [Lifecycle][13]    |
-[openSUSE Leap][14]             | 15.6, 15.5                   | Arm64, x64         | [Lifecycle][15]    |
-[Red Hat Enterprise Linux][16]  | 9, 8                         | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]    |
-[SUSE Enterprise Linux][18]     | 15.5                         | Arm64, x64         | [Lifecycle][19]    |
-[Ubuntu][20]                    | 24.04, 22.04, 20.04          | Arm32, Arm64, x64  | [Lifecycle][21]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.20, 3.19                  | Arm32, Arm64, x64     | [Lifecycle][7]
+[CentOS Stream][8]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][9]
+[Debian][10]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][11]
+[Fedora][12]                    | 40                          | Arm32, Arm64, x64     | [Lifecycle][13]
+[openSUSE Leap][14]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][15]
+[Red Hat Enterprise Linux][16]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]
+[SUSE Enterprise Linux][18]     | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][19]
+[Ubuntu][20]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][21]
 
 Notes:
 
@@ -76,12 +76,12 @@ Notes:
 
 ## Windows
 
-OS                              | Versions                     | Architectures      | Lifecycle          |
---------------------------------|------------------------------|--------------------|--------------------|
-[Nano Server][22]               | 2022, 2019                   | x64                | [Lifecycle][23]    |
-[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86    | [Lifecycle][25]    |
-[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86           | [Lifecycle][27]    |
-[Windows Server Core][28]       | 23H2, 2022, 2019, 2016       | x64, x86           | [Lifecycle][29]    |
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][22]               | 2022, 2019                  | x64                   | [Lifecycle][23]
+[Windows][24]                   | 11 23H2, 11 22H2, 10 22H2, 11 21H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][25]
+[Windows Server][26]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][23]
+[Windows Server Core][22]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][23]
 
 Notes:
 
@@ -93,19 +93,16 @@ Notes:
 [24]: https://www.microsoft.com/windows/
 [25]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
 [26]: https://www.microsoft.com/windows-server
-[27]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
-[28]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
-[29]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
 
 ## Linux compatibility
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-Libc                     | Version  | Architectures      | Source             |
--------------------------|----------|--------------------|--------------------|
-glibc                    | 2.23     | Arm64, x64         | Ubuntu 16.04       |
-glibc                    | 2.35     | Arm32              | Ubuntu 22.04       |
-musl                     | 1.2.2    | Arm32, Arm64, x64  | Alpine 3.13        |
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.23    | Arm64, x64            | Ubuntu 16.04
+glibc           | 2.35    | Arm32                 | Ubuntu 22.04
+musl            | 1.2.2   | Arm32, Arm64, x64     | Alpine 3.13
 
 Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 compatible glibc](https://github.com/dotnet/core/discussions/9285), for example Debian 12, Ubuntu 22.04, and higher versions.
 


### PR DESCRIPTION
Contributes to #9417 and includes generated parts similar to #9479. So I would recommend doing this PR after #9479 is merged to reduce the change-set in the PR.

* Moved Debian 11 from supported to unsupported on .NET ~6, 7~, 8
* Moved RHEL 7 from supported to unsupported on .NET 6, ~7~
* Moved Ubuntu 23.10 from supported to unsupported on .NET 6, ~7~, 8
* Added SUSE Enterprise Linux 12.5 to supported on .NET 8
* Added SUSE Enterprise Linux 15.4 to unsupported on .NET 8
* ~Moved SUSE Enterprise Linux 15.4 from supported to unsupported on .NET 7~
* Added SUSE Enterprise Linux 15.6 to supported on .NET 6, 8, 9
* Regenerated supported-os.md which also fixed `Windows Server Core` entries (already in #9479)

~I did update .NET 7 even though technically not required since it's EOL anyway. Just did it to also see if I covered everything in my adjusted distroessed tooling. If you like to keep it on the old state, I can revert the changes. I did not add any new versions like SLES 15.6 to .NET 7 of course :)~

I compared all versions to the last-before-being-generated ones and according to https://github.com/dotnet/core/blob/56290a0acf2e15e4aa8b0ffa0a02f41501fc088e/release-notes/8.0/supported-os.md we seem to have dropped SLES some versions on .NET 8 (which I re-added here).

/CC @richlander @leecow @omajid