### PR TITLE
Typo fix in RC1 sdk.md

### DIFF
--- a/release-notes/9.0/preview/rc1/libraries.md
+++ b/release-notes/9.0/preview/rc1/libraries.md
@@ -17,7 +17,6 @@ Libraries updates in .NET 9 Release Candidate 1:
 
 * [Discussion](https://aka.ms/dotnet/9/rc1)
 * [Release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/README.md)
-* [Runtime release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/runtime.md)
 * [Libraries release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/libraries.md)
 
 ## WebSocket `Keep-Alive` Ping and Timeout

--- a/release-notes/9.0/preview/rc1/sdk.md
+++ b/release-notes/9.0/preview/rc1/sdk.md
@@ -4,7 +4,7 @@ Here's a summary of what's new in the .NET SDK in this release:
 
 * [Workload History](#workload-history)
 
-SDK updates in .NET 7 Release Candidate 1:
+SDK updates in .NET 9 Release Candidate 1:
 
 * [Release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/sdk.md)
 * [What's new in the .NET Runtime in .NET 9](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/overview) documentation

--- a/release-notes/9.0/preview/rc1/sdk.md
+++ b/release-notes/9.0/preview/rc1/sdk.md
@@ -13,7 +13,6 @@ SDK updates in .NET 9 Release Candidate 1:
 
 * [Discussion](https://aka.ms/dotnet/9/rc1)
 * [Release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/README.md)
-* [Runtime release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/runtime.md)
 * [Libraries release notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/rc1/libraries.md)
 
 ## Feature


### PR DESCRIPTION
This pull request includes a minor update to the release notes for the .NET SDK. The change updates the version number from .NET 7 to .NET 9 in the release candidate section.

* [`release-notes/9.0/preview/rc1/sdk.md`](diffhunk://#diff-912d9f553dd7f8b4ac02e0f4bdb46db1ef9c8e4d63b916c7282b900633581726L7-R7): Updated the version number from .NET 7 to .NET 9 in the SDK updates section.