### PR TITLE
Fix broken links and update

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -4,14 +4,12 @@
 
 |  Version  | Release Date | Support | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- |
-| [.NET 9](release-notes/9.0/README.md) | November 12, 2024 | [STS][policies] | [9.0.0][9.0.0] | May 12, 2026 |
-| [.NET 8](release-notes/8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | [8.0.11][8.0.11] | November 10, 2026 |
-| [.NET 6](release-notes/6.0/README.md) | [November 8, 2021](https://devblogs.microsoft.com/dotnet/announcing-net-6/) | [LTS][policies] | [6.0.36][6.0.36]  | November 12, 2024 |
+| [.NET 9](./9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | [9.0.0][9.0.0] | May 12, 2026 |
+| [.NET 8](./8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | [8.0.11][8.0.11] | November 10, 2026 |
 
-[9.0.0]: 9.0/9.0.0/9.0.0.md
-[8.0.11]: 8.0/8.0.11/8.0.11.md
-[6.0.36]: 6.0/6.0.36/6.0.36.md
-[policies]: release-policies.md
+[9.0.0]: ./9.0/9.0.0/9.0.0.md
+[8.0.11]: ./8.0/8.0.11/8.0.11.md
+[policies]: ../release-policies.md
 
 * [Binaries and installers](https://dotnet.microsoft.com/download/dotnet)
 * [Installation docs](https://learn.microsoft.com/dotnet/core/install/)
@@ -31,8 +29,8 @@ Release notes include:
 
 Example markdown files:
 
-- [6.0/6.0.32/6.0.32.md](./6.0/6.0.32/6.0.32.md)
-- [8.0/8.0.1/8.0.1.md](./8.0/8.0.1/8.0.1.md)
+- [8.0/8.0.11/8.0.11.md](./8.0/8.0.11/8.0.11.md)
+- [9.0/9.0.0/9.0.0.md](./9.0/9.0.0/9.0.0.md)
 
 Example JSON files:
 


### PR DESCRIPTION
@richlander I found that some of the links are broken and that .NET 6 was still shown as LTS although EOL.