### PR TITLE
API diff between .NET 9 RC1 and .NET 9 RC 2

### DIFF
--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.AspNetCore.App/9.0-rc2.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.AspNetCore.App/9.0-rc2.md
@@ -1,0 +1,6 @@
+# API Difference 9.0-rc1 vs 9.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2.md
@@ -1,0 +1,9 @@
+# API Difference 9.0-rc1 vs 9.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Reflection.Emit](9.0-rc2_System.Reflection.Emit.md)
+* [System.Runtime.Intrinsics.Arm](9.0-rc2_System.Runtime.Intrinsics.Arm.md)
+* [System.Text.Json](9.0-rc2_System.Text.Json.md)
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Reflection.Emit.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Reflection.Emit.md
@@ -1,0 +1,10 @@
+# System.Reflection.Emit
+
+``` diff
+ namespace System.Reflection.Emit {
+     public sealed class PersistedAssemblyBuilder : AssemblyBuilder {
+-        public override bool IsDynamic { get; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Runtime.Intrinsics.Arm.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Runtime.Intrinsics.Arm.md
@@ -1,0 +1,23 @@
+# System.Runtime.Intrinsics.Arm
+
+``` diff
+ namespace System.Runtime.Intrinsics.Arm {
+     [CLSCompliantAttribute(false)]
+     [ExperimentalAttribute("SYSLIB5003", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+     public abstract class Sve : AdvSimd {
+-        public static void GatherPrefetch16Bit(Vector<short> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch16Bit(Vector<ushort> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch32Bit(Vector<int> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch32Bit(Vector<uint> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch64Bit(Vector<long> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch64Bit(Vector<ulong> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch8Bit(Vector<byte> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static void GatherPrefetch8Bit(Vector<sbyte> mask, Vector<uint> addresses, [ConstantExpectedAttribute] SvePrefetchType prefetchType);
+-        public static Vector<int> GatherVectorInt16SignExtendFirstFaulting(Vector<int> mask, Vector<uint> addresses);
+-        public static Vector<uint> GatherVectorInt16SignExtendFirstFaulting(Vector<uint> mask, Vector<uint> addresses);
+-        public static Vector<int> GatherVectorSByteSignExtendFirstFaulting(Vector<int> mask, Vector<uint> addresses);
+-        public static Vector<uint> GatherVectorSByteSignExtendFirstFaulting(Vector<uint> mask, Vector<uint> addresses);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Text.Json.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.NETCore.App/9.0-rc2_System.Text.Json.md
@@ -1,0 +1,10 @@
+# System.Text.Json
+
+``` diff
+ namespace System.Text.Json {
+     public readonly struct JsonElement {
++        public int GetPropertyCount();
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2.md
@@ -1,0 +1,8 @@
+# API Difference 9.0-rc1 vs 9.0-rc2
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Drawing.Imaging.Effects](9.0-rc2_System.Drawing.Imaging.Effects.md)
+* [System.Formats.Nrbf](9.0-rc2_System.Formats.Nrbf.md)
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2_System.Drawing.Imaging.Effects.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2_System.Drawing.Imaging.Effects.md
@@ -1,0 +1,11 @@
+# System.Drawing.Imaging.Effects
+
+``` diff
+ namespace System.Drawing.Imaging.Effects {
+     public abstract class Effect : IDisposable {
+-        public virtual void Dispose(bool disposing);
++        protected virtual void Dispose(bool disposing);
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2_System.Formats.Nrbf.md
+++ b/release-notes/9.0/preview/rc2/api-diff/Microsoft.WindowsDesktop.App/9.0-rc2_System.Formats.Nrbf.md
@@ -1,0 +1,10 @@
+# System.Formats.Nrbf
+
+``` diff
+ namespace System.Formats.Nrbf {
+     public abstract class ArrayRecord : SerializationRecord {
++        public virtual long FlattenedLength { get; }
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/rc2/api-diff/README.md
+++ b/release-notes/9.0/preview/rc2/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 9.0 RC 2 API Changes
+
+The following API changes were made in .NET 9.0 RC 2:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/9.0-rc2.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/9.0-rc2.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/9.0-rc2.md)


### PR DESCRIPTION
Repo area owners:

- WinForms - @merriemcgaw @lonitra @JeremyKuhne
- Libraries - @artl93 @jeffschwMSFT @jeffhandley @karelz @ericstj @stephentoub @SamMonoRT 

Libraries area owners:
- System.Drawing @dotnet/area-system-drawing @lonitra @merriemcgaw @JeremyKuhne 
- System.Reflection.Emit @dotnet/area-system-reflection-emit @buyaa-n  
- System.Runtime.Intrinsics @dotnet/area-system-runtime-intrinsics @tannergooding 
- System.Text.Json @dotnet/area-system-text-json  @eiriktsarpalis 

**Known api-diff tool issues**:

If yo usee any of these, please provide a GitHub suggestion in this PR to correct it: 

- The AsmDiff tool sometimes skips adding `{` or `{}` [arcade#10981](https://github.com/dotnet/arcade/issues/10981)(https://github.com/dotnet/arcade/issues/13814) 
- RequiresPreviewAttribute not getting auto added [arcade#14498](https://github.com/dotnet/arcade/issues/14498)
- Changes to `protected internal` visibility should stop showing. https://github.com/dotnet/arcade/issues/14579
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect: [arcade#13814]
