### PR TITLE
Update macOS OS version in Supported OS

### DIFF
--- a/release-notes/6.0/supported-os.json
+++ b/release-notes/6.0/supported-os.json
@@ -80,10 +80,10 @@
                     ],
                     "supported-versions": [
                         "14",
-                        "13",
-                        "12"
+                        "13"
                     ],
                     "unsupported-versions": [
+                        "12",
                         "11",
                         "10.15"
                     ],

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -25,7 +25,7 @@ OS                              | Versions                    | Architectures
 ------------------------------- | --------------------------- | ----------------------
 [iOS][2]                        | 17, 16, 15                  | Arm64
 [iPadOS][3]                     | 17, 16, 15                  | Arm64
-[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[macOS][4]                      | 14, 13                      | Arm64, x64
 [tvOS][5]                       | 17, 16, 15                  | Arm64
 
 Notes:
@@ -139,6 +139,7 @@ Fedora                  | 34            | 2022-06-07
 Fedora                  | 33            | 2021-11-30
 iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
 iPadOS                  | 12            | -
+macOS                   | 12            | [2024-09-16](https://support.apple.com/HT212585)
 macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
 macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
 Nano Server             | 20H2          | [2022-08-09](https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring)

--- a/release-notes/7.0/supported-os.json
+++ b/release-notes/7.0/supported-os.json
@@ -79,10 +79,10 @@
                     ],
                     "supported-versions": [
                         "14",
-                        "13",
-                        "12"
+                        "13"
                     ],
                     "unsupported-versions": [
+                        "12",
                         "11",
                         "10.15"
                     ],

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -25,7 +25,7 @@ OS                              | Versions                    | Architectures
 ------------------------------- | --------------------------- | ----------------------
 [iOS][2]                        | 17, 16, 15                  | Arm64
 [iPadOS][3]                     | 17, 16, 15                  | Arm64
-[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[macOS][4]                      | 14, 13                      | Arm64, x64
 [tvOS][5]                       | [None][None]                | Arm64
 
 Notes:
@@ -134,6 +134,7 @@ Fedora                  | 36            | 2023-05-16
 Fedora                  | 35            | 2022-12-13
 iOS                     | 12            | [2023-01-23](https://support.apple.com/HT209084)
 iPadOS                  | 12            | -
+macOS                   | 12            | [2024-09-16](https://support.apple.com/HT212585)
 macOS                   | 11            | [2023-09-26](https://support.apple.com/HT211896)
 macOS                   | 10.15         | [2022-09-12](https://support.apple.com/HT210642)
 openSUSE Leap           | 15.4          | 2023-12-07

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -72,7 +72,9 @@
                     ],
                     "supported-versions": [
                         "14",
-                        "13",
+                        "13"
+                    ],
+                    "unsupported-versions": [
                         "12"
                     ],
                     "notes" : [

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -25,7 +25,7 @@ OS                              | Versions                    | Architectures
 ------------------------------- | --------------------------- | ----------------------
 [iOS][2]                        | 17, 16, 15                  | Arm64
 [iPadOS][3]                     | 17, 16, 15                  | Arm64
-[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[macOS][4]                      | 14, 13                      | Arm64, x64
 [tvOS][5]                       | 17, 16, 15, 14, 13, 12.2    | Arm64
 
 Notes:
@@ -122,6 +122,7 @@ Android                 | 11            | 2024-02-05
 Debian                  | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05
+macOS                   | 12            | [2024-09-16](https://support.apple.com/HT212585)
 openSUSE Leap           | 15.4          | 2023-12-07
 SUSE Enterprise Linux   | 15.4          | 2023-12-31
 Ubuntu                  | 23.10         | 2024-07-11

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -69,7 +69,9 @@
                     ],
                     "supported-versions": [
                         "14",
-                        "13",
+                        "13"
+                    ],
+                    "unsupported-versions": [
                         "12"
                     ],
                     "notes" : [

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -25,7 +25,7 @@ OS                              | Versions                    | Architectures
 ------------------------------- | --------------------------- | ----------------------
 [iOS][2]                        | 17, 16, 15                  | Arm64
 [iPadOS][3]                     | 17, 16, 15                  | Arm64
-[macOS][4]                      | 14, 13, 12                  | Arm64, x64
+[macOS][4]                      | 14, 13                      | Arm64, x64
 [tvOS][5]                       | 17, 16, 15, 14, 13, 12.2    | Arm64
 
 Notes:
@@ -114,4 +114,6 @@ Note: Microsoft-provided portable Arm32 glibc builds are supported on distro ver
 
 Support for the following operating system versions has ended.
 
-None currently.
+OS                      | Version       | Date
+----------------------- | ------------- | ----------------------
+macOS                   | 12            | [2024-09-16](https://support.apple.com/HT212585)


### PR DESCRIPTION
macOS 12 ("Monterey") reached end-of-life on 2024-09-16.

Contributes to https://github.com/dotnet/core/issues/9542