### PR TITLE
API diff between .NET 9 RC2 and .NET 9 GA

### DIFF
--- a/release-notes/9.0/preview/ga/api-diff/Microsoft.AspNetCore.App/9.0-ga.md
+++ b/release-notes/9.0/preview/ga/api-diff/Microsoft.AspNetCore.App/9.0-ga.md
@@ -1,0 +1,6 @@
+# API Difference 9.0-rc2 vs 9.0-ga
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+

--- a/release-notes/9.0/preview/ga/api-diff/Microsoft.NETCore.App/9.0-ga.md
+++ b/release-notes/9.0/preview/ga/api-diff/Microsoft.NETCore.App/9.0-ga.md
@@ -1,0 +1,7 @@
+# API Difference 9.0-rc2 vs 9.0-ga
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System](9.0-ga_System.md)
+

--- a/release-notes/9.0/preview/ga/api-diff/Microsoft.NETCore.App/9.0-ga_System.md
+++ b/release-notes/9.0/preview/ga/api-diff/Microsoft.NETCore.App/9.0-ga_System.md
@@ -1,0 +1,15 @@
+# System
+
+``` diff
+ namespace System {
+     public sealed class String : ICloneable, IComparable, IComparable<string?>, IConvertible, IEnumerable, IEnumerable<char>, IEquatable<string?>, IParsable<string>, ISpanParsable<string> {
+-        public String Trim(ReadOnlySpan<char> trimChars);
+
+-        public String TrimEnd(ReadOnlySpan<char> trimChars);
+
+-        public String TrimStart(ReadOnlySpan<char> trimChars);
+
+     }
+ }
+```
+

--- a/release-notes/9.0/preview/ga/api-diff/Microsoft.WindowsDesktop.App/9.0-ga.md
+++ b/release-notes/9.0/preview/ga/api-diff/Microsoft.WindowsDesktop.App/9.0-ga.md
@@ -1,0 +1,7 @@
+# API Difference 9.0-rc2 vs 9.0-ga
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Formats.Nrbf](9.0-ga_System.Formats.Nrbf.md)
+

--- a/release-notes/9.0/preview/ga/api-diff/Microsoft.WindowsDesktop.App/9.0-ga_System.Formats.Nrbf.md
+++ b/release-notes/9.0/preview/ga/api-diff/Microsoft.WindowsDesktop.App/9.0-ga_System.Formats.Nrbf.md
@@ -1,0 +1,17 @@
+# System.Formats.Nrbf
+
+``` diff
+ namespace System.Formats.Nrbf {
+     public abstract class ArrayRecord : SerializationRecord {
+-        public virtual long FlattenedLength { get; }
+
+     }
+     public static class NrbfDecoder {
+-        public static SerializationRecord Decode(Stream payload, out IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap, PayloadOptions options = null, bool leaveOpen = false);
++        public static SerializationRecord Decode(Stream payload, out IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap, PayloadOptions? options = null, bool leaveOpen = false);
+     }
+-    public struct SerializationRecordId : IEquatable<SerializationRecordId>
++    public readonly struct SerializationRecordId : IEquatable<SerializationRecordId>
+ }
+```
+

--- a/release-notes/9.0/preview/ga/api-diff/README.md
+++ b/release-notes/9.0/preview/ga/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 9.0 GA API Changes
+
+The following API changes were made in .NET 9.0 GA:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/9.0-ga.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/9.0-ga.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/9.0-ga.md)


### PR DESCRIPTION
Repo area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @lonitra @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffschwMSFT @jeffhandley @karelz @ericstj @stephentoub @SamMonoRT 

Libraries area owners:
- System @dotnet/area-system-runtime
- System.Formats.Nrbf @dotnet/area-system-formats-nrbf 

**Known api-diff tool issues**:

If yo usee any of these, please provide a GitHub suggestion in this PR to correct it: 

- The AsmDiff tool sometimes skips adding `{` or `{}` [arcade#10981](https://github.com/dotnet/arcade/issues/10981)(https://github.com/dotnet/arcade/issues/13814) 
- RequiresPreviewAttribute not getting auto added [arcade#14498](https://github.com/dotnet/arcade/issues/14498)
- Changes to `protected internal` visibility should stop showing. https://github.com/dotnet/arcade/issues/14579
- The AsmDiff tool shows APIs with decorating attribute changes as removed and re-added, instead of showing only the API. Please ignore this, it might be confusing but technically it's not incorrect: [arcade#13814]
