### PR TITLE
Update dotnetcli domain

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -12,8 +12,8 @@
             "support-phase": "active",
             "eol-date": "2026-05-12",
             "release-type": "sts",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/releases.json",
-            "supported-os.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/supported-os.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/releases.json",
+            "supported-os.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/supported-os.json"
         },
         {
             "channel-version": "8.0",
@@ -26,8 +26,8 @@
             "support-phase": "active",
             "eol-date": "2026-11-10",
             "release-type": "lts",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json",
-            "supported-os.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/supported-os.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json",
+            "supported-os.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/supported-os.json"
         },
         {
             "channel-version": "7.0",
@@ -40,8 +40,8 @@
             "support-phase": "eol",
             "eol-date": "2024-05-14",
             "release-type": "sts",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json",
-            "supported-os.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/supported-os.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/7.0/releases.json",
+            "supported-os.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/7.0/supported-os.json"
         },
         {
             "channel-version": "6.0",
@@ -54,8 +54,8 @@
             "support-phase": "maintenance",
             "eol-date": "2024-11-12",
             "release-type": "lts",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json",
-            "supported-os.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/supported-os.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/releases.json",
+            "supported-os.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/supported-os.json"
         },
         {
             "channel-version": "5.0",
@@ -68,7 +68,7 @@
             "release-type": "sts",
             "support-phase": "eol",
             "eol-date": "2022-05-10",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/5.0/releases.json"
         },
         {
             "channel-version": "3.1",
@@ -81,7 +81,7 @@
             "release-type": "lts",
             "support-phase": "eol",
             "eol-date": "2022-12-13",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/3.1/releases.json"
         },
         {
             "channel-version": "3.0",
@@ -94,7 +94,7 @@
             "release-type": "sts",
             "support-phase": "eol",
             "eol-date": "2020-03-03",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/3.0/releases.json"
         },
         {
             "channel-version": "2.1",
@@ -107,7 +107,7 @@
             "release-type": "lts",
             "support-phase": "eol",
             "eol-date": "2021-08-21",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/2.1/releases.json"
         },
         {
             "channel-version": "2.2",
@@ -120,7 +120,7 @@
             "release-type": "sts",
             "support-phase": "eol",
             "eol-date": "2019-12-23",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/2.2/releases.json"
         },
         {
             "channel-version": "2.0",
@@ -133,7 +133,7 @@
             "release-type": "sts",
             "support-phase": "eol",
             "eol-date": "2018-10-01",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/2.0/releases.json"
         },
         {
             "channel-version": "1.1",
@@ -146,7 +146,7 @@
             "release-type": "lts",
             "support-phase": "eol",
             "eol-date": "2019-06-27",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/1.1/releases.json"
         },
         {
             "channel-version": "1.0",
@@ -159,7 +159,7 @@
             "release-type": "lts",
             "support-phase": "eol",
             "eol-date": "2019-06-27",
-            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json"
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/1.0/releases.json"
         }
     ]
 }


### PR DESCRIPTION
- Updating to new domain
- This change will be made to the matching file on the CDN next patch Tuesday.

Related: https://github.com/dotnet/core/issues/9671

Fixes: https://github.com/dotnet/core/issues/9675