### PR TITLE
Update windows license information

### DIFF
--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -12,7 +12,11 @@ The following binaries are licensed with the
 * coreclr.dll and .NET runtimes included in binaries published as single-file (due to [extra telemetry](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/dwreport.cpp) included by .NET runtime in Watson crash reports)
 * Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
 * PresentationNative_cor3.dll (used by WPF)
+* vcruntime140_cor3.dll (used by WPF)
 * wpfgfx_cor3.dll (used by WPF)
+
+Note: vcruntime140_cor3.dll is the same binary as
+vcruntime140.dll, which is included in Visual Studio, relicensed under .NET Library License by Microsoft.
 
 The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -9,7 +9,7 @@ This document is provided for informative purposes only, and is not itself a lic
 The following binaries are licensed with the
 [.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm)
 
-* coreclr.dll and .NET runtimes included in binaries published as single-file (due to extra telemetry included by .NET runtime in Watson crash reports)
+* coreclr.dll and .NET runtimes included in binaries published as single-file (due to [extra telemetry](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/dwreport.cpp) included by .NET runtime in Watson crash reports)
 * Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
 * PresentationNative_cor3.dll (used by WPF)
 * wpfgfx_cor3.dll (used by WPF)
@@ -20,7 +20,7 @@ The following binaries are licensed with the
 * D3DCompiler_47_cor3.dll (used by WPF)
 
 All other binaries and files are licensed with the
-[.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm).
+[MIT license](https://github.com/dotnet/core/blob/main/LICENSE.TXT).
 
 See [license information](./license-information.md) for information about
 other operating systems.

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -7,25 +7,12 @@ apply to your use. By using any or all of these files you agree to their associa
 This document is provided for informative purposes only, and is not itself a license.
 
 The following binaries are licensed with the
-[.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm)
-
-* Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
-* PresentationNative_cor3.dll (used by WPF)
-* vcruntime140_cor3.dll (used by WPF)
-* wpfgfx_cor3.dll (used by WPF)
-
-The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
 
 * D3DCompiler_47_cor3.dll (used by WPF)
 
-.NET 6 and earlier:
-
-* api-ms-\*.\* (used by .NET runtime)
-* ucrtbase.dll (used by .NET runtime)
-
 All other binaries and files are licensed with the
-[MIT license](https://github.com/dotnet/core/blob/main/LICENSE.TXT).
+[.NET Library License](https://github.com/dotnet/core/blob/main/LICENSE.TXT).
 
 See [license information](./license-information.md) for information about
 other operating systems.

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -9,7 +9,7 @@ This document is provided for informative purposes only, and is not itself a lic
 The following binaries are licensed with the
 [.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm)
 
-* coreclr.dll and .NET runtimes included in binaries published as single-file (due to [extra telemetry](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/dwreport.cpp) included by .NET runtime in Watson crash reports)
+* coreclr.dll and .NET runtimes included in binaries published as single-file (due to [extra telemetry](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/dwreport.cpp) included by .NET runtime in Windows Error Reporting crash reports)
 * Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
 * PresentationNative_cor3.dll (used by WPF)
 * vcruntime140_cor3.dll (used by WPF)

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -2,9 +2,17 @@
 
 The Windows distribution of .NET contains files that are provided under multiple licenses.
 This information is provided to help you understand the license terms that
-apply to your use. By using any or all of these files you agree to their associated license terms.
+apply to your use. By using .NET on Windows, you agree to the following license terms.
 
 This document is provided for informative purposes only, and is not itself a license.
+
+The following binaries are licensed with the
+[.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm)
+
+* coreclr.dll and .NET runtimes included in binaries published as single-file (due to extra telemetry included by .NET runtime in Watson crash reports)
+* Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
+* PresentationNative_cor3.dll (used by WPF)
+* wpfgfx_cor3.dll (used by WPF)
 
 The following binaries are licensed with the
 [Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
@@ -12,7 +20,7 @@ The following binaries are licensed with the
 * D3DCompiler_47_cor3.dll (used by WPF)
 
 All other binaries and files are licensed with the
-[.NET Library License](https://github.com/dotnet/core/blob/main/LICENSE.TXT).
+[.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm).
 
 See [license information](./license-information.md) for information about
 other operating systems.

--- a/license-information-windows.md
+++ b/license-information-windows.md
@@ -4,28 +4,28 @@ The Windows distribution of .NET contains files that are provided under multiple
 This information is provided to help you understand the license terms that
 apply to your use. By using any or all of these files you agree to their associated license terms.
 
-See [license information](./license-information.md) for information about other operating systems.
-
 This document is provided for informative purposes only, and is not itself a license.
-
-The following binaries are licensed with the
-[Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
-
-* api-ms-\*.\* (used by .NET runtime, .NET 6 and earlier)
-* ucrtbase.dll (used by .NET runtime, .NET 6 and earlier)
-* D3DCompiler_47_cor3.dll (used by WPF)
 
 The following binaries are licensed with the
 [.NET Library License](https://dotnet.microsoft.com/dotnet_library_license.htm)
 
 * Microsoft.DiaSymReader.Native.{x86|amd64|arm|arm64}.dll (used by .NET runtime and SDK)
 * PresentationNative_cor3.dll (used by WPF)
+* vcruntime140_cor3.dll (used by WPF)
 * wpfgfx_cor3.dll (used by WPF)
 
 The following binaries are licensed with the
-[Microsoft Visual C++ Runtime Software License](https://visualstudio.microsoft.com/license-terms/vs2022-cruntime/):
+[Windows SDK License](https://learn.microsoft.com/legal/windows-sdk/license):
 
-* vcruntime140_cor3.dll (used by WPF)
+* D3DCompiler_47_cor3.dll (used by WPF)
+
+.NET 6 and earlier:
+
+* api-ms-\*.\* (used by .NET runtime)
+* ucrtbase.dll (used by .NET runtime)
 
 All other binaries and files are licensed with the
 [MIT license](https://github.com/dotnet/core/blob/main/LICENSE.TXT).
+
+See [license information](./license-information.md) for information about
+other operating systems.


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/108905

We were given the guidance that the license we were using for `vcruntime140_cor3.dll` was wrong and that we could use ".NET Library License" instead for it.

I also took the liberty to do some cleanup to make this document easier to read.

We can merge when @jkotas approves.