### PR TITLE
Fix support phase for .NET 6

### DIFF
--- a/release-notes/6.0/releases.json
+++ b/release-notes/6.0/releases.json
@@ -4,7 +4,7 @@
   "latest-release-date": "2024-11-12",
   "latest-runtime": "6.0.36",
   "latest-sdk": "6.0.428",
-  "support-phase": "maintenance",
+  "support-phase": "eol",
   "release-type": "lts",
   "eol-date": "2024-11-12",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",


### PR DESCRIPTION
I think this is the root cause for the EOL alert not to show up for https://dotnet.microsoft.com/en-us/download/dotnet/6.0