### PR TITLE
Correct architecture support for Ubuntu 24.04

### DIFF
--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -51,7 +51,8 @@ OS                              | Versions                    | Architectures   
 [openSUSE Leap][14]             | 15.6, 15.5                  | Arm64, x64            | [Lifecycle][15]
 [Red Hat Enterprise Linux][16]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][17]
 [SUSE Enterprise Linux][18]     | 15.6, 15.5, 12.5            | Arm64, x64            | [Lifecycle][19]
-[Ubuntu][20]                    | 24.04, 22.04, 20.04         | Arm32, Arm64, x64     | [Lifecycle][21]
+[Ubuntu][20]                    | 24.04                       | Arm64, x64            | [Lifecycle][21]
+[Ubuntu][20]                    | 22.04, 20.04                | Arm32, Arm64, x64     | [Lifecycle][21]
 
 Notes:
 


### PR DESCRIPTION
.NET arm32 is not supported on Ubuntu 24.04. See https://github.com/dotnet/runtime/issues/101444

@richlander @rbhanda