### PR TITLE
Fix `wiki.centos.org` links

### DIFF
--- a/release-notes/1.0/1.0-supported-os.md
+++ b/release-notes/1.0/1.0-supported-os.md
@@ -29,7 +29,7 @@ Mac OS X                      | 10.11, 10.12*                  | x64          | 
 
 OS                            | Version                        | Architectures| Notes
 ------------------------------|--------------------------------|--------------|-----
-Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7     | x64          | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
+Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7     | x64          | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
 Fedora                        | 27, 28 (1.1)                   | x64          | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 8.2+                           | x64          | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu <br/> Linux Mint        | 16.04, 18.04 (1.1) <br/> 17     | x64    | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases) <br/> [Linux Mint end of life announcements](https://forums.linuxmint.com/search.php?keywords=%22end+of+life%22&terms=all&author=&sc=1&sf=titleonly&sr=posts&sk=t&sd=d&st=0&ch=300&t=0&submit=Search)

--- a/release-notes/2.0/2.0-supported-os.md
+++ b/release-notes/2.0/2.0-supported-os.md
@@ -31,7 +31,7 @@ Mac OS X                      | 10.12+                        | x64            |
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy/)
-Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux     | 7                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
+Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux     | 7                             | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
 Fedora                        | 28, 27                | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9, 8.7+                   | x64            | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 18.04, 16.04, 14.04       | x64            | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)

--- a/release-notes/2.1/2.1-supported-os.md
+++ b/release-notes/2.1/2.1-supported-os.md
@@ -30,7 +30,7 @@ Mac OS X (macOS)              | 10.12+                        | x64            |
 
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
-Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br/> [Oracle Linux lifecycle](https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
+Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html) <br/> [Oracle Linux lifecycle](https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf)
 Fedora                        | 33+                     | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9+                             | x64, ARM32     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 21.04, 20.04, 18.04, 16.04           | x64, ARM32\*   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)

--- a/release-notes/2.2/2.2-supported-os.md
+++ b/release-notes/2.2/2.2-supported-os.md
@@ -30,7 +30,7 @@ Mac OS X                      | 10.12+                        | x64            |
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6                             | x64            | [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy/)
-Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
+Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
 Fedora                        | 29, 30                        | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9                             | x64, ARM32     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 18.10, 18.04, 16.04           | x64, ARM32\*   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)

--- a/release-notes/3.0/3.0-supported-os.md
+++ b/release-notes/3.0/3.0-supported-os.md
@@ -31,7 +31,7 @@ OS                            | Version                       | Architectures  |
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 6+                            | x64            | [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy/)
 Red Hat Enterprise Linux      | 7, 8                          | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/)
-CentOS                        | 7, 8                          | x64            | [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d)
+CentOS                        | 7, 8                          | x64            | [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html)
 Oracle Linux                  | 7, 8                          | x64            | [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
 Fedora                        | 30+                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9+                       | x64, ARM32, ARM64     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)

--- a/release-notes/3.1/3.1-supported-os.md
+++ b/release-notes/3.1/3.1-supported-os.md
@@ -37,7 +37,7 @@ Alpine 3.14 and Debian 11 are now supported with the .NET 5.0.10 and .NET Core 3
 OS                            | Version                       | Architectures  | Notes
 ------------------------------|-------------------------------|----------------|-----
 Red Hat Enterprise Linux      | 7+                            | x64            | [Microsoft support policy](https://dotnet.microsoft.com/platform/support/policy/)
-Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
+Red Hat Enterprise Linux <br/> CentOS <br/> Oracle Linux | 7+    | x64            | [Red Hat support policy](https://access.redhat.com/support/policy/updates/errata/) <br/> [CentOS lifecycle](https://wiki.centos.org/FAQ(2f)General.html) <br/> [Oracle Linux lifecycle](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
 Fedora                        | 33+                    | x64            | [Fedora lifecycle](https://fedoraproject.org/wiki/End_of_life)
 Debian                        | 9+                       | x64, ARM32, ARM64     | [Debian lifecycle](https://wiki.debian.org/DebianReleases)
 Ubuntu                        | 21.04, 20.04, 18.04                  | x64, ARM32, ARM64   | [Ubuntu lifecycle](https://wiki.ubuntu.com/Releases)

--- a/release-notes/5.0/5.0-supported-os.md
+++ b/release-notes/5.0/5.0-supported-os.md
@@ -44,7 +44,7 @@ Note: .NET 5 requires OpenSSL 1.x. Newer distro versions such as Ubuntu 22.04 us
 [Alpine]: https://alpinelinux.org/
 [Alpine-lifecycle]: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases
 [CentOS]: https://www.centos.org/
-[CentOS-lifecycle]:https://wiki.centos.org/FAQ/General
+[CentOS-lifecycle]:https://wiki.centos.org/FAQ(2f)General.html
 [CentOS-docker]: https://hub.docker.com/_/centos
 [CentOS-pm]: https://learn.microsoft.com/dotnet/core/install/linux-package-manager-centos8
 [Debian]: https://www.debian.org/

--- a/release-notes/6.0/supported-os.md
+++ b/release-notes/6.0/supported-os.md
@@ -135,9 +135,9 @@ Android                 | 12            | [2023-05-08](https://dotnet.microsoft.
 Android                 | 11            | [2023-05-08](https://dotnet.microsoft.com/en-us/platform/support/policy/maui)
 Android                 | 10            | 2023-03-06
 Android                 | 9             | [2022-01-01](https://developer.android.com/about/versions/pie)
-CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
-CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
-CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+CentOS                  | 7             | [2024-06-30](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOS7(2e)2009.html)
+CentOS                  | 8             | [2021-12-31](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOS8(2e)2111.html)
+CentOS Stream           | 8             | [2024-05-31](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOSStream.html)
 Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05

--- a/release-notes/7.0/supported-os.md
+++ b/release-notes/7.0/supported-os.md
@@ -124,9 +124,9 @@ Alpine                  | 3.16          | [2024-05-23](https://alpinelinux.org/p
 Alpine                  | 3.15          | [2023-11-01](https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html)
 Android                 | 11            | 2024-02-05
 Android                 | 10            | 2023-03-06
-CentOS                  | 7             | [2024-06-30](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009)
-CentOS                  | 8             | [2021-12-31](https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111)
-CentOS Stream           | 8             | [2024-05-31](http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+CentOS                  | 7             | [2024-06-30](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOS7(2e)2009.html)
+CentOS                  | 8             | [2021-12-31](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOS8(2e)2111.html)
+CentOS Stream           | 8             | [2024-05-31](https://wiki.centos.org/Manuals(2f)ReleaseNotes(2f)CentOSStream.html)
 Debian                  | 10            | [2022-09-10](https://www.debian.org/News/2022/20220910)
 Fedora                  | 38            | 2024-05-21
 Fedora                  | 37            | 2023-12-05


### PR DESCRIPTION
* Fix `https://wiki.centos.org/FAQ/General` -> 404
* Avoid unnecessary `web.archive.org` links