### PR TITLE
Add .NET 10 support information

### DIFF
--- a/release-notes/10.0/README.md
+++ b/release-notes/10.0/README.md
@@ -1,0 +1,5 @@
+# .NET 10
+
+.NET 10 is a [Long Term Support (LTS)](../../release-policies.md) release and will be supported on [multiple operating systems](supported-os.md) for 36 months.
+
+It is currently in development and not supported.

--- a/release-notes/10.0/README.md
+++ b/release-notes/10.0/README.md
@@ -2,4 +2,4 @@
 
 .NET 10 is a [Long Term Support (LTS)](../../release-policies.md) release and will be supported on [multiple operating systems](supported-os.md) for 36 months.
 
-It is currently in development and not supported.
+It is currently in development and not supported. .NET 10 is expected to be released in late 2025.

--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -1,0 +1,356 @@
+{
+    "channel-version": "9.0",
+    "last-updated": "2024-12-06",
+    "families": [
+        {
+            "name": "Android",
+            "distributions": [
+                {
+                    "id": "android",
+                    "name": "Android",
+                    "link": "https://www.android.com/",
+                    "lifecycle": "https://support.google.com/android",
+                    "architectures": [
+                        "Arm32",
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "15",
+                        "14",
+                        "13",
+                        "12.1",
+                        "12"
+                    ],
+                    "notes": [
+                        "API 21 is used as the minimum SDK target."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Apple",
+            "distributions": [
+                {
+                    "id": "ios",
+                    "name": "iOS",
+                    "link": "https://developer.apple.com/ios/",
+                    "architectures": [
+                        "Arm64"
+                    ],
+                    "supported-versions": [
+                        "18",
+                        "17",
+                        "16"
+                    ],
+                    "notes": [
+                        "iOS 12.2 is used as the minimum SDK target."
+                    ]
+                },
+                {
+                    "id": "ipados",
+                    "name": "iPadOS",
+                    "link": "https://developer.apple.com/ipados/",
+                    "architectures": [
+                        "Arm64"
+                    ],
+                    "supported-versions": [
+                        "18",
+                        "17",
+                        "16"
+                    ]
+                },                
+                {
+                    "id": "macos",
+                    "name": "macOS",
+                    "link": "https://developer.apple.com/macos/",
+                    "architectures": [
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "15",
+                        "14",
+                        "13"
+                    ],
+                    "notes" : [
+                        "The iOS and tvOS simulators are supported on macOS Arm64 and x64.",
+                        "The x64 emulator (Rosetta 2) is supported on macOS Arm64.",
+                        "Mac Catalyst apps are supported on macOS Arm64 and x64."
+                    ]
+                },
+                {
+                    "id": "tvos",
+                    "name": "tvOS",
+                    "link": "https://developer.apple.com/tvos/",
+                    "architectures": [
+                        "Arm64"
+                    ],
+                    "supported-versions": [
+                        "18",
+                        "17",
+                        "16",
+                        "15",
+                        "14",
+                        "13",
+                        "12.2"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Linux",
+            "distributions": [
+                {
+                    "id": "alpine",
+                    "name": "Alpine",
+                    "link": "https://alpinelinux.org/",
+                    "lifecycle": "https://alpinelinux.org/releases/",
+                    "architectures": [
+                        "Arm32",
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "3.21"
+                    ]
+                },
+                {
+                    "id": "azurelinux",
+                    "name": "Azure Linux",
+                    "link": "https://github.com/microsoft/azurelinux",
+                    "architectures": [
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "3.0"
+                    ]
+                },
+                {
+                    "id": "centos-stream",
+                    "name": "CentOS Stream",
+                    "link": "https://centos.org/",
+                    "lifecycle": "https://www.centos.org/cl-vs-cs/",
+                    "architectures": [
+                        "Arm64",
+                        "ppc64le",
+                        "s390x",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9"
+                    ]
+                },
+                {
+                    "id": "debian",
+                    "name": "Debian",
+                    "link": "https://www.debian.org/",
+                    "lifecycle": "https://wiki.debian.org/DebianReleases",
+                    "architectures": [
+                        "Arm32",
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "12"
+                    ]
+                },
+                {
+                    "id": "fedora",
+                    "name": "Fedora",
+                    "link": "https://fedoraproject.org/",
+                    "lifecycle": "https://fedoraproject.org/wiki/End_of_life",
+                    "architectures": [
+                        "Arm32",
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "41"
+                    ]
+                },
+                {
+                    "id": "opensuse",
+                    "name": "openSUSE Leap",
+                    "link": "https://www.opensuse.org/",
+                    "lifecycle": "https://en.opensuse.org/Lifetime",
+                    "architectures": [
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "15.6"
+                    ]
+                },
+                {
+                    "id": "rhel",
+                    "name": "Red Hat Enterprise Linux",
+                    "link": "https://access.redhat.com/",
+                    "lifecycle": "https://access.redhat.com/support/policy/updates/errata/",
+                    "architectures": [
+                        "Arm64",
+                        "ppc64le",
+                        "s390x",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "9",
+                        "8"
+                    ],
+                    "notes": [
+                        "RHEL-compatible derivatives are supported per [.NET Support](../../support.md)."
+                    ]
+                },
+                {
+                    "id": "sles",
+                    "name": "SUSE Enterprise Linux",
+                    "link": "https://www.suse.com/",
+                    "lifecycle": "https://www.suse.com/lifecycle/",
+                    "architectures": [
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "15.6"
+                    ]
+                },
+                {
+                    "id": "ubuntu",
+                    "name": "Ubuntu",
+                    "link": "https://ubuntu.com/",
+                    "lifecycle": "https://wiki.ubuntu.com/Releases",
+                    "architectures": [
+                        "Arm32",
+                        "Arm64",
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "24.10",
+                        "24.04",
+                        "22.04"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Windows",
+            "distributions": [
+                {
+                    "id": "windows-nano-server",
+                    "name": "Nano Server",
+                    "link": "https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images",
+                    "lifecycle": "https://learn.microsoft.com/windows-server/get-started/windows-server-release-info",
+                    "architectures": [
+                        "x64"
+                    ],
+                    "supported-versions": [
+                        "2022",
+                        "2019"
+                    ]
+                },
+                {
+                    "id": "windows",
+                    "name": "Windows",
+                    "link": "https://www.microsoft.com/windows/",
+                    "lifecycle": "https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet",
+                    "architectures": [
+                        "Arm64",
+                        "x64",
+                        "x86"
+                    ],
+                    "supported-versions": [
+                        "11-24h2-iot-lts",
+                        "11-24h2-e-lts",
+                        "11-24h2-e",
+                        "11-24h2-w",
+                        "11-23h2-e",
+                        "11-23h2-w",
+                        "11-22h2-e",
+                        "10-22h2",
+                        "10-21h2-e-lts",
+                        "10-21h2-iot-lts",
+                        "10-1809-e-lts",
+                        "10-1607-e-lts"
+                    ],
+                    "notes": [
+                        "The x64 emulator is supported on Windows 11 Arm64."
+                    ]
+                },
+                {
+                    "id": "windows-server",
+                    "name": "Windows Server",
+                    "link": "https://www.microsoft.com/windows-server",
+                    "lifecycle": "https://learn.microsoft.com/windows-server/get-started/windows-server-release-info",
+                    "architectures": [
+                        "x64",
+                        "x86"
+                    ],
+                    "supported-versions": [
+                        "23H2",
+                        "2022",
+                        "2019",
+                        "2016",
+                        "2012-R2",
+                        "2012"
+                    ],
+                    "notes": [
+                        "Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview)."
+                    ]
+                },
+                {
+                    "id": "windows-server-core",
+                    "name": "Windows Server Core",
+                    "link": "https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images",
+                    "lifecycle": "https://learn.microsoft.com/windows-server/get-started/windows-server-release-info",
+                    "architectures": [
+                        "x64",
+                        "x86"
+                    ],
+                    "supported-versions": [
+                        "2022",
+                        "2019",
+                        "2016",
+                        "2012-R2",
+                        "2012"
+                    ],
+                    "notes": [
+                        "Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview)."
+                    ]
+                }
+            ]
+        }
+    ],
+    "libc": [
+        {
+            "name": "glibc",
+            "architectures": [
+                "Arm64",
+                "x64"
+            ],
+            "version": "2.27",
+            "source": "Ubuntu 18.04"
+        },
+        {
+            "name": "glibc",
+            "architectures": [
+                "Arm32"
+            ],
+            "version": "2.35",
+            "source": "Ubuntu 22.04"
+        },
+        {
+            "name": "musl",
+            "architectures": [
+                "Arm32",
+                "Arm64",
+                "x64"
+            ],
+            "version": "1.2.3",
+            "source": "Alpine 3.17"
+        }
+    ],
+    "notes": [
+        "The [QEMU](https://www.qemu.org/) emulator is not supported to run .NET apps. QEMU is used, for example, to emulate Arm64 containers on x64, and vice versa."
+    ]
+}

--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -1,5 +1,5 @@
 {
-    "channel-version": "9.0",
+    "channel-version": "10.0",
     "last-updated": "2024-12-06",
     "families": [
         {

--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -47,7 +47,7 @@ Notes:
 OS                              | Versions                    | Architectures         | Lifecycle
 ------------------------------- | --------------------------- | --------------------- | ----------------------
 [Alpine][6]                     | 3.21                        | Arm32, Arm64, x64     | [Lifecycle][7]
-[Azure Linux][8]                | 3.0                         | Arm64, x64            
+[Azure Linux][8]                | 3.0                         | Arm64, x64 | None
 [CentOS Stream][9]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][10]
 [Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
 [Fedora][13]                    | 41                          | Arm32, Arm64, x64     | [Lifecycle][14]

--- a/release-notes/10.0/supported-os10.md
+++ b/release-notes/10.0/supported-os10.md
@@ -1,0 +1,122 @@
+# .NET 10 - Supported OS versions
+
+Last updated: 2024-12-06
+
+Note: .NET 10 is unsupported and is expected to be released in late 2025.
+
+[.NET 10](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
+
+This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).
+
+## Android
+
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Android][0]                    | 15, 14, 13, 12.1, 12        | Arm32, Arm64, x64     | [Lifecycle][1]
+
+Notes:
+
+* Android: API 21 is used as the minimum SDK target.
+
+[0]: https://www.android.com/
+[1]: https://support.google.com/android
+
+## Apple
+
+OS                              | Versions                    | Architectures
+------------------------------- | --------------------------- | ----------------------
+[iOS][2]                        | 18, 17, 16                  | Arm64
+[iPadOS][3]                     | 18, 17, 16                  | Arm64
+[macOS][4]                      | 15, 14, 13                  | Arm64, x64
+[tvOS][5]                       | 18, 17, 16, 15, 14, 13, 12.2 | Arm64
+
+Notes:
+
+* iOS: iOS 12.2 is used as the minimum SDK target.
+* macOS: The iOS and tvOS simulators are supported on macOS Arm64 and x64.
+* macOS: The x64 emulator (Rosetta 2) is supported on macOS Arm64.
+* macOS: Mac Catalyst apps are supported on macOS Arm64 and x64.
+
+[2]: https://developer.apple.com/ios/
+[3]: https://developer.apple.com/ipados/
+[4]: https://developer.apple.com/macos/
+[5]: https://developer.apple.com/tvos/
+
+## Linux
+
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Alpine][6]                     | 3.21                        | Arm32, Arm64, x64     | [Lifecycle][7]
+[Azure Linux][8]                | 3.0                         | Arm64, x64            
+[CentOS Stream][9]              | 9                           | Arm64, ppc64le, s390x, x64 | [Lifecycle][10]
+[Debian][11]                    | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]
+[Fedora][13]                    | 41                          | Arm32, Arm64, x64     | [Lifecycle][14]
+[openSUSE Leap][15]             | 15.6                        | Arm64, x64            | [Lifecycle][16]
+[Red Hat Enterprise Linux][17]  | 9, 8                        | Arm64, ppc64le, s390x, x64 | [Lifecycle][18]
+[SUSE Enterprise Linux][19]     | 15.6                        | Arm64, x64            | [Lifecycle][20]
+[Ubuntu][21]                    | 24.10, 24.04, 22.04         | Arm32, Arm64, x64     | [Lifecycle][22]
+
+Notes:
+
+* Red Hat Enterprise Linux: RHEL-compatible derivatives are supported per [.NET Support](../../support.md).
+
+[6]: https://alpinelinux.org/
+[7]: https://alpinelinux.org/releases/
+[8]: https://github.com/microsoft/azurelinux
+[9]: https://centos.org/
+[10]: https://www.centos.org/cl-vs-cs/
+[11]: https://www.debian.org/
+[12]: https://wiki.debian.org/DebianReleases
+[13]: https://fedoraproject.org/
+[14]: https://fedoraproject.org/wiki/End_of_life
+[15]: https://www.opensuse.org/
+[16]: https://en.opensuse.org/Lifetime
+[17]: https://access.redhat.com/
+[18]: https://access.redhat.com/support/policy/updates/errata/
+[19]: https://www.suse.com/
+[20]: https://www.suse.com/lifecycle/
+[21]: https://ubuntu.com/
+[22]: https://wiki.ubuntu.com/Releases
+
+## Windows
+
+OS                              | Versions                    | Architectures         | Lifecycle
+------------------------------- | --------------------------- | --------------------- | ----------------------
+[Nano Server][23]               | 2022, 2019                  | x64                   | [Lifecycle][24]
+[Windows][25]                   | 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 11 22H2 (E), 10 22H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26]
+[Windows Server][27]            | 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][24]
+[Windows Server Core][23]       | 2022, 2019, 2016, 2012-R2, 2012 | x64, x86          | [Lifecycle][24]
+
+Notes:
+
+* Windows: The x64 emulator is supported on Windows 11 Arm64.
+* Windows Server: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
+* Windows Server Core: Windows Server 2012 and 2012 R2 are supported with [Extended Security Updates](https://learn.microsoft.com/windows-server/get-started/extended-security-updates-overview).
+
+[23]: https://learn.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images
+[24]: https://learn.microsoft.com/windows-server/get-started/windows-server-release-info
+[25]: https://www.microsoft.com/windows/
+[26]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet
+[27]: https://www.microsoft.com/windows-server
+
+## Linux compatibility
+
+Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
+
+Libc            | Version | Architectures         | Source
+--------------- | ------- | --------------------- | --------------
+glibc           | 2.27    | Arm64, x64            | Ubuntu 18.04
+glibc           | 2.35    | Arm32                 | Ubuntu 22.04
+musl            | 1.2.3   | Arm32, Arm64, x64     | Alpine 3.17
+
+Note: Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 compatible glibc](https://github.com/dotnet/core/discussions/9285), for example Debian 12, Ubuntu 22.04, and higher versions.
+
+## Notes
+
+* The [QEMU](https://www.qemu.org/) emulator is not supported to run .NET apps. QEMU is used, for example, to emulate Arm64 containers on x64, and vice versa.
+
+## Out of support OS versions
+
+Support for the following operating system versions has ended.
+
+None currently.

--- a/release-notes/10.0/supported-os10.md
+++ b/release-notes/10.0/supported-os10.md
@@ -2,9 +2,9 @@
 
 Last updated: 2024-12-06
 
-Note: .NET 10 is unsupported and is expected to be released in late 2025.
-
 [.NET 10](README.md) is a [Long Term Support (LTS)](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
+
+Note: .NET 10 is currently in development and not supported. Supported OS versions are subject to change.
 
 This file is generated from [supported-os.json](supported-os.json) and is based on support information from [endoflife.date](https://endoflife.date/).
 


### PR DESCRIPTION
We are building up infra for .NET 10. We need to know what the min supported version is for each OS/distro.

Please comment if these versions should change, now or in the future. I've made some initial changes w/rt to .NET 8 and 9. It's all open for discussion. Note that the versions should be based on what makes sense to support as of late 2025 not late 2024 (now).

Compare with:

- https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md
- https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md

Note: We're moving to two digits (before the `.`). I'm sure that will break someone's assumptions in their code.

Related: https://github.com/dotnet/runtime/issues/109939

@Falco20019 @leecow @rbhanda 