### PR TITLE
Update broken dotnet-blog link in 9.0.2.md

### DIFF
--- a/release-notes/9.0/9.0.2/9.0.2.md
+++ b/release-notes/9.0/9.0.2/9.0.2.md
@@ -68,7 +68,7 @@ Your feedback is important and appreciated. We've created an issue at [dotnet/co
 [checksums-sdk]: https://builds.dotnet.microsoft.com/dotnet/checksums/9.0.2-sha.txt
 
 [linux-install]: ../install-linux.md
-[dotnet-blog]: https://devblogs.microsoft.com/dotnet/net-and-net-framework-february-2025-servicing-releases-updates/
+[dotnet-blog]: https://devblogs.microsoft.com/dotnet/dotnet-and-dotnet-framework-february-2025-servicing-updates/
 [aspnet-blog]: https://devblogs.microsoft.com/dotnet/announcing-asp-net-core-in-dotnet-9/
 [ef-blog]: https://devblogs.microsoft.com/dotnet/announcing-ef9/
 [ef_bugs]: https://github.com/dotnet/efcore/issues?q=is%3Aissue+milestone%3A9.0.2+is%3Aclosed+label%3Atype-bug


### PR DESCRIPTION
The dotnet-blog link to the February changes was broken, it seems the blog naming structure may have changed.