### PR TITLE
Rewrite URLs to builds.dotnet.microsoft.com

### DIFF
--- a/release-notes/9.0/releases.json
+++ b/release-notes/9.0/releases.json
@@ -24,97 +24,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6ad62cc2-7db5-4961-9192-84d50536b636/19e78b86ce8b40becdca65a7b7e8d8df/dotnet-runtime-9.0.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-arm.tar.gz",
             "hash": "be31b790c8a5347c1a7fb75ecbbab16c675ff5e6352561631220b94d417f19eed07220d5c3972905123704dd6bd67d00138ff42484815e0def7d8ad916a30d94"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3658cac0-6e40-4467-af08-02cf5bc0309c/ad2d0efa6e2bf05fd1078182d232f052/dotnet-runtime-9.0.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-arm64.tar.gz",
             "hash": "460133ddc2582a209bd80673721e7b9add2b9b2967ef1503a7dc29be2777870870990ee7549351e8207c3e3e84dabeca6d5bdbbdea75e5e3e749eb16bd13e7ef"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/efa5ec39-7af0-4941-9886-6c37758df9cd/9b0910cf8f0be4645fd7bde1f2665e5c/dotnet-runtime-9.0.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-musl-arm.tar.gz",
             "hash": "38e03d8c12fa4520e311cf2d15fb2c2f0e019c7165b13fcbe58fc46914743ecea8e0ac4d914385b1430cfb5e0df3db6299424cfdccea6ffe469a681e2d9d93b7"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a74dfdf-3b5d-4e92-bd17-878401c55dd5/a9fcf25e0571144a1cf08b23da3476fc/dotnet-runtime-9.0.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-musl-arm64.tar.gz",
             "hash": "0bb0dc7a4388c5b95d4fec9fe7ca1273f9afa502021c73eb946ed2928d6d6d0836414400f667eff30da97b83b04f66d3032c2344bb2587007b4001d75b696a16"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e848109e-b3a7-4496-ae31-345b92345a81/78db157b0850dd7d9ce22c908d53154f/dotnet-runtime-9.0.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-musl-x64.tar.gz",
             "hash": "df116ef9b7f6b717b7c7f057e826c9e1f1ed0d743fa6b26e9229fc36e500ab834d19ae1ab55ebc28b1c9b8cb4a7f41c62edd08c2dd2cdcb6e912defea2810ffb"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a15e92d8-e1db-402c-b06d-b6dcf7ad58eb/8c4233bceadcf8f57b40f64aceda69f7/dotnet-runtime-9.0.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-linux-x64.tar.gz",
             "hash": "dc4af24d5d298392fd53491a56c6d4e3d1e85e3e294cb4a848c7ac8f0dce287f11dcb274f18f95f7db7195681386e5c6b0d99500808c1b3e68b9c6097a3484d7"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/016550c2-bc46-43e1-9a9b-31ddb92608ed/7f2a45a4560de9ce447a681162e2e753/dotnet-runtime-9.0.2-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-osx-arm64.pkg",
             "hash": "18e680670708b1230786c1433f8126c926d261d6516917f2d65a9038f819eb1deeea473e5f14e74020c68e6d67e393ef1f69c70f6220d1d7d0482802cdd6460b"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e559996-ff59-4cdb-8a91-e6c7d7235f4e/e5766287ef607672cc47be8119afc28a/dotnet-runtime-9.0.2-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-osx-arm64.tar.gz",
             "hash": "5ad890311607a5fb14f9a64103acd76385781e4b75085a8e755da474ffc1d50730bb8064e8bafb117afdb9d04ceacbd58452539f1e0e63be0b9731e19fd65156"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8639e61e-f1da-4e5b-a3d1-f1a92f726b3d/4a1f32a0db1e3858dee4f2f3823941e3/dotnet-runtime-9.0.2-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-osx-x64.pkg",
             "hash": "a9bb2cda7b53410880cecd51ba9798f0b4872e4327f4f5a619876f6d85b24bdf83f134f523edfa547640993c1e87f1a61c4f42ad738887d10d665ca7b597ec48"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5a5d3a4-2054-499f-99e2-cf64bbc7ad24/bf987a5f19a84196621b725b9e41b332/dotnet-runtime-9.0.2-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-osx-x64.tar.gz",
             "hash": "abe0752f3437ce0e2415d1f70879b6b062dfda59128ef5b96db946639b506a54cac81845b6775d19014d52271abeb8dfaacfeb783452b98f66265c5efb1b3b55"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/13aefe6a-ec97-4166-9b8c-278d026a8db9/58b4801e50bdfd60eedef192248cb8fd/dotnet-runtime-9.0.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-arm64.exe",
             "hash": "d66e00748adcf3d43124cfaff1bb6122dc984ee20a488966e1d6a36b3c83671b91100f985812d1553d52498e8b40d5eccbad87a4778c5aa4c6debe5ca59390d2"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f54f2ae-49f3-4c94-a49a-4a4a5331d106/8b71ca2d99b8a4c7360d4dbfcf9b4b1b/dotnet-runtime-9.0.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-arm64.zip",
             "hash": "2fa9ff1951b62399e3b201e8c247f6646e9c2099ea302bf5b18e5a00e156017f438c6c68d3c7b634f744c250d8acdc8eef6e17bab6f25982ef5f0e36a5f8be90"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5b463-833d-4275-bcaf-5e10c24b31fd/f55af40f168e104e5d93aa1998879570/dotnet-runtime-9.0.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-x64.exe",
             "hash": "da1d1ba1973d24bb42cf511d12931de88fd1e73efe26690fef60c61d20a6ca63018fd59d5a358f5a7a2bc8219ea294e0fb2786dbcea7d6c05b0a007ffef76e3c"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1b2400e-b3c9-487d-af4c-f46d78e24752/3769330a99d7556c0f625e657fe9b361/dotnet-runtime-9.0.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-x64.zip",
             "hash": "a8c9402fab7f9f9afefea433e2f35f894f8411ea9b7139321b4dd4cc1a39cce59c678158dc0178e376d5bdd11bbdd48c1c748b7d0fdf7cbea7a8c5f8b7afb987"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e6149c1-93a5-4c39-93f7-acedb3b8f576/01b7d995fb8cf6d87d71bc625b61dc96/dotnet-runtime-9.0.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-x86.exe",
             "hash": "d86fc1c6473d9a365a43b39da988b39a9a008f2c3fdde8b68cc6e0893af1e99a9fb5473a10128d55e3e02e808db088438431cce4610153fe3c4d0aadcaf6c7c5"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/25bb6f46-a94f-4ebf-952a-52c5d2310240/fc7a4440f6d8020483821e437d40cf5e/dotnet-runtime-9.0.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.2/dotnet-runtime-9.0.2-win-x86.zip",
             "hash": "ed9cb618e20abe5a03a2d132e6ededd7ef1e4338e61edbc301063ab2d82287cf9781e1e1738d175e73de751f3359671ed35d36e76bc6688485e6b2e0a2bf9864"
           }
         ]
@@ -134,97 +134,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3dde7d92-2a9d-44a5-8e83-6ef57d976c93/dddb3f71a8145f2729c38570694f95c3/dotnet-sdk-9.0.200-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-arm.tar.gz",
             "hash": "476a9a686af234482ea99ef53fd1a3b6bd65e4ef5f24eb1e2e94b60f146e7b7e7b99519a66a896836682e702007027a04e10ede857fc4540c3bae56b16cb3780"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b94570d9-8cb1-4672-be62-4acaa8675749/2697b4ae3923b16e72f6443f30333f5d/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
             "hash": "c2d18644243d67d103471713f0e9ba659df0c0d5e098bd441310418dd03798d6a5a8539da7c8cc320d57085c193c753ff78bdff8a97a97c51f500433538fb722"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f65430d6-4ddf-4ed4-a91c-025933457f61/8e0766a17389dd840585ddc440431e19/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
             "hash": "4297ed3b4f112e1d64a6617cb96191bfb4ebf6a5fbd01c75de6c0592897173f011aef3d9be7e61738e0c8ce8ba1815b06f28e0c251c840f2e0de2630d36616ca"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/071e3ccf-eb10-4658-814b-c86dc60525ee/2ef91c84593fb6f465082ee069502085/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
             "hash": "f1a70807e0a2b5ee272bdd714535a2fa3d31bb8c2216b43c151a72cb364f64a6f893590baeebc7dfb2b78ff50e4ba11c3e4cadf11c75744404fefabdc7ff08db"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/625fe095-f8b3-4666-a4ab-b44931f482bf/bbc206404c3e402749523e37063931b3/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
             "hash": "96b032d5209a838e97522528963e2e9589f8384dff4292e567030b0da0849104a57cd6d0f05e5fb7e7787730f47c6112a014df17c76010864f55c110a971f216"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3606de37-1325-4f5f-bbe9-1bc44b3c1c7f/91872629e9f0c205cace9c462d5e89a4/dotnet-sdk-9.0.200-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-x64.tar.gz",
             "hash": "1af5f3a444419b3f5cf99cb03ee740722722478226d0aff27ad41b1d11e69d73497e25c07ef06a6df9e73fb0fbdc4b9baca9accec95654d9ee7be4d5a5c3ac23"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5dfd4eb-19f4-4ba5-9a0c-50af354aa434/3f307be41112d4a8de659535e8badff2/dotnet-sdk-9.0.200-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-arm64.pkg",
             "hash": "5f7528922738e520edf714cee636d8e1b44c62d1af984804ca00508f22bff54776a232cdd1e94d386c1d70fc02219f8e4d05db9b449bbe7853fdce284e5fc8db"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/be46fe4d-4225-4681-a301-8d2bd5c2e044/362014a73e57d02b9ffce618c5ab46e9/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
             "hash": "a45d5a6fe5f046e9cd0a4482a41f0884822903134bcd2f25face71e1322749dacc53221cee21f814c6171326da0f64f42204ebd79f633a3bd1075c04fa73d1bc"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/24e6d730-e336-4ba9-a248-4519bdd38251/e35a7403d4b03ffa8ced47dff6b3111f/dotnet-sdk-9.0.200-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-x64.pkg",
             "hash": "a9dd1005ae1ab833c0c95a4ca1850e29a01b712b224eddf1edae3f152ea2a212402abb61956dbc8e8804762b10ca980371ddb0735cc950422c9ce3ba08c6f64f"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9983e36c-5e9f-4895-8f56-1d0a61cfa9cf/945b1788d8624457b631a383d55f109b/dotnet-sdk-9.0.200-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-x64.tar.gz",
             "hash": "f38a641d17dedf0be24c721cc4f78784050cd5184fb5cc6c04c4b2e6f7602c55fc5a3c80dcf2a1df5ec59aedad42947720510f07b2b3c59b6185b91aff2010ae"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/480881fc-fec9-468f-89de-17b1e50a6cce/bf53315c59df9c14f68398357503f047/dotnet-sdk-9.0.200-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-arm64.exe",
             "hash": "06d7c4133bf7cb6f72b60b97f11c1f8773291e888f556c355d45dc66e3b36e597ac5562359fb3221b970b28f02649f0693d5109467698310752e0a8dc60f6703"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fde8f9b5-2f06-4a1a-a026-f5f49b686906/1709ada276f45c0e39af4af728e36a16/dotnet-sdk-9.0.200-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-arm64.zip",
             "hash": "3a996171562f30ac2f4a73d196bcf5ae3077ed5425c4d9aec562116e886dc3a9c20a227753501ac3741a5a8c7473d95a5861100e9d38fc2b09de09193e1bb00f"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/83c595a0-def1-4aba-8284-2fd98007aa3d/5e5b47fb819ee59b2a10485f8cf5a89a/dotnet-sdk-9.0.200-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x64.exe",
             "hash": "801d4a40a7bdad5c7b50e75c55c5ab657da44b5d779fe50da5683450e23c595e8b18e6bc9ffb80636ffb347b72e575379cd83c7554dc27f5ba75246169f327a8"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6f8a9285-8627-419c-a2f9-3f9463b06bf3/6d0c9057e0f61f8a6e5708fb9261ff1e/dotnet-sdk-9.0.200-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x64.zip",
             "hash": "e274e0e8a0d926c58a2199e020fc5b2c2867689772f51673f655ee853a50a9ca0e435ae5682bb4ae146d1fbc9a40f6d4a7ecff14d5fea24db8a3f67d0dcbf2a9"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0804e70c-d375-4d40-8e62-fe355c58751b/340302fa7a9950697106fa0f87965923/dotnet-sdk-9.0.200-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x86.exe",
             "hash": "3ddeb620fc45c623ade58f179e80cea64b7af5b76b0b4b1f65b766df3c5614ce04809f40614ebeb98dd6b4662dc1c2bed38d1f78eadc489360d54e35b98b9904"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9c32ade8-845e-4171-8ab3-777890c8a4a0/f2f3cc161effa1fa31a43ff0aab570e7/dotnet-sdk-9.0.200-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x86.zip",
             "hash": "65daea90e55f93abe1484dd86bcf2b447d0caf20fb80734a361f2dba0e6ded2158b40d5a7834c192e51b108fb2205aefc856c2a1b34e363413bc371e3a7f2737"
           }
         ]
@@ -245,97 +245,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3dde7d92-2a9d-44a5-8e83-6ef57d976c93/dddb3f71a8145f2729c38570694f95c3/dotnet-sdk-9.0.200-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-arm.tar.gz",
               "hash": "476a9a686af234482ea99ef53fd1a3b6bd65e4ef5f24eb1e2e94b60f146e7b7e7b99519a66a896836682e702007027a04e10ede857fc4540c3bae56b16cb3780"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b94570d9-8cb1-4672-be62-4acaa8675749/2697b4ae3923b16e72f6443f30333f5d/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
               "hash": "c2d18644243d67d103471713f0e9ba659df0c0d5e098bd441310418dd03798d6a5a8539da7c8cc320d57085c193c753ff78bdff8a97a97c51f500433538fb722"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f65430d6-4ddf-4ed4-a91c-025933457f61/8e0766a17389dd840585ddc440431e19/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
               "hash": "4297ed3b4f112e1d64a6617cb96191bfb4ebf6a5fbd01c75de6c0592897173f011aef3d9be7e61738e0c8ce8ba1815b06f28e0c251c840f2e0de2630d36616ca"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/071e3ccf-eb10-4658-814b-c86dc60525ee/2ef91c84593fb6f465082ee069502085/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
               "hash": "f1a70807e0a2b5ee272bdd714535a2fa3d31bb8c2216b43c151a72cb364f64a6f893590baeebc7dfb2b78ff50e4ba11c3e4cadf11c75744404fefabdc7ff08db"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/625fe095-f8b3-4666-a4ab-b44931f482bf/bbc206404c3e402749523e37063931b3/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
               "hash": "96b032d5209a838e97522528963e2e9589f8384dff4292e567030b0da0849104a57cd6d0f05e5fb7e7787730f47c6112a014df17c76010864f55c110a971f216"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3606de37-1325-4f5f-bbe9-1bc44b3c1c7f/91872629e9f0c205cace9c462d5e89a4/dotnet-sdk-9.0.200-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-x64.tar.gz",
               "hash": "1af5f3a444419b3f5cf99cb03ee740722722478226d0aff27ad41b1d11e69d73497e25c07ef06a6df9e73fb0fbdc4b9baca9accec95654d9ee7be4d5a5c3ac23"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b5dfd4eb-19f4-4ba5-9a0c-50af354aa434/3f307be41112d4a8de659535e8badff2/dotnet-sdk-9.0.200-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-arm64.pkg",
               "hash": "5f7528922738e520edf714cee636d8e1b44c62d1af984804ca00508f22bff54776a232cdd1e94d386c1d70fc02219f8e4d05db9b449bbe7853fdce284e5fc8db"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/be46fe4d-4225-4681-a301-8d2bd5c2e044/362014a73e57d02b9ffce618c5ab46e9/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
               "hash": "a45d5a6fe5f046e9cd0a4482a41f0884822903134bcd2f25face71e1322749dacc53221cee21f814c6171326da0f64f42204ebd79f633a3bd1075c04fa73d1bc"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/24e6d730-e336-4ba9-a248-4519bdd38251/e35a7403d4b03ffa8ced47dff6b3111f/dotnet-sdk-9.0.200-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-x64.pkg",
               "hash": "a9dd1005ae1ab833c0c95a4ca1850e29a01b712b224eddf1edae3f152ea2a212402abb61956dbc8e8804762b10ca980371ddb0735cc950422c9ce3ba08c6f64f"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9983e36c-5e9f-4895-8f56-1d0a61cfa9cf/945b1788d8624457b631a383d55f109b/dotnet-sdk-9.0.200-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-osx-x64.tar.gz",
               "hash": "f38a641d17dedf0be24c721cc4f78784050cd5184fb5cc6c04c4b2e6f7602c55fc5a3c80dcf2a1df5ec59aedad42947720510f07b2b3c59b6185b91aff2010ae"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/480881fc-fec9-468f-89de-17b1e50a6cce/bf53315c59df9c14f68398357503f047/dotnet-sdk-9.0.200-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-arm64.exe",
               "hash": "06d7c4133bf7cb6f72b60b97f11c1f8773291e888f556c355d45dc66e3b36e597ac5562359fb3221b970b28f02649f0693d5109467698310752e0a8dc60f6703"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fde8f9b5-2f06-4a1a-a026-f5f49b686906/1709ada276f45c0e39af4af728e36a16/dotnet-sdk-9.0.200-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-arm64.zip",
               "hash": "3a996171562f30ac2f4a73d196bcf5ae3077ed5425c4d9aec562116e886dc3a9c20a227753501ac3741a5a8c7473d95a5861100e9d38fc2b09de09193e1bb00f"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/83c595a0-def1-4aba-8284-2fd98007aa3d/5e5b47fb819ee59b2a10485f8cf5a89a/dotnet-sdk-9.0.200-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x64.exe",
               "hash": "801d4a40a7bdad5c7b50e75c55c5ab657da44b5d779fe50da5683450e23c595e8b18e6bc9ffb80636ffb347b72e575379cd83c7554dc27f5ba75246169f327a8"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6f8a9285-8627-419c-a2f9-3f9463b06bf3/6d0c9057e0f61f8a6e5708fb9261ff1e/dotnet-sdk-9.0.200-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x64.zip",
               "hash": "e274e0e8a0d926c58a2199e020fc5b2c2867689772f51673f655ee853a50a9ca0e435ae5682bb4ae146d1fbc9a40f6d4a7ecff14d5fea24db8a3f67d0dcbf2a9"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0804e70c-d375-4d40-8e62-fe355c58751b/340302fa7a9950697106fa0f87965923/dotnet-sdk-9.0.200-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x86.exe",
               "hash": "3ddeb620fc45c623ade58f179e80cea64b7af5b76b0b4b1f65b766df3c5614ce04809f40614ebeb98dd6b4662dc1c2bed38d1f78eadc489360d54e35b98b9904"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9c32ade8-845e-4171-8ab3-777890c8a4a0/f2f3cc161effa1fa31a43ff0aab570e7/dotnet-sdk-9.0.200-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x86.zip",
               "hash": "65daea90e55f93abe1484dd86bcf2b447d0caf20fb80734a361f2dba0e6ded2158b40d5a7834c192e51b108fb2205aefc856c2a1b34e363413bc371e3a7f2737"
             }
           ]
@@ -355,97 +355,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c2cb3c08-be1a-4b0f-95f3-3c2b2c2371fb/04c3b5830bb78065424666956d65a503/dotnet-sdk-9.0.103-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-arm.tar.gz",
               "hash": "9b9ddbbd8a090ee78f40576ac9f3daca5a6845ee39448b10c3bb51b2b4f9e7e0a979b6a00c31da08f3e68601fa77a687a556d079c19d532aee4d7f25bc9f13c9"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/226328f5-ac73-4daa-99dc-04961042c422/18787af4ca8bd7d646534c559e4a3c75/dotnet-sdk-9.0.103-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-arm64.tar.gz",
               "hash": "32b5494e77689086e8d5b936434e4e87a8d88039f77c3381d96592757e7d716f58de1003fe41c7ef3a2089366a3205187f56d733d5f9d2f1505d83b1c16d3a0b"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/63a41de4-93be-4cbd-ac13-93d1feec6a30/a6bb2018d1a952daadf70852064686c9/dotnet-sdk-9.0.103-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-musl-arm.tar.gz",
               "hash": "663c3351edb0d38b25fa854be092a2cf7b6fefd568f4d7458ff40740b9637605390b48a4acdbb35640d40dc9efe666a6ee2947f10fe9c9a16b9743fd75bcf0d0"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bac1de02-acf7-442c-9caa-5267f24060c0/e94ab7e0015a34f7a76d33d3d0955fbf/dotnet-sdk-9.0.103-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-musl-arm64.tar.gz",
               "hash": "bcc5019831f9636d81a87369e1cf56e70dc52c2993eb64468f62029629a610333b23c2062e3f93647bebcbdf7de2aaefa7e9c96d6e96ec161e3a745766ae109f"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0211b6cf-e6b2-4034-b2a4-f47828046fe3/fcbc490417d2ea0114a74aafbb46b92b/dotnet-sdk-9.0.103-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-musl-x64.tar.gz",
               "hash": "ac4e2116f99999f249c290e9a87c628f6236f59c65eb7672bbb484cc1159bf739c9585dad80b50ff727335e4bf626e175913156b13a283f175dae7f6a965a542"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/053d1161-da60-4c43-bcf4-cfb91d3d3201/18cad0308294c91e3ca9913a33cb4371/dotnet-sdk-9.0.103-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-linux-x64.tar.gz",
               "hash": "afda487365cf2d082f1dc462ff01607eae10657de8281c53c4e8775df72f5ed5b31b427ea8afd0917886e73b104a25db4c607e0510f8be3a761de9445d797b75"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/06a9e1cc-16a2-4054-810d-02538924b96f/c29ef6a7597763178cb3026973e23cf4/dotnet-sdk-9.0.103-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-osx-arm64.pkg",
               "hash": "49e9eb2a3ca79b94f9062b130201962415befa18c5365458c1584f52379ab661a3d095e31a4269d068f56feb30285e665b190a925e2c9f1308f5fd93ef5986bf"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c54a9a42-e212-42ce-b00e-ac352d2fc848/3cbf76fac85c39e1eb8ba4a4bd9fcd55/dotnet-sdk-9.0.103-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-osx-arm64.tar.gz",
               "hash": "52f29d18f7789bc53d15b0e1e96b83b8811eaecb3eb6035dfb94e2d2f2bb1a011d08b46912805a2860c574913ad338f5f0808ad66310dd87cf78163c3b025925"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f04372d6-2f53-45fb-b7b1-b91f64ceab57/2d7ccbe05b267ec9c7e08a940638abb6/dotnet-sdk-9.0.103-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-osx-x64.pkg",
               "hash": "4f0e90596b5b5d9878f58b28bdadf6fae0e07ffc7903609bf00087a1cda91b6c8d32efd65949f44d77905b456a9956ac1a2d78f71471b5d7569a4b389c34407e"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7306a1d9-153d-4417-9d94-950e2d2d0426/fa4dfb44bce429d39ebbc916e949c3cf/dotnet-sdk-9.0.103-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-osx-x64.tar.gz",
               "hash": "7acefa171aacba663589d5c9ead080a808ee60696b789ce89aff88e0626f2085d32a198154a7ec94a8cd5cd272f70bd57e199819b3ec89997ea52e3c0f6b96f0"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a12cf12e-5a09-4ae3-aa2c-6023afa76b67/241a7d94a78c830a9a727e536d9d489c/dotnet-sdk-9.0.103-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-arm64.exe",
               "hash": "b7a19c6c8c62c9db8605258b4fb21b1a9ea64646ab26f7b055bbe90154d462568d5ce202356f8f81b0cac1a1afe90d89252689f4ee6b65a4d4c27fa17a0e8f31"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0580d1d7-4ff9-4e8b-9801-fc084507d7cc/f7afd81cc0d6e6f17def4258a617405c/dotnet-sdk-9.0.103-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-arm64.zip",
               "hash": "e85fae99d88be4e2db63dedea809a97c29a9ff9cde04fb93247cad1feb19119bc7d2d9f4976075af534f8b9dc22af8df60b78a8bdba801a8eea67e521479b443"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/25df6db4-4cf7-4cb2-94aa-1138932e840f/bf87e06f6da564de405d3e9c4f38f025/dotnet-sdk-9.0.103-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-x64.exe",
               "hash": "a4150ec3c57d2e1c77a889ef9eb6cf913e43c7aa6039a1b156fabfb70862187b60d43161dcde8b4edd606122f3b68e8583ee6438f1303607b7f9f29e9f926e56"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ab33cf70-527c-4517-9ed1-97056db08896/997dd9b12cce454426babec7e0071bde/dotnet-sdk-9.0.103-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-x64.zip",
               "hash": "9b691e4a4fc297ced20267975ee84641d4346052f6b5c192d27c05fb273b0a31966a2447277d9a7a948b944306bcaf7b8495ed1c15718d8bf2252e3adb43318e"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/80088bbe-136f-4cc6-9c16-212dd5a39ffc/cd51139a737774c90b1b90f051f42ca6/dotnet-sdk-9.0.103-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-x86.exe",
               "hash": "282409ca8eb5e5f2e543a6450332436266e079703b8f0640f10f38241d42efb7def82f4509fe7d56a2545dd82cf7d657cb75b54f807eece55930c3dfce0ef726"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2fd8d789-df0d-4031-a8b9-87f7e7a22c4c/a2b6818b1e626904502f3ce5d79d0917/dotnet-sdk-9.0.103-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.103/dotnet-sdk-9.0.103-win-x86.zip",
               "hash": "9c2b5e1e764792abfc4eadb51c3177e6371af3985c15022042a34ef300724019ed38896fd021be27980e535fd128fe0a78ab0cb893ea54d6294301769a92f7a6"
             }
           ]
@@ -462,127 +462,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0b7ddf3f-d43d-49c2-be1d-bf59075d85e7/b1da14023ea7fef1fada6c8898635fbb/aspnetcore-runtime-9.0.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-arm.tar.gz",
             "hash": "5576751ea9414449add100cb60c917f72305209dc831ecd3698b8ef6a69e2a802850148b33caf5a05d049be66b19c7404531ea6ecd643cc1fd6ae61179e1249b"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/744cd467-ac89-4656-9633-ed22e3afb35e/4277cdc84219d6515cb14220ddc0bde3/aspnetcore-runtime-9.0.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-arm64.tar.gz",
             "hash": "aa95ed396e5012cb7815db25f07b196261b91e4ca2e7ba07352896e1ab351a96232fdb692fbde1d1ddd1c916987353d2d3382e9e16bd7a97ce4b411c6426e0f6"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5eeaba7e-4140-4e62-b96c-7223293f3bd5/9d8d51b099c3141cdf63597816bd1eb4/aspnetcore-runtime-9.0.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-musl-arm.tar.gz",
             "hash": "f96a66442f7db558e40491f1deba42a58b697286a8c592f20b9b17006040544c3cde3851dbe9d5dd0be4ff68666575a10a8e1225dc97069081a66726a9f0fc8b"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/07c2a8a7-1b36-4ed3-b8c6-48674ad102e7/ed621013baa55acb77a88013d28ae14d/aspnetcore-runtime-9.0.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-musl-arm64.tar.gz",
             "hash": "5e74871d9133c52389559eb34ee82ed7b8ff2ee990857ef80ebf2b27c405e0dee1ae951c9a87355168901d98acfbe37bd6d516d6a0b4f5f495c58326243c0630"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/435eb32e-b24f-4c82-b044-6f4b97e7338f/5e79b00ea13180f349e28f127cf1c26a/aspnetcore-runtime-9.0.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-musl-x64.tar.gz",
             "hash": "ff070ebfabb1fa776df69ce6fb1e6990069ff6e4b795dd0ea0ee028dcceaa278500f695c9ba6b6c839310ee0d9aaca398e079ebd9081ec36c1e2d5a63c5bc109"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36ab7b0d-966a-44ce-ad19-bc0d7e835724/a38c1f97ccc9f4ccce58427c830c32fb/aspnetcore-runtime-9.0.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-linux-x64.tar.gz",
             "hash": "48a39dd4bee3e719273a4e4404b556e2e59e7f659def49f89745ae575fc976f7ebf121d9263c3d009db6081976f8261ca82de34aef69b0776a28fd0485bb6d3b"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e3c0776-3b1b-4e34-8dc5-1f764e435f68/3fc575fd1def4bba8258cdf39cf24e35/aspnetcore-runtime-9.0.2-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-osx-arm64.tar.gz",
             "hash": "66fcd7a0589fb166d85caebd6f08c16049bdd0cacfd01ab3f199c442b98d54f8610c225a2a9a6f52bc4bce12bba8a3001e23689240996c697e2bc3a008957226"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/80ab707c-4568-4bb3-998d-04b1935648dd/cec09318721d7d5e3cdd64e987a1dd8e/aspnetcore-runtime-9.0.2-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-osx-x64.tar.gz",
             "hash": "4e3b76bc423e9312b55449ff156bf65044f566445c4106fc47314517651d4d510c0418b1f8f17853b1cbc14769100b846f414f80d6a9cee5f95f5a6fb8547d9a"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3575d404-da7d-4461-b032-4090fe1e8378/689e6cf07417805b2ce74c1b807d64f9/aspnetcore-runtime-9.0.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-arm64.exe",
             "hash": "2fda149e90311f5f5bda6be635bbbe23fdcaf95359865a9880ae56e14eb5fbf36e1433ea772ae6427031bd8192bcaf50dbbfaa900044769ef462aeaa2636ad2e"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/47a58b15-5ae9-40ba-836f-2e5f4fac689b/4e4444de85c10de9a950f6a883ba351a/aspnetcore-runtime-9.0.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-arm64.zip",
             "hash": "a9612f88ae232e9dc517f02cb9a4faa605d2c0fda94a33897ba0ddb75979ee2eb09df5c49ad7ea93e90ba0dd5ff933af959a55c4ec9526eee06dbbdcd10a245b"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ef8f48ce-bf76-4ffc-bb8f-40991ec99b6e/f68b6492c75839333ad8c2fd3ff9c7b4/aspnetcore-runtime-9.0.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-x64.exe",
             "hash": "8a6e225a03319f5995c943b32482f73ae08bdcb20a0f8ad24a049162c5e66d3071f271cad6829202794cc7066391777caa8ad5bd3514ced213ba8093d1e5784c"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/01a196ac-edf8-4574-b9af-35db73e21094/d55bef75bde4f8a83c28b7913d56a76f/aspnetcore-runtime-9.0.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-x64.zip",
             "hash": "0a5b0d4a0ac65dc0b11b104154143ef310e47b3aa92dbff32e7002d1ea6005b6444a6699eb03a5c728326c6ad97234a1fc9607972a133130727173247111472e"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b985a5f3-8a2c-4854-a69d-e6a585a277fd/8e9965972940a2efd07b150432ee7f5f/aspnetcore-runtime-9.0.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-x86.exe",
             "hash": "a633235f06943865b4176a919b1601d95618a4e43b3af6d374949700df68e02d0e71629c772a9b78c25bff609993d106621ed34a27856adce650bd47e9961e45"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d2415741-da8d-49b2-b2a6-364799efdfcc/25ff042f508f91f14ed4f25f4a88bf66/aspnetcore-runtime-9.0.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-9.0.2-win-x86.zip",
             "hash": "2b05a90bb7f59286ca2e6eb631ea49d999a66a8e2e7d3f13e12daeae412a71de073afeff9d1121b89133ed0e8b125f959b3678e5c4fdfa7639ad6eb0ff896762"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ff894111-ac98-4f95-962e-572af715ebda/e5f073c7a5d45544bb135a225bb2419f/aspnetcore-runtime-composite-9.0.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-arm.tar.gz",
             "hash": "9008fec9c3cc98b9608eb6635f73cb86d37cb721d6f4ba3dbb8eaee4d7adacf832cbef6c223320895656743a82b5a81209c78936973ba469e551dbf05bc40ce9"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e9c59a5-551f-47c2-9eae-357cea44683c/e6c8fb5bf951847abf28697ca1a8e096/aspnetcore-runtime-composite-9.0.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-arm64.tar.gz",
             "hash": "8387f486d692f1299cc08f33c57e647000f986e6a69ccb4b426b6a207be28a0b5b6e636bd0d91fa2d9452d0c0bb00e48179e965612b7f66641884430675130e9"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f40f94b-d02b-4c72-ace9-6987a4e95d58/8da22c3c69dd03f14e1b2a28d2d4f215/aspnetcore-runtime-composite-9.0.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-musl-arm.tar.gz",
             "hash": "9240868535b83a81f2dff1226be734d5f4d31095988c286455679e1b56a2ba7a56cb7d30d4c6f74d645024ed2526a2d5a2a06dae4194b2ffc2d86a8fbf2a42ef"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c47bb124-30c3-48ae-a1ae-75f3c2b1b974/95554947e0b06df6cb12f851a4d7b4f5/aspnetcore-runtime-composite-9.0.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-musl-arm64.tar.gz",
             "hash": "cde805a00d9db6de6e57fb573f392df8bcd2f21ef029a6ac22f059b85af635cd4553d9d749d6391b637a9958f3cea3f6430b3c575d217c428758330f864e2841"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4fcfd90f-1cab-4da7-bb8c-4468b6b90735/8153f9dc459a5dc83000b8b4aec6ed64/aspnetcore-runtime-composite-9.0.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-musl-x64.tar.gz",
             "hash": "7257c9093bb4fe4ce09e2169ccaa8500dd23008464aab7ae50f57e7ec187d8a0a3fad8c8d67fa0561801bce59300839f0d2044b0b4232b0e320d1305662fa465"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b1f88d20-3be3-45d5-942b-b800113c91d7/9f41b6252793ae58d98b5f138150021b/aspnetcore-runtime-composite-9.0.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/aspnetcore-runtime-composite-9.0.2-linux-x64.tar.gz",
             "hash": "b819c4421c1110ecadfa4f1e790efb14d9788e7456be016d26023b993dda40c47f22e356483c5c6f00d0941e0daea8cf2c5fe6aa405c7422ec911a46b81b552c"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/785df3b0-8483-4eb0-8826-3cfb0d708ba7/28ad125421135a4fad3f03cea41cd673/dotnet-hosting-9.0.2-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.2/dotnet-hosting-9.0.2-win.exe",
             "hash": "b275c7f67f46d8d65da5fd07dadf52ab544d5f40aad02c12dc24c1460b8a92b6b5ba418101c4a5e29c29e547eb3c1c794e40fb8531a5e4d35233fdc8e12312eb",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -595,37 +595,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d8b26b48-2f5c-4814-a253-c752a45b504e/2ff9ba5aa7ab19d3736a3c5d9d346b3d/windowsdesktop-runtime-9.0.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-arm64.exe",
             "hash": "5c086ef4d49e510319bed586049d443c4861dc2b826f531e992855c0abe9818fd60d6ed5cb87a9ea3b21bfff76190337470428cf08dad49c4bb6a77afc4792fa"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/75abfa33-809b-41c4-b94c-69ee9b99c479/191c39940d49bc74e12389fc227dd6fe/windowsdesktop-runtime-9.0.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-arm64.zip",
             "hash": "5ad933a83adbfa72ffe8d388b6e9902ea91c977f11dce9ae7a6b033fc7cb5371fefa1ad8f9d494e291ea68e97bcda1927bb560854e479b716b08cb63bd1fb61f"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e1df956-98b6-48cc-86ac-8b6c02feb6d9/cb90f6c099d4cdefe8d35af6115a3ec5/windowsdesktop-runtime-9.0.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-x64.exe",
             "hash": "60958279f9ff96cc953ed6cf404d8deb68e554374d08dc31e8b62a226ea67ae13d6c9eaf1fb44f783fa6241862e83d1cb8c21bbbadfc9386200fbb0345714be9"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e735ff26-3688-4614-abf9-fd0ed0a25957/bd48e68990f8d9054e550712da812c91/windowsdesktop-runtime-9.0.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-x64.zip",
             "hash": "7929c2a718eef9db6964b08657dda04e6ac2bd86a60d756b0c4497cd68209e2f7a41ca7f7ea163748870c6e86e4a2f4234675afa893f2d20db5a9d8724a9e683"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f9db1de7-9170-443f-955c-565c56ede288/b0a583d9f169ee3357639479786d1eb8/windowsdesktop-runtime-9.0.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-x86.exe",
             "hash": "798b3e13f0276ccdaa4c593c28e83d8c90652d454ffd0e8fe878bfb44b6485a5b21cc5a93eb0c72586d170b3632283cebeaab25c70c793eff30a73e6369c819f"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e4d30006-ea09-450d-a4e2-95c523c80ccc/bdd10fd7bca8f5941e830bff1589c756/windowsdesktop-runtime-9.0.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.2/windowsdesktop-runtime-9.0.2-win-x86.zip",
             "hash": "d868b73dbc79a36eff3500419fa0a46154fee80692c1dbfa8873ca5cd97aca49e18352d18e93902754f997ebdaa0999d52d4b3b50e587b6ba9378c0a4f90cd5f"
           }
         ]
@@ -663,97 +663,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f8762afd-ce2a-461c-9280-0f6c377b92a7/9ca2330917e1ed7dadd5f1838b6ba44d/dotnet-runtime-9.0.1-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-arm.tar.gz",
             "hash": "b1cccb86da9912fcb816413718e264d899e9efc42a19fd8a6ccb8265b65ce4fe8c878d0b8d5c0633b1e0e4b2ff3ee53313a66e3f92c3b153fbdfe3044f1bcc96"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8a8a85c8-3364-42e4-a9fa-bc4d33e4a263/cb6b67c1ef5a8fd779dc43096c1f2a14/dotnet-runtime-9.0.1-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-arm64.tar.gz",
             "hash": "38399b6139f72ef1d836e418455494a80428bf41f3aaf2351749ff144311766487533d5a3c9bd359c189b9373f24377ae886827f45272c4019e22b594773b87b"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/391e3ee0-16aa-4294-8641-3438307e624d/d244e58fbeff1482b0f8d3aacc6cc621/dotnet-runtime-9.0.1-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-musl-arm.tar.gz",
             "hash": "ac8a7be3ab0895539813c1f67c33aa93ee72e2ac7f2d88ee3ca21f14479e11a4064cde9a7e15a2944222b8d7c2858ddd39de9f6c2d278b4129f5e3ba8b9c38e3"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/966184c6-ae9d-42d9-a5d6-1f14c46ffafd/fc65efc3447d3f1dced1c156742be6fa/dotnet-runtime-9.0.1-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-musl-arm64.tar.gz",
             "hash": "cf6865754e3c28b63bf4e73db95a2079028b9132ffc6bee4aa7af03ee15c7560a13d07260965833b43985d8b5e2f50a776ff17bf5343605b1c1bc239ddaf3c5c"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dec9d9de-effe-48df-83b1-0c83f54e4cbc/cfe914fe2e2e9edb6138ce9328051f10/dotnet-runtime-9.0.1-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-musl-x64.tar.gz",
             "hash": "39bc73be712afcab41425c2e42aa5098133cf9a2080f91d4c65f274c2c6bc6f812793a17f8ed6b3a5bcabde4cc5ee5be83dc9bef9d3f3b10d79d0d3f00b4b55f"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4ec0d4e4-9774-4d69-b9a2-db99ccb24a1a/b108f97029f83c8a27d041e90583ba5c/dotnet-runtime-9.0.1-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-linux-x64.tar.gz",
             "hash": "d4a31944a5ab063037dca5141dbc8466d0c894b8d2560256782bdbe5a8e86585e8c4c789c40fbe51d56b3853e15adba0985bdc6ae91c85a763565316e1c3cfcb"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/94c702e9-6334-4f72-814b-4a26d492771e/b583daf604626c9dfeee7ab5f5bb5c14/dotnet-runtime-9.0.1-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-osx-arm64.pkg",
             "hash": "8fb808f613f37cddc61c43d11c0265aa71394266db0529d1c6f806f2c79c40ebb43f6dde0f4246a0feb06da276564a2c37c9bec265950dbe61c4d16a063a4639"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5c1d13ac-90d1-4f76-bcb1-d404b1ef6748/137435417c82ec2a5a519555b93b2344/dotnet-runtime-9.0.1-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-osx-arm64.tar.gz",
             "hash": "f65f650ee3c289ca092fa151a3d9cf34fea2f5426f09882c194fe71655ecaf2a681b2d508b9c7849d6c908ca679625dc48171d00580cdff7f981f0518a843c65"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e71b09a9-de09-4641-84f5-d8f0a2220874/57d2fdfabe715eccb6a38fceb712b6a2/dotnet-runtime-9.0.1-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-osx-x64.pkg",
             "hash": "f9d040bf19abfc79fce730f0fb50114b8002dbafd4dfa8e5315763cc342d85c02e34637e135f26168fe809bf3fffd54bfcf2d67ec79bf43365cc4da2dc5dc4e7"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36d3662e-b23c-46cb-994c-3a46bf2b9759/2c090a2be99f96cb33a56183e747e27b/dotnet-runtime-9.0.1-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-osx-x64.tar.gz",
             "hash": "b997c2c0f0350ef29ba6e865ac09ebecb1d3632e2a7561b5abe23bd0fb6abc8c0ca7388d6cf17c59ca87dd8168604ded6839a7b16cea1afbe36ca57234515e1b"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ee58a24d-2e62-468f-9349-de77065b4fcd/8c1a8bc6d3a693f73513790beb210659/dotnet-runtime-9.0.1-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-arm64.exe",
             "hash": "3d866122fe7b560fce9d8313a37d2eb247e3e375079f456099854fdfcb5ab5c453b762ed347a48f23c56affb2d9cb9a4b92975290a6ef517fd69a6ff849a8cea"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d6ace5f4-cf28-4386-9f9a-9d756fb50763/82d2cebd4f7fc8692f5d5e16787bc1b7/dotnet-runtime-9.0.1-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-arm64.zip",
             "hash": "2127e5064f6d446c4bf30610f48ca748eb67d6a8dcce55c22095f7e59720985339b07f64b887dd92ba5ed20bff10ce0f9fda69018da49e4cc2e30516b0769639"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/24046c49-1b56-4c1b-9c15-75c94d7a841a/d089fe00210b8113c33ea96e1e932fb7/dotnet-runtime-9.0.1-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-x64.exe",
             "hash": "1031c5c76dbc8a5605354915a2f5e4c7b0d1a6b666ff6366589498f5b20f8a41366449dfbcb0e9181e8e79f42230a87eeb235bfd1d41b1128bf9b76bcdb4f200"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/057a1dae-2fb6-4adc-ac3f-d3f8c13926d8/6716df81f86b00a9e032134b1bab9d07/dotnet-runtime-9.0.1-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-x64.zip",
             "hash": "30b880c3cd6c39355e92b5422e8c044a26fba1da15b4f1f8a89dc4622962c8a3537b075064c33c8493d8bbc909ae8c135a5533110080e95ef31e3407eade291f"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/21eed405-253a-4ac5-8eed-e54d36bffdaa/3692b7badff8c4311474b4511c3ab929/dotnet-runtime-9.0.1-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-x86.exe",
             "hash": "191a9a61e8d6692b6d35a176cbcb7a9659128c646289977297744c64c98f4e18fa02751d1912e24a4450dae8ec459e7856a73271440a8abb7e9d479a23f3cdc1"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8ac967c1-7da4-4cd3-ad31-32ff01934f51/e3a1057ef293d962a3a59adc692c1c20/dotnet-runtime-9.0.1-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.1/dotnet-runtime-9.0.1-win-x86.zip",
             "hash": "b0914634b4b29230a000e0b00005992eb6e37094862e2d0a9e0975b366dad47455d6d26aeefe953563091f25538bf00ef9d74b8c01eca7f0ba6dd2888163b797"
           }
         ]
@@ -773,97 +773,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8f7ff743-f739-4b7c-835b-9405b3f7604f/b903530c774c08f30d3de3029f2e0bf9/dotnet-sdk-9.0.102-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-arm.tar.gz",
             "hash": "2c4c69d46c3e57ed990518a9d82963665d835c66a57da54b9d21e22c2a20e8018020dcb190eef54dfe68c001fcce385361eb2bd29896311a1683599ff9e6a777"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/555b12ca-d25f-4d4a-8c62-03b57998981e/b8f8f88c7809ea6c0e1d127deb18d8c6/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
             "hash": "cb78931dcbb948a504891f112f11215f2792d169f0a0b53eaa81c03fc4ba78d31a91c60a41809ae6e2ddcae8640085a159e492035cedfda68d265bbeb4bf8b2e"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/db81a835-d9dc-4094-9c5c-cda20e684556/2d80354042afe6c8a2ef2f54c48a86cf/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
             "hash": "e363e3d4edca93830d18bcebd41e01bf2856b095ae70e1a24b0533abb0a507e4c1f1542ff3046c285689318dac7e2b5c71a166bcb5933a8ab68d800bf3eedf03"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a35ae2c2-e906-4bb1-b12a-a9d435231626/d0da093a240d41c06da2f49dc3011a13/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
             "hash": "5da98e46c280e21c3734a0c9081e7ddb78ad62775a51a129b42a6f021330d263a875da2f44a7aafe8156e7c9ae0f9bb21b502057692b360f2afe0882f0e61132"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5e11d2af-f335-44f6-90a0-a99cdf806855/97268da6caffc1e8182525c7a2f01b74/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
             "hash": "60e091854d17da9a6011569f0a4819eac72ce6fe06d01757feeb83ad56c17645fa438257631ecbbf6ee94ac3a973eff9ad4d3e12deadda3eb41c1b69ca8d5308"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e717d01-aad7-475a-8b67-50c59cf043b1/6eaa1c636e15ec8e1b97b3438360c770/dotnet-sdk-9.0.102-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-x64.tar.gz",
             "hash": "f093507ef635c3f8e572bf7b6ea7e144b85ccf6b7c6f914d3f182f782200a6088728663df5c9abe0638c9bd273fde3769ec824a6516f5fce734c4a4664ce3099"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/96489126-b9ba-414a-a2d0-d8c5b61a22be/fe047e117e9cc43738ba2222f4769da2/dotnet-sdk-9.0.102-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-arm64.pkg",
             "hash": "bf5759734f7aa010912e4806d1d7bcb86d635f7d1573e6bdc00eb5c443f64a43313ba0699ce249989b855b77d52b0209ad331cbec7a1493492d684f026d1d267"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1b4a1593-695b-4496-aa2a-55fa572bd71a/3b44622f52d4695513dff04f0bbcc404/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
             "hash": "13632c9e58d8fa46f191256d180ed19089e08b242881825dd3682f082d65bcc6d9756629fefdab609c11265b6043dc11635263fe8761339b72d36608acb43574"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2bda19b1-6389-4520-8e5e-363172398741/662eee446961503151bb78c29997933e/dotnet-sdk-9.0.102-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-x64.pkg",
             "hash": "25cf5bf146803d64a51b1fb6dc501edfa4cb8226531a70e5d651f2dbf13968a3a70c54434c7d65e2c5b12f58c358b35a97dff43931e54bf0214c6e5f59abc606"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/373e3b64-d88b-4d83-adf3-eb48a6d6e76c/0d24e9cdbb0e75999fc0c17dafb1ea17/dotnet-sdk-9.0.102-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-x64.tar.gz",
             "hash": "023e910b64819991831aa0e530443fa985fa673920ff291541ad7b7a4a532e20f5ac89f9a91b2e956cf69b3821ef1369828cf46c544e183a85425ae4b725e187"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/99315d83-565d-4f1f-9f89-2d07aae98af8/9348c4708d04cc933979d139413e3bc3/dotnet-sdk-9.0.102-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-arm64.exe",
             "hash": "b9b78e41a3ecb4ea017471e8213ecfd1b0e0ec6504b74fa0fc4c8c601468fe9e966b76ce173b0d124478a5430d940408ee8f379725988bb3e0998054357d7239"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8ca0f979-057c-4bf2-9a7c-3d5feeff533f/2c1517241a46552f2525952acc083f39/dotnet-sdk-9.0.102-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-arm64.zip",
             "hash": "4aa7343ab96b0403d9d543d1e2f11f8f10dbc5ebeb60f5be1dee455fd878c77f24e1710de3fc85ad0850d3913680f2d2605121db934a4ad6f969e73d9d6ee334"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.exe",
             "hash": "91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/044ede4e-08d0-4c85-8c46-60e8b2e8e340/690f9b2c25bc27062edc71e0ccc2a639/dotnet-sdk-9.0.102-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.zip",
             "hash": "c3713f4db98fec9bcbb5be1378e7505a49cdb362e20e060045dc8e320ebc62e0f422e125efb9e966e957ee64e33219dea9b42c18ac5b8e51dd3648e5aa1319c5"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7bbae865-0dcb-4a44-bc26-c94b1e776cc0/6041bed29060817cbc6088962a2c600d/dotnet-sdk-9.0.102-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x86.exe",
             "hash": "fb043c6deb487a743f86caacdd13d6dfd8a5239c40b54df99e6bdef8b9567289bfce715a8bbad452500c445b487b5d2a0aaaaf1e1065b08a0a23a6e2c98419ed"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/139daba9-b797-4dc9-a5a3-873604311459/90623d54cab92d97f66343147e318d6a/dotnet-sdk-9.0.102-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x86.zip",
             "hash": "898229b1c92ac1925d7155036755d451afcd52f39f4f204554918c7b0d16a78cf0ec1df06208d40c8d14ce43d8cf66107f9d93a5a3c4e62801d7fcc340a73fe5"
           }
         ]
@@ -884,97 +884,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8f7ff743-f739-4b7c-835b-9405b3f7604f/b903530c774c08f30d3de3029f2e0bf9/dotnet-sdk-9.0.102-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-arm.tar.gz",
               "hash": "2c4c69d46c3e57ed990518a9d82963665d835c66a57da54b9d21e22c2a20e8018020dcb190eef54dfe68c001fcce385361eb2bd29896311a1683599ff9e6a777"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/555b12ca-d25f-4d4a-8c62-03b57998981e/b8f8f88c7809ea6c0e1d127deb18d8c6/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
               "hash": "cb78931dcbb948a504891f112f11215f2792d169f0a0b53eaa81c03fc4ba78d31a91c60a41809ae6e2ddcae8640085a159e492035cedfda68d265bbeb4bf8b2e"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/db81a835-d9dc-4094-9c5c-cda20e684556/2d80354042afe6c8a2ef2f54c48a86cf/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
               "hash": "e363e3d4edca93830d18bcebd41e01bf2856b095ae70e1a24b0533abb0a507e4c1f1542ff3046c285689318dac7e2b5c71a166bcb5933a8ab68d800bf3eedf03"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a35ae2c2-e906-4bb1-b12a-a9d435231626/d0da093a240d41c06da2f49dc3011a13/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
               "hash": "5da98e46c280e21c3734a0c9081e7ddb78ad62775a51a129b42a6f021330d263a875da2f44a7aafe8156e7c9ae0f9bb21b502057692b360f2afe0882f0e61132"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5e11d2af-f335-44f6-90a0-a99cdf806855/97268da6caffc1e8182525c7a2f01b74/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
               "hash": "60e091854d17da9a6011569f0a4819eac72ce6fe06d01757feeb83ad56c17645fa438257631ecbbf6ee94ac3a973eff9ad4d3e12deadda3eb41c1b69ca8d5308"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0e717d01-aad7-475a-8b67-50c59cf043b1/6eaa1c636e15ec8e1b97b3438360c770/dotnet-sdk-9.0.102-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-linux-x64.tar.gz",
               "hash": "f093507ef635c3f8e572bf7b6ea7e144b85ccf6b7c6f914d3f182f782200a6088728663df5c9abe0638c9bd273fde3769ec824a6516f5fce734c4a4664ce3099"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/96489126-b9ba-414a-a2d0-d8c5b61a22be/fe047e117e9cc43738ba2222f4769da2/dotnet-sdk-9.0.102-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-arm64.pkg",
               "hash": "bf5759734f7aa010912e4806d1d7bcb86d635f7d1573e6bdc00eb5c443f64a43313ba0699ce249989b855b77d52b0209ad331cbec7a1493492d684f026d1d267"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1b4a1593-695b-4496-aa2a-55fa572bd71a/3b44622f52d4695513dff04f0bbcc404/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
               "hash": "13632c9e58d8fa46f191256d180ed19089e08b242881825dd3682f082d65bcc6d9756629fefdab609c11265b6043dc11635263fe8761339b72d36608acb43574"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2bda19b1-6389-4520-8e5e-363172398741/662eee446961503151bb78c29997933e/dotnet-sdk-9.0.102-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-x64.pkg",
               "hash": "25cf5bf146803d64a51b1fb6dc501edfa4cb8226531a70e5d651f2dbf13968a3a70c54434c7d65e2c5b12f58c358b35a97dff43931e54bf0214c6e5f59abc606"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/373e3b64-d88b-4d83-adf3-eb48a6d6e76c/0d24e9cdbb0e75999fc0c17dafb1ea17/dotnet-sdk-9.0.102-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-osx-x64.tar.gz",
               "hash": "023e910b64819991831aa0e530443fa985fa673920ff291541ad7b7a4a532e20f5ac89f9a91b2e956cf69b3821ef1369828cf46c544e183a85425ae4b725e187"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/99315d83-565d-4f1f-9f89-2d07aae98af8/9348c4708d04cc933979d139413e3bc3/dotnet-sdk-9.0.102-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-arm64.exe",
               "hash": "b9b78e41a3ecb4ea017471e8213ecfd1b0e0ec6504b74fa0fc4c8c601468fe9e966b76ce173b0d124478a5430d940408ee8f379725988bb3e0998054357d7239"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8ca0f979-057c-4bf2-9a7c-3d5feeff533f/2c1517241a46552f2525952acc083f39/dotnet-sdk-9.0.102-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-arm64.zip",
               "hash": "4aa7343ab96b0403d9d543d1e2f11f8f10dbc5ebeb60f5be1dee455fd878c77f24e1710de3fc85ad0850d3913680f2d2605121db934a4ad6f969e73d9d6ee334"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.exe",
               "hash": "91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/044ede4e-08d0-4c85-8c46-60e8b2e8e340/690f9b2c25bc27062edc71e0ccc2a639/dotnet-sdk-9.0.102-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.zip",
               "hash": "c3713f4db98fec9bcbb5be1378e7505a49cdb362e20e060045dc8e320ebc62e0f422e125efb9e966e957ee64e33219dea9b42c18ac5b8e51dd3648e5aa1319c5"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7bbae865-0dcb-4a44-bc26-c94b1e776cc0/6041bed29060817cbc6088962a2c600d/dotnet-sdk-9.0.102-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x86.exe",
               "hash": "fb043c6deb487a743f86caacdd13d6dfd8a5239c40b54df99e6bdef8b9567289bfce715a8bbad452500c445b487b5d2a0aaaaf1e1065b08a0a23a6e2c98419ed"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/139daba9-b797-4dc9-a5a3-873604311459/90623d54cab92d97f66343147e318d6a/dotnet-sdk-9.0.102-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x86.zip",
               "hash": "898229b1c92ac1925d7155036755d451afcd52f39f4f204554918c7b0d16a78cf0ec1df06208d40c8d14ce43d8cf66107f9d93a5a3c4e62801d7fcc340a73fe5"
             }
           ]
@@ -991,127 +991,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/463fb01d-fcad-46bf-8e5f-0e568bb9ccf4/a3ac380fdc1e29ec25e5fa0a292a61df/aspnetcore-runtime-9.0.1-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-arm.tar.gz",
             "hash": "fa75d8d5ae99ade0d1ab90018839fe3f5ddc4e7b7461715caf2b0bf7a88c8e86e1d4f10ab69703d2318b289c0700846e2155746d7bb1ace3d2d12e175ab18be1"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2a193300-e0b1-4e9e-acc4-a4a695c7b94a/f197be75380aaa333c949bb8a1fe0510/aspnetcore-runtime-9.0.1-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-arm64.tar.gz",
             "hash": "e37dc1445e53c00bd950a531fab83354defbbe06c6f73af4bbef20bfcedc0483a98f478369a7bc7d7e52e35b2b33ad73781e255b46900d831e2770cd445d69c5"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2cfd68f3-5259-451d-83b1-6b5e80932813/bae5e023e887e42639426dd0824ac6bf/aspnetcore-runtime-9.0.1-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-musl-arm.tar.gz",
             "hash": "3ea55cc5098dc08909a385219fad1e38635f6eef6cd66ea526b92dd57f765dc348380422e5e0b9c8ade286e18e713caa4b7ff2d06a23c3fed31b8b5c91d2dc6b"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3b0e483-26b2-4115-8a8d-983c9b0ca58a/4d0058d82438c8de99347f40d3dee091/aspnetcore-runtime-9.0.1-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-musl-arm64.tar.gz",
             "hash": "e9a7e257f6b09e48c522b725be8ab498e57189d6687f840a37ab9fe4192e985bddd99a663418c5d5d96ee7c7c2b9f70e08f786aa4a1b207548586bd3fcc3710e"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d55550d5-16dc-4b17-90c7-e8bf65657e09/b3d4c31dd4c933aaa50e920f5465b111/aspnetcore-runtime-9.0.1-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-musl-x64.tar.gz",
             "hash": "d3f609184959849f7524fdfb55c5cf9a8391d0a773483aa6659d9baa152656835f26c2fe9ba322e718a8eb7781fb996eb4ebc6953beaf6fdfb5628ef31bfc853"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/78308995-ac02-4bed-b5c3-eefb06ff907c/795e0c20df95d8c432fda2a189235b67/aspnetcore-runtime-9.0.1-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-linux-x64.tar.gz",
             "hash": "e5fc3093aed5756deae3e61f98b9f4bb0c847319db30cbd1668c2511e06529c2f6a5e1917ec776fe2b36a1f7bb7e009fc925fee57f87696a8d502a6c8f5dc613"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/26f85624-0eaf-4edc-a83f-428472ab31df/ba32371bac29f1738b9b0eb959dab0a3/aspnetcore-runtime-9.0.1-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-osx-arm64.tar.gz",
             "hash": "b8ab3899b10b871159b01889694484cc3d9b3ae78a159638d68649a22c3f3328b92c435c5bcdf49a86bc488bbbd0fca7143f6f664f6594c552423c37ead99998"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6655b880-82dc-43d1-b5b2-f76d6a3c431c/4752d9d4811a2148de7eef5dcfd08441/aspnetcore-runtime-9.0.1-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-osx-x64.tar.gz",
             "hash": "4aeb0943877dbf935f6554c637d2aa18f8ef22e9692e6cd3d716dde2dd5411e4881767cbe9c554bd8ec43c209a86a26194c2618c60d115ba0638e92e80423cc0"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2985fd4b-f7af-4654-a7a4-e2c14b42af0b/9849c95576f43d40a63016af552b9dd9/aspnetcore-runtime-9.0.1-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-arm64.exe",
             "hash": "e6e9a564919a63ab268269610b65dd47a03770aa1f4f9fcd4b4f3c1363400e4037eaf4f614e337741abb44c8d97c092efcf63bd200dc05a5686accf97cc1e447"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8e308ca2-de0f-4202-9d52-81b0ed50ce01/169ea645ba895a387192fc9ff160a994/aspnetcore-runtime-9.0.1-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-arm64.zip",
             "hash": "52c69b68f22a3fa1251716e96a64102fcc97c887ecb3c9a160c59c70e625b2ec8a7ef4f71626f522274a1e5f4c1286bb58b8fa31d4605ca4b3a239439e46472a"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3f41e6c7-c80d-4e44-afb4-9b9bc98547b7/d2f0ede399a87d7a4a78c2b5a0f90bf9/aspnetcore-runtime-9.0.1-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-x64.exe",
             "hash": "82b4237d0589a70ffa5ca37c2ecce6c9548c839acc2215f218e27572a161da7caacd3857553d5a4c331e3f6a3aa3e468c6e9de802dbd63f2dd5c54befb9b047b"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0d79cb49-287b-4cf4-af5d-0fd6c1af4f64/12613555f622bf17c91a6d0d68fd7aa7/aspnetcore-runtime-9.0.1-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-x64.zip",
             "hash": "613492bec0899bc451b11c572024feca2e068a471f2275b55b276c0eae85a695e2b7582b07101b9bc75e32cba6c198dc50ca65df0564e1c4c0241fe45db60c7d"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41921adc-acf1-4274-869a-ae605234f513/137993139816c6db85bdafc82facebab/aspnetcore-runtime-9.0.1-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-x86.exe",
             "hash": "1a93e0d6df3eed98fc46ff5877fe7796f2aa4e01b3dcfb1b566cc68dcd3bcfe400e556f7f82fc99c1c53af7d496a319ee54dc67f01ed7ea43ea8a6a555813134"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dac9d379-bc70-4bcf-994b-14dde1467256/5999be7787bd5264aeaadae246cb0e22/aspnetcore-runtime-9.0.1-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-9.0.1-win-x86.zip",
             "hash": "915335f60d3ef189c599372c2043b9a115cf538a22f3f6297070cab2913a89517ca69ecbc7aa2a600c8f0ff5ba86d77e992d3d2cb5d5d5eb21b8669e7694428b"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d66b5069-33c6-458b-a23c-55f2371fa9e9/aada72716d2b7c511e16fc5b3469da7e/aspnetcore-runtime-composite-9.0.1-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-arm.tar.gz",
             "hash": "ac2c004657e3f1c65d1b338272aecd16445b5130eab9dd1229440b0bbb29b9d2a94ed7cb4f2d5d7325dfce8b19ea64da3008403d4b18cc251781d6543bd94052"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/56dc5b89-ff34-467b-bdd0-16a93f2bd854/f6575b298c84d7b4f2f92377b0b3a736/aspnetcore-runtime-composite-9.0.1-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-arm64.tar.gz",
             "hash": "28cafe4ca6061397a1eafb21ee0ce5fee850c4368633ca16773208620ac47a6b94f35a0890740112118743b92e6652e46e27eff0b8d6a8a053ae4fd9af62f226"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8b8f6a71-419c-423e-92e8-d863f2868849/e012a04c7cbc0dc480df47152cf0f907/aspnetcore-runtime-composite-9.0.1-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-musl-arm.tar.gz",
             "hash": "46deba46b4458a3546da4db8118798d8baf5a230f1691c9a9745771a80f48a50c93a0ea56d0348fdbbdd9952eb397f8e1153274e0aeccb8e1d91f68f700f30cf"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d07d7f41-0df6-4eb5-96c9-474bd766a844/aaec7ce41fea5cf7da88aa816fac1e2d/aspnetcore-runtime-composite-9.0.1-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-musl-arm64.tar.gz",
             "hash": "5de05d1c2a12a4276d788295a78484360f2a65a99dab935469696bc8588d8a23a10ccdbc777df9dc9445dda7541e33f4f583ef7b00d06cfbcdfd43339cffa809"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e13dce8b-68b2-4841-b80b-ebefe704e5c4/f31b12d1c2e66bc6b660769664e2fdde/aspnetcore-runtime-composite-9.0.1-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-musl-x64.tar.gz",
             "hash": "fff2915b8bfe74fd4d882ed2d0a2e9d82c174e6ac186cfce7b28f87ef3043145e19d9be7f60b90e9af7b6532ee75b3e527a360f2fac4574e4b248b3ce3fe4367"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/abe4d958-5ae2-479d-86e6-c64393b0bd10/a70087aacb760aa42e3a1e52d1eefbe7/aspnetcore-runtime-composite-9.0.1-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/aspnetcore-runtime-composite-9.0.1-linux-x64.tar.gz",
             "hash": "ce1034cc058d68869edacd5ed1feb8ff4a3e5a2931ee057789413da7fe17ce484ea563ab9f38a7d2c2d53d7a91d47e32680da7ed0953f81ff42b56489b8e47d0"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/450a6e4e-e4e3-4ed6-86a2-6a6f840e5a51/3629f0822ccc2ce265cf5e88b5b567cb/dotnet-hosting-9.0.1-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.1/dotnet-hosting-9.0.1-win.exe",
             "hash": "aa468f04071201827889d97bdf4c899bde5dd5ef9590b368761a40d5bf1db75ed7e647cc8580bd0f5676035e35d52c2e9b687f2dffc2995a372326f786145d6a",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -1124,37 +1124,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4f816906-ea17-4076-b207-a66b4e06cb90/3bbcd6b97900356387435220ebf631e8/windowsdesktop-runtime-9.0.1-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-arm64.exe",
             "hash": "df2c1a51ef9b1118b7a5f3cc20df25b7616b3340b62abcb2cebc383ec188ac2e955bf4804f2066a0848614b249f2e3149751a932912d4a6a12383add69817806"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fa64dc36-e7ac-4742-8ff5-5c17eea57d24/528acce3232887137f7d24aecc67c131/windowsdesktop-runtime-9.0.1-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-arm64.zip",
             "hash": "c62e4586129b9597cc8c323e6ed88e43ed6cf84836f33b2c86a30be25b8eb2d8ebeabcc50aaf16233a319d052d5e277c5bee59a541a811a94334f83d040b02d4"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ae0291d4-bcdc-4e56-a952-4f7d84bf2673/1bc4a93f466aab309776931e5a5c4eb4/windowsdesktop-runtime-9.0.1-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-x64.exe",
             "hash": "4ad450ba0f0efed458a07f8d1ed8c5e75b78c349d6cd2b3374b190f878b3af80119e6797861a5ce2f9ad61216fb85ed046bfd905bd3006e940bd86bc0164ae46"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e274cb3b-49b9-451e-aa84-be569ed98eb7/61c81caf06d1d11a2fb6eb0f68555097/windowsdesktop-runtime-9.0.1-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-x64.zip",
             "hash": "1256825e6d82cc05c19ae006f64171f63ae1b9114fca9d40666e665460c9a4e3d48a8afad1fca15c0b94b16a783fdf3c455298fe599bcd5a2c3509f9499389be"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dcd86c7a-9e55-4cc0-8c71-b99ece1350c4/7cc9c0996933075f56ad69c1169e0c1c/windowsdesktop-runtime-9.0.1-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-x86.exe",
             "hash": "b67c00b76ed6a601ee50cdc84126cec50d4f8f3d39f0280360555b600a38220ad683290b5fd5f3fe5b9bd6984fef8ce2f39f7ba82d417fb85b3801e41586911f"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/eb821758-fbac-46a2-aa38-e908c0e94b9f/fe3b0722e3c2a0fb9ee8976ac5443c2b/windowsdesktop-runtime-9.0.1-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.1/windowsdesktop-runtime-9.0.1-win-x86.zip",
             "hash": "15fe87903087a705759ba6477cc9e4ad841c2ff44bab3583e56fa06d7daa3c25de1bb91da5bb2f91da996443704fcb459410ace7563ecb06dc107cf292820eb3"
           }
         ]
@@ -1184,97 +1184,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8f639af4-29e2-474e-ad2d-ad1845c09e21/d6a1fac24aa5bed41dcc8c35017a44f4/dotnet-runtime-9.0.0-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-arm.tar.gz",
             "hash": "fab552df6d884090aba1f658c8812b5369e9bea17e6a1f905145cde512772b57db5d5cf586c6c2b7f2e56a8cb83c206f0cf7594bcf42d32844b8103538bd883f"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3ae34de0-5928-47c4-9abb-e0b8f795c256/1ea2ed5a50af003121ebf32cb218258e/dotnet-runtime-9.0.0-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-arm64.tar.gz",
             "hash": "4f9c2dd544af0b8540c16352b9f01f75f828b8e4e084057a300a4dec652fb3d6532906cdd4246399cc13f16b571b17575812ec2f9c297e27bbed678baf4b2fde"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f2566d5b-8b22-460e-86fa-94388974ab09/a4ae7832d06be1e5ef0b55ecc22b1ad1/dotnet-runtime-9.0.0-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-musl-arm.tar.gz",
             "hash": "97dc1ddcac177d73b517d651326ec484eac52501c506c8c837c3f9ceaf476ddf929ccece9b6dc2c0a4e7d378576fd73930a8835814690631a560642527335b33"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/51a64e2f-043f-460b-a048-ea79617d9a06/b3274372b27c70fc4da62cc994890f8d/dotnet-runtime-9.0.0-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-musl-arm64.tar.gz",
             "hash": "33523364d9310b75d9819a4866b120c03b9ef7946bd3646b15930e37ff1e211de294c8a94b4ad6c1c0f7d291cb70601a4188e396d4252f5767a36a6dbe68502a"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/53729aa8-9540-4ddc-ad77-4b7126b36b30/5156249a151c4d334c19c89bb63b940d/dotnet-runtime-9.0.0-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-musl-x64.tar.gz",
             "hash": "9c33d73a898fa9b4e84ae1844468b69086979f7c2c8ea6b32db0fea62a4014513cea0619025f9edb23e67ab4ae4e2f2725d1d9bb892858bba7dfe8ed17aee799"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/282bb881-c2ae-4250-b814-b362745073bd/6e15021d23f704c0d457c820a69a3de6/dotnet-runtime-9.0.0-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-linux-x64.tar.gz",
             "hash": "5176bd68637646cd36fce7a88f83effe1065fb075e6d4a46b8be3c33d5a8394740577f0ed4f8b4fb13fa69fe83b229eb55ab7f45caac90849bf0392a670ed5af"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a129df43-9d92-421f-9d63-eb9a8218e16a/9533b915759dcbe7cbd2fb0bed4d1ba2/dotnet-runtime-9.0.0-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-osx-arm64.pkg",
             "hash": "e0de96a405b00f68922ecc02db7bf52b9ddaf6f3491b7d7cf821e2ee6074e870cb282aecf9fb3d13519cfc07bb0eeff94551791ceaa4a031596bc5bb13cde41d"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/013e0f03-e1e4-4f97-a5cc-e6504f684620/0c0ea6a0c124d87027d8ff6abeb7b697/dotnet-runtime-9.0.0-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-osx-arm64.tar.gz",
             "hash": "66c487ae2f5fc24d5baafdfb4286e23737664bd3efc181abc31cf5ded60dc22e4ba1791744a506da343e6034b1fcda2dee761d9e71229945a177b7508ba6ddb6"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c36c7ef4-59b3-40e5-ae06-798b485fc007/579afa87e7f72dc6af44bc96aa6c2477/dotnet-runtime-9.0.0-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-osx-x64.pkg",
             "hash": "7fadb1f8a039efe22f66498919c58d4d8f24e6b75bb1035d15edc997229d3c52e4d66ec972ad61b846bbeea99e7228ee21185cac9b36cc0819426f2e429ba9c6"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4be484a1-a095-48cf-8407-cae1d3dcc944/9f373dc1d85022e004df3ac1071ace59/dotnet-runtime-9.0.0-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-osx-x64.tar.gz",
             "hash": "1ebd6a97ab744fe752068639d676b145960d820501c792751404507e8d82cd9268d7e239c437f9de73b08141c3b693bb24eeb3cf3baf30e3bf33b460bb95d4b0"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1736a901-4535-42e5-9cf8-4d1d07699b45/f7dc8e4cf85bf579170043799e356e9e/dotnet-runtime-9.0.0-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-arm64.exe",
             "hash": "7ac11f3b388170ddf8d2248aa719bffd1202f3946a1bcf0701bdd8988d030d0ea2cd321eb2e6150e30bc0444a8af0b5a9ad5db3ac58b15f4338ce34193ba470a"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cfecd946-5932-496c-a2b6-ba3c99318f24/4a5b2d8e244b4db3db110ff5751ed35b/dotnet-runtime-9.0.0-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-arm64.zip",
             "hash": "4f33049397341e8302fd01ece043fdd1935a7dbd75007ec5739ce5eb5c205cac4bc1399550907f71f2e4b218e40297a89bf5d605882f5544c4deec37f9b0d026"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/99bd07c2-c95c-44dc-9d47-36d3b18df240/bdf26c62f69c1b783687c1dce83ccf7a/dotnet-runtime-9.0.0-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-x64.exe",
             "hash": "97334bbe82e2d6db090279b178d0bdfb1d675e0fcd9ca0c951bbcac05598b0424f66eb74599eb8d1a6790699a931974924f79815941944f440a261dce2cd9ca1"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fed1ee33-4574-4d89-85b5-3b8d7762b56a/432725cb9d6d235424768defea5ce6ee/dotnet-runtime-9.0.0-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-x64.zip",
             "hash": "23ae6ce34fe1271a5a48675a9cb7ed728af4be4014a7ee4a6a60a84fc23e55b50a5cafd7ec20197bd73ee47901e4239e0c4cd8fd0f5deeb34cc3da1de3960e46"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e89cce9-dc02-423c-a657-0c2b421edf21/af2e916785775fe7e023b953af404db5/dotnet-runtime-9.0.0-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-x86.exe",
             "hash": "7d744cedfc81f911b51ac05741a77953a18d1415bc7c1667fd8fa8e89b4a0df597046f25a82a960bf65e7e7fe453edf87aacc25abd6bb05d0b289adedd6b2ab1"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/73b2d717-c521-47cf-857e-e353f05f3b83/db5484cdaef7f85c94b484fbeb42299d/dotnet-runtime-9.0.0-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0/dotnet-runtime-9.0.0-win-x86.zip",
             "hash": "dc345e64174a9bec4bf9c27d6a80c946aec3a418a7ac42e2ed9c20737c014cb0b1dbce3bd33eb6cce211ebf60ddcb0e13e1d60051017e4c0c11bd6ab4fda1c80"
           }
         ]
@@ -1292,97 +1292,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fa0fa6b6-8db2-441e-a393-2dd2f5c841b9/19b664790a03e20ce4069449eaa74b21/dotnet-sdk-9.0.101-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-arm.tar.gz",
             "hash": "cdf8989d02e4a6aa21e68081e956318c94c601583a757d5eb433919ebe7fa518f207aa0f58a09ee28cf95f445c486386c229de69891433a4a29145ef596aa1a4"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/93a7156d-01ef-40a1-b6e9-bbe7602f7e8b/3c93e90c63b494972c44f073e15bfc26/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
             "hash": "c5f9c17dded5101cb4b65ad1033ae4d82fc5b04303bdce4eb61a6dc47efa84202bd726d05caf117e536a01bd78ad773b8d23cbf43bc655e5eb9912b12078e0b1"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5528c94e-1708-4291-917f-c9b693df3389/b851b22328c11e88f9fb61ea3e18582f/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
             "hash": "7e6560e69b83b9e64961e91155f8585421c3a2ce76897871d386492c623e9280f66f2284dc49362bc38739e48172523ce54b2269524437394ea3e908728a0118"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a8f1d5c7-c724-451c-8659-fe6ea4e72ea8/1c90dea91c1e117b96198bdccdc0b594/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
             "hash": "6a6d6a6d6dfbdacb48374c0ac9bdb1c93781f3970c8778b0bee1f159a22b00176868264e605331fef833cb9fed829b4ffd414276d0d1140a8b0e257195c2f374"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/73c11b94-0188-458f-b599-f7591718fc28/c44e21ffbf353b50ef88a76122e89e24/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
             "hash": "3f4e14fb7b52dfb57b1e31cb5973e6e0a338f7f030f12b3082d3b55f12f9587ddf4926a7c5fcf86b7671397e44f8e5c20fb949d70e9a7dd0dc27be73a548dffc"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d74fd2dd-3384-4952-924b-f5d492326e35/e91d8295d4cbe82ba3501e411d78c9b8/dotnet-sdk-9.0.101-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz",
             "hash": "91b37efd64242e5f1f3c2025d183eb34e17f3a9271c5602f29ddf794845eee103723ef955ed869788ebf5a731e8ddc69328799c92c64cb118e1328d259a6ad01"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/00630dd1-1470-4f65-9238-a9262d170a29/86e0e51d908e9b12b017423c2f915998/dotnet-sdk-9.0.101-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-arm64.pkg",
             "hash": "52f0efce397b2e3ab182a98e7bc69967143399c8ec512687f7893cf5ed85784a9b1ce181980827c6fe0a8866755eece4ef4aafc01d10048f01117164b186782b"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6707b71c-f95b-46b9-a4f8-067922291242/93d5be41bfa39461c47bae856a8ad93c/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
             "hash": "c6608ed280e5a76c46ce8f9b06b8c7014c7bdb54a9795c4585deb8e057db4d524037e4e82f9caf32444eede427c9cb5fdbb722508f389ef89a864f0bbae4766a"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1fec6f64-0d7f-4b39-acd1-e9e2701a6b1d/b7b6246d0c20cfe703c6c88ffdbb081e/dotnet-sdk-9.0.101-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-x64.pkg",
             "hash": "3d5567891ceed07837d7f00bd81dd5dc73accd2e007b6adc12218bd5ce9f7d5563e64ede3e49bf96a532d282ca764a72b9ca4d8cf9aa8ab1764e9b4fa55a59e1"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/330381bd-72dc-47ba-b5fb-884bd8b0bb44/8f1eef9415fc29a806fbf80a54e28c0e/dotnet-sdk-9.0.101-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-x64.tar.gz",
             "hash": "0c13e3081348dd2bcf2e0c6b84bc375f806550f6c389b1fca61767ad6b9004300af7272de199358f32afef295513ba5ec43f5f8614d12437bb884be8eca4de01"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4d9233cf-ec91-49d9-919c-0ac0070e1bad/f0c3580e34ac9c4afd2197785a11521e/dotnet-sdk-9.0.101-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-arm64.exe",
             "hash": "d09cb91e49313e7ae891d28c8fc7841b2a92cfcc3f610b249b9ef81230615335daa30ad210d9db6942ac1d02d446c8d1cf9d7cab0daff543221bb4e6697cd3db"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4b0e6d09-25eb-4e69-a3d7-9da8f20b939a/8b1bec15740a22f5a255d2570376c802/dotnet-sdk-9.0.101-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-arm64.zip",
             "hash": "a14fec6786c28523795f98c074ca8da972860134e3549f5be20c1bf41a0b8b946f3ea1251196c356d4d869591a333203401d08323ba9e498fe8e6a5bde1e3011"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/38e45a81-a6a4-4a37-a986-bc46be78db16/33e64c0966ebdf0088d1a2b6597f62e5/dotnet-sdk-9.0.101-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.exe",
             "hash": "6c1899452dc855698ccc2a9928301352e5700e7829f0d42a1e567b51f08089affc67801ba7cd49d7e45b4a4dcb79cba54561163d64c27c3f36108737b3bf9f62"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/43fd03f0-72f4-43a9-9f33-15933d232447/d8576131aa13a6eda440cf7217ad2add/dotnet-sdk-9.0.101-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip",
             "hash": "53f16be2079ed85d230a6c98fa9220046930ca0eaaf1f928b63cfae9fd9a0a5ad87c60c07833ee16dedfa582ce5d9ae68b5b4292aec56fd44203fe9e7bcfba92"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/838bc4f1-96ee-43f9-8e47-2dc2656590c0/15cbe313b18ccbeffdb61cff66f5ef26/dotnet-sdk-9.0.101-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x86.exe",
             "hash": "14d22475bf0d13b01d36f472353239de0351454f3b570d0629f6003aab55032ff575fae237e20d2e9e3d45a9f6a884c6d1330e025ebcf22a8e19d68d7f64c149"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a5fc9a9-c8b4-43d5-8314-0f757968f1a2/c355d463e19e329572d04514a8116188/dotnet-sdk-9.0.101-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x86.zip",
             "hash": "c04a7c2601d2d21678f2f9833973bf9b687156520044f13d7092c77331f6e29fcad808443d6001aec1f76233990e523aeaf3516b0084603a848da934f3e78d6d"
           }
         ]
@@ -1401,97 +1401,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fa0fa6b6-8db2-441e-a393-2dd2f5c841b9/19b664790a03e20ce4069449eaa74b21/dotnet-sdk-9.0.101-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-arm.tar.gz",
               "hash": "cdf8989d02e4a6aa21e68081e956318c94c601583a757d5eb433919ebe7fa518f207aa0f58a09ee28cf95f445c486386c229de69891433a4a29145ef596aa1a4"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/93a7156d-01ef-40a1-b6e9-bbe7602f7e8b/3c93e90c63b494972c44f073e15bfc26/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
               "hash": "c5f9c17dded5101cb4b65ad1033ae4d82fc5b04303bdce4eb61a6dc47efa84202bd726d05caf117e536a01bd78ad773b8d23cbf43bc655e5eb9912b12078e0b1"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5528c94e-1708-4291-917f-c9b693df3389/b851b22328c11e88f9fb61ea3e18582f/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
               "hash": "7e6560e69b83b9e64961e91155f8585421c3a2ce76897871d386492c623e9280f66f2284dc49362bc38739e48172523ce54b2269524437394ea3e908728a0118"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a8f1d5c7-c724-451c-8659-fe6ea4e72ea8/1c90dea91c1e117b96198bdccdc0b594/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
               "hash": "6a6d6a6d6dfbdacb48374c0ac9bdb1c93781f3970c8778b0bee1f159a22b00176868264e605331fef833cb9fed829b4ffd414276d0d1140a8b0e257195c2f374"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/73c11b94-0188-458f-b599-f7591718fc28/c44e21ffbf353b50ef88a76122e89e24/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
               "hash": "3f4e14fb7b52dfb57b1e31cb5973e6e0a338f7f030f12b3082d3b55f12f9587ddf4926a7c5fcf86b7671397e44f8e5c20fb949d70e9a7dd0dc27be73a548dffc"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d74fd2dd-3384-4952-924b-f5d492326e35/e91d8295d4cbe82ba3501e411d78c9b8/dotnet-sdk-9.0.101-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-linux-x64.tar.gz",
               "hash": "91b37efd64242e5f1f3c2025d183eb34e17f3a9271c5602f29ddf794845eee103723ef955ed869788ebf5a731e8ddc69328799c92c64cb118e1328d259a6ad01"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/00630dd1-1470-4f65-9238-a9262d170a29/86e0e51d908e9b12b017423c2f915998/dotnet-sdk-9.0.101-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-arm64.pkg",
               "hash": "52f0efce397b2e3ab182a98e7bc69967143399c8ec512687f7893cf5ed85784a9b1ce181980827c6fe0a8866755eece4ef4aafc01d10048f01117164b186782b"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6707b71c-f95b-46b9-a4f8-067922291242/93d5be41bfa39461c47bae856a8ad93c/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
               "hash": "c6608ed280e5a76c46ce8f9b06b8c7014c7bdb54a9795c4585deb8e057db4d524037e4e82f9caf32444eede427c9cb5fdbb722508f389ef89a864f0bbae4766a"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1fec6f64-0d7f-4b39-acd1-e9e2701a6b1d/b7b6246d0c20cfe703c6c88ffdbb081e/dotnet-sdk-9.0.101-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-x64.pkg",
               "hash": "3d5567891ceed07837d7f00bd81dd5dc73accd2e007b6adc12218bd5ce9f7d5563e64ede3e49bf96a532d282ca764a72b9ca4d8cf9aa8ab1764e9b4fa55a59e1"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/330381bd-72dc-47ba-b5fb-884bd8b0bb44/8f1eef9415fc29a806fbf80a54e28c0e/dotnet-sdk-9.0.101-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-osx-x64.tar.gz",
               "hash": "0c13e3081348dd2bcf2e0c6b84bc375f806550f6c389b1fca61767ad6b9004300af7272de199358f32afef295513ba5ec43f5f8614d12437bb884be8eca4de01"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4d9233cf-ec91-49d9-919c-0ac0070e1bad/f0c3580e34ac9c4afd2197785a11521e/dotnet-sdk-9.0.101-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-arm64.exe",
               "hash": "d09cb91e49313e7ae891d28c8fc7841b2a92cfcc3f610b249b9ef81230615335daa30ad210d9db6942ac1d02d446c8d1cf9d7cab0daff543221bb4e6697cd3db"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4b0e6d09-25eb-4e69-a3d7-9da8f20b939a/8b1bec15740a22f5a255d2570376c802/dotnet-sdk-9.0.101-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-arm64.zip",
               "hash": "a14fec6786c28523795f98c074ca8da972860134e3549f5be20c1bf41a0b8b946f3ea1251196c356d4d869591a333203401d08323ba9e498fe8e6a5bde1e3011"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/38e45a81-a6a4-4a37-a986-bc46be78db16/33e64c0966ebdf0088d1a2b6597f62e5/dotnet-sdk-9.0.101-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.exe",
               "hash": "6c1899452dc855698ccc2a9928301352e5700e7829f0d42a1e567b51f08089affc67801ba7cd49d7e45b4a4dcb79cba54561163d64c27c3f36108737b3bf9f62"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/43fd03f0-72f4-43a9-9f33-15933d232447/d8576131aa13a6eda440cf7217ad2add/dotnet-sdk-9.0.101-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip",
               "hash": "53f16be2079ed85d230a6c98fa9220046930ca0eaaf1f928b63cfae9fd9a0a5ad87c60c07833ee16dedfa582ce5d9ae68b5b4292aec56fd44203fe9e7bcfba92"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/838bc4f1-96ee-43f9-8e47-2dc2656590c0/15cbe313b18ccbeffdb61cff66f5ef26/dotnet-sdk-9.0.101-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x86.exe",
               "hash": "14d22475bf0d13b01d36f472353239de0351454f3b570d0629f6003aab55032ff575fae237e20d2e9e3d45a9f6a884c6d1330e025ebcf22a8e19d68d7f64c149"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5a5fc9a9-c8b4-43d5-8314-0f757968f1a2/c355d463e19e329572d04514a8116188/dotnet-sdk-9.0.101-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x86.zip",
               "hash": "c04a7c2601d2d21678f2f9833973bf9b687156520044f13d7092c77331f6e29fcad808443d6001aec1f76233990e523aeaf3516b0084603a848da934f3e78d6d"
             }
           ]
@@ -1509,97 +1509,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/526d93c5-bae2-4cfc-a9cf-b2d28d7b5c98/17c926df21958999f74992973837d261/dotnet-sdk-9.0.100-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-arm.tar.gz",
               "hash": "de06e89e559bc763ff6773bcf852d915ec47f2d89f4e7065ba0800da99ab56357f31437391a77d7096e405f63318625b0cb074f6b410036fbe906fce7f3794e8"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6f79d99b-dc38-4c44-a549-32329419bb9f/a411ec38fb374e3a4676647b236ba021/dotnet-sdk-9.0.100-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-arm64.tar.gz",
               "hash": "684450e6d1f7c711fffdbf32a2b86a932d17a51f4742bd27a4289e319c5b24f6743553fc7e0ad1c7163e448ed5c40cd1ecf4198b2e681acc4622d8e6193a5cf2"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c77904f4-57f5-46cf-bf99-d0dd1e4b9b3b/d7b454d3500c1a930b38e39a916aa38f/dotnet-sdk-9.0.100-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-musl-arm.tar.gz",
               "hash": "b0920f80e866a7603cea628a1130df003bc5d7818275c8a5882a31c6e4e29f07322fc5cfd87333893e4131bd96130fb2384d008cbad704022c89267d52686e07"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ca5a82b7-704c-4405-bde2-4bde4b932d2e/0332e51e8d339cbc0410079f911205f3/dotnet-sdk-9.0.100-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-musl-arm64.tar.gz",
               "hash": "dae06d007327f6f53f50cb3a2884b93cd2fcbb73c756a8ac5ff673617f9bdf00093932f3a83652211fc2eeb57c271078644ef5c28a42897d8397f76d0e89586d"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/404c65f4-7595-4792-85ab-e26084ebb5cf/db570cf4dc8d0a61270243c61fbdf619/dotnet-sdk-9.0.100-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-musl-x64.tar.gz",
               "hash": "e2032e6b4ed99adb3a92b7e041ea895ee09c6ed2455a1f68e55ed53bd613c8c20ef4aa5c434393bb5fdbc2f5635a83067f77451fe2fd3febcee264fe077acdaa"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/308f16a9-2ecf-4a42-b8bb-c1233de985fd/be6e87045ab21935bd8bb98ce69026c4/dotnet-sdk-9.0.100-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-linux-x64.tar.gz",
               "hash": "7f69bda047de1f952286be330a5e858171ded952d1aa24169e62212f90a27149e63b636c88ad313a6e3ec860da31f8c547ff4ab6808103a070f7fb26ba99c1c7"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2787e86a-6efe-4c4d-a3d1-8fd8c302c639/d386f92a6b2b819cb11cc0382dc98bc7/dotnet-sdk-9.0.100-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-arm64.pkg",
               "hash": "91cadc95a2dc8674a8e1fd5a8a54a6e1f4adaf1a364365e79ff69457079f5be3d0fd254325924a7c94bac531b84752bb17bb37e206b12b5b7bd43c9526ded9c7"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4569c514-16ac-49fc-ac41-4416f547c249/851fb0aa9b2a8bdcb0d1d9f9493a952e/dotnet-sdk-9.0.100-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-arm64.tar.gz",
               "hash": "94dfa49652195a884f06d06ceb23ef6f7d7380fe0c4015b96e8f950b57a9558711fba61128710f9c8de0081dd91af48a90f7bd0f8b90038aeb5aeb24fb6724ff"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ce4a7dd7-1baa-45b1-a447-76cac8d50218/128808a7422ca2e0ae37901d7c78cd53/dotnet-sdk-9.0.100-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.pkg",
               "hash": "b51da89b449bda3fe81e9be2356473536558ba7cfdd5c60adb765b215c437c7d753f1dd60468e519dcac859a64edaba3078b473891b95b3d4f744e55f47ff080"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/cab5bf72-f0c7-46c7-a8f2-074f71e4b6ca/a14ec2fc3b6fd32d47b4293994ab3c61/dotnet-sdk-9.0.100-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-osx-x64.tar.gz",
               "hash": "59ef320289796abbdc573036d0d1b4aa1919c83140b7a363174abd68be5cc0252741546a21d46c201586331f5f9211787bd19b5381b902f3bd7c226220344ae9"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/19ebb0b1-8f0c-4b8b-b5d6-ec835e2ce02c/a10305403c47790226ec809cea0d4251/dotnet-sdk-9.0.100-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-arm64.exe",
               "hash": "071c44e59d4b7b58e9d0e5c8752229e5b3d6cd5bc1fe9f1f06409fa36392ef969f93e0faa0fd437c5fb8f5e525719f1b4fcd664d38c9f386b0cee1103b23adc3"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c44bc697-44f3-4367-b40c-7bd6196039fa/742da26e7cb9b91bdb83361d44429883/dotnet-sdk-9.0.100-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-arm64.zip",
               "hash": "8e22602df5ea84a0a4234dc677d5ac3b9c077c7cfdaf8257e281fadb864ed245a38e1b93a058b3d0eedeafc6a7598d6b0ed621855f5d672ac4a72077d6c60d70"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.100-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.exe",
               "hash": "a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c5650c11-6944-488c-9192-cbab3c199deb/059197c7e46969164e752eec107fbea1/dotnet-sdk-9.0.100-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x64.zip",
               "hash": "fdc42c1b339335b3b9470401f731af4bdeca64c0c2aedf6ffda831eba0b18869f9a83855994bd9806644aeaa31e7086a9ced23319e45d66cf1a055c9f9cbb47f"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9ac55860-8ff9-4506-b005-d88df3092c01/bd204d9ae6b3ca66dab904f1169729a3/dotnet-sdk-9.0.100-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x86.exe",
               "hash": "854053f68672d922740e82849b7608ecdf63019fbcaee5970aac097a33b743f76df281e64b298c0bf138d0043aa01b3cd9627199f7fcb6a523210d6ad086a90d"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d7af32e6-aaec-4fcd-aabe-0d927fa73a6d/80bbc4143ee82e40b8b4341795e92f4e/dotnet-sdk-9.0.100-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100/dotnet-sdk-9.0.100-win-x86.zip",
               "hash": "5d624181cfa8a440b359645293f3508f5c9e162e0e8c14a646b13f5e5474f93d03d3813fd4c9640497b109d3917bb7f52d7fcf829f50af7fee8c55834f13a5e3"
             }
           ]
@@ -1616,127 +1616,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/84aa8e86-c6a1-4562-84f3-828e836ef26c/96772a224b9ff3be8904b63f37d7cf63/aspnetcore-runtime-9.0.0-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-arm.tar.gz",
             "hash": "f711af1fd17f6976d98609feba32dbc8b027e3b851439ab0d5a68082ba6fa87ee3888cfd8cdd368b90fc3b3710220be2de9864ab50297e3797adc4bcbaab7e99"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b2029a3e-c67e-4905-ad1f-08b164322520/bd68ea0b77f12df21b935da338fdaf25/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz",
             "hash": "d5df4b549a59c8b9b2bcee5e0ffa9fde81fc3df74b299ab49820af6bc0ccfb89eec3714ea558ffcdd2a16821a4d1ecdcc64e9981804978ee3ff1d444b8125681"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/59a041e1-921e-405e-8092-95333f80f9ca/63e83e3feb70e05ca05ed5db3c579be2/aspnetcore-runtime-9.0.0-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-musl-arm.tar.gz",
             "hash": "9558c873308ce275a367643d953271ac8877e0c3535fc1717cef013ec37f42177f013dd875a12719bf9d1c1533b51592cb8f87195d1e398e528ee5d0b04f7c1e"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e137f557-83cb-4f55-b1c8-e5f59ccd3cba/b8ba6f2ab96d0961757b71b00c201f31/aspnetcore-runtime-9.0.0-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-musl-arm64.tar.gz",
             "hash": "fb5255619fa0c1082020b750789e86936cc1a07b9e321297e3af336af3b7f75d425c20fae9f4dd9d76c0b04d444e1e6dd15fd545feec0f6a9137a64701ad4633"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/86d7a513-fe71-4f37-b9ec-fdcf5566cce8/e72574fc82d7496c73a61f411d967d8e/aspnetcore-runtime-9.0.0-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-musl-x64.tar.gz",
             "hash": "09e3709664f099b4116f8a2aac4b365247d11d0d19ecae262949de38fa9d41cc6c521a67e5b1ffecd63c610c1e9b41459bfb18f62b9d9d3b5176e3856e9ad35b"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e4791376-b70d-431f-bd98-5397c876b946/64ffc29a4edc8fd70b151c2963b38b09/aspnetcore-runtime-9.0.0-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-linux-x64.tar.gz",
             "hash": "1a81023f119dd5e5b0f9d87b0e3c42df89824b9fcb73192a4670cc2c67358cd018a7c9c965245c7883de468bda88c81d64a21c60f9bc68a6559d76f32d34ce96"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a9c3126c-91ab-4ab1-bc0a-e6bbeee7a786/3f848ed6f804c50f3a4c24599361e0eb/aspnetcore-runtime-9.0.0-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-osx-arm64.tar.gz",
             "hash": "4aa3037e5b8b723f69d59ea733780dcecb5c8e17af924d945b369237bffad6a6a11cefbfb6db5cfb2e1f281e2385ac88e8253120b1a52f4db93186084f230f51"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b3d48d74-e9f8-4b6c-9ef7-6f5729873f21/2139bfd7650c0fd8ddce3195ada43ae8/aspnetcore-runtime-9.0.0-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-osx-x64.tar.gz",
             "hash": "ea778a7aa7eecd2c46c38b187119e0afdb02532743550a4bdbc56a9125e328a089c16af74c3ffe649263f456ef26f5fc3b932f4d1f76d36a47cb419f203c6587"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fe012fbe-149d-4235-9d1a-81bfdefa6cc6/852e5c8a18ccb168316f66e1b2f4ac25/aspnetcore-runtime-9.0.0-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-arm64.exe",
             "hash": "0f5290d42c8ed3b9a8168b618a8abb6ef0dd77f006339699bda8e9a182434143fecb0da4cd1b1d48cfbb8e95212c6d5b45bdd84fa77fcf3e8299671f0827c26c"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/38471b06-b719-4d02-a866-cd31eadb2d61/11b17d533d2feac0ae65f1a1be13de2f/aspnetcore-runtime-9.0.0-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-arm64.zip",
             "hash": "6550abfc7a00c50dc90513a3ac842b6df395b9d2204ecb8268fdff18cd555c71ca490b68c126c1f2d4caf4519eaa913ec0ce5601388d3c6c221463aa8a204a4a"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/815e6104-b92c-4cd5-8971-cba2f685002a/37befaa217f3269a152016da80a922c1/aspnetcore-runtime-9.0.0-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-x64.exe",
             "hash": "604b63941a063087d84d3bf92513cf3b2237faa11995b2854e25bde43181487d42f05bd084b412d0abfbec801b3c6c5dc6ae03df339c1a04bf08d86a9bf8fcfd"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6f43674a-fedb-414d-a709-6cd21f295ed3/6d041dd6f1812d804994a7c6c45a23bf/aspnetcore-runtime-9.0.0-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-x64.zip",
             "hash": "9c48f8b05fa2476b0afd4983e789aabc2ea951055c617c7eb9617df92da01242874c0ca8922794cce6d63799fb87540ec7560e0926f78ffd6def73f8afe508e4"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/70c1a68c-e5e4-45ef-9f2c-df1d3f195a2e/6b8e20fe1e45f886e464908cf18efd96/aspnetcore-runtime-9.0.0-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-x86.exe",
             "hash": "ea65734b83c7443d4d702cb80a255a897a9ec4ed90e986dc681b124decd1fe6b55385e7f5beae59ff23341d9747d00cf4f8e60cf657c66243ad7e5cef9622e4b"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c1c22ca6-181e-4f44-ad83-5f2664694529/81c3cead48ad0e5aeeee2a83db0a64db/aspnetcore-runtime-9.0.0-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-9.0.0-win-x86.zip",
             "hash": "c1b966542699932a3bf39e48c19a97b5d6f1513782fc8d3c94c5d6c875ccf19944bb807376570ea485dd7f04e3640c3444baa8cd449a2af43d5bba22f0a0f50e"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/005078b8-dd35-475e-a8fd-83cd63cb4438/b3cd0e81df04333b6d17cf37389d4204/aspnetcore-runtime-composite-9.0.0-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-arm.tar.gz",
             "hash": "49360cb623d848f32520a18f3943271b2970c5b81eb8f7f7f04986795bcf0400e224957bcbb8d4a9e92e75a9f60b222818bfd748442d95257d93ec65cc6d546b"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/66eccc6d-6fd3-4ca0-8230-d13097728962/6c9a2fa811e69ca8abb12c700bb5d392/aspnetcore-runtime-composite-9.0.0-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-arm64.tar.gz",
             "hash": "e7bd3d2a51957d9174bde49ed5be141534261cddd5908881e86d56c2f8ac2c207f29d91af2df387b2c6daa9091436a7c998564ea36c3f2d29e74de0b552e1339"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7c960cd9-c2f1-49f0-bd92-25488c910e5c/1d00f01ed028462b5a38f4f15ad32980/aspnetcore-runtime-composite-9.0.0-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-musl-arm.tar.gz",
             "hash": "106457de6f34a2996923a77589e841815239a760382ee525c3b714f9e6f65039d8555a5e371aaad0e89c02f9dfa5bb267cac22fbc1cd383f696facebe5b34a97"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d95f7f9f-da8b-4316-8e7c-13b8172761c3/b6b990bd12f755bfced7f16fabebec06/aspnetcore-runtime-composite-9.0.0-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-musl-arm64.tar.gz",
             "hash": "24354dcba020e0bdbf0da867e1a3cb3c45ce214cf7dcab4d1be966c0bcba8d1701605e7681e9adf093c5d23f96574d077ca8fef9ea3d4071b7a275ab5901f86c"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7d0c8c38-d0d3-4f99-9ddd-212a6537758d/21c6304587312c1151044e32656ce164/aspnetcore-runtime-composite-9.0.0-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-musl-x64.tar.gz",
             "hash": "d2f370d46fd24909015353c9488c68c526b931e3fbe5f34385a092a59ef21ebbf123ee491a896e65b3127bdd3e03349feb9c7f54e2ecf9c827d5d86da52e64d4"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3bd9050c-4605-4d8b-b4f0-2c7dbbd0ebb4/9de6d98389cd8ccb36c72cdd979a06df/aspnetcore-runtime-composite-9.0.0-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/aspnetcore-runtime-composite-9.0.0-linux-x64.tar.gz",
             "hash": "7771734dd826ee714a65f7d0963f81ec061992c9848c02d335e8423a676c7d9fa7b6e2fdac72280d8e9c8df712a3f7723d3113f37d9e052f7314b06b661e4dac"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e1ae9d41-3faf-4755-ac27-b24e84eef3d1/5e3a24eb8c1a12272ea1fe126d17dfca/dotnet-hosting-9.0.0-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0/dotnet-hosting-9.0.0-win.exe",
             "hash": "07857f982392d18b0aae269fb455573a3a02dce7bd6cd9fc476b514b1792430dfb793799606a7cd7afcd80813ca269abfa5427520e9b4ac589288d6de8eb1a4f",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -1749,37 +1749,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b3a8a99d-5c1c-475a-ba68-4849de9ea6e9/c17f07553d7723165f98f27128fec048/windowsdesktop-runtime-9.0.0-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-arm64.exe",
             "hash": "36ff3e8dd5f989c87a95b0220e618cb685104c74b4f7fcb553221983a804b67c6a1b57298830519dcd8f9233d78219adb3f1762716b83209326d25353c6bcb67"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/097ced3a-0b77-4867-b9ff-226d0e4a0a3d/4f21dfcbf0da3e1b127b1eb751c96098/windowsdesktop-runtime-9.0.0-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-arm64.zip",
             "hash": "b0277fe40efd961c6853dd86dcd55f5958e6c588fdd9739d690907898f44edbce6171d43293e61792af817ebe4dabf24e8021743d52ae6ee43f98010f4d3b95b"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/685792b6-4827-4dca-a971-bce5d7905170/1bf61b02151bc56e763dc711e45f0e1e/windowsdesktop-runtime-9.0.0-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-x64.exe",
             "hash": "e48e015327598623cac9081a556f76f4d4d74c33e35a7cecbd2989a5b2bcb6575017e922883fc841e10efdec3d9577a47ed2b036b7f431d8f8442bb1066e72ac"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d3c1e69d-79e4-4f08-a13a-75c9c36706b9/773a05ecaad2432302fc66f2dad032c2/windowsdesktop-runtime-9.0.0-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-x64.zip",
             "hash": "b1c4a49d33cebaee3abcec44d151ba49784a5f221daaba3fc16249386fbd285a97bdd29124dc290b5615071a1f45be9bb0fd8c173626de20a0b7d2e399880d13"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8dfbde7b-c316-418d-934a-d3246253f342/69c6a35b77a4f01b95588e1df2bddf9a/windowsdesktop-runtime-9.0.0-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-x86.exe",
             "hash": "f597d55205b776391ac1aeb56c40abf5274e6473193c4e6c48982582c135db199d8e75adba87bdacca8981752f04f596105548ab9cc267139e681c7858890543"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4da91bba-fe5a-46e6-b61f-3ff20b0cdb4e/c3e0ae8478071f337668d19bf4c22370/windowsdesktop-runtime-9.0.0-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0/windowsdesktop-runtime-9.0.0-win-x86.zip",
             "hash": "c11bbfa7bcc1dd9b165c802eba633dc8015ad5f38130b85d1b0c1bfe98546ab7326d00b98008ae324c19bd8baca94826df2ec483fc87d976749c58dad36d458d"
           }
         ]
@@ -1817,97 +1817,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a0fea09f-b78f-4381-be80-3bb7c363f010/7dbd31bdfde0fd28038f9feb5c24de4e/dotnet-runtime-9.0.0-rc.2.24473.5-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-arm.tar.gz",
             "hash": "c3ea1494aed56c557406786e16dae25a2d1b09e086fa470bee7850203f3c995ff0878ba36707a11719db1e517c6fcba53b103a6987b4fda9158df536cbfd27d0"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/59fcedfa-70be-4166-ad7a-aa724c8d0754/56ab42fd18b3ec36eca8e9a52398032a/dotnet-runtime-9.0.0-rc.2.24473.5-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-arm64.tar.gz",
             "hash": "355cdb3ab0a01fbe23b7067916c7516b316ada360dea9b7735fe935eca1723ca1b32407eca3afa7c722bbf061990019a6d563bc3597fdf72940ceb38ae2ad04e"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1ae9bcc8-f0c6-4e58-ae9e-1a97ad4176e7/97a25ba8dd8535ed125d0c3773a8f64b/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-arm.tar.gz",
             "hash": "59e2d7cb35a63984752d296bf02a1e8c2a8db0dcbb2bbce43375f9f7ea8ded93867ce4c20b09c03de94e3e33463f15cbf9aff058a9331daf0ac504c4771db96c"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f5868a65-9c13-4020-8f22-afbd6ce09d13/7a342e4798cebc6cba90a6569e9dbec0/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-arm64.tar.gz",
             "hash": "3de9320983e8e043eb5bc301e324425570b21ccf0d5eb97c3e1fde2ab97e98206d8d1784d96d6913be0bb4b8ce50c5cff956e7f8981ee0a1f1c9df227679212a"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d9e2009e-5bab-4a62-88e1-ae5e3ed4e0a0/617b2bf0e8292164424e71c342ed8d13/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-musl-x64.tar.gz",
             "hash": "d40a1861d4e550a46d4e9104176d107eaa0a1be94cc6ac583ef331e6ad31ccaf4d37a427620300a37376c86f122a920a2b7b40b4e4ac347be2d62a38dc83d965"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/69beb740-ba0e-4a0b-a82a-737c61cb75cb/eff5e94b382efcdcd2a80278e04edb92/dotnet-runtime-9.0.0-rc.2.24473.5-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-linux-x64.tar.gz",
             "hash": "ba0431e7bb82accab144cf1666c470549d8102a17f260cd7e0d988923a27f3ad5c10cadd160b5a180d5bb15972143f30fdb73b687d1f8ccc02e9e9334ab8c2cd"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/999d2168-46c6-466d-a305-f968e8026616/582cebc362a0ec4c8afcb22bd35c573b/dotnet-runtime-9.0.0-rc.2.24473.5-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-osx-arm64.pkg",
             "hash": "e482d903959159b3b17ce92fc562f7cc32acd3e63a143a9cb1d57eb08279e9a196e905ef94563c90529b1a1b2cfc25c48ea9cf5868caae6c54e2a6e978c4c1b2"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cb30091f-cc2e-489f-a8ae-87a08a9d220d/7ce11a740f6d5641c514fe68b2cb2dd2/dotnet-runtime-9.0.0-rc.2.24473.5-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-osx-arm64.tar.gz",
             "hash": "7b50c5defc32183398294e4cb91a59060617678408a586ce981e0f47fb833c8531b30e03fc4657a09163460605730241e366c9213c381077e6547538e356e8b3"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5ff31639-be1e-437b-b448-dfa11291ccdf/6e271fd741ac91c7beffd6cbcae285e5/dotnet-runtime-9.0.0-rc.2.24473.5-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-osx-x64.pkg",
             "hash": "e73fe0397eb8d1237d7e6a900c4b44cacb985461c1ca20f17afaf718d20fca3f5658240e31254a3ea5e48ac73a905dfff82d0aedbea2be1617afe61b5681571b"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b9385375-2ccd-4e9f-9e4a-8d7f6d58c3d3/00e123163e6bfaae9119c5fb355f0d53/dotnet-runtime-9.0.0-rc.2.24473.5-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-osx-x64.tar.gz",
             "hash": "4d260dca0c229b640e90e4554b5161c0b9d95f8bb980eb53e61940be22c832849d3289107e1c8158c8189258761a27695e9a4296b9086a0d44c8c12440531fc8"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/27640c4b-41d3-4cd4-a11e-70e0feb29504/3bfc756fac4edf66f058126f3a6cf49d/dotnet-runtime-9.0.0-rc.2.24473.5-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-arm64.exe",
             "hash": "acfeaec4566696bb22c276219eb7690007c13c09a681bfcbb245406b9308dad1e5620e7deb4fd5af07062b2e32175cc8f3611704a7708090cb99e6e1b847a7bd"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bb286ecd-ae9e-4938-ab23-fcda7a10c89d/14770e7df2cca094cba4c55a8f49f499/dotnet-runtime-9.0.0-rc.2.24473.5-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-arm64.zip",
             "hash": "34d0213403e43a89ff7499111af59793c1fc231defd9861cb999e2bd4b7aed5221cf2fd31d1ec3b926b42b4d802024bbd2c6cd676c226d90ac4392c8319508ab"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/19f3f64f-4734-44d8-aa2b-aba6f2940bfe/405c15d5bd31713faaddf9cd9e8d4fc0/dotnet-runtime-9.0.0-rc.2.24473.5-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-x64.exe",
             "hash": "521f57ed8f68227643e311db9449d6df16f5402705cd792147bb7d665ad6302abc4baec90792bcc5b8a42920b2f52b61a611bbfdb683dc517a531048b4d194b1"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/433ad885-2fc1-4387-9413-d017eb9fb11c/db7a7e5df34d1bea2d25a0a34a6c12c4/dotnet-runtime-9.0.0-rc.2.24473.5-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-x64.zip",
             "hash": "bf1cb18fe8cf7f42d84ff02974949b27bc311e29320ec48bd7707815f69e4ff91abce701791962f0b59a2ac6d3fd3c05db2cf49fbe6651c85e6ff7cd114c0c91"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/508704e7-25d0-4df6-864a-f070091a7a6b/45ec71800b5b829815ba861e1f510e2c/dotnet-runtime-9.0.0-rc.2.24473.5-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-x86.exe",
             "hash": "87c84bafa2db77ea290990e94a011c5bca3078a71a854e6862527534920dfcc6ff2ae3b13a03ca2a7578f13257ba65d4c9dd6171ec79a73971e579848beb7535"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d192fd75-02a6-47cb-a734-295d2f70624a/26500396a3603ae5e159855e13f9582b/dotnet-runtime-9.0.0-rc.2.24473.5-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.2.24473.5/dotnet-runtime-9.0.0-rc.2.24473.5-win-x86.zip",
             "hash": "03bc4281a2e55a37b2ef18859c84c7395d427985aab1817db3ce995ca83bb69d53e8420a0f38005e1fc56bbf93fdc120a2cd71018c6db5f0f1d25e75cd30e645"
           }
         ]
@@ -1927,97 +1927,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ba992713-4a38-4b45-9c24-8222f2ba01d7/e8746f2e70e0f06e3d9282c6d43bce65/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm.tar.gz",
             "hash": "736a0e1bf7791528e6c98848517f6ce71d94fa1a5a72b1e5da2c9b572709d57964ab53b20f1e2b9fc68e2cc739cdba3b91fc08d85e8407fbbfcd0d5fbb11c7d9"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/817f5589-0347-4254-b19a-67c30d9ce4f8/3dfe6b98927c4003fc004a1a32132a76/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm64.tar.gz",
             "hash": "b532dcbcb47c4fd2c906018d2ec663de1719179f7c9da8f62a3f21a62e34cd2609fb7ceec89f5aedb2a35247f67f543a02c684e1692053bff2fdc4184df63f53"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ce9a6b41-d58d-4def-bf4d-2ff6a022c846/321706c736aaf0391a642d5d1e4d3e1b/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm.tar.gz",
             "hash": "a739f8d29744152d33b7b3b749386f0f513b66d1f2e363c1082bb876ded388e1cc6dd26b0f902b3bcdf9574edd3869f800b923648c3dda90dc91b76c4ad5cd97"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/add40efa-8de0-4fb8-9ac1-bed94c85caae/30527cbdf0f429eb778ab03f2fadf896/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm64.tar.gz",
             "hash": "2a55a8e0e31b520dd9cdf3efa80f527ae87bec3b80dba44bc613caab4756b73d1f145086489fab0f55a96688029aca14061ae258d1dcfc36ede8ee0b2a8f47b7"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5e1ed970-6da9-42aa-840c-784c63c3a1af/4bb5d67f6983d22667d4d198d6e72ffd/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-x64.tar.gz",
             "hash": "242c82a361d739cb997619c982047b05fa46c8d72564eab84da49d2b831beb1c5cbf2bde580df0b6855874bf1a4360a263191277d5602dcdc6a019435a00ced8"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/202e929a-e985-4eab-a78a-d7159fc204e4/0c85219d441cd3bbffd4fb65b7e36fe5/dotnet-sdk-9.0.100-rc.2.24474.11-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-x64.tar.gz",
             "hash": "126a92bfa9ef4e70609f8b27cde0fae1b144a91af8a46de949d803d2aa1bad0285b1b9b8fc60d40206d346aac49e48709bec4e76cdf6e549f8905086003e8098"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2d099a55-d6f5-43f8-bf05-fe90f023554d/03b79d057c06c1ae0855c8e8c5696680/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.pkg",
             "hash": "cc149335d94a79281d519745fd6c5bb3fb247cc7aa69ecc567c2bd0830dff9a327642353d4c9b84523a11465a009b0b34d990183120aae5bd1fd8b19e67ec097"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/90c92374-0f9d-457b-a612-13cef4db7507/fc5ff8876123abfcde954906215ed1d0/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.tar.gz",
             "hash": "c245685c1257295697aeac6cf169cd6375d7e725ebb8760efcebec39fa6ebf6fe3ad5b6099426f899f8a0a0332c047977de7f8432a4e6f28a34848914a925ba1"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/71285611-e6d6-4758-8a5b-fec2b48fa25b/4aaf5fe8828150531679788c418a5920/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.pkg",
             "hash": "2ee81a99188368a44f8c2a10e366da7ceeb926d583d851c9b4b8137ed2e36b97115a1b282220cace0fe36ca07275f3bf5f0de071fd3f5a30a92c575ecbc4ad26"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/33f4f5cb-7423-4930-8e4b-d96f1fd088a9/87d414df2c160713cdaeec06c62cf6a9/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.tar.gz",
             "hash": "118fa956dd330d0df449e14685b362e2eb7b44fbe9541b97c125d93a78dc2e530288a3ba1eba3928d305f4a0b9254c8480c0b89304187226679f95bd6f1bc75a"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e282a46b-bc82-4385-85a1-5960b2640f70/a40e95d4db7b72a3d5940569a8bb2d59/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.exe",
             "hash": "0da1f676d50005313c90940ca8896102ce30e1931dbbf900e84eddeb27c5cfd68761165d0d1adb7e5db72c0c635dd2e70b887c71d3926d37774cd940b4070199"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f8db4312-d81d-4b4f-bcd7-5d8bea4b8d4b/1fbd8938f5e322bb64b88d17802a9023/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.zip",
             "hash": "5bc7758d0be1a23e761dc532ef0498abc3d3c3c8378fc06c4cde151ae692e7dc7f059829843dcf5fef52d16a5619a599b426e056128261a5b022837cdcada35b"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/084bfbb9-6197-49d9-ae9c-ad3825534f37/e1a071d344c9b24849f8034f7ce72aa6/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.exe",
             "hash": "29091a2b4d08f7fdc77065f2805a82afae0129a6b886caec71124016843a29c6abcec828794aef1c9a73a84df3f7b7258863991f61a780ea362575da0ca6879b"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/af6bbccc-1d18-4bcb-aa3a-ce76f864f977/8ecffe6494804fb6c6be93488c58eef6/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.zip",
             "hash": "9abd147e58ec166ec1fb0ac0d7499dbafc82af8bc814ca83710f4d3d2e37194c841a603f66f278f05dd4efa27aeb6515e6357e8e7d074407cc5de8944d52e7c3"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d052307a-2d94-4192-935c-b6586e7077d2/3e3dfc72d4bf97bf2d6281ef250114d2/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.exe",
             "hash": "42622d7145da2cd246c4490213ba0fd9e9a8c4f567a0f6b940f24029a6f342264be6b3f65ea79b46ee4048a7d74201d25ba98402ce4c245f82ee318f5442af1c"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f34a8c71-c150-41d7-a233-e5d35338970f/a58a721a06c0f167a4d81efe0d270b92/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.zip",
             "hash": "e1e7935b5c8e7635eb8d7373a3ae760943785fafa3e6ac39343a614c279a0e4d4c0c8724ddb7e3af37c9d806ec11a4e240066fc090a2bd5c21e23c002798ece8"
           }
         ]
@@ -2038,97 +2038,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ba992713-4a38-4b45-9c24-8222f2ba01d7/e8746f2e70e0f06e3d9282c6d43bce65/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm.tar.gz",
               "hash": "736a0e1bf7791528e6c98848517f6ce71d94fa1a5a72b1e5da2c9b572709d57964ab53b20f1e2b9fc68e2cc739cdba3b91fc08d85e8407fbbfcd0d5fbb11c7d9"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/817f5589-0347-4254-b19a-67c30d9ce4f8/3dfe6b98927c4003fc004a1a32132a76/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-arm64.tar.gz",
               "hash": "b532dcbcb47c4fd2c906018d2ec663de1719179f7c9da8f62a3f21a62e34cd2609fb7ceec89f5aedb2a35247f67f543a02c684e1692053bff2fdc4184df63f53"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ce9a6b41-d58d-4def-bf4d-2ff6a022c846/321706c736aaf0391a642d5d1e4d3e1b/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm.tar.gz",
               "hash": "a739f8d29744152d33b7b3b749386f0f513b66d1f2e363c1082bb876ded388e1cc6dd26b0f902b3bcdf9574edd3869f800b923648c3dda90dc91b76c4ad5cd97"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/add40efa-8de0-4fb8-9ac1-bed94c85caae/30527cbdf0f429eb778ab03f2fadf896/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-arm64.tar.gz",
               "hash": "2a55a8e0e31b520dd9cdf3efa80f527ae87bec3b80dba44bc613caab4756b73d1f145086489fab0f55a96688029aca14061ae258d1dcfc36ede8ee0b2a8f47b7"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5e1ed970-6da9-42aa-840c-784c63c3a1af/4bb5d67f6983d22667d4d198d6e72ffd/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-musl-x64.tar.gz",
               "hash": "242c82a361d739cb997619c982047b05fa46c8d72564eab84da49d2b831beb1c5cbf2bde580df0b6855874bf1a4360a263191277d5602dcdc6a019435a00ced8"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/202e929a-e985-4eab-a78a-d7159fc204e4/0c85219d441cd3bbffd4fb65b7e36fe5/dotnet-sdk-9.0.100-rc.2.24474.11-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-linux-x64.tar.gz",
               "hash": "126a92bfa9ef4e70609f8b27cde0fae1b144a91af8a46de949d803d2aa1bad0285b1b9b8fc60d40206d346aac49e48709bec4e76cdf6e549f8905086003e8098"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2d099a55-d6f5-43f8-bf05-fe90f023554d/03b79d057c06c1ae0855c8e8c5696680/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.pkg",
               "hash": "cc149335d94a79281d519745fd6c5bb3fb247cc7aa69ecc567c2bd0830dff9a327642353d4c9b84523a11465a009b0b34d990183120aae5bd1fd8b19e67ec097"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/90c92374-0f9d-457b-a612-13cef4db7507/fc5ff8876123abfcde954906215ed1d0/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-arm64.tar.gz",
               "hash": "c245685c1257295697aeac6cf169cd6375d7e725ebb8760efcebec39fa6ebf6fe3ad5b6099426f899f8a0a0332c047977de7f8432a4e6f28a34848914a925ba1"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/71285611-e6d6-4758-8a5b-fec2b48fa25b/4aaf5fe8828150531679788c418a5920/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.pkg",
               "hash": "2ee81a99188368a44f8c2a10e366da7ceeb926d583d851c9b4b8137ed2e36b97115a1b282220cace0fe36ca07275f3bf5f0de071fd3f5a30a92c575ecbc4ad26"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/33f4f5cb-7423-4930-8e4b-d96f1fd088a9/87d414df2c160713cdaeec06c62cf6a9/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-osx-x64.tar.gz",
               "hash": "118fa956dd330d0df449e14685b362e2eb7b44fbe9541b97c125d93a78dc2e530288a3ba1eba3928d305f4a0b9254c8480c0b89304187226679f95bd6f1bc75a"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e282a46b-bc82-4385-85a1-5960b2640f70/a40e95d4db7b72a3d5940569a8bb2d59/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.exe",
               "hash": "0da1f676d50005313c90940ca8896102ce30e1931dbbf900e84eddeb27c5cfd68761165d0d1adb7e5db72c0c635dd2e70b887c71d3926d37774cd940b4070199"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f8db4312-d81d-4b4f-bcd7-5d8bea4b8d4b/1fbd8938f5e322bb64b88d17802a9023/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-arm64.zip",
               "hash": "5bc7758d0be1a23e761dc532ef0498abc3d3c3c8378fc06c4cde151ae692e7dc7f059829843dcf5fef52d16a5619a599b426e056128261a5b022837cdcada35b"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/084bfbb9-6197-49d9-ae9c-ad3825534f37/e1a071d344c9b24849f8034f7ce72aa6/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.exe",
               "hash": "29091a2b4d08f7fdc77065f2805a82afae0129a6b886caec71124016843a29c6abcec828794aef1c9a73a84df3f7b7258863991f61a780ea362575da0ca6879b"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/af6bbccc-1d18-4bcb-aa3a-ce76f864f977/8ecffe6494804fb6c6be93488c58eef6/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.zip",
               "hash": "9abd147e58ec166ec1fb0ac0d7499dbafc82af8bc814ca83710f4d3d2e37194c841a603f66f278f05dd4efa27aeb6515e6357e8e7d074407cc5de8944d52e7c3"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d052307a-2d94-4192-935c-b6586e7077d2/3e3dfc72d4bf97bf2d6281ef250114d2/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.exe",
               "hash": "42622d7145da2cd246c4490213ba0fd9e9a8c4f567a0f6b940f24029a6f342264be6b3f65ea79b46ee4048a7d74201d25ba98402ce4c245f82ee318f5442af1c"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f34a8c71-c150-41d7-a233-e5d35338970f/a58a721a06c0f167a4d81efe0d270b92/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.2.24474.11/dotnet-sdk-9.0.100-rc.2.24474.11-win-x86.zip",
               "hash": "e1e7935b5c8e7635eb8d7373a3ae760943785fafa3e6ac39343a614c279a0e4d4c0c8724ddb7e3af37c9d806ec11a4e240066fc090a2bd5c21e23c002798ece8"
             }
           ]
@@ -2145,127 +2145,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bb68e2f8-fc3e-42ae-85f6-ba2bf4bc8ecb/524d5256a3798a7795837d7b104fb927/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-arm.tar.gz",
             "hash": "d6aaa61df66bc42296350f56a13e4f5a5b56770e62cdf4bb2a647f80db3bca632e7f8b64dbb2d2b8426e862edf3ca75bebcfe9db5f6a6e94ec08557a4f7a461b"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/687495c2-a3a5-4cf5-98e3-2adfef55a1e4/ef59f43e13c7107ab17e59c276da2485/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-arm64.tar.gz",
             "hash": "b6de668ce8714476be78ae00ed66027f3a5b06d95c6768ad6b3eca4d0f396c91843267c0e8c03160b709a7acdcbc2b09047f1ec8d46309d40c3d31f849cc981f"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bc4a32ff-51a4-44af-9f7e-fec219ed91b6/4ef16e8019a45a760fc00569cb979ccd/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-arm.tar.gz",
             "hash": "fa6c236044b167dfa0e389aaf3b8e42d1429f193af014b9ae6857e2dc1b64a65a8028c6ac17e83dbe5ec876e68ee9cb853dfe019c88b3a9fa15fcc6aa0b017f8"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8548303d-93c5-4846-87ad-af4c79877a26/6e3dc8573f2cd923959bdc39c8d37eb4/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-arm64.tar.gz",
             "hash": "6303def8508ee4df979e6ee6801077da7d0517d3203bdff74a36cdbae57089d7c72691eda00a5daa740b283190950b5ca8ed0fa1112b7d2ab11c145909de9199"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ee8ef896-6330-4f7f-86ad-172d67793e08/fdbe8aa1eb6fe38e8ad3fe471495d388/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-musl-x64.tar.gz",
             "hash": "9c41aa3bfca63c948ff873cc341a091049841167e644cc14f1f543fea3be75b10808c3848303916ff3472003accd801f7bc81fcc86d92c1a5c9ecd29d9bde3ba"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f75b68ca-9e93-468c-925d-3ce85f8a4d0f/3a31e60149a0ca0f9e8d7c05666cfcba/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-linux-x64.tar.gz",
             "hash": "9370c26174cd7f1b2fef58e0a53041c94b7d5412f15ea5865fbc653a65b148b1f92e7992f147610a6ca2e92011ff28c43480ab26a6e7f8cd56f2189af0610be8"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0ffcfb0e-3d17-4b00-8bf2-db75b095252c/5bd0a672caf63b32b39b92c0677a2a4f/aspnetcore-runtime-9.0.0-rc.2.24474.3-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-osx-arm64.tar.gz",
             "hash": "1dd5ea0b3800dd38bda62392809336039ba69b3ac3f1a8273a68664ca0c23b632848a348b8d9e9e0e76539b6e5e15824320b830571c2fae3df94ad0f26288d30"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7a757e46-1c68-449e-8b1c-64293c30242d/aa10955edc95ab4419bbad34f8e4899a/aspnetcore-runtime-9.0.0-rc.2.24474.3-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-osx-x64.tar.gz",
             "hash": "b62af025296774fd30f60ebe38a80612f8aa07802ffcf1c93d3da9052b461108fe5caec356f95ccd8772ea7514862c379afbb3c19b23c8e8b53af9a18408813e"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/88a1c08b-ac1a-48d7-b0b6-29717a38d482/a0e70586c7e36ca115d5c1f00d6b68a4/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-arm64.exe",
             "hash": "b9c844bc25991492e94b9ec4c6636fb64de270018154dbc0c1cb3b63624e0df56b5c1eab22d0b8f9ca175d1efc878784b907e6fad7d8430fbe88be23d3c85d9f"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bd6d5b35-e94d-4291-9b9f-8a9970e08346/1269b69928f4fa1158c3570a8c5d957d/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-arm64.zip",
             "hash": "e4eee89df6eb0b79d23f93d8221b5e7ce4f5d5cd29b5e75b730b8c121f72d15b7ece921027fc270302bbb49130d81d153ba5475b53a1216a4e6e51f4ec689666"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a6506b9a-1839-476a-91c1-61ea79144b45/4158c6a3ba3eeccbaed806abcfad7d07/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x64.exe",
             "hash": "710955c39094887356b5bf14e634511796962d3b84348e74d659b128eb0d40f351ecd881a129459661317fc647f0df8cad2929648b79982f3cbb3ce2ac413a88"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a8cc652d-ed75-4cd6-9962-979857b90ec0/f966c69fbdb3ac127baa94e2a7141d2b/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x64.zip",
             "hash": "16f3ceb3fac1949b6bc4f7f6b9eddbb4806f156fc5cea060c8411847688dcd3d56ec0b79ae13d2b5e49c1a224891795cb85b4425fdf171417b700fab981e8b82"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a5f93dba-813b-45e5-8c8b-62ed494214b7/a28cec13a364ca326827bcb97211bd66/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x86.exe",
             "hash": "2030ed1048032f51bb45b55da16a03b68fdb19a58d710d693214eceff6b1e4971fc625c4f221b67fc01561e8459a960efa1525631b73e907cffdc0c553baefe1"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/71f3df11-d883-4c21-9e41-62539b970583/4b07e65f1f12d51bbb18569897f78d5a/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-9.0.0-rc.2.24474.3-win-x86.zip",
             "hash": "1265946601b59350a071092656afbc6c501e4926b82876da951b923cf83155c7c0abcc735915f97e2f059402807028c7fbaa261788c9769c20f88c4738c86415"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/61fcb638-a068-4ff9-8efb-72defbee4739/b4f0aba681a2d3b47efcb35ebf42e57f/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-arm.tar.gz",
             "hash": "49d9a1ad1dc35df3c3009a5378b52832b4e4c17cbbddadd50c1b3868a7a1fe312520392b961275b5587093573f9a5f8c230e33988459367fd6e0062cd3b3a354"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/48b30377-ff5e-47b3-b4cf-e42c5122324f/26c15647c2ccf058230b8341feac53ab/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-arm64.tar.gz",
             "hash": "f2383e700646cdda26796bfed343ac0e6753c9cb6eae4b36c3aa4a018cc66fe0ef6d55bd3340177aee6dad3ed1f41d77598eaef56ebcbb7f70e70becd774473b"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9e2f40fc-1392-4636-98eb-3c75ec8e60cd/06b885eda138d35175511fa51ce387fe/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-arm.tar.gz",
             "hash": "d99e0acd14bfa0ad3be16d6923c052f8afdf1f169297fc3fc2799a3bdc24a9512c2b2eac9e2781ce80229b7e29a27c503b406bc5eaf0fcea3d46c0f1ed46c980"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/61185e82-3ed1-4f3d-9a2e-8653249f090c/8db3913d8bf7c4244f894de244bf8bbc/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-arm64.tar.gz",
             "hash": "1af4fa6295698d857d9955a197b0d88e263e758a118ece8a7d8188fdfe8efdfd55b363b7f5102b5a47d8355e73f54312a4a9652bd7dd87a2400452bcde9ff4ff"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/38974c30-d6ea-4dfb-a619-e29b18cc8910/b6404f477a049504207570cd2230ecf5/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-musl-x64.tar.gz",
             "hash": "efad7ff66e5bac390e55b964c028ee25f6cdb4d7d58eb6c114db08f307c8d8139f60a10cdab5e3b09679ccd8f93b94f12400a0c295a09ac2666ba2ef3902fbc7"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2ee59ccc-f3ba-453d-9186-60714c2b199c/b9cd51934396f1cdb0106365381b9d88/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/aspnetcore-runtime-composite-9.0.0-rc.2.24474.3-linux-x64.tar.gz",
             "hash": "0b215df947c2bef3cdd9bd298cea18f6c3f5e21fa46d2ab9f6faec3b9f7f062fb35819432e7e1015f27f793b4850f2cfa40040e60f28fbbfec258acd43094695"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/680964e9-9a8f-48b8-a1d4-c67ee809e5ba/7eec74d77d93ffa51eee2117aea60876/dotnet-hosting-9.0.0-rc.2.24474.3-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.2.24474.3/dotnet-hosting-9.0.0-rc.2.24474.3-win.exe",
             "hash": "270a38e4318a2783f1f3462b727304124bbc801a20ae1e6cef99200d8c5ee5d4991791876455b00df409b52d9f64ba7358e024e6f342cfae463654da9d078d73",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -2278,37 +2278,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6da33b87-daa8-4855-a348-fea6f05e38e0/31bc1017385dbc17b53f0a5d9c07a38e/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-arm64.exe",
             "hash": "3d336f0e6e5ec7d18ca21b59858ccc0c7d683e3b0a68b0fc035a3a34119f377104259c89ab7d7a3f0af1071cd550409ab91eb0d4a4072e36571c86900194e82b"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/06e5689c-c4ba-41c8-9595-c5ff65d176a0/ae5e7d82fbcb1787c32e280d52f8dc2e/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-arm64.zip",
             "hash": "dd9bf2b472dc076ba68346a866a67a86af192a39e132fa91b1b35385a1ae4af166cf56a5e3ccd12d33ab4aefafcd4388c75663de802e10452e63dea5dd80783c"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/30d1fcdb-8bf1-4b6e-ad06-f66ed68017bf/20abf38df849587b0a2de99a31f5c1c8/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x64.exe",
             "hash": "820ab1505e138cb5552d7904d6faff20ceea7c2dc087e3e0004ec6644139e51771e9c2f927ba7206d53db7f66732b750f389a2adec75f5f00f0ecc20abf31fcd"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e0bd3746-e35e-47f3-9304-e34b645539f6/512af162a45ed217f2967f7dd696b1a3/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x64.zip",
             "hash": "8449e2233d2ad2f72215c3caaa8e13dd320ce8678500c98ffdb0483f9f10d983bee834138a266dea652faca6ebf821019c0e263bfe2be60ab2cb75266a30e6a5"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f6a4c462-a2a6-4488-9448-574b659c31e5/7eb8840cb5e42e0fd41a57964fe3472c/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x86.exe",
             "hash": "65f24e6785f76bcad76c6284383f74c2f7cf5186fee4cd13f0e2796dad5aef2873e8cf73a7a04ce3250c37b1f6171dcabcc07133759e4cb959bb2dc68ba90738"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1d7354f-de3c-4e29-9861-9caa37d72fec/41af54ea14130ce6025bd647ef0eb74f/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.2.24474.4/windowsdesktop-runtime-9.0.0-rc.2.24474.4-win-x86.zip",
             "hash": "834e0936f2fce5ac079c3658986549c3d07ece93f96aa4cd8ebab4a9a612d09704b6d3e907018dfdbcfb74760aa2fe154de29188f0058b112c22c3dc1ef97dbb"
           }
         ]
@@ -2329,97 +2329,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/26c238f2-53a2-4fdc-981e-31272c80d107/67c11b008d57d501cd2e5ca642cbc8c1/dotnet-runtime-9.0.0-rc.1.24431.7-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-arm.tar.gz",
             "hash": "8a83de300e8f9ec67f705004f55229573dd8bfb106f6c42389efb296c2386ee27846f81baafe6b4269e9c7269037e5ec3f1376c72bc103e4641c9181a7e57647"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/54f6fb3b-da5b-4a2d-98f4-ae07c814a586/e5f2a5ba551ffe53ea1c2ae9b7681f0b/dotnet-runtime-9.0.0-rc.1.24431.7-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-arm64.tar.gz",
             "hash": "8542bb9381e4eca6f0ebceddec68525cc59e34f7244613cf33cb2151f570c3345cb6d081c492b01070e762d3440f02d4558234532d58ff3dc919057e06b7bdac"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c948e710-a590-4492-870d-1e44ce476a55/86522880c5160af3c81bfa71378b79b9/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-arm.tar.gz",
             "hash": "11189bcc13148694913ac5fb050b77db8104ac62dd39b970cd96aef399f7a7cee656a314b44f0113f96726e7ee0a269dea38637020fe06261a8b01ca0df9e4b4"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9ef6c8f0-49ac-4b37-9e7a-0f2cbbc74472/ceebdb8281a18bc80d17147ec3146cd0/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-arm64.tar.gz",
             "hash": "dd62a73736b275a15b5affa3465a0ef3d69619a06ccaaa3916b331f45b3859a9028e78eb7cd85c766deffb9703c7bb96788f4061d549cbdf325bf81894310521"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/30c11bec-b456-45de-bb45-5e892fd1a509/cd72910d2c8b0c908f717a3563c2445f/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-musl-x64.tar.gz",
             "hash": "bd77015ca46b8928f70a61e6cfef23c5e308ad40c03ddd421c210141b1a38cd5c4d8edf5365e8baee227db5a6ac71fbea481c1a8b3c5ba6ea58330afdd7fe231"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/72048153-7c19-4e69-bcf3-22563060db07/cd181715a0f7cd3cec8c87b115181da9/dotnet-runtime-9.0.0-rc.1.24431.7-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-linux-x64.tar.gz",
             "hash": "9f9a85b8d9f6362ed2c2d0edefd04999181b2c386647644fbc1d9f248255387324399edb1c40bc7fa8c47adc22e2d71db5f25ce794521d59e46c40593b5f6cc5"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cbe92155-7b32-44c2-8544-da54f51e1aff/89a8488bec9e2b8baf1b44691de76591/dotnet-runtime-9.0.0-rc.1.24431.7-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-osx-arm64.pkg",
             "hash": "8a0dd36bd239c676302affa7ad25568cd6c4593c57d215a11c81884e5b0ae15d1c3e1a98e38e6211c9c597dd9568df60af63d33abd32fade9d10077d29f8077a"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8abf3e03-1ab3-40fd-a9cf-fa22005be2e8/cb0c3c5d130ef8ae76a982860fd3606a/dotnet-runtime-9.0.0-rc.1.24431.7-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-osx-arm64.tar.gz",
             "hash": "a825fca9edde53ab6abc0efe0c44d6fb25c5c77aeb2d35b6c414d42f364453ceb069ed9db8865c2bb82523989fceb7cccbf86047699590ff756a6b9c54c21d74"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/69f9f39d-731a-44af-b2bc-16e2032e68f2/ff83940c685cf51cf19a58e3a3fd0fd4/dotnet-runtime-9.0.0-rc.1.24431.7-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-osx-x64.pkg",
             "hash": "a026498852db5902959e90ca53ea4567d28972c6bad1f23e42dd2cec2d966e2ff3b9824e3747566a942ac7149cde577b1af079ceca806f8d5a50015f7210fd00"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/13d7d905-549f-44e8-9062-a678a742c5fb/94c51ca9c08ef9b5cceabafc2337118f/dotnet-runtime-9.0.0-rc.1.24431.7-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-osx-x64.tar.gz",
             "hash": "f62f867eab633737c450ffb0543a726f1ba2f46a4265cb47978d88dad0c6b80a8db5ccf6f583842f85cb613b96d2f7c6806d669826f4b92b906e71d8d10e53e8"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1e08ea13-3a13-41ad-8555-cc20e7b760bc/3f2a126121eb7a0561d78bad9a2e9a5c/dotnet-runtime-9.0.0-rc.1.24431.7-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-arm64.exe",
             "hash": "64a5655077cb6fbe40f7b3bdbcdeae41c16794ab93c86f00cb803bbab3f2d5207d5bad3f84a2e3fc92e1ebf322b7c47b25ed926b9ae17b1e3b3175820db1eed9"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/60cd407e-f995-49cb-bc9e-b990542469ce/1e269314a9fa5de60990bb5879775e23/dotnet-runtime-9.0.0-rc.1.24431.7-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-arm64.zip",
             "hash": "888f39b40a3baf573208b4d6d5e1d102e00da9128d086c8b706d5116f1325ad953ab44b6bdc7b82a3e5e59192e4b2cd53ba46849658ed7960293079ea58cf209"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/98d8bcc9-a242-4b85-9764-e1fd3088cae9/71109ed672b325c05b895eba2afe3918/dotnet-runtime-9.0.0-rc.1.24431.7-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-x64.exe",
             "hash": "1a6c34911e922541c89c8138507119c22519081df5a33d30f238fc7c2d03b3cbf834c495d21cd2a11ac1d93f9296616d192f75eb326f8308e08e12bd905e6020"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/11bfe5b9-8c18-4840-b12f-027a94e9ad39/a58ebaa1cbd0df24a6529689530aef8d/dotnet-runtime-9.0.0-rc.1.24431.7-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-x64.zip",
             "hash": "b73b3ab9ab37b703b00bcb71eb180caab3f4e32dca16afbe4bcb28b3608604456c288edd7fb9254c8facdebfe3d00b28e17e10d6abb96ca0768427b773983e26"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e19676b9-e0d7-4ecb-b2ad-5e1ceeaf1d8d/93016ee5df25f623b959f49e546bf935/dotnet-runtime-9.0.0-rc.1.24431.7-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-x86.exe",
             "hash": "90f74c10c717a663a0c400fb6998b0d33d1a7760c63a804f4e3a4505b6c9b0c5ae3a3a259b8d8cbaf7ce4b872d784b8473a25b65b4b1faaffb22ede870f0fab0"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/870e89c2-cf3f-4b43-affc-2febef06d043/4cca866139bbcec02cfa85f7eeb9b59b/dotnet-runtime-9.0.0-rc.1.24431.7-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-rc.1.24431.7/dotnet-runtime-9.0.0-rc.1.24431.7-win-x86.zip",
             "hash": "78451848ddbb5080865c9ea0ad5f67c26ebe9a708104eba72166e708abd73bb647b2ec063180c39b3100e5261312f7efac7c594f12fe4319864ce4e31cd5f7ec"
           }
         ]
@@ -2439,97 +2439,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/87c96627-cf20-47d7-8cb4-d5e083084dd4/07d4b533e746b344a3dbf9f7279f450b/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm.tar.gz",
             "hash": "f31a4a2c3080a921cfdd71933d1f57c2f57ff4c43f5a0ad6f52640bc791e54f8c0526d8e1206ad21f8682357a53cf6d488a8b01107e7c34beafe2c8c3425dd8c"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f7739964-9e84-4bb7-9435-509458a15f9c/a95ad7f9deb8ce2fd30173dfe86f55ba/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm64.tar.gz",
             "hash": "f5742537128801c199a127266175066058788a26e8a603cbd26a1c16e9ef33a5d418e4790a3cea722d7de483eee8b68e0de4bb1dfdf279713369ed3b4d163a11"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8cb683aa-4558-45ac-944a-73ac40b708d2/2795bd0253d5518490378edc7f7b562e/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm.tar.gz",
             "hash": "8480900e14bd1034f586c3e17402be2f04cab250d79b4d1dda3aa887e9fafa683ad388adf7f25b5c7b0dc433375ce1c272b3d9419636e6db0f7bf300e841a0a5"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8737d284-0c4b-49a0-984c-23fddc7abcd8/ada586539e4417b557d60d0214e8b2eb/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm64.tar.gz",
             "hash": "656bfa4e7c4a3ee280b99eaffa620b09b89b3a3b9f6d33c9d787c1f8938b84afb5aa43d80546e81a2bfd532770c282c59aea167f50d01a57027a2061e595f0e9"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/791e9a41-59da-4f92-9dfb-2cceaaea001b/710f7adf35dc2f32be49ac2834ad0afd/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-x64.tar.gz",
             "hash": "b1d8004cf9c3ffb530fbb3d4259174cb076a32ba00268daa43dbf452fe6d46ccf979a63d7f53ae70a2fa7a101a9df1bd3b840552ac92a852119bb7385a65f65f"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3b2b3c23-574b-45d7-b2b0-c67f0e935308/23ed647eb71a8f07414124422c15927d/dotnet-sdk-9.0.100-rc.1.24452.12-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-x64.tar.gz",
             "hash": "e8130817b779d0104a6eee33d98d97c3fad1c336013435f47c0e9e22370172b75da37ade76e49dec7cbe696884390d2e6941cc69e2bad5593d6d1c6b41083051"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/556d3bd1-88f9-4193-899e-3253b3f1cb6e/81869aaa34551cd754dce5d2b7907a7f/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.pkg",
             "hash": "c5a54b42d13ef1b20ed01e089c812f0c39e7a9a091330eb69387cc7e41f14fd319909321bd7cdc2c5f6b3d9f75fbe64b906028ad4a3ef1d75ece1a225676b14f"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/930f4eb8-188f-47d5-8a26-28ca393b7d1b/c07a519e3d7e326c3f640ef72ea1193e/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.tar.gz",
             "hash": "af30b31cd937e9fc97e164b83628c2c1ecd21329b75f742d9f5232aa68427d25b5d702cc565aa860d3c738c8727790569bf66a3ed74e5cef719ae589d302846f"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/66064632-b4da-426d-8c92-964ef60a1705/d89d50709014f11cd6dd6118d0fe653f/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.pkg",
             "hash": "a0ac40a3b8a67447fe75b93c34a283049621de39a6791932320178c48e61cf7783eb1bcb3a6105ac5ff9c9aed718fefec8841f0172c8325f2c5cc0e30ced1e4d"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e26e36f6-746f-462c-8599-5d0a1f00e786/f1b8264ac10442b40009aa8cea46b23b/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.tar.gz",
             "hash": "0d1f0718eeef006c3ecfbefeebf9df0772ec22c74db4bb635b6463b8aedfd3957274b908b51ec019ced69d3e7af4ae9252f18e87b14a4411e1089a4cc41e37d0"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a6e58d24-e9a2-4889-86b0-5e813968eb2e/3f2ad317193daa6a15f25aeddf6b55b6/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.exe",
             "hash": "30a6ab47431eba8d82609f12739d7373e1a4ce903ab3f98a4e327b472fb7c3ebfdec6a8e2f3abd24af64a1962bd3aec0cc82c6030abbbae4c712e2037e9b3a5f"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/43608406-ee61-4781-815f-29b07d3b1792/0df27a14349cd33f4a80751820f0d4d1/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.zip",
             "hash": "d8ed11c6490cb532cdadd9f36b75e11643cc4ce771d8d68efece94fa3be438c2304eabd890dff7363c7fdb18214bb7ef1534fe28a7a9d5672c4ede81a70ade0e"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/39d8f777-bc77-4261-9f50-5228cc275ca1/d5445753af7ab151f3a36a48c55b5404/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.exe",
             "hash": "f8f3002242c76b5eb786b8c7788556563a22151a7e09032e7b0edcf4de17c3c69cf7f8dd598b2c5752df62d40798bcc4bc63f6bed8ce377d0938fe8b0ce631d1"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0439a9c2-0190-4595-92b3-9e14822f4a84/5c83aaa1c16ed9f464a56fee5320e358/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip",
             "hash": "88b4e63017663e807a26b6e3775cb67644f205a03e865f2b67c327e17120e46e0bf6aeb6f4c098cacb9822987d9f167a890c69d733e83dd998041d24c09ceb84"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e6011f62-e3a1-4e61-9db6-a9916d3b8b67/c48fab3dc0c018ad8b857dc5862b620f/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.exe",
             "hash": "4da5b031405105db0cbd1a0c5656ac7ca481021f38694e7bbb6c1b3293ca3a398da2b504ac7726192defd9b7bee5e0231f18a334a0a7d4060e60e157d97b2619"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bc54d4a8-bf7b-4eb3-ba16-9b6284f41568/7721ac6e6aff216832c3f93225c2450f/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.zip",
             "hash": "376ab68351566f8eebb837959d2e5c441e33081ca67fe1aa1223bc9bb7f0e86b626da01be9f5fb7e5a8601e61b48bd5a73955a0911633951c68aedbff4b53a57"
           }
         ]
@@ -2550,97 +2550,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/87c96627-cf20-47d7-8cb4-d5e083084dd4/07d4b533e746b344a3dbf9f7279f450b/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm.tar.gz",
               "hash": "f31a4a2c3080a921cfdd71933d1f57c2f57ff4c43f5a0ad6f52640bc791e54f8c0526d8e1206ad21f8682357a53cf6d488a8b01107e7c34beafe2c8c3425dd8c"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f7739964-9e84-4bb7-9435-509458a15f9c/a95ad7f9deb8ce2fd30173dfe86f55ba/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-arm64.tar.gz",
               "hash": "f5742537128801c199a127266175066058788a26e8a603cbd26a1c16e9ef33a5d418e4790a3cea722d7de483eee8b68e0de4bb1dfdf279713369ed3b4d163a11"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8cb683aa-4558-45ac-944a-73ac40b708d2/2795bd0253d5518490378edc7f7b562e/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm.tar.gz",
               "hash": "8480900e14bd1034f586c3e17402be2f04cab250d79b4d1dda3aa887e9fafa683ad388adf7f25b5c7b0dc433375ce1c272b3d9419636e6db0f7bf300e841a0a5"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8737d284-0c4b-49a0-984c-23fddc7abcd8/ada586539e4417b557d60d0214e8b2eb/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-arm64.tar.gz",
               "hash": "656bfa4e7c4a3ee280b99eaffa620b09b89b3a3b9f6d33c9d787c1f8938b84afb5aa43d80546e81a2bfd532770c282c59aea167f50d01a57027a2061e595f0e9"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/791e9a41-59da-4f92-9dfb-2cceaaea001b/710f7adf35dc2f32be49ac2834ad0afd/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-musl-x64.tar.gz",
               "hash": "b1d8004cf9c3ffb530fbb3d4259174cb076a32ba00268daa43dbf452fe6d46ccf979a63d7f53ae70a2fa7a101a9df1bd3b840552ac92a852119bb7385a65f65f"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3b2b3c23-574b-45d7-b2b0-c67f0e935308/23ed647eb71a8f07414124422c15927d/dotnet-sdk-9.0.100-rc.1.24452.12-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-linux-x64.tar.gz",
               "hash": "e8130817b779d0104a6eee33d98d97c3fad1c336013435f47c0e9e22370172b75da37ade76e49dec7cbe696884390d2e6941cc69e2bad5593d6d1c6b41083051"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/556d3bd1-88f9-4193-899e-3253b3f1cb6e/81869aaa34551cd754dce5d2b7907a7f/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.pkg",
               "hash": "c5a54b42d13ef1b20ed01e089c812f0c39e7a9a091330eb69387cc7e41f14fd319909321bd7cdc2c5f6b3d9f75fbe64b906028ad4a3ef1d75ece1a225676b14f"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/930f4eb8-188f-47d5-8a26-28ca393b7d1b/c07a519e3d7e326c3f640ef72ea1193e/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-arm64.tar.gz",
               "hash": "af30b31cd937e9fc97e164b83628c2c1ecd21329b75f742d9f5232aa68427d25b5d702cc565aa860d3c738c8727790569bf66a3ed74e5cef719ae589d302846f"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/66064632-b4da-426d-8c92-964ef60a1705/d89d50709014f11cd6dd6118d0fe653f/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.pkg",
               "hash": "a0ac40a3b8a67447fe75b93c34a283049621de39a6791932320178c48e61cf7783eb1bcb3a6105ac5ff9c9aed718fefec8841f0172c8325f2c5cc0e30ced1e4d"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e26e36f6-746f-462c-8599-5d0a1f00e786/f1b8264ac10442b40009aa8cea46b23b/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-osx-x64.tar.gz",
               "hash": "0d1f0718eeef006c3ecfbefeebf9df0772ec22c74db4bb635b6463b8aedfd3957274b908b51ec019ced69d3e7af4ae9252f18e87b14a4411e1089a4cc41e37d0"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a6e58d24-e9a2-4889-86b0-5e813968eb2e/3f2ad317193daa6a15f25aeddf6b55b6/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.exe",
               "hash": "30a6ab47431eba8d82609f12739d7373e1a4ce903ab3f98a4e327b472fb7c3ebfdec6a8e2f3abd24af64a1962bd3aec0cc82c6030abbbae4c712e2037e9b3a5f"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/43608406-ee61-4781-815f-29b07d3b1792/0df27a14349cd33f4a80751820f0d4d1/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-arm64.zip",
               "hash": "d8ed11c6490cb532cdadd9f36b75e11643cc4ce771d8d68efece94fa3be438c2304eabd890dff7363c7fdb18214bb7ef1534fe28a7a9d5672c4ede81a70ade0e"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/39d8f777-bc77-4261-9f50-5228cc275ca1/d5445753af7ab151f3a36a48c55b5404/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.exe",
               "hash": "f8f3002242c76b5eb786b8c7788556563a22151a7e09032e7b0edcf4de17c3c69cf7f8dd598b2c5752df62d40798bcc4bc63f6bed8ce377d0938fe8b0ce631d1"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0439a9c2-0190-4595-92b3-9e14822f4a84/5c83aaa1c16ed9f464a56fee5320e358/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip",
               "hash": "88b4e63017663e807a26b6e3775cb67644f205a03e865f2b67c327e17120e46e0bf6aeb6f4c098cacb9822987d9f167a890c69d733e83dd998041d24c09ceb84"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e6011f62-e3a1-4e61-9db6-a9916d3b8b67/c48fab3dc0c018ad8b857dc5862b620f/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.exe",
               "hash": "4da5b031405105db0cbd1a0c5656ac7ca481021f38694e7bbb6c1b3293ca3a398da2b504ac7726192defd9b7bee5e0231f18a334a0a7d4060e60e157d97b2619"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bc54d4a8-bf7b-4eb3-ba16-9b6284f41568/7721ac6e6aff216832c3f93225c2450f/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x86.zip",
               "hash": "376ab68351566f8eebb837959d2e5c441e33081ca67fe1aa1223bc9bb7f0e86b626da01be9f5fb7e5a8601e61b48bd5a73955a0911633951c68aedbff4b53a57"
             }
           ]
@@ -2657,127 +2657,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c414fabc-f831-4c5d-af5e-8e85ebecc6a0/670acec9f83315bec2788393db85e708/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-arm.tar.gz",
             "hash": "1201ddd76c54a676cb287443ef1b3316d087b9f3557c797f724cd4fcb86986eb499b3122959b24976444e262285c05a8a0f8f3f282894631e58fa4de42bb5489"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c5075cd5-2552-4f77-96ce-31450f9ff8d5/e6ff2b52e2a27a60eb3585cbca01d60b/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-arm64.tar.gz",
             "hash": "84610a38fb9a98eb7bd26ba89a9c4998682ec3fffb5eade5bbafbafd63cac7d9a5279618bb5b2575d27feec098da5fe6f7150c67253f3f37762601590396e122"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8d4492ed-c733-4cfc-bf16-4f13191587f2/c843723067d5fc1d790ffa1810c683c1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-arm.tar.gz",
             "hash": "29dbeee2ca4379b33457e2b056588114fa31813506c5359a23145f23a41d063d05eaa097ea117623a40fab113516b45150bd17a2f057287562c33fe9168bf299"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bc3735cb-fea1-4f97-8669-3ab0e389d055/084b94228b13a45478ac75f5158801b3/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-arm64.tar.gz",
             "hash": "9f4f1a3a4f39377779bf4f76ce0b9763102d9ca617ffdf61ff75a0d81c5cc63fb5042708ff10b1a83e558050d9b95bbaf159fa77e27cc03e0ad343441e164b5e"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/10aac5f7-c037-4874-8c05-425e668b0a24/4706d38e511259862e93a61f15dda28f/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-musl-x64.tar.gz",
             "hash": "0f945f9c7619918d619a66cfb6c8b01fd9939438ce8ef8be0797faea4cbd73cede6fd25c225855efb793be670bfc0f7198e9f231fa0511d7cf319d2fabbac9d3"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/da25731f-e296-4e2a-8f2b-0213d26e1799/859039cd012f8cfba53991f8f5543609/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-linux-x64.tar.gz",
             "hash": "f8fd285d67bb044d631596869d6301e10a2a243c81c9a05096a66aff4fb3431529812c7482e6cf0e065e8e065fc50b16b50d7f2a495ab30077a68bd45b3ba376"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0bae8dff-9440-4388-a03e-af44e20673a8/8ab257a4963967970cd59c31c213f38d/aspnetcore-runtime-9.0.0-rc.1.24452.1-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-osx-arm64.tar.gz",
             "hash": "03f7e03352d1ad2d54e9de4c1cdd7a94c2311bb36d4c6296661fab286cddebf3f57204f73892efd53f43cfb13ba73cafae95d0522c47be03203d5fb69a0ecfe9"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b0414fd7-20f9-4363-9dbf-072880e97b17/89584fa06e9ba1154a7e02402a28d82f/aspnetcore-runtime-9.0.0-rc.1.24452.1-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-osx-x64.tar.gz",
             "hash": "ff4a6e35b41f5200521ea4b257b293e4d48f1786ccaa9cd85b55ba96ad36036dbc149d2ff820f1dff5f2d9acf6c38b6c3540e700c2c2db5fe6d82d4f85f461ae"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/081a9fee-fefd-49ae-aaa1-eca16408292a/a6fe095b83415dab426a2d3565b07d0f/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-arm64.exe",
             "hash": "9dfd2fb830533936ba424a44abafb580bbbf01480b612b29965c779569bfd45a33925dac792c0a4d8c0ce80bf15307e86166b157b2a8ed8bf0643a517b36ba71"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/16d665ba-a478-462c-b71f-1c33205cad9f/9d3e421691c3e341852b6986a76c8974/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-arm64.zip",
             "hash": "73d3b632f718d34e0029a85ef43c69c8f68aab74eda4fb0758f3f6edbdb8d89e62752ba2fb51cccca23a2440ce328955b9f6ef9bafe6f181a9bda6e3443a9f7d"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3e0086bb-e60d-4357-a583-574e143fe998/926a13080470152c1d84eb618d92612b/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x64.exe",
             "hash": "da1a1d24f104c7a4b3ab993663620e599c4c54593858990196090983a285b0cec0321db0a9e9d4f040260046f2035850e3077d62a01fc11232a1847cb971c6e9"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/794b8c46-03a9-4379-899b-d40d629a99e4/737cd88894b6720eb4ac02723a25bca8/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x64.zip",
             "hash": "089020e21b337c74860c2c67ba367bdc4c270da822f9f1b181e092a9d96e8d6ff2609f05bc6ac5410523aa991fb5fa876477362dcf2f72c4c2ea2ea0e295b3b5"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9cd27e9e-80d6-46d1-b987-0ce1fa685d40/b7ed2424f5b1412da37da8b87dc5a11c/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x86.exe",
             "hash": "fb864ba977436649e9a0e6ca6b9dfb58e6a62316259f5321e10a7fde8d590a054815b17c6e6754217089703fd4816046cac3f4e57b3b822c4df47e4f6fa36caa"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b566c52c-fb4e-4512-94d2-b9da281cd733/c07c752e86e7d20fbb68f11812d51160/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-9.0.0-rc.1.24452.1-win-x86.zip",
             "hash": "eab9f7515bdc4b0577db2cfd83da3f3bb4f6ef5f9fb58ed50f8c0882c2dc1a9a26bbc177bdebf62ec87160d797022b3a5ffc4fe8126afa38737aff777bcd698f"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f79e08cd-827b-41ff-90ea-d14ad74b1591/894ae03f6c8a9059aea91316521d768e/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-arm.tar.gz",
             "hash": "33fe5cc1474420b97525635c4587328ee7a75ee9d41adadd82748beb82d98416f0ea1003f73cb71475ca9ae376c597e03eb046f370c94340f6973b508de46757"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4726f360-e432-4d96-ac58-336a1af4dc6a/d39b1f10448110b2b22e6a0b91f7ef84/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-arm64.tar.gz",
             "hash": "38bf53375c10224af2240209f65eeaed4f5519679b0e2cf217c662d2dffa9c3de35122aab560fd663b7964f294700e2c3059dfb64dfb4ac8e791a65f5a8d802c"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/944c0fcb-a40a-40a1-88c2-bb3f71a73118/a5b2b2d34f8369e2750e7260f7076b38/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-arm.tar.gz",
             "hash": "5a6709c2e707e05ace840ede35bbf462e6eff3d8497b1afa9909e5daf6adb735f1a1f14256238765d7dd4b326a933a3cd93f9aacab43d39c22eb9d2b0c592c0b"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8a06a0cb-df24-40d9-831b-2def232b25e2/921c1efa5eed69d35f6e149519919fdc/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-arm64.tar.gz",
             "hash": "9078ff4024ccae3acb05661c2be3f61ac8ca24a1cadd5999d1b7466c819ac36d2b57837c91f19f8bc00cba6cb8d0c694ada2d80de5a5eb930a66c0cf90273967"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/aab84d2d-84fb-4b99-86ed-c853290f14c5/3aee7978f038b921def87a863302bd5e/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-musl-x64.tar.gz",
             "hash": "33ddf922b107124112d4cb42efe040d04299aabe77e0cf47791e0e7ee9ccd106bc5c56cf792b49965570a0cb55ff40693e20eb9e3b868557b53000a091a9adaf"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/541d88ea-68cb-4cf2-8f8c-014a6cd84022/04e2eaf6093dcb6e2ef942959d2c4e22/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/aspnetcore-runtime-composite-9.0.0-rc.1.24452.1-linux-x64.tar.gz",
             "hash": "eb291957efda04e117be857279261fdbe657980003fe321ead8fa65121be903459db9cab4a5454e719fde4e9d353e266054d6c18c62bad9f9204993068f71a5c"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/70dcf334-d01f-4025-9648-da1ad1679040/b742a72f09f6b001dbbb1ac530b274f1/dotnet-hosting-9.0.0-rc.1.24452.1-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-rc.1.24452.1/dotnet-hosting-9.0.0-rc.1.24452.1-win.exe",
             "hash": "221f75ee6e5a8fc27ccb24ab8b0fe0da70835f215355700b8ae9d9e278e939f16055793d2726732ba68d1607b778c55694654f7811cd7dc7b3f752606aed0503",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -2790,37 +2790,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/75c36f38-bd95-40e3-ae0e-6c837b83f0fd/4aa804036271e7f180eaee45fded745f/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-arm64.exe",
             "hash": "c95b712758f09bde75213c5e9d2313887bf57619ea300d1342287ebf5ef9ae272f6d833af9053a1f79452a6d6ce3c0604cd3b6de7ecdf32cdd106c3b79ec8bb2"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fa9d434e-5562-4e5b-b146-9c855800477d/26cb637f1d465c2052e83af6656f02c8/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-arm64.zip",
             "hash": "11a4f6fb62146abe7e4177eb81d5a9b9ef1860bdb87953dcb49802b3c1c5cf8d7dc07b0b698ab959b0b0ad70a6a73d1dd31244333f0d27818ce39db362a7c215"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/42d0d927-a9fd-4466-85b9-a92881127771/ada1c6949c9e4a173284391d91add261/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x64.exe",
             "hash": "032ae99f815ecb1c5b07377885955de621e49da4a3ddac994e251fc8dfb3911768a079e996d988e8cd6c9c154f2f9c0656c6f57ecce515fe90e88a0659381038"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a76a20cf-8db4-43c0-b688-8285da2984da/abd95894de9f7a29a238930bb19790bc/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x64.zip",
             "hash": "e7d72c19182533a72e14a90b79f5467a913b81ca89cf453d51e1a1acc47b66e31ef35c13c08b12e5338787d1e7d0f4bad842aed3e1c58b7a0800020e308f7b9b"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ad33dd90-1911-497e-87d9-f3506c17f87d/2c8aec980e150fa37a65b4bb115bfaf0/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x86.exe",
             "hash": "1ea195d2efa597af4e03aface594d868d5e935af9a72196f3ce212e3c93626abcd48f95aa9c25a736539fc9c32c80d25334ec377ca6c7406f22a2fb0709df080"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/542e843e-1449-4da6-8061-de681f7a4554/559fec68bfb5a4c772d0cc219005a198/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-rc.1.24452.1/windowsdesktop-runtime-9.0.0-rc.1.24452.1-win-x86.zip",
             "hash": "20ba8fd3c04c03e9008db73b5a007c87a9b191badbe7e469f98c40b86dbf3dc80bc81d6435a75154c8b1879e5283c412bd843e2efca0a86b7ed5ebb893de8ea9"
           }
         ]
@@ -2841,97 +2841,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/074a9718-7e48-46ad-99c2-1de78504111f/23e4f1e407d3c7f019156e633a59f753/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm.tar.gz",
             "hash": "6bf40d4e837f74f0ac92ce504c187b33ee1d6ba653dee8006bbaf5a6f923eeffba2cb9c2f938207856c84bb9e41d5c3f42d0a0b1dd62bbd9997e885beab6a3af"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/248e66b8-594d-4738-8b01-2aa045faf3fd/686e989ba0365848fb4f81f8d780812c/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-arm64.tar.gz",
             "hash": "f7440b679315c6d35b12d839a1cf52c961784d56524f52e96a7834bbda7bf4e5bfd726081148cf71fb19b3107c7b1f39681a2fae7e87f1d9fa0634b70a47f4b2"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4c4efbb5-befb-41fd-aab2-7b1a0d0b4921/69e5daec0c5b967f7f27abbc49343c06/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm.tar.gz",
             "hash": "d627507d36e0ee3e8a6253d0488bb2c85458ba124016b32c8a481ec3d603f4393b700f1cd08c5640aad1971546526898ffb049e9590cbd655dda4375b7d7757e"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d680fd8e-6530-4da3-85d9-9c76c56cc737/c4d4b30f592e8a374f86c7f261886207/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-arm64.tar.gz",
             "hash": "57bb109d2bd66c6e273b54d4bbb4836a53375f1cb13bed1139c6bc950f85de774070014fd19ddb8b43588fa32f6de60811b43cbff5d29b1f537cb8206561fc5c"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0c5ee877-7142-41e4-bca9-244fa4fa129f/46a54128a24c0a2c75ca2d4e8aca5f28/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-musl-x64.tar.gz",
             "hash": "343d911894ff3b61cf6ee560b5a5da14a8b84e9dffa2211529d885e81314a6b0e88b6018b3a116f05b0bcd6e80b2a1e8cb45547f193a49a3aafcdf3992b580e7"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41a47c9d-c08b-4abe-a2d1-920b51fe16b0/f6af3aa0615cc1625bfc77cd38e16d02/dotnet-runtime-9.0.0-preview.7.24405.7-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-linux-x64.tar.gz",
             "hash": "9ede46bc2e6f87a9f592f888562a4cdda6ffa01ca9822f6d4ae586a7c478d3e4fe6c70758a4e9ecbba86445978c68f805d1d6d6f4d37fc653a2b7510309dd5dc"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f79b68ef-768b-462d-a96a-33d7a8129021/94bcf8b454c20f901564223fcc5b4e76/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.pkg",
             "hash": "b6d520b49da68a823a0279ab93f5aef4f8381fe8fb45ea3e0998eccd111300331f1196d95e22f9d7bb64e74cc5f0dde2c33b63a4db3b56da60b3e0cf8c9e4cbb"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a71e7742-36b6-4f68-a573-b3437fc53a77/571d8fff000e17abd5d820cafc600b63/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-osx-arm64.tar.gz",
             "hash": "ade75303e39c33af6d7ea10369bb87d5d446619d2ffa630db1e8342b1577efe6831d8f32316fb0e0536e56e0adb7978c4e1b75ddef9a2d1cda8657b8fc457356"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/117d87f9-aa46-4ca0-b884-a04580c7edac/3cdfbfd89b544c9726aedd7b32e00d3d/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.pkg",
             "hash": "1be6f9be0cab72e50a99350b4a8517a428c468b83e9c69eb0fe3253ae62586507f1600173efacc049dafae5252721120a27611c68854104d3f737ec3d87f47c7"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dc29a044-d48d-43cd-a56c-2b8cba456df2/888138574a36ee8c2fe1af2e33c1119d/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-osx-x64.tar.gz",
             "hash": "17352746d1b780272766c6ea20bdb0961f8004bafc529877644fa536bc0e7441eb48d65cd05c4eb9017249651361c773d89b1ec1c1720bd4fce0fe965614d48a"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/89f9e7e7-67fd-4524-8dde-9b89ca1ca74a/7a5880589767e7270561fc544143493e/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.exe",
             "hash": "cf8b6518c1daf0d5c25d42c7ed5370a6f853b496903822cb254af9064bc91578ce8476d75c8373ad3492d182c3db4459a933afb28f134059937ab5b7c27b7dd6"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/151ce0ec-b807-4a23-9ae4-ba674d45b29b/3853e079685484b17d9e38b17e3b2e10/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-arm64.zip",
             "hash": "5f45a3ccde7dd587451d45eaf70756877df4646f4b9411948e2b71bd7da2d48d513c54f0642e44d306d75e969a01f4d2931eb980de3c71cb1172604c89838432"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7ed661b8-ac50-444b-9540-5ee529b2e4aa/8780dd90140b747748e1ec15705c64e2/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.exe",
             "hash": "7246da48251745c46acba6c3cf0c53e66eed0c17c8579e167a0cec928190e7a38ecc905dd1dcefc7e9e3baaf633186858b6dc7d4b8d52218192bc3580fabd05b"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e7391d24-2880-452a-8fd0-5b72cf81049c/fdd37234b82b7e50a8a1575680246df4/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-x64.zip",
             "hash": "063c60a61ef96c06be677f9a418e807134563b8cd03be861924ab13325051070a570457a1e32ac676e8e70158a5fcf5e652b4484f15b517086e34faaee1071ee"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/98c838c8-d2c9-4660-9bb0-2e4587a8e016/d1fc3857e4914f991bf3ef769972ee0e/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.exe",
             "hash": "e3292dfa9b747f15d7a928b2f09cc0e1e3662276303aea0535f96018d9ea58bfd36d5353638438bab611e491551fea8bf38773351065b13a3ef69d7f19ab9ea6"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bf90ebe8-dd13-49c1-9945-c62c742739f7/dc34e583261c1acb3de46c36e3837572/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.7.24405.7/dotnet-runtime-9.0.0-preview.7.24405.7-win-x86.zip",
             "hash": "545d98b9757995faff8222e18a918519ca0e4fe4ecfd3216d622bf380a5b1a49109b07957b22f7069b8aa2d1bc89e0d0be6dc1c079e7d95d481b77d164125923"
           }
         ]
@@ -2951,97 +2951,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d684965c-26a1-4ad9-964e-eba707075cb2/a76775d98eb7565314c7061881ebda5e/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
             "hash": "b97c357cf8a2e129b222748e23b59343c4264b6dc9dbe00c5a01bf2d3f57c1a6bc61e5ec053b75ce0d17434977e1616d3efb7c4642aca18d8bb5fe7b6c0f906d"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9dce0bb1-16ab-4670-9af4-57b6bd1c0c21/ba6055b1ad714158742dd1b2373adaed/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
             "hash": "c8ae08858c9ccf16d7b4879b7201ea22bd59e97f1924d4ff2b25079168c906d88a2864e6796244b67db612a36170969fef212879aa3b2232418795c7e7e6d526"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ad7426e9-3acf-402b-a2d4-de7046d67137/8c596827e70ab0960dad22502e17d7fc/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
             "hash": "cd27cfd56483c51f48d12c204e3de0bd490b081d2add0d3db9f1ae905cef7470613727beb5213c6e68a9dacd2c46ccab8e4bf2b37eb5a8ea19a5d30447c42918"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dbf65449-bd68-4127-b39e-0a63b7807d01/107d0ef2ea0f771da9922f9bde0f04c4/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
             "hash": "1ccb6b8ad6e2d32f3d27b234783cde01e25e5c319ca8c5f90320e1ea2cf4f2a3cc58841a9d781c3a63d8a03b458391dd45a16c96d20a0c4f80e570d6decd80f9"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0499097c-376a-4e66-b011-fe4996c96795/c3e842772e3edaedfd3410467b789519/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
             "hash": "f558d4d3e8ae430ce544a8157197f9084849998f8788e26b9a20f742761ac1ab09c12423e0d1eed1d3bed7a25788b717e3525586b10977f9bec414ae76ac3515"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/84a39cad-2147-4a3e-b8fd-ec6fca0f80dd/d86fc06f750e758770f5a2237e01f5c5/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
             "hash": "3bc1bddb8bebbfa9e256487871c3984ebe2c9bc77b644dd25e4660f12c76042f500931135a080a97f265bc4c5504433150bde0a3ca19c3f7ad7127835076fc8e"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1f851fbf-f9d3-4b2a-9189-a1686bcb4853/8f8c50e3186b29bfc0a65f9a0ba7c31d/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
             "hash": "43667fec64adddd6b61628a047c0cea2c4c14b4958a5e6589ba0df7a56727416d293c559c6a9089a8d703a8444ebf929df2db6f3362f40c96cee14aebcd6a815"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/49e6076a-438d-44de-a34d-6ad47af02423/f20bca6b909e3bd42679c14c8288fd0f/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
             "hash": "0af77ffeb27e44b2e695caabfa85254f94c77807be6d96fc6abdda1d71be266857320c5dc02d5df968da8963a52cd2aea4b4cad6dfc6540ad26b7b532bf83fd9"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8fe9315f-284a-400c-8e09-6f8ad474ad46/8ebb620e266c23d064f2cb7f0de1e635/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
             "hash": "ff9d18978e2e6b18baeb5b731a52f39458fa65fe2f6ff758e5b1b31b831817ca27149ce9231840ba39a88e2ec5f649b734097129cd8dbfef7f96bf21ec8a23d7"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4a7fc24d-481e-4202-8654-06cf5fba0ebd/a4084481acd9aa803ad1ebf3cd668646/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
             "hash": "b410a65d69f991ea55c81e5f7ea58c98ceef309d63ddd21a7689848a4a4516cdb898f8e36702a554a51fc22420cfbffe7a662a785175bbc1ebe1c33fcf6ffbf8"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1b2a7758-984e-43f4-9277-bf33de3b3c87/af83a9dc52a935e10e80f9584d8cfdb1/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
             "hash": "0d6db7e772809f87bd70c6b5468f37ff14b466c59f3f3c0f85848b2cb7e938f550768b0a8a70ddb3dae0f900a6abe69dd6c641393e772d857a5160167c4b76cc"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/017ef318-d4b0-407a-8850-255a96480d9a/90cea33924e1ae3ddab243fb4c25ce41/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
             "hash": "69c9b7fd4772509a343907a3cc386660caff5295fda42e64ae62c52147ba2adbd9511fa976dd9738df0643a3596a5c7eaa3e51a0f8bc8ffd4101eea706a5dd2b"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7f691a3a-ddc2-4d1e-b447-7e87da162f9f/b320579c671f8f08ed6979bb93f23ff4/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
             "hash": "53a429eec91b4335d2ff1822bd2b41c826b06a53d187d24645a991066f28498d93f06557bd1c471a9334dc02bcdb3b6d075cfa9d6c894bdfc0f29c0b6e0d7a02"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dee149e6-a8bd-4290-ac01-ca2740fde18a/bffedcce6bab8b98bdbc75201cfbc9ad/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
             "hash": "99ed1ff4207b8e465b0a483649be860164fb9d4003ee08b1758d0db0df194dda523be4896572c21bfc6ca333f3408b48c14872cf5748a5af7c4d2682f29d8d3b"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c25296ec-5287-4386-9a05-d45536f34943/0050fe9eaf6e3c4bbaa150a179d01829/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
             "hash": "fd527045869746eb27acde707a054618f5f9757ea44333d1088013de9d5efef0c398ebfc911127a6a1a3ea292572db4e1f5d0e687f3e3e44bf45a3aa7816595c"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/acffccad-e120-49de-b2a7-f02883a53063/6dbe2a464e389c3d2a57bf069538c44f/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
             "hash": "ba3b33dc34e811e9d740e9af00844a5cc67372718e45226b859812b917ac50b9249397752c8b0b63ce87339df5530f1e27d8863bfd2690834e51c38cb3bf4be7"
           }
         ]
@@ -3062,97 +3062,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d684965c-26a1-4ad9-964e-eba707075cb2/a76775d98eb7565314c7061881ebda5e/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm.tar.gz",
               "hash": "b97c357cf8a2e129b222748e23b59343c4264b6dc9dbe00c5a01bf2d3f57c1a6bc61e5ec053b75ce0d17434977e1616d3efb7c4642aca18d8bb5fe7b6c0f906d"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9dce0bb1-16ab-4670-9af4-57b6bd1c0c21/ba6055b1ad714158742dd1b2373adaed/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-arm64.tar.gz",
               "hash": "c8ae08858c9ccf16d7b4879b7201ea22bd59e97f1924d4ff2b25079168c906d88a2864e6796244b67db612a36170969fef212879aa3b2232418795c7e7e6d526"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ad7426e9-3acf-402b-a2d4-de7046d67137/8c596827e70ab0960dad22502e17d7fc/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm.tar.gz",
               "hash": "cd27cfd56483c51f48d12c204e3de0bd490b081d2add0d3db9f1ae905cef7470613727beb5213c6e68a9dacd2c46ccab8e4bf2b37eb5a8ea19a5d30447c42918"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/dbf65449-bd68-4127-b39e-0a63b7807d01/107d0ef2ea0f771da9922f9bde0f04c4/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-arm64.tar.gz",
               "hash": "1ccb6b8ad6e2d32f3d27b234783cde01e25e5c319ca8c5f90320e1ea2cf4f2a3cc58841a9d781c3a63d8a03b458391dd45a16c96d20a0c4f80e570d6decd80f9"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0499097c-376a-4e66-b011-fe4996c96795/c3e842772e3edaedfd3410467b789519/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-musl-x64.tar.gz",
               "hash": "f558d4d3e8ae430ce544a8157197f9084849998f8788e26b9a20f742761ac1ab09c12423e0d1eed1d3bed7a25788b717e3525586b10977f9bec414ae76ac3515"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/84a39cad-2147-4a3e-b8fd-ec6fca0f80dd/d86fc06f750e758770f5a2237e01f5c5/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-linux-x64.tar.gz",
               "hash": "3bc1bddb8bebbfa9e256487871c3984ebe2c9bc77b644dd25e4660f12c76042f500931135a080a97f265bc4c5504433150bde0a3ca19c3f7ad7127835076fc8e"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1f851fbf-f9d3-4b2a-9189-a1686bcb4853/8f8c50e3186b29bfc0a65f9a0ba7c31d/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.pkg",
               "hash": "43667fec64adddd6b61628a047c0cea2c4c14b4958a5e6589ba0df7a56727416d293c559c6a9089a8d703a8444ebf929df2db6f3362f40c96cee14aebcd6a815"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/49e6076a-438d-44de-a34d-6ad47af02423/f20bca6b909e3bd42679c14c8288fd0f/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-arm64.tar.gz",
               "hash": "0af77ffeb27e44b2e695caabfa85254f94c77807be6d96fc6abdda1d71be266857320c5dc02d5df968da8963a52cd2aea4b4cad6dfc6540ad26b7b532bf83fd9"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8fe9315f-284a-400c-8e09-6f8ad474ad46/8ebb620e266c23d064f2cb7f0de1e635/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.pkg",
               "hash": "ff9d18978e2e6b18baeb5b731a52f39458fa65fe2f6ff758e5b1b31b831817ca27149ce9231840ba39a88e2ec5f649b734097129cd8dbfef7f96bf21ec8a23d7"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4a7fc24d-481e-4202-8654-06cf5fba0ebd/a4084481acd9aa803ad1ebf3cd668646/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-osx-x64.tar.gz",
               "hash": "b410a65d69f991ea55c81e5f7ea58c98ceef309d63ddd21a7689848a4a4516cdb898f8e36702a554a51fc22420cfbffe7a662a785175bbc1ebe1c33fcf6ffbf8"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1b2a7758-984e-43f4-9277-bf33de3b3c87/af83a9dc52a935e10e80f9584d8cfdb1/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.exe",
               "hash": "0d6db7e772809f87bd70c6b5468f37ff14b466c59f3f3c0f85848b2cb7e938f550768b0a8a70ddb3dae0f900a6abe69dd6c641393e772d857a5160167c4b76cc"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/017ef318-d4b0-407a-8850-255a96480d9a/90cea33924e1ae3ddab243fb4c25ce41/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-arm64.zip",
               "hash": "69c9b7fd4772509a343907a3cc386660caff5295fda42e64ae62c52147ba2adbd9511fa976dd9738df0643a3596a5c7eaa3e51a0f8bc8ffd4101eea706a5dd2b"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7f691a3a-ddc2-4d1e-b447-7e87da162f9f/b320579c671f8f08ed6979bb93f23ff4/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.exe",
               "hash": "53a429eec91b4335d2ff1822bd2b41c826b06a53d187d24645a991066f28498d93f06557bd1c471a9334dc02bcdb3b6d075cfa9d6c894bdfc0f29c0b6e0d7a02"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/dee149e6-a8bd-4290-ac01-ca2740fde18a/bffedcce6bab8b98bdbc75201cfbc9ad/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
               "hash": "99ed1ff4207b8e465b0a483649be860164fb9d4003ee08b1758d0db0df194dda523be4896572c21bfc6ca333f3408b48c14872cf5748a5af7c4d2682f29d8d3b"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c25296ec-5287-4386-9a05-d45536f34943/0050fe9eaf6e3c4bbaa150a179d01829/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.exe",
               "hash": "fd527045869746eb27acde707a054618f5f9757ea44333d1088013de9d5efef0c398ebfc911127a6a1a3ea292572db4e1f5d0e687f3e3e44bf45a3aa7816595c"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/acffccad-e120-49de-b2a7-f02883a53063/6dbe2a464e389c3d2a57bf069538c44f/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.7.24407.12/dotnet-sdk-9.0.100-preview.7.24407.12-win-x86.zip",
               "hash": "ba3b33dc34e811e9d740e9af00844a5cc67372718e45226b859812b917ac50b9249397752c8b0b63ce87339df5530f1e27d8863bfd2690834e51c38cb3bf4be7"
             }
           ]
@@ -3169,127 +3169,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5e16d860-eacd-48cb-9d3b-a29894cf74fc/f1e9a698798f7325b1e28588c7075cfb/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
             "hash": "c5a60fc24cfd9ccb27c022938a93668a344f1f3f1bdb41e01f4740bb798ad04341b5b30fd4aef129d936c909ad8473cf6072a76f999ec626221df9696c73dcc5"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/28370706-3338-4dd5-9992-6cd1d86ba666/354c9434538f587c3198fe57fa0d2e00/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
             "hash": "706925fde5bb93b98e347540fe0983ce0819a2ca2520ed2d5bfc4515cb6852587a30f29852b512509b660daf8ee76ff3c8bb2d2fd78e47c6ae156e6f00cde918"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/058d32bd-03e3-4867-8c62-79e88b5b9b69/784891ca110016d0afa902cc4176e46f/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
             "hash": "08b67ca34122f063370d0f24606174026d3e67f8767ac2e4c4393c214e608d47d82dad177a97c5e6e28d089412403f75012c00cdaabb109e461e266ad6a620c5"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/94ac38de-a00b-45a1-a37a-c7b4d8a52ddf/135aa93213a5f87c7feaf267e305a3b3/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
             "hash": "df15606e28e68162739d6b5f3a3852664cbd8d78ff8e8ebed07e2f78c8699d0dd4bd2a3c3b5c98b63bfdae1106720fd4069d349d0d4e32037deea77a4e97efed"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/60441f64-edc5-4c33-8022-107be30d728b/a3375f19b72b8e23d5394e3a1e2a1806/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
             "hash": "bddb66623e26d391d4587b46f6b7be5280788eb0355c558044016c1a12062005f2627bd3fdf51cb271f85eaa91fb920532ef235edd764e4ca63931595e1fb52b"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bdb8a419-432c-4f1c-b5ad-ae6e27617b5c/65b26a64e3dda62c456a7a45df73dc1e/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
             "hash": "44f86c407b501a700aaeae2ce95cf544d85c08b41cdd12cee22bfcfdd03c4f6a16e495d9f8315f5e56a66b7e6187a4fc39d899f967a65f73883e40172343275c"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b2836c76-8c1d-4030-b7f6-0cd5ec1b640b/ea922caf251b0245b96ba2afd7ebb2b4/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-arm64.tar.gz",
             "hash": "8200af559c76f5bf12f5e0495c285a837dbe29c7ac2d6c562540f7077aa68fa65dc05205b4b219e72f78d55c20a75a514f6ccf3f53d6ecf34fd2cea0817a7ede"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d0813855-fdde-47df-8d71-119af034e409/40989f36db96de19bc682d62cbadd8e3/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-osx-x64.tar.gz",
             "hash": "0f309d6b849ccec8e13812de9ff70fac5cc78785b71f356fc63e5070296305766892a3dfd74bae9b4775ec4449335d03d046494a416304f56e5ba7746f3316ca"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d56241f9-9411-4ee7-b656-872d5666bb99/5015011e1f74c0be2e3e88ec842112d2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.exe",
             "hash": "c3acd624e17bf532bc7c3a1045d551e94a1cc70b8c126c816c64dc788db0152c6737cb703bc76a04a84cf6a11dc589f46e38c1c825860d5f32514bb2fa41e54b"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/18014125-ce33-4c3b-94d1-365b12e16aee/c0981da139aa9fbb392cf9d88b8b3da6/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-arm64.zip",
             "hash": "aa0fcb2d6f74856e9e65d13504c313d4237cb98e55b122c3a2fd89bb4c4307b65bd6386f7350e264d6e4499eaf55ff79766218a2708bb556a66502c62ecf6a7e"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5e085306-10ef-4184-a5ef-113ccadcd55f/ac63196a2fcccbbcb41a7e73de73caca/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.exe",
             "hash": "a1b17cbe3b028f41c8d8b3c9608112692004259a62ce45efe658ff9506016b8c16e7482708b0f1a861bac21fed19205bed880c790d58c3d1cfd62b81933953ae"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/150e0d3c-4bca-4c0c-acc2-09ac93f32a6c/0ad15ba162c80b92f5bea820c6b646e4/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x64.zip",
             "hash": "ce32f77bfb17c15c85968bd3062d6d628ce5d7b1b1bc5d1cab1c7b659253ad869c264b6e98773a57ce80cb818c22db5da79ed6b32affe6f8be0f1952069c7714"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b4aa5307-82ed-462f-aeb2-b461c4eeb6f6/875b2ae1460fff14911a6ae9ee723c15/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.exe",
             "hash": "3b3bdf4c59fea2035881a95d611f06f64d468e57c85f1c4c04566e6286bfebe1f35837f61c28504697856a782dbcf3b613b51fac41003b3f5bec0ac816894971"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fb394383-000b-4ec1-a995-6270b205201f/74866e7e6391f5fa17c479ee0cd4b9e6/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-9.0.0-preview.7.24406.2-win-x86.zip",
             "hash": "42c04862e239e07b698dfdc1f39633c42ff196e84569660a1dc2f74ea910a705c91cd1f2453efbc8243de883c89452ede139647c272552e29fb9e57c7dacd494"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1c178b77-927a-4852-9637-6dc401a290a3/3c485a7d5ebd8e80d73d3d6c693e0f88/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm.tar.gz",
             "hash": "7839fa20a2a6459f2c4ba41844ac6c57a0eff6ffd8eaef0463ca44918405a0ab3d1b80e7d3943d7c14db21d0d2cf5490a44d1bdfbc9492138d80dbe228910960"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ff3b69c9-f76f-4a7b-af13-123d491c0861/baf999495f1dd404918562f079db60fc/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-arm64.tar.gz",
             "hash": "9805dfd4167cf7d67153044265921df12883d67812342779f26b7f400658a117a25b54e29e83bbc8757899d6c96af52d7b35226ebaf2b7a9524b1114d580a741"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6201b645-6b36-41ff-911a-3a2807b8ff22/efaabeb363f451008341297b8a500c53/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm.tar.gz",
             "hash": "ada585f833f0d4617d36df8ccdf716553e275cb7b49bae3e44945fd3826d3152eef1830339d069cdc0d60f3947f031647929c7580c97ad768e8b32b7f06274ef"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/21b93eac-4fd9-4606-a87e-4c9e5ab2383f/f72967bdefbc4c75379a477bfbd10f02/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-arm64.tar.gz",
             "hash": "d4ec9d402d78a5da914642622a47da05e6c0b55c80ccbd1ba0c1a6c336e38f8598b0b30b986e5d0d296d1ff1783f53cb369d9a7a3c4da25b94c8c6ed4cf67291"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1a9130ec-0085-4a3e-8a24-1f8378108e84/a3d8bbd3d85578085cc5a3583f63d371/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-musl-x64.tar.gz",
             "hash": "2edd041b05b65e35464d7941bd1453f97d510408f51ea6e08dadcc81a76529e3500f4c62c48249b68ac2662a42bf8b00d4bcc6f998d3bdf594929914a9d5deed"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9c538089-9dc0-44bd-9872-34881002e6f9/6690bcaed6d067f6599420052968a9d0/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/aspnetcore-runtime-composite-9.0.0-preview.7.24406.2-linux-x64.tar.gz",
             "hash": "5a580a89c144a268ceeaf2171f2a60f31ab99c3c1879d043920cf4a0a70eb5d3aa0419029408f64ddb1930ebf830e4988d9356dd7dd7819fde570622aeeab7b5"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fdd84cd2-f012-47c1-bf90-df245aef7fdc/04161e728311f32a1ec0f9f973a9d606/dotnet-hosting-9.0.0-preview.7.24406.2-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.7.24406.2/dotnet-hosting-9.0.0-preview.7.24406.2-win.exe",
             "hash": "84426e1c134c0bf6227ed9610a252c562470b65c76a10153e5123b2939f3daaa2e7e067f65de9629ed8542b480ba8549dd0301b58ad94380b8b35cf096882b56",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -3302,37 +3302,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b0080098-a31b-49e1-9624-2864c4d2c4f1/843fbd5a038f44630b0e007da84a2ac1/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.exe",
             "hash": "c559f8c488d2b94e12e5fe7e61c89eb28ef74b7fe0f52b991e52361d417385521e60384b7db8b7ade2b81cd5f8e905bb31b2d1574e16c506bc998e81171ed0e1"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1a4c7151-99b9-4601-b160-01d09cd8ed4c/893ed6327a2f1367c0d59d30121b0fc7/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-arm64.zip",
             "hash": "463b8ac6e5b9f62eddec20009ff2517b2a5f90cc1d6047cc005fb446a344c1337cbf0f59ced2749e1b569ef44942c5c7150dbeb10e0ce1f9a76e9c45a1d1bbe4"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ef26a963-0101-4288-900e-71c17f210316/99d1cccde7fffb997ee4af1cf024ae54/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.exe",
             "hash": "77ffd490b614126debd79a3984df39cacfaa11049e4d209ccbde0e37e48f8169183b369c294b2f5b4e51ed1bee78ae56b4fcb794a663b6c4515248346f838ea3"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dbecfc4d-1b43-4fe1-833c-6fc188f7b7eb/99b15fbc905fdf2343bc6813c8d4c6b7/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x64.zip",
             "hash": "296cf946d83670772dc6794f1019549f59987cfc50cdfa4d04e756fc16174381249b15fc0dd2b154f17be0df2fc4e2b25f95601a238765cf29ad103033125b2a"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3373f83-b929-4d53-bf74-c0095ad6c900/e7f11b0a8e2a617fbbd55bba7dc15007/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.exe",
             "hash": "7eb2c020a8849ff267e6bbe441913773d5a1e8cdb4bcd81bccc73d424a55f398ca4228fcbbd48e191d333d4a6a0b37ed7a4db03edecdd19262dc3f0cbec77d03"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/86a1653f-b9ca-4bc1-8b75-07d31812de15/de93ce0c63d3ff059f1e147ed3618680/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.7.24405.2/windowsdesktop-runtime-9.0.0-preview.7.24405.2-win-x86.zip",
             "hash": "d29732075a45d16dfde9c02957ab2532053721c9cf3e41f37cd59afe866ed06138d82b1aa94668f0f0697abd07c983a309e6f79aac9f0b17a8470cff6be8e281"
           }
         ]
@@ -3353,97 +3353,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a5921e58-68b9-4436-a410-59ef6182c029/ea09e5cc7ef7e81ab04339de9817b1f6/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm.tar.gz",
             "hash": "8a3d23bdd25b69599c9ac6009c76bbb66af2b1312121da4951266630ffd3a31e91b6479ec1324814a1dcd850d145d47f03f3debea9e6b6d1292573824c239f6a"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c19fa925-faec-409e-8a8d-2c106581014a/ad8f61c688682647a6a2daa4fac8fdd3/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-arm64.tar.gz",
             "hash": "755961903291c262a1f5f7b70543016c8f85f6993e861a6f83f8509fd2a828f4a34f4161a3b9f15114663e8073b37937748befeef9ea9818d513aea1b27f944c"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dadb9bfc-0b55-45be-9ca9-9231555136b4/cd84e333aa8a6907f45c358c9ab5ef3c/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm.tar.gz",
             "hash": "cd49793061602577d7d1017c2e0f43c205bc48eff50b9234ff8a56d2a873ffb1167429f5f132e5ac201a460efeed83c82c404e47ae87fe336970fd04b3cff697"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8619f9c1-40fd-4762-bf82-e913e6fe74a4/8ede733c84d21905ed757adc9ed7d62f/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-arm64.tar.gz",
             "hash": "643fcc319138f31bb2cc7e7896e14caead677e16fa79b2d5031f339103f2bb5dbb9994485ed24281c93ecd32bea179861330c69e75d03db30a58d46fc932dad6"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41574d6b-f1ca-4455-87c3-622cb06fe292/1172197d3202e6ab7ba0b92eac740cc9/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-musl-x64.tar.gz",
             "hash": "7c477a29faed51ea6bc01a1314b3c8d5907d41b2bebce28b52db453722bee703e3edf167e3143b316eca572a1e976619f3925cfd965953376cda38157e9395c1"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/484c439d-3a87-4eb9-9a08-683a1c2bb334/0edb0aa500ff6bfa446940e1773ff203/dotnet-runtime-9.0.0-preview.6.24327.7-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-linux-x64.tar.gz",
             "hash": "09aa8c4e6ae3ada1a265a5cd2b46779a763163e4dd9a1892b44606b89cf147339e10b7c584dbcaf5404af0553f0ef6c5801436c217f4fe1a5d3bdb6d74aef1d1"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/95fc5ad6-2935-4afb-aaa9-6e3a85096c9b/df3060250716bf7813aa2e6258dbabf1/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.pkg",
             "hash": "6c04ea05763dedf173f374d7aac7b12749880e6c5e3e4b08dbfacc5b3a94000d409912875b5fcbe9b8b3e4e8dade7bfd2c81cff5469154e8aadf28abe70fcdd9"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/866edb84-2362-4941-b63c-8480b2133c5f/2750c6b8cdf26e9214f040c86b040d33/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-osx-arm64.tar.gz",
             "hash": "9f038f1ddf51a6fdb96081932c889d63d9ee818de8b5e71af905ede052c17bb22293599baaf9295f42e560d8073d41785507f752fbba316b446664fb762a60f7"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5e90a5c-5ac5-4a74-8066-afb3f9616737/3aba6bd3250ea5f6a537be3c0a982c6a/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.pkg",
             "hash": "b15a5a018dfcea34ccf1999826a16a6fab2688402bca889e5a19b57985f48bdcb1bb552908a98b14fb589ce7536e19ff7dfb98a6c05f31ec3a24d39bf2f38697"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0bee7cca-fd9f-4769-8409-30bfea40aa07/e6e565aa83cbf8fc8a27cb054e83d45d/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-osx-x64.tar.gz",
             "hash": "53d7fd172cc4bfd0a380847b7d38cfdab03f469579458e3c7ab26dbad82b54a663261b60ebc35009f232509e486657ebc4b8516866016510f66e9a3fbec53eb2"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/25bd95c6-6b8a-44ef-b324-b5bebe70d532/5cd96a6c69d278fa0c1a43499a0f5c52/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.exe",
             "hash": "bc144ecf6a370c4885663513571ec865aeffac1ceb91f4b089bf5e6c39819c27577f9fb1dce5991952e2fc38d2a29eaddb851e14b4aa7b670934f6f9fefda39f"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c452b715-ed66-48d7-acd8-0db06f7b06aa/5bbb3d458b9f8c60cfc390d457bf2934/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-arm64.zip",
             "hash": "0fea090b348df52be11c7053429fd82227e5d5093ab758c756f091ebb2c1f6e47086bbb8a23ed1d6eb97b6b4960b0b67639ea6025b2d516e1e30f7cb458b3ead"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b9378c8d-7415-4d91-b116-02ee0abcb536/49e294d54fbc2aaef4135625d51b30d8/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.exe",
             "hash": "3610d07f38263fb7a3f107b0c7a3b859f08103ec3eec7c9256e90f68313de9d88f306041e2eb79fcb4085152b86d8a6ca100e56aa7cb7a8e87b8c3cc08f12032"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8cca5125-0359-4dcd-b88c-e7bc0e14f7cf/764aeec7baeb3aedde755a45059eb5d1/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-x64.zip",
             "hash": "0f54db8195bc2082feb9895be1effe9e5beaef9158f18570dac752877177ced94bc8b2da12468dd3076d8ca5c573aed032bd47de589d52841adbdd27eb9c3b2f"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a409bd1-1ea7-4b64-8e5d-bd84660cf1a6/46da365616d4dbaf68dd7c16ab9238fc/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.exe",
             "hash": "bfbbbd3ff343b621a573a237468ae93e0ce186347b9147470c40dc938ec675fc6c16483753317062d17c404efb226d22a924e72d67bdcb649346453d36a063ba"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/618fe300-8cd6-4029-bd30-5624ffc092da/dafb4244931a312cfded7332ffd68ffb/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.6.24327.7/dotnet-runtime-9.0.0-preview.6.24327.7-win-x86.zip",
             "hash": "09cc78ee9c8fa1da7415d007e541ad674b1a103349ff7467fdeb18483791fca6268411646ee1df030a136dc66f73473ccb020a65d48186ff557f701ef11bbdf0"
           }
         ]
@@ -3463,97 +3463,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b0b225be-9431-4098-a3d9-f7ed8b2435e3/2dff72be21a0da2e9a82ddbb47e3e521/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
             "hash": "9e57776a5fbb257e39318d485d02ec7a0b07c680cc6cf9dfc8a6cbebd98c6eb70f39131c3bdc1ea1a34a4df2c9cc9ed4f512ee4be8156f3ecd9f36c32e371e77"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4129d95b-c724-43cc-b1f5-f394c6fddf5d/24f44d474f12d33f4f74f6913d9b233e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
             "hash": "f4822637ed89f856736bb947cfc1fd4f1c81452016884cdf10ca9ac97c36d5bf810316d534263b3219843096fd5ffc15972714041f85caab243efb5fb910d7fe"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7c1dc66f-1d62-4996-9a96-90f9d7a86660/fb956c6fc95f73a98c530a7518363cc8/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
             "hash": "b3e1bfb0f46c5d49fb44a38bd1725cf6cf2660f34ee3457fea7b73d477f41b686e34b363ebd5000e2d8e16e49f9fb800721106cf5546fc6c4f5fefccaa2ad955"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dda0d54d-9ee3-4410-9cc6-007718fed183/b2ad0ff295895c56f7e353d4bff57c0e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
             "hash": "49c15fb243534f54bf2711bc10b5e233acd2d76459110f87e9e756fb312f63a6ac61bba106028a73a9f76563230eabe66fc0c03a8dc8e82922231c333e8ab87e"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/270d6741-6525-4811-b378-2194408cc835/54b6ef775ad1679752a35e9a8016a26c/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
             "hash": "6e57001dac6b78de5976529543709b05d5cf57790a72904c72ad35215646a03c9f1219aeb6c4e979a7a86d6ca20f65b4febfe87f12291f61b52704291d40ff87"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a01db0ce-d997-41c7-83de-08ddbb1bad67/49da8a4fae2e0e803854738e5098d89e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
             "hash": "ff040c456b096aeac707053517d5f9f5f0df92b6754a4af6b6fe635fd8f4a569589b8241cbad0c5db998dc5bc54682b2f1e4dc4f3d88024a3ef56c1ecc9f4c97"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c0231fde-8a62-4e17-b396-25a4f8d6cf1e/753d07aa1f5d1652e6f69dab4fb588c5/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
             "hash": "a323f9856ca9ac447d0a34f7aa23fa8d3360b8db2ac63bc882227eb1bccb927f001879dd77dfa61ee9b5a188569f98c3f4139e7dfc2bcf0cf33b6d8db0bdf8ef"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4dec7038-6ff5-4490-a383-4e98596b3265/671e5c37c62486c331a3c2cea7c8572a/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
             "hash": "0aee16fc9a8e9729a5016d12e656ea2f8f0703116a778d3e33cc05c7f2d9870239fb3a0f4e5d7152cd7d6942c41853855fced70f777cbb7d40b5a3e03da2b4c8"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c7132bf0-f591-4bbc-877e-bb881008c442/12a5262ac08f9d3d6e0cfabfc8806611/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
             "hash": "ae2437e7450a2f001e380ef61bb2dff22ffaf087452dae2191122c5a3621b92751c8eed7a7a3d231d3ef7ca3189bffec6637e6f9b675ddb097c98b928445fd45"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a856c115-c1e0-4050-bcc2-5a2e8840a60d/dd16b2fd886ab6e66ce56f6e7c08beb3/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
             "hash": "db4e9122cb0ba6d4560a6396cef194735ad41c22ee8cebbfedd41c7b8eca049209e9eedb5013927d6a1f76fea134b78e637c0b3d02523fa7f7a7d4311a059c18"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e42cda14-704a-44fb-b565-9ce82673b41d/f08d42872a41a6d98025b62fa3fa9536/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
             "hash": "9ce4ef04fa4d9e4e7872adc104f54060761c2ced3f6c2a866f345cf2f36fd8ef5b044025afea64534b5faaa8ab5a3d81724b81ddcba6141818977a40c906b39d"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/06126587-13d7-4a76-a80b-d0353fca10be/e146117dcb49deb82efa6f94fed18607/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
             "hash": "d67792819626d5292fce195e57a541078e604f012d706f71b0eb3414249d32c8ab8e85ee46065c5503fc3d31601705d30543883876c862e95c2c31c032474eac"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fe2ada54-887a-4bf6-8872-d91a6b201b3c/5cd457720c0d17b1efab4989dfdea6bb/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
             "hash": "c13e4012dccb0037bcd7d48593947765a5faa05a2181bd2a3a7e32a5acfc74fecb251f602652d82410fb10b8f7174bf444e5a50dc226f137f0b1ced6a31976e5"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a889b484-004a-4cc2-844d-d5040cea4193/292354e7dec9e3a55932afdb66719c80/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
             "hash": "cc4a5ecb76cbb5efbe229f8154451d6866e2157f4124fedf7588706b8a356babb0c1f1007317336803bf9674a988f2f6ac7e359d6390521ce4bd355fcb6831c0"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a3070acf-317a-4a8d-bf40-48049d215cc3/ec90f6a7803b646000d96fa6c0b96ef2/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
             "hash": "9ff4057a1c5e7b5fc088415244ea795462f708ba6fff4d68bd6cc0e2cb7d10ecfd7ad2b6157999e1a815cc6ba01fc816c9ab5a15976eccc2f5adbd7c815ef8bc"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/089a937d-6e0c-4cca-803e-6aaab0c6360c/26b6fd99102654de3fa064a25c0d635f/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
             "hash": "50587f8d0f40cbebc6a56eb5045a458e4f78f26a76c9a98313832ac6aa623120e72eb3028b39babeb635efc9518716bbe246f08339a5c75ff8b2453a32e22b7a"
           }
         ]
@@ -3574,97 +3574,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b0b225be-9431-4098-a3d9-f7ed8b2435e3/2dff72be21a0da2e9a82ddbb47e3e521/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm.tar.gz",
               "hash": "9e57776a5fbb257e39318d485d02ec7a0b07c680cc6cf9dfc8a6cbebd98c6eb70f39131c3bdc1ea1a34a4df2c9cc9ed4f512ee4be8156f3ecd9f36c32e371e77"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4129d95b-c724-43cc-b1f5-f394c6fddf5d/24f44d474f12d33f4f74f6913d9b233e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-arm64.tar.gz",
               "hash": "f4822637ed89f856736bb947cfc1fd4f1c81452016884cdf10ca9ac97c36d5bf810316d534263b3219843096fd5ffc15972714041f85caab243efb5fb910d7fe"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7c1dc66f-1d62-4996-9a96-90f9d7a86660/fb956c6fc95f73a98c530a7518363cc8/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm.tar.gz",
               "hash": "b3e1bfb0f46c5d49fb44a38bd1725cf6cf2660f34ee3457fea7b73d477f41b686e34b363ebd5000e2d8e16e49f9fb800721106cf5546fc6c4f5fefccaa2ad955"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/dda0d54d-9ee3-4410-9cc6-007718fed183/b2ad0ff295895c56f7e353d4bff57c0e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-arm64.tar.gz",
               "hash": "49c15fb243534f54bf2711bc10b5e233acd2d76459110f87e9e756fb312f63a6ac61bba106028a73a9f76563230eabe66fc0c03a8dc8e82922231c333e8ab87e"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/270d6741-6525-4811-b378-2194408cc835/54b6ef775ad1679752a35e9a8016a26c/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-musl-x64.tar.gz",
               "hash": "6e57001dac6b78de5976529543709b05d5cf57790a72904c72ad35215646a03c9f1219aeb6c4e979a7a86d6ca20f65b4febfe87f12291f61b52704291d40ff87"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a01db0ce-d997-41c7-83de-08ddbb1bad67/49da8a4fae2e0e803854738e5098d89e/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-linux-x64.tar.gz",
               "hash": "ff040c456b096aeac707053517d5f9f5f0df92b6754a4af6b6fe635fd8f4a569589b8241cbad0c5db998dc5bc54682b2f1e4dc4f3d88024a3ef56c1ecc9f4c97"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c0231fde-8a62-4e17-b396-25a4f8d6cf1e/753d07aa1f5d1652e6f69dab4fb588c5/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.pkg",
               "hash": "a323f9856ca9ac447d0a34f7aa23fa8d3360b8db2ac63bc882227eb1bccb927f001879dd77dfa61ee9b5a188569f98c3f4139e7dfc2bcf0cf33b6d8db0bdf8ef"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4dec7038-6ff5-4490-a383-4e98596b3265/671e5c37c62486c331a3c2cea7c8572a/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-arm64.tar.gz",
               "hash": "0aee16fc9a8e9729a5016d12e656ea2f8f0703116a778d3e33cc05c7f2d9870239fb3a0f4e5d7152cd7d6942c41853855fced70f777cbb7d40b5a3e03da2b4c8"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c7132bf0-f591-4bbc-877e-bb881008c442/12a5262ac08f9d3d6e0cfabfc8806611/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.pkg",
               "hash": "ae2437e7450a2f001e380ef61bb2dff22ffaf087452dae2191122c5a3621b92751c8eed7a7a3d231d3ef7ca3189bffec6637e6f9b675ddb097c98b928445fd45"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a856c115-c1e0-4050-bcc2-5a2e8840a60d/dd16b2fd886ab6e66ce56f6e7c08beb3/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-osx-x64.tar.gz",
               "hash": "db4e9122cb0ba6d4560a6396cef194735ad41c22ee8cebbfedd41c7b8eca049209e9eedb5013927d6a1f76fea134b78e637c0b3d02523fa7f7a7d4311a059c18"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e42cda14-704a-44fb-b565-9ce82673b41d/f08d42872a41a6d98025b62fa3fa9536/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.exe",
               "hash": "9ce4ef04fa4d9e4e7872adc104f54060761c2ced3f6c2a866f345cf2f36fd8ef5b044025afea64534b5faaa8ab5a3d81724b81ddcba6141818977a40c906b39d"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/06126587-13d7-4a76-a80b-d0353fca10be/e146117dcb49deb82efa6f94fed18607/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-arm64.zip",
               "hash": "d67792819626d5292fce195e57a541078e604f012d706f71b0eb3414249d32c8ab8e85ee46065c5503fc3d31601705d30543883876c862e95c2c31c032474eac"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fe2ada54-887a-4bf6-8872-d91a6b201b3c/5cd457720c0d17b1efab4989dfdea6bb/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.exe",
               "hash": "c13e4012dccb0037bcd7d48593947765a5faa05a2181bd2a3a7e32a5acfc74fecb251f602652d82410fb10b8f7174bf444e5a50dc226f137f0b1ced6a31976e5"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a889b484-004a-4cc2-844d-d5040cea4193/292354e7dec9e3a55932afdb66719c80/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
               "hash": "cc4a5ecb76cbb5efbe229f8154451d6866e2157f4124fedf7588706b8a356babb0c1f1007317336803bf9674a988f2f6ac7e359d6390521ce4bd355fcb6831c0"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a3070acf-317a-4a8d-bf40-48049d215cc3/ec90f6a7803b646000d96fa6c0b96ef2/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.exe",
               "hash": "9ff4057a1c5e7b5fc088415244ea795462f708ba6fff4d68bd6cc0e2cb7d10ecfd7ad2b6157999e1a815cc6ba01fc816c9ab5a15976eccc2f5adbd7c815ef8bc"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/089a937d-6e0c-4cca-803e-6aaab0c6360c/26b6fd99102654de3fa064a25c0d635f/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.6.24328.19/dotnet-sdk-9.0.100-preview.6.24328.19-win-x86.zip",
               "hash": "50587f8d0f40cbebc6a56eb5045a458e4f78f26a76c9a98313832ac6aa623120e72eb3028b39babeb635efc9518716bbe246f08339a5c75ff8b2453a32e22b7a"
             }
           ]
@@ -3681,127 +3681,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0d850aa0-1aab-41b6-8659-bf780e19a699/5bedc9ef82acdf760d1a976e470569f2/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
             "hash": "592961f315d2ec54687c5c4f2a6a15eceea2f5eb7b4e3614adf777c395f611a280b454f43f98f528a1b4a96cc8514b2dcdf22bb30ba6cc182c40fd07f50ae7b5"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9c7b5592-95fd-4d00-8515-3d6a5c24264f/59f528496c3ab6576bac71982f2dcd98/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
             "hash": "55e5ea839ddf9cb40d538af961e26959a2dbeaa2dac5de3c85ea50b15927fd5f132ce614e2e4abeb2c8f46f13902cc5f04591f4d12196ae0f8761822e107972e"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/59484924-72aa-45dc-82ad-0c546a659270/1d3c62f9a09fb6b421596583b2b222d3/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
             "hash": "836212e6c83f790096bcbc131f7bea1175a0ab17898c8e872e88bcb0e27b52e5f94cf27dcde815e54e102610cf2d002ffed4f325da815d3b6be416d2425f0d46"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e2db14f2-5366-4965-8af2-1a030b731742/b620ee26104d3dab57ecaac499b9746d/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
             "hash": "f7e0e8c258d4199c3e79fbdfd12f2ccd02cf57afa9bd53add921f40e05bf300c29dde18589eb446e1a13fb0833eabecf46fe15ce04fe5cba915fcab6ad1091ac"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b2391445-7b08-42a7-a249-d8593eff2da3/91cbb8a4248f5a502aaf740836d4b0ac/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
             "hash": "c95601ea6775f229a7de6daf8ae92b947ae7942b134de7cb7073eab22114c940738b44273f6ddaafbabc5363c9f4cde1eff7423781b5a821eb9b0aa2535a3952"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2ca1c5cb-12bd-49f5-8924-b1ca8031a856/ed898523c59ab06231f833b15b46006d/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
             "hash": "4e178bbd26c70a3f1690c2b84b01c5a43cbf546adc878617fdf4c39d10e8063684420126261aacabcaa7f72c697290c1c06d3e93d9f3babe57c72d5fe98346fb"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/62ec355f-dbe5-4674-a3c8-a745079e11cc/f50999d4b748511662feb80dc3950f3e/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-arm64.tar.gz",
             "hash": "181c501df6e92ecf85d4c81df755eb06b1734d1814653818164175977a40ac94044341d97c8d40b185dd70685eb55212e9fbb93c4538dbc48529433a336d6af2"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b37e6088-911d-48ae-9bb1-920c5c784e44/eec60edf24e317a9df244a48a73f6ba3/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-osx-x64.tar.gz",
             "hash": "b80a2ab4ed45878a7817fb0a60da2e1a0f1a4f4477e8e15a6245e5b94fd4cf4fb57dc57a6daa9c8256648e42f1d33a7680a4b8b8eeb41a0d4fcd020b0e216e06"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/068d4d44-7491-47c0-8323-93af5e4a9670/bdc53f3b1471062a6228bca376a5b2f9/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.exe",
             "hash": "17d77898cc0dbe726ed9db15903e1698f6a768b20a44409fb2f3527d5604f57b500fa5185bdc18932ce578406a887ee3fab9668866ff548ee8ad3a07d4c3c9cd"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dffbe139-0a56-478f-85d9-72621e0cc3cc/9ca1aaeecc2fc48a2e55062ca7a3ab00/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-arm64.zip",
             "hash": "87db6953ae3919633447cf598b449b1bfac80c7a1ca8be1cd573076a90de0e67e312180804a27b487737fd75b42a77bedac0232c5e399b1a5c5acddbea834d7a"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a516941-84be-4bbe-9fdb-3b9ad784acdd/eaed3af65bda0067f26fd8f1a1ebbccd/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.exe",
             "hash": "27b9c3e84415ecb777d1bd8e2521825f9983a35ae1f3f0f17b9178d3012c805f65d9789644c3bb1a18731b33e5d760ab433984268d07c7b5b20dee42d65971ca"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f987ce84-daa7-4a09-8537-683568ee838d/cd3cdb3e26e71103014fcd4d7645d24b/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x64.zip",
             "hash": "6fbb3aee8c4844b0d578edadb4f4120b4ddeaaee1f5925a7c986746227a50a7586993879b338e93e932c7bc2145285e096e67cab374a71b5617e1ad1111453c1"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9d0959fb-bdfd-41b4-b3ec-9c360bd60092/1560ab71035697b2767c68b06d730d8b/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.exe",
             "hash": "fd935802e478dcf3bd539b41b280d008a06c605887d6515f8a659291a592a003cd0b9c19349e5b96da36c8eabb6b2e2b9b7cabd3c12b0d3f44df1d7d05b063b1"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e669318f-279a-4c59-9460-18c6dae7b637/884c1aabe8ca5a5d2b0d07f993904008/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-9.0.0-preview.6.24328.4-win-x86.zip",
             "hash": "c6ef82bbb4cd033183bc4e7938590ff595721e59cb80ec38a5b9d3985822972a027e1b18cf880161830a78e6b5cb3faff29ea71439fe4db6385002fdb4e5589c"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/45d67589-b962-46c8-8497-c79eee46e2de/f38f3b6cf4d8d60001b1aa489fb2cb2c/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm.tar.gz",
             "hash": "7ba1c3965913cc462dd18e6076b0bd5b2060afcaa87da015036c4a855fd49a651c32c230963a610c5142a2d6a3d845b1d766df5273cfee78b20550c9d35ba61d"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1b813ae4-d5d0-40a3-b890-f29b0cd0d481/42bc9c6998a3fed0fce51970043d151c/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-arm64.tar.gz",
             "hash": "4f400682bfdbb8644462ef49ed267142fca9b0823b80bddac759285b3eaa5e71a03d79e3d7bb1fd2264dfe68e40e9e647e619e0d4cdab24e18fd1bf7d8914c36"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/48ade329-ab4b-4497-94e6-62519ac6e0da/dd58fc59e31176c0656edf54e42682ba/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm.tar.gz",
             "hash": "bd2d95e485d363156931c7fd451937e88fab482aa1fab8d2425bd2b02192afb1513289ee7b121850f82ab19aaa66a952aeea69deb5e5806321f02ef22ca338ee"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1ac4709d-f5cb-48c5-a763-ff4eb4dee8d6/b81f5456163a9eda99ccab797a69a1b4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-arm64.tar.gz",
             "hash": "bbe4754055920ecbe0dc4f16347834be3b5cc4fc8903e4ca9b520dd166dd02696a03ad6dd0a266f836d2cc437eed3c4cc372497f8321deea49733f7a690c13f8"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b1c56531-dbcc-43ec-aa72-835f59806e7f/17c4a08883877e0139455b5a87c2e599/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-musl-x64.tar.gz",
             "hash": "519569f665d13409fdc9444d17ff9cf77275ebc4f0a6b29c290b70c51ca1be60ab557962b4ed118567956b0aa29c6bf84e74845b62ebf47e579174c44143b4b0"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a40d0b31-f3cb-4e49-aa3f-dd24c4be148f/ba028e5db90d6b2166f78551a82f39e8/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/aspnetcore-runtime-composite-9.0.0-preview.6.24328.4-linux-x64.tar.gz",
             "hash": "30249d6228d37f5a76ea75a130afedc71c62b7e7618474dd25aaf87734bdf39758bf4ba318924e74e3d955cf511e6b537f016cb88a30685fcd00e783aeb0ecef"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4d1bd32e-b91d-47dd-adde-e9871ff54127/b47f402aca31e6c2093f3f55c069f84f/dotnet-hosting-9.0.0-preview.6.24328.4-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.6.24328.4/dotnet-hosting-9.0.0-preview.6.24328.4-win.exe",
             "hash": "5820ce5df0099855ce078b8f7c2039f6680afa9f3a7374d20d33624a0774026533b98cfa48b9d846257a8c1b17fb5e843476d23c6b49687b412270a4b670ca04",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -3814,37 +3814,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7fcc2e2e-536f-487c-9606-fa46a5dbc11b/fe46f091471d88a46222a125280975e3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.exe",
             "hash": "8f5d4d070541105ec838e79ec36e097e281ebc7f947fdada663ce8f91ea1733f4c25b711bdf90ace632135ff1b44c6ab4d06fd19b5ce5c860a2f36f33a0562ec"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/970fb36e-b8fa-4cbb-a4a1-0a50bb403be2/37ec1a3f29546faac9b0029c1cfaf8f3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-arm64.zip",
             "hash": "8c263fc12fc160eccced8069fff1e8d12d96a25dffd3402b35de7bd5ddab7591562445e4f05f82f49d7b989777e5b4496fa7593faa96e6ad9095cf79431831df"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/32b2d8fc-5f11-4773-bb42-953c09def1da/dc794fff482d2d89db656e4e139943fd/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.exe",
             "hash": "88a39af22ef1e01e9161db019daf35edc2ea8a9bd359a4e10f9b9053bcd81babdf8867f2cffb43508914991648605646a3ad9c7d6e23e08d6010e9d64e573d28"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/33bf60f8-51e6-4224-bd19-c6f4e653e0a4/a42f1c6c3dd70817651ec6349d2de723/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x64.zip",
             "hash": "e16afec8e8615de42d766e3ba1c4318458c6cb1c9a08e60cd21eab32f36a7cd10acd942c05733e29a1997355155f7f188913da39cb4646e2d2205dc0b36a06cf"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3ab0f618-276c-4f8b-a25c-50b1fc43ba7c/805a32b93762155832111503300120d3/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.exe",
             "hash": "79b565fed3bcc8eed6e430dfd162ed59a8c6d9d8e860cb3ce9ed9237a2cf654310527d7667fee891cd1cc9c103e81fb6bceb23e08e8512c0dae7edf57d49a277"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6eda409d-742d-4241-887f-31501b4c88d0/1c686614a0b2302b07d982d231bbc134/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.6.24327.6/windowsdesktop-runtime-9.0.0-preview.6.24327.6-win-x86.zip",
             "hash": "076f7760efdb5c9123dea168bdebfb714b541b817f93b8ca73f6b91137ac90b71110c954721b1fae004de685c75eed4b50973b304b873b997d0698516c5ee91d"
           }
         ]
@@ -3865,97 +3865,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/31e7d9fb-9414-40f5-a12a-bee1649c4402/09ca8c548f4492c664ab654a225bc1cc/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm.tar.gz",
             "hash": "0aafb3386223e1d06e6e2e92255a198a10780f9be82fe430f3a0ae450a145f8b266e1075825a9b20392d0741a226d6552ba3c06acaca11f4d223285e3794a651"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7ac3c308-bdeb-4fff-98b8-b22ff6c479aa/31e3d32e7732b17506d41cb6cd7a51b2/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-arm64.tar.gz",
             "hash": "8e49eb2e279684c665031e04c915d63c19e617bf44194655374c957bb13d7f22c8c0e233196711c029653958f98788732e1bbf200d22fad27f76523d7506a91e"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/76b19839-edc8-47ce-9d60-72aa67ff8c41/6d659b8e3ff0b7bd76e2f79b82d6cdf2/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm.tar.gz",
             "hash": "62aa5ac3fb049900dceb7eda01fc6d0392291ce15a26435c5ce502c0dac607d1d38c29864c3042838bf82da0294b10ff245211bac51f1c3a21e05eed8ec5a290"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9dfae8d9-9567-49de-8872-3f8a1f218380/6ce317e891b4426f435cf5189d1ea925/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-arm64.tar.gz",
             "hash": "d81305d5715c84ea1c424102714198f974e977ba24b5f40ed38288c38b3b0d2ff55f0c4803a9535f8b4f2c1bc3456fdce94a30b9ba49dd02ebf4c259a80fe48e"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36b2f309-949b-4366-be8f-cdcf152c617e/8ea218ed0b23fc78a351cab9b1ed1f0c/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-musl-x64.tar.gz",
             "hash": "8c41a36a84bfed4b74a20329566146558bb3cf4ba6b9aec56e93a1c7c2439a7a3c54dc7b152b1c822a6067cc7806557958c6f6389d535a83205651d9ed80ba51"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/acc83ac1-a75a-453d-beb1-ab0eef7544b6/fc1c9260c812441c5c51370aa57ea1f9/dotnet-runtime-9.0.0-preview.5.24306.7-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-linux-x64.tar.gz",
             "hash": "6d5a313eb3213bca2ac209021218d978a7d8291041f4572780dfb48b5ccb7efe9ace509c75dad1db8e6a427c0bd5e4b2596c3e9f66eec5df4e717a66f8c3d7fa"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/127371ea-846e-4a3a-9f2b-9d9f4058caba/9fdf695f9a388cef6a0af6a92dc18c18/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.pkg",
             "hash": "e1eb051ebf5e909c89dd24409a7ea888661f59600f97de0835aa01a4f443f21b7b9cd103c64f659778c4d5396582f4ecefce7b4fea91921f0f3d9b3e6a40f121"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/42df8bc2-3414-4253-99f0-50d52d4b0c36/a9b0b1664e2dcba0622b9dc6c6a8a8e8/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-osx-arm64.tar.gz",
             "hash": "7c61293b719016dc8212e5564a80a3686a6947d220e2243438616559995c2d415629bf583148513d0691325ebdac91b6a13cbf4d37d7328426b73989edd8ef7c"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/509552cc-02e8-438f-8c88-dd82b3775550/382bb36a28229b8c5f9798c91822a2b9/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.pkg",
             "hash": "c07849bc1360081e99c76b389bddede1a590ab0cedef5f53eba70c65a8eb6eab4e25ad5f0596ecd65ae1d55361164b2c04c57c22964e60ffe7b1cbb034c7dcf2"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4a7db5f1-a6b4-4232-ba81-f848a8f6dde7/20b9502eb9b73e2f7ae047ae53cd1f21/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-osx-x64.tar.gz",
             "hash": "617847ec35016e4c51359fb8585563a432b8a9ff2c6656d6c10f2e3db70c20dada36509a73b31622c91ccfd5246f51c1c0df79852035f65521ac3f78943f37ca"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4933af57-6528-4320-bd0a-6ff672c6aaa7/1b7989cd8590fe25af0b915cb61cf100/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.exe",
             "hash": "1ba7123b16b25b6b04c8fde6b0c1e8298453cdd60c0a43b43374c8612071fd4939cc0ff62b6179b28dac654bbdcf2e81da3e249893718d41145b0d7d62f9f4d7"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5a8db69-0aed-41ea-b6e2-18f59b74e8a3/f241e4b6b0e8b837fcfd4c0c320cb6eb/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-arm64.zip",
             "hash": "d29287f4fef0999a5bc8aacbe327e374b83720d0f4c97fd9886e7e2f1f298b41d9ec3ba0d98f866ec63b6a25644a74a77eb291397a6d8f51b0e0a5920e98ded2"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/aa73bf2d-5bdf-4c20-b673-9bb003e6fa1c/0c0fab1e7c74c74bdef199ac814a13d1/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.exe",
             "hash": "9f8e928c896edc6807639286eb4d064ffa931a4a9c4cf166e6e3969ec5f3f2325a376810a8842376d9ef22fd832ab94b95772faf438593c37730b23316cce290"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d4578076-c2c1-4083-931e-4bdfc0545d3d/c153c8ea28930c65a3247e24c18d85fc/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-x64.zip",
             "hash": "078864a20e4efe15aa1008bcd1696474dcbeca721e1c2d13dd8f11652630cc1b7adca74591fe910424c56e565fa499785eb882ce3889b87d476de0181dc71e83"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6bf7d5fa-0998-4ed1-b595-7fa89efe5782/5f52d09fff08eb17ccb7586174b67471/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.exe",
             "hash": "49a755ac3c9ae403290856a2255f5574d180f29a5c3b6d5def899fd1f72adf886b0f051e7c73c02f56c021259b3d02d416d4f5531f87bf8f7adc2da58d6ff1e0"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b169201c-2a05-4555-a923-7054c5f3f912/3b53906e9a1b455e09edb80e0e7d3428/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.5.24306.7/dotnet-runtime-9.0.0-preview.5.24306.7-win-x86.zip",
             "hash": "7b23fa2374bc68a2288e410a0a2c96e9b69c814f0f801b3ef68f8f49aadad26cebf20a1199dd415ac73670891124b5ac354131c03ac3b1f4921fa6c48706c86b"
           }
         ]
@@ -3975,97 +3975,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ff4f1830-f8bb-4be5-a065-ca27005ee25b/ab73d8a64752e5f94ca5de8e45871e5d/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
             "hash": "39b94bed670ffe0abe0482222cef8d706995ee00531e077b856c6cc600cecc81bfe34c1d0cea3172796b694fecd150f350e08d2884e237dfc024d942667b1676"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/25f41d0d-d27c-4dc5-8884-6c49897d89d1/c51387b8bde1d278a0982b03c3e8c1b1/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
             "hash": "3c6f7e6f2f56e86bc8a9633f50129cfa992c52c287dc89551b23cd62fa471199e90392eba7414659c8ff8eecf1dad04016615a98cf85f6c2045d61f6f14c9e73"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2a31f873-8093-4c63-8481-1d3cdc8f6f0a/c305f1ca9f40bad90c380fbb5f0de559/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
             "hash": "347dc481e1c752e1560ac856d3dfe53b78c42e5c70d7eaeae820329a03a46b2ae9aacfa150fe8a8e141b82ee79373cd417c99f75166ee036cc5943fcb358db5d"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9281b5de-3ec7-4452-8e0c-5b18d02f0203/76790fd16370719461f1ee565fdf1142/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
             "hash": "4a98db47ab702ad98b647cdb4db2e429d41a8759c174c0b8ff16b98644feadb9b094d268701b4b8a0651e795d63971715231d36caeee197a24d7298081a20cd2"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/26ae7803-8ea9-4fb3-8b86-fc7218e5f57b/18b08c66b2a5872ba0b71078f0a80a80/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
             "hash": "085a930d44dc9c8048af4bd3cd0b370b4b8a8abc10393d118fa9594812d23cc37cd3ca56c5bbe35bac17c83885c411e32179fd689c350d59de09a8c8724b8bba"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/96e19e8f-579e-4a1d-a18e-6773a44d7cd1/092cfc588686cc698c449998b7d5ae35/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
             "hash": "13b9934b3e7b736ab802a8c580aad95ed4dff6b8f31047c71ce9ffcf4d07e55105d4b0170d309551707b9d232d297cb305c67ed5b5f7026f47ec072ee1bbc121"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4138605e-d1df-4672-b024-862b8b1bc4dc/bbf19075238cb836aa0483014f8174e3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
             "hash": "c578766dc35c61bafeb6ab07e70b6e6664504d2e5560bc37aa50fc75690dac485bb635c86d9264670717a04514787a0344561ce428e30e25e17f820fc2cd8d09"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/090175ff-fe42-4064-98fe-b6d90e08162d/bc72a57ada79f0ee7b71d74f5deb66a0/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
             "hash": "8c1a13d14f2502d3897871f82abd2c2df8cb41ff9d754e79693b99d0780deb910dad7486e05ec065c4a38490de00d251c64b0b2a734863e0a452f0ed23b1e1a0"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f4139839-15fa-4ef6-a1b0-fb77ee467b2e/7529958cc121871a79d3da1a0f851333/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
             "hash": "c82ca4055e7d2d8cae3f9a9924a9fc05392f3b58a5bf4b690efc233d61c061e185f2b125967733bf69936d5db8b1a4d06dcbc3c1d28d3bd131edcedf780a2697"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a6731f1c-ffd0-4cca-a309-89576e55552c/3000f43ca4b3b51bb034bd7daa514841/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
             "hash": "ebb84f920a7bb663238a10007d784a7c90f66d073089371fc2c9d5556cba945918fd8b193e02eb3d889676952b79616398aa2555d7d46d080088f01f67ede43e"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4f58d46d-3ff2-4ad5-9e25-6abaf2a98699/d96c5e7e2b2f7bba1f56b73875a2f764/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
             "hash": "a8e398611736c4a5a20402b2cb9de2b3320319e03b0904182f258d095523299c7c2ff6774df9301baf1d8bb4e1f5ae0985992ef21c89ef668f291db3f1dafb77"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2c38b883-86fd-4970-b5fc-3486740fcb4e/17024f80e99c45f74ef69700c982d214/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
             "hash": "137ae59e968091bca5316452d4345830b5743578a65167d493d3b12242f54d6cf40181471236060803a3e29e51bed254b86dc436582bece8915666dd0193cc0a"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ad4f7358-9797-4301-bb3f-2bbaeffb1aea/7e740c0f41c8dd1e2282e5b88a65e727/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
             "hash": "911abd43eb7b7b49eed69304dfe2e0fab3360bf7e72d5e421b2954e1f6dc33e9db7dd4bf357382e57d71b663c3bf242284592a4130c9141d9c782e602edb6779"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b08c26a7-83de-4d9a-b4d7-d87942b6d35e/d6d973d0cfe914189692af1154690935/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
             "hash": "297797f709933f435021be0068bdf9e7051e493d60212c29a9746cb5e6672ee8f2f6a2b2c214f1d4753e87e449faf712f60edc7c4eb32d34e555dee07c8a04a2"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/99dfb394-02cb-4ab6-82ee-b15c7b5bb69a/cf6e482460f5237237f9232e9f9afedc/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
             "hash": "2223918e2b3bdc3623a7ff323ae5c930da47408c1276035c10408de80a65c9220d9bcab79435690f9d0473e60939935bd5ce77a532486deb89b26b9e9b4417f3"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7e6cadfb-b694-4d94-9f0c-55b3a72e6089/11c7bbd8d2f072e483e274fec5e8654d/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
             "hash": "8d167c0926d6d3aaa7739c7417039b9be27aefa4b7f52fef3c6503173d3580dbda6e688bd68716e07441aa072d9bc94faaa34651c2ff0b57a06fec65a8a81260"
           }
         ]
@@ -4086,97 +4086,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ff4f1830-f8bb-4be5-a065-ca27005ee25b/ab73d8a64752e5f94ca5de8e45871e5d/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm.tar.gz",
               "hash": "39b94bed670ffe0abe0482222cef8d706995ee00531e077b856c6cc600cecc81bfe34c1d0cea3172796b694fecd150f350e08d2884e237dfc024d942667b1676"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/25f41d0d-d27c-4dc5-8884-6c49897d89d1/c51387b8bde1d278a0982b03c3e8c1b1/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-arm64.tar.gz",
               "hash": "3c6f7e6f2f56e86bc8a9633f50129cfa992c52c287dc89551b23cd62fa471199e90392eba7414659c8ff8eecf1dad04016615a98cf85f6c2045d61f6f14c9e73"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2a31f873-8093-4c63-8481-1d3cdc8f6f0a/c305f1ca9f40bad90c380fbb5f0de559/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm.tar.gz",
               "hash": "347dc481e1c752e1560ac856d3dfe53b78c42e5c70d7eaeae820329a03a46b2ae9aacfa150fe8a8e141b82ee79373cd417c99f75166ee036cc5943fcb358db5d"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9281b5de-3ec7-4452-8e0c-5b18d02f0203/76790fd16370719461f1ee565fdf1142/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-arm64.tar.gz",
               "hash": "4a98db47ab702ad98b647cdb4db2e429d41a8759c174c0b8ff16b98644feadb9b094d268701b4b8a0651e795d63971715231d36caeee197a24d7298081a20cd2"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/26ae7803-8ea9-4fb3-8b86-fc7218e5f57b/18b08c66b2a5872ba0b71078f0a80a80/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-musl-x64.tar.gz",
               "hash": "085a930d44dc9c8048af4bd3cd0b370b4b8a8abc10393d118fa9594812d23cc37cd3ca56c5bbe35bac17c83885c411e32179fd689c350d59de09a8c8724b8bba"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/96e19e8f-579e-4a1d-a18e-6773a44d7cd1/092cfc588686cc698c449998b7d5ae35/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-linux-x64.tar.gz",
               "hash": "13b9934b3e7b736ab802a8c580aad95ed4dff6b8f31047c71ce9ffcf4d07e55105d4b0170d309551707b9d232d297cb305c67ed5b5f7026f47ec072ee1bbc121"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4138605e-d1df-4672-b024-862b8b1bc4dc/bbf19075238cb836aa0483014f8174e3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.pkg",
               "hash": "c578766dc35c61bafeb6ab07e70b6e6664504d2e5560bc37aa50fc75690dac485bb635c86d9264670717a04514787a0344561ce428e30e25e17f820fc2cd8d09"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/090175ff-fe42-4064-98fe-b6d90e08162d/bc72a57ada79f0ee7b71d74f5deb66a0/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-arm64.tar.gz",
               "hash": "8c1a13d14f2502d3897871f82abd2c2df8cb41ff9d754e79693b99d0780deb910dad7486e05ec065c4a38490de00d251c64b0b2a734863e0a452f0ed23b1e1a0"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f4139839-15fa-4ef6-a1b0-fb77ee467b2e/7529958cc121871a79d3da1a0f851333/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.pkg",
               "hash": "c82ca4055e7d2d8cae3f9a9924a9fc05392f3b58a5bf4b690efc233d61c061e185f2b125967733bf69936d5db8b1a4d06dcbc3c1d28d3bd131edcedf780a2697"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a6731f1c-ffd0-4cca-a309-89576e55552c/3000f43ca4b3b51bb034bd7daa514841/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-osx-x64.tar.gz",
               "hash": "ebb84f920a7bb663238a10007d784a7c90f66d073089371fc2c9d5556cba945918fd8b193e02eb3d889676952b79616398aa2555d7d46d080088f01f67ede43e"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4f58d46d-3ff2-4ad5-9e25-6abaf2a98699/d96c5e7e2b2f7bba1f56b73875a2f764/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.exe",
               "hash": "a8e398611736c4a5a20402b2cb9de2b3320319e03b0904182f258d095523299c7c2ff6774df9301baf1d8bb4e1f5ae0985992ef21c89ef668f291db3f1dafb77"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2c38b883-86fd-4970-b5fc-3486740fcb4e/17024f80e99c45f74ef69700c982d214/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-arm64.zip",
               "hash": "137ae59e968091bca5316452d4345830b5743578a65167d493d3b12242f54d6cf40181471236060803a3e29e51bed254b86dc436582bece8915666dd0193cc0a"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ad4f7358-9797-4301-bb3f-2bbaeffb1aea/7e740c0f41c8dd1e2282e5b88a65e727/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.exe",
               "hash": "911abd43eb7b7b49eed69304dfe2e0fab3360bf7e72d5e421b2954e1f6dc33e9db7dd4bf357382e57d71b663c3bf242284592a4130c9141d9c782e602edb6779"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b08c26a7-83de-4d9a-b4d7-d87942b6d35e/d6d973d0cfe914189692af1154690935/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
               "hash": "297797f709933f435021be0068bdf9e7051e493d60212c29a9746cb5e6672ee8f2f6a2b2c214f1d4753e87e449faf712f60edc7c4eb32d34e555dee07c8a04a2"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/99dfb394-02cb-4ab6-82ee-b15c7b5bb69a/cf6e482460f5237237f9232e9f9afedc/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.exe",
               "hash": "2223918e2b3bdc3623a7ff323ae5c930da47408c1276035c10408de80a65c9220d9bcab79435690f9d0473e60939935bd5ce77a532486deb89b26b9e9b4417f3"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7e6cadfb-b694-4d94-9f0c-55b3a72e6089/11c7bbd8d2f072e483e274fec5e8654d/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.5.24307.3/dotnet-sdk-9.0.100-preview.5.24307.3-win-x86.zip",
               "hash": "8d167c0926d6d3aaa7739c7417039b9be27aefa4b7f52fef3c6503173d3580dbda6e688bd68716e07441aa072d9bc94faaa34651c2ff0b57a06fec65a8a81260"
             }
           ]
@@ -4193,127 +4193,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9885e829-9401-4f84-8948-33bfbec4a486/40b414d190c0c85614c18f42f6c4d1a9/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
             "hash": "5f41868ee89d47b391968d7f01772e6c223ae12d7d86461d38972f56de8e6278ea0aaf723d736bb2f03ddfb7ba0627f1ce7f0447c62aa6b48854b5434b33da9b"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e8849fb4-309b-4008-b697-4b5af127cc8e/285762b4db9cfb18abad4e005b37f2cb/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
             "hash": "6e6198d26b16ebae7bf7f7a428b0026d3c7edb20fa0acf844670a98cdb78a8b0d37cad5df22f35dc3379de8069fdc95318f5eeebcd5b03ad99cf595699116abb"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0ac17d7b-df82-4c78-8be8-cedd92c28f23/f80b29a59db088239e19970058cd6c49/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
             "hash": "44628326e3efb241ee24e9a39abf6f4318d415d1977655d8fcdbdb8c61aa05f4b4c058dd8c0c52cf206c3979e5b5b2cad86cdb9f56e0a2b10bf2d9994ae8ebde"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d1c32044-fdd8-49b9-90ee-87531de750e8/8c2d4018226292cebbe470335614f9e3/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
             "hash": "dfc4e8f082214ff796ca6b3c548b38b1e61221faa90eb96e1f19771f14197e2e4ee616057cd29b37addeba91098ba151859be8eb51015b1bc38113fe2d3c41b6"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f6f9b71c-095a-4aeb-8eb7-fada01704860/117e89d575a73207194a9cffdbec78b9/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
             "hash": "f82ec65e016c0996b74c144c1a11de7d2f3bc8bf7a51f217d697fc8a019039995df23c7e64df1e98950ff5cb3a8f3c815735102288bd73efd1192a20f21761c2"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f43de71b-3bf6-49ae-99ec-66499bfa6990/438e1533bbb47d3d7e1f58983677a4f6/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
             "hash": "b4358041bfc42bf614644e7f3c38a4fb73185a8d3541065bfd6758622860b0d0addff6a7ab6e7439d029b0b54238864279d19f1b5096b5d7c0fd10c0435e652e"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b4c5eec1-4026-4e58-adfd-64dbf4426b1e/1f05059da0484ade0ba1ce6a3e8f6bd5/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-arm64.tar.gz",
             "hash": "f6ed6cc22e20e986cf54ddd0c8868b524efcf84ccbcd5335bdb4ac44fbb08641850448aed5d85bcfd2d403b3a89a73cb932d73db1b590cfc704a58aa8ec79d5f"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f07ad200-6654-4341-a594-9a1eb1ca66f9/929c2533f6fe9c402fcb5fee99ee1103/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-osx-x64.tar.gz",
             "hash": "104b0b8f216bd36710ee912c92c89c4a5be97774eb21cf090c5c12acbe3ff8a8ec22a2b2bca56feda8aa21690c734d5a4b8293569cbf45172ead6b587d3858fd"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c78c4ab8-5fad-4d72-b5c5-6edd4c51fa2d/2154d7e93cc29caa92df1f8d990a8ea8/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.exe",
             "hash": "93c04f3dfd446180cf143d8839abba89f389b3def23489b249636cba3a7a032406066a0e6db67adb3f9a87897778ec11117599a6524b5e0b69b470edfee10314"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8d13b17d-912a-4f52-bc64-05113d585ab3/40cab8f4d7efdf30ea9d5178e8f16de3/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-arm64.zip",
             "hash": "6f49d789c314b1f3ead17d2c9870f5255cfe53871418ba626946b4128bde87d24c7427bc9176d98c528f458a69aa11ec016bd0e4a23a8f129351dde43a84de5b"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/33d48eed-15df-40b1-86db-86cfd602b8a9/f68eedd88c935d4e73028861f95f001b/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.exe",
             "hash": "0a1f2b3d84864c543fb1882eca2409730bdb8f661422e13d53f664d90b9133d1a651d095467e6881491f8326fd31ab533cff480352af2468e4369fa12fec5d23"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b341e7de-2607-407e-a539-744dc7c0af3a/2a78d3e9a34f4e5f23150554921cdf6c/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x64.zip",
             "hash": "b5d2160fb4af420ee73cb9205372518d9401333b91a1852758288b7fe9f198092ae4e029e4b49164d5c8303ca4c8fd0845280d70e2c79d5679ba6cec6c6045b0"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9b5c5c65-532f-4498-93a9-5b38449f577a/3369bf02ce5d8b74a109cb221baf5c2d/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.exe",
             "hash": "1a209d3bcc4e29dc7afb0bb0aecc66e0762640030d89a32ecd61387c9eeb84f48147a095dfaef4b79c27d3b682a250e3f3de7776e7d0c95570d18f8bef41cdf1"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/86db0409-ec32-4dc6-bcc9-d5534ec20220/b5ed337c859e403f4b33a31891e1cd22/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-9.0.0-preview.5.24306.11-win-x86.zip",
             "hash": "19d750ac6418996ae9bece2198ea576cba161bf5e4670f256ba2f17972f7bacbae35463bfbb40a32887739fa8b2dda906df395df150b356f2350e00279ad20bc"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e04de0f4-59e6-42a8-9530-16af0bf369cc/c66a4ec5be50872a6606a8f8b2f78404/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm.tar.gz",
             "hash": "2b80333b0c8513ed18adfa715121290575c71e0101f920b8bc105d3d81ce3ba104a823d36a8ad5c871b6db42d1078b19f72979ca4e1225ff0f15980ab5aac5d7"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b0f62525-01d8-4ed4-a091-086fd0210846/00a6b88fc1c125bde4a47b3ba9d6b209/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-arm64.tar.gz",
             "hash": "441abcf355a94f02929f3bb16899180ce3e253daebd7591696dd7f934e5d2033b341a1cb1944b06e0b205afabc3189432fdca26d89bd80f82db132d5589262dc"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1d24de4-4253-4689-b74c-49200f858bb2/302418f944d071fc5add18730a928c9f/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm.tar.gz",
             "hash": "976d8f04c387a42f107fd4a0c1ecef798cf1d3a3e961aa4f06bd9ddf08b15155cead38876d4cda60ec68664562d7883f03e642aadec32693c6a42265cfad4463"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/060552c1-2c74-40d7-b625-b35a7e41f827/c5b91c025b6ef6bf62b6fd1050fa67d2/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-arm64.tar.gz",
             "hash": "ce547b2e4249f0028fb12b5d2f16560c959263874b63983797128ecc091099f374c89dd2386aaa8db9ac559114255932ccca9511378bc0a43db05e99408d333e"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e1b305a5-cee3-47c6-919e-8772e5dd76ff/8dba7a53c74a331a667de203b2d2191f/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-musl-x64.tar.gz",
             "hash": "abf43f18b74bca8a7e6e4c2faf136eae844012f6a1e77e886e2d5a414c0bfd450de6d0916a78951218e39f8c162ea5803a061e833fb73763e9c56ef821b684f9"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/44d88b11-6c78-407c-8f2b-c1c08065afc1/1e62a37ac72e089926415447b1989f8e/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/aspnetcore-runtime-composite-9.0.0-preview.5.24306.11-linux-x64.tar.gz",
             "hash": "5273644b48020ae3cfddd4035f17b0499d9cb0bc253bf53b6332bba0e8460b1994f0a4d3ad7d644533d84fea481cc521294f91e9e28608b815d9b332de7fc075"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1eb7f78f-c605-4e38-b5b0-33b58ccb8460/c7421e8b5616b751a9a66c0c5abba81d/dotnet-hosting-9.0.0-preview.5.24306.11-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.5.24306.11/dotnet-hosting-9.0.0-preview.5.24306.11-win.exe",
             "hash": "04a1299e7fbf65ad6587f58013c03cb557e34790193aeb98af95a29e26bf836649730d76060042b0a99566d85b02f4aa69a5558aa777865b087bd59cb6f8d836",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -4326,37 +4326,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fabdb881-9c52-4744-ae24-b529aca98806/c5b048d0f5d46b66ddec6643b3b8bbb7/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.exe",
             "hash": "483b81fbada3d60b94c7bdd6163c04449243aadaf5805d0135ab732b9a2a7aaf1a271e6de37b0704b1586523751a30131ac42415bd841ffb4cf77d5eee9d63ed"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2ed957d2-54c3-479c-a17b-e4c721d25a86/0f56cbf7a7454a15de16fe20273ed8cb/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-arm64.zip",
             "hash": "d4b865cdcaf3e346b16eaabff77c4f2a911a408c37439dfdd4f632170dec2900b8745d0fc80fe8463ef25b768031c2b741663a8e02bdc930de56d14076996cc5"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6c481981-dc6b-4e69-9c60-7f0c3ce64e0d/0b5a8d18e2014143af7faed2e2c5e251/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.exe",
             "hash": "c294acd9d6b022193f12605adbb1cf8609990455990d46ed307a5b9cae2d0977b4e81dacbaa7539386059307b83e7f4de07c22644689f7df109346970bd569bf"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2790489a-2b90-47f5-a281-353a05c4cdd9/0833d5448b6481a29d8a58b6db98feca/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x64.zip",
             "hash": "85e7a9465091f4bbe63c47938f042404e40ccf6b1f217713994fc67404a95607cb0664543cabc54b3aa017233243299139a1ac90570e36a0a3020bf9c15f141a"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/976bdb90-8f89-49f0-871d-8aafcc1337c6/67bf6ba2ff55915f3c99dd88b0bbb6c0/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.exe",
             "hash": "0d406c96f0c38eb1a887bd7327c0bb4c75c456003098203b34100a7c64e06072e2d7b913714a9cd64f9fd727203f1b30f6aa51a99f40503b9da6d0a70a7fe1e9"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4dea813a-bc32-49f9-96c3-09b1762b4034/0b3bac88273cbce4e1d939114801c396/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.5.24306.8/windowsdesktop-runtime-9.0.0-preview.5.24306.8-win-x86.zip",
             "hash": "d3b44cdad9da672e4cd4480e2092f2492455b3e36f25782e323af9b79d29bd57997164c0395bbd10e4cbe8a8bcde63e021b8e64ef6a1fa8a3b137d276ec55d5f"
           }
         ]
@@ -4377,97 +4377,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a99b6e0-105d-432e-8df1-9f881aab7d86/4018c96b74950f6943e9102b99baec58/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm.tar.gz",
             "hash": "9ecc3c6afdc445b0008d8f6bc7a0635ba6abc00ed0e5b66be3bc2e4a4da2579d0c1cce848635a5046a086f2c7154e3befeb9176219af7c8feadeb41a78b1ea5a"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/18801fdd-b1f5-4856-8288-c306b11f0f43/5c62f28b9a269b1a840cfb310a9a9f86/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-arm64.tar.gz",
             "hash": "ce8c21b6c854b6772578e84d42e2df5f5144d5a15aff3e6d48953feb1aad517215b6349c20fc22542364a9c439fe19a562f070f88eabf14b5d95ab50fe1ecc00"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/35dd9b11-2055-4d52-9169-1b6c3dd11594/a35d42236e89f7e0bea13545138e170e/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm.tar.gz",
             "hash": "cd38668eb106653c9ce2ec62e8b0443f3c7c90105302afdf790153b19b677af6b931af5b2a836b226c54ab8b7f8609265f81c37653697ac15d2688cfb2261902"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/242ea287-a11a-4248-8c85-bfca8d2057e0/c0da08d4b4f8b07c966d9169ec56ed1d/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-arm64.tar.gz",
             "hash": "969aa069d1719e7dc0c5f1abfd13d3960e58111ecfd61cf557979ec4f3e30cfb2b9082250041bee49841ac5b40eef3f80caf921b63ea148825289ccfde582f6e"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5139dd2b-c1a7-4be5-9913-18e09aed94f3/f9a8615238ec30073a7c1bcb3c7ae247/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-musl-x64.tar.gz",
             "hash": "964110b4637ada5eb605aa035c30f4cde754a5ffbe26cb11b63d10cb6e0f3287e746662fb85c421c4c3b9b3a334755f59c123b65799b461d22e1d53c42ad496c"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bd635e31-a279-4078-ac0d-f82ad8940f84/2e9b04bbe40e28507e8483c73eafdd7c/dotnet-runtime-9.0.0-preview.4.24266.19-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-linux-x64.tar.gz",
             "hash": "b366a4f19f25281c5b325e737f8c9fe0fa97ca4e19e0e8f00cd42cac84f4134469d02558b07412c66cde62e53f1cb1a7efd68357713ce4d3e816c19ee538e9b6"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7e461d11-8e26-429b-a35e-6f67c84d5b3f/0d7cfe48dcbfaa6a8284850793c984d7/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.pkg",
             "hash": "247fca6bd0fcdb80cc4fdfee87520b2ae12c54eb8399bb625ba226cb845971d562037b37c2d507d4d7405976410929e41ab7f9bb02c17c66e080aaf99f0867ea"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c53cab87-a771-422e-be8e-f33a8a6ca637/6e72c3d16f517c6e692572a5cc9546c2/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-osx-arm64.tar.gz",
             "hash": "f9e8188c71ab47631c28d3fb9314b382eec31ae5592a73eaf8c944fcdc240147ac23ef4530a871e9a5deaf311b84ac5b0d5a1f4b6ff22134a8f4eda4555c43a2"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/73f4cbbe-9a84-4403-ab5a-4ea15abe6890/95fb54f4ccd9024e7d41cee510cf3fa6/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.pkg",
             "hash": "7efa0a175811039994d605e6ddc0aa007f28e17516230d335ee1a3af469515aff8ae681aed56a7fcaafecf52f17cd93d07bb7d0d4e219d14afd9e659b0e6358c"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6bd91ad7-ac3c-4027-8674-239367730906/007b8c98680c550fb801c34dea28bc9f/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-osx-x64.tar.gz",
             "hash": "9e7364e1448d98df03922bd315f788ce564dfcbec1a9e83c9e1437c22d8d52f72f061750de2f9e149e7662c168b7a781e7450d2c1e8b7f048cb62b360f12d6f6"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e377474e-7847-4bca-a032-07a50104e7f5/97851ebb43ff0e3dce49a0ca9d0fb0d1/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.exe",
             "hash": "6c3695d936ebfde747f5d656afe764fe2bcde551f2808e4018be4358f1a98e63cc91f340af6ec2f2370165a068eb12bb45f81e4e2d4d6c7ab916fa0c491e42e2"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/28a070f2-adb7-4d2a-8363-6c4e285a8e63/9156f37f7cdcf63739881a80d8dbc050/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-arm64.zip",
             "hash": "47e92441bdb222b3c69dab181504de00a1c89c75d9b42cc6b093c1ae81dc184fb962319c6cd3e6fc78835b27257e5799f04c6c8481ceee30af9163d97bb9f93a"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/62b4e83e-1346-4c01-986e-33047bc2a6d3/852c4d4ff7a7517a5edbd896e4796e15/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.exe",
             "hash": "5b6865c131836c1bfb2b9e78c515b3ad5aab5fa5a7317d2024d216de8964b9e749a6878a43cbf8e1b8ed587ba4641011d5250c95f6b15c5e0a2c4a0bdf78bbfd"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/676e985a-6242-426e-84dc-caa80beac6be/576a6d8e8f74c9520c8e7942c4d5278f/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-x64.zip",
             "hash": "61ec667e4c6394ba21748a3529969e54ca514c37c42b5acca2a87dbf7f816d6c7c4add8962efa51db7b99a7177546ad439121c53053b5fe6e01763f77f42daf5"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4415bda1-d266-4128-b194-0d4d280128c4/685282429a7c7affd9134fd5d2d9a2c0/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.exe",
             "hash": "5226d35e6325443448e2897a05394212a4b475025b5bf1e3702093f00daa05bb1a64be3a986114c528b1cbf7a50a3d358f8bbb5020451ca4e56aa61f6f977d76"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/284b822f-4ff7-409b-90ef-9b37eb487dcc/26719d69cfcc500a1493bb9d4de6fd7f/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.4.24266.19/dotnet-runtime-9.0.0-preview.4.24266.19-win-x86.zip",
             "hash": "df01e6fae6ec5aebda2ece30617bf9c4e04e105b4ccd8f3da8e790650e22c1333e5080a949f43814033fe60a2e8061be53c2923d17b2a31e61c6a0c77b726bab"
           }
         ]
@@ -4487,97 +4487,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/eb98063a-61bc-443b-b51d-0bc82cfa10bb/ef920311f783df4ade75298fcd45c9f7/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
             "hash": "3728477aaba64f03f28b4690caffcc90852960d7bb573cda142a49decc394ba38cd1090e7c00275d3f8e5af0ffd0cbbde04c27102cad72814d8503281bf1fe65"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/098a764a-8756-47c5-97e9-118431c31b9f/2e1b737cb4750deadb0136283346c7ed/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
             "hash": "519d529c74a972484af49ea72053466e09fbfaec0142cd924705dddc117dc40901ac22ddcb11c05caf7b43ef8cf44ec8a0a9dd4c56fbd329b0f750513ae3100c"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/42b4a871-aa76-4e76-81d8-4de3adc015b7/1e6a598bb1c74ca1bd0f97701c1beec9/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
             "hash": "952735f8b305ecf67f644acde4e5176a17399c4616a51a9a279d84763cb30ed67bac6b64caf2ed359f103794de5d4082d72da79f5fe5486b2f32a22e78893f32"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5970728d-630b-4a98-b92e-c7411094995d/97319be6b9b617c0e5529a89476d4431/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
             "hash": "85e8caab9e74882fe4959f7078d7e4f736c0c2109b6167aeacec1518348945e093839774baf2a90163f8868ae5593912caf8477f5ac8ce20e0cca1bead066da8"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/42143563-4bb7-456d-b3ce-698869c0feee/129e62b28eb216976385ddb095159013/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
             "hash": "5861ccc9b1670a134c6d76be3ba0aa3606c8c3c110cc8415d2015c921c86bc19cc6363e64f7a2f9a3dd261e042956e55d0c9c2e5410bcce2dcefe309dae631d1"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/87f2eabb-8ba2-4677-9f91-526672f51857/9ed7fb997d40a369c038269a514fc4e4/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
             "hash": "28b63633a1e6f4078ccc60218b9f7b6663eb960f0ab1c41069ed8f7f67757fa22ce9f4c04d88b9015c417aad34a7a57986451682bd7aa7b966eda45ace23d283"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/343689ab-65e1-4633-b85a-ca1bb8a0e5d1/e04cf1a20a665f377e2ea45d3a9734c5/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
             "hash": "7d3ccf857593bfc53a60d6085d41b9e6afcb57c8e18e7e79bfc9d61bd269466c7c69cab4f3801496b1314bbaa134d6226b37493b01b70b20a8b4b7c6fa0bace6"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e003d2d1-abfd-45f6-aca2-e3f2199e3633/dcefd0cccdfb48a3fbb20b14fd2fe22c/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
             "hash": "3791e2134f7cae53c430ae5306f325eecb84058da07d90f276f8d4045701c6c85567472ffc2c535002bb3066817683c0a8e82d23ba6ce32a52f7217867db30d2"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f0858498-9230-46ee-9cf4-fb68aec0e37d/58e82c5b5705f0fd9efb2d4ecc74c02b/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
             "hash": "a672acfbec52b2f636614a2cff682ddde5ecd8c82eab884608af1bb7ef508ef5bd202c25e31ecece7d81766ffae6c96b518841f215bb6361bbf66f45ca6c0a1b"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c3cee1ac-1bb3-48b0-8a35-813e511d1d41/dbcba8b2e6d28886d07bec53ab509225/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
             "hash": "da35a51180e75a238b7a4b5d1a5b7e3e33f1a1c179b40957deee98c8e01a9bfade62e2c909d2e5b377f43cf2dc78687b34b349b27b2f8f841165c3c05b3fe443"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/29c1ff6f-0156-43d4-b86c-9e7d3d99676d/d6097b452228be86bc95b995688685c2/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
             "hash": "b855a6a68dd1e4fe93348d20a7940685ab46540a4037512d99e30269a9a941c8a740f71984876b876441597e2830aff4bc2940666043a3ba565016c491f982ee"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7b9dad11-8a62-4521-9984-3a099d9ce61d/a0a1fe27a63ac76480db3281577edcef/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
             "hash": "611c04fe90746c82c4902eb75a98e6219222cd82733388b79cc81fe3c9401ed261474e92993439e06efa6eec6230604bbb05a77a0894f030ea75dc22808d1edb"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1515bcb1-1862-43c5-a86c-180b1ec9049d/c4049cf3b8eb87e40dff823573cf563d/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
             "hash": "32eee5f12a564098fe19253a50260bffaad34fd92d7a2d10612993eeef0a78fc7aee051dff9c72738091f3c38029d4579886a626541f656e090497080ffce22d"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5bb0c9db-5ddb-44e7-90d1-bf34c1ac688f/8ba52405d812250c4b31e81e94c62334/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
             "hash": "5abe780d515bf82692752d3defe6317bdd17171ddbd5aa9b769ba8f63edd713868c26b8735ba427c9f193ac0daac28c2cd87c4321565c3b2c4545b906f5c3587"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bb1317f1-6c8d-4287-b10e-618e67cff2ff/d7537c37617a5d5d56b87079a24a2a66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
             "hash": "2c3ad59a9e57b9a56aaf825f4eb23f90caffc1508c9bb5ef511865455e051fb65e2834f3ceb829931d6ee74ab81c52885c2c862d02c23a015593d6fc182030f7"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ce78ba3f-c369-408e-8026-a2318844db65/d1636d07dd075acfdaad4d80d69b6262/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
             "hash": "ea8617ced22a2b4e0e048f3560e350cd720d5529776bd5cd5e165b139bf287624178870cdaad68e613a18122f3d2ca5e917c46ff8390a8a92631787e21a39243"
           }
         ]
@@ -4598,97 +4598,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/eb98063a-61bc-443b-b51d-0bc82cfa10bb/ef920311f783df4ade75298fcd45c9f7/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm.tar.gz",
               "hash": "3728477aaba64f03f28b4690caffcc90852960d7bb573cda142a49decc394ba38cd1090e7c00275d3f8e5af0ffd0cbbde04c27102cad72814d8503281bf1fe65"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/098a764a-8756-47c5-97e9-118431c31b9f/2e1b737cb4750deadb0136283346c7ed/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-arm64.tar.gz",
               "hash": "519d529c74a972484af49ea72053466e09fbfaec0142cd924705dddc117dc40901ac22ddcb11c05caf7b43ef8cf44ec8a0a9dd4c56fbd329b0f750513ae3100c"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/42b4a871-aa76-4e76-81d8-4de3adc015b7/1e6a598bb1c74ca1bd0f97701c1beec9/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm.tar.gz",
               "hash": "952735f8b305ecf67f644acde4e5176a17399c4616a51a9a279d84763cb30ed67bac6b64caf2ed359f103794de5d4082d72da79f5fe5486b2f32a22e78893f32"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5970728d-630b-4a98-b92e-c7411094995d/97319be6b9b617c0e5529a89476d4431/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-arm64.tar.gz",
               "hash": "85e8caab9e74882fe4959f7078d7e4f736c0c2109b6167aeacec1518348945e093839774baf2a90163f8868ae5593912caf8477f5ac8ce20e0cca1bead066da8"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/42143563-4bb7-456d-b3ce-698869c0feee/129e62b28eb216976385ddb095159013/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-musl-x64.tar.gz",
               "hash": "5861ccc9b1670a134c6d76be3ba0aa3606c8c3c110cc8415d2015c921c86bc19cc6363e64f7a2f9a3dd261e042956e55d0c9c2e5410bcce2dcefe309dae631d1"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/87f2eabb-8ba2-4677-9f91-526672f51857/9ed7fb997d40a369c038269a514fc4e4/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-linux-x64.tar.gz",
               "hash": "28b63633a1e6f4078ccc60218b9f7b6663eb960f0ab1c41069ed8f7f67757fa22ce9f4c04d88b9015c417aad34a7a57986451682bd7aa7b966eda45ace23d283"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/343689ab-65e1-4633-b85a-ca1bb8a0e5d1/e04cf1a20a665f377e2ea45d3a9734c5/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.pkg",
               "hash": "7d3ccf857593bfc53a60d6085d41b9e6afcb57c8e18e7e79bfc9d61bd269466c7c69cab4f3801496b1314bbaa134d6226b37493b01b70b20a8b4b7c6fa0bace6"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e003d2d1-abfd-45f6-aca2-e3f2199e3633/dcefd0cccdfb48a3fbb20b14fd2fe22c/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-arm64.tar.gz",
               "hash": "3791e2134f7cae53c430ae5306f325eecb84058da07d90f276f8d4045701c6c85567472ffc2c535002bb3066817683c0a8e82d23ba6ce32a52f7217867db30d2"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f0858498-9230-46ee-9cf4-fb68aec0e37d/58e82c5b5705f0fd9efb2d4ecc74c02b/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.pkg",
               "hash": "a672acfbec52b2f636614a2cff682ddde5ecd8c82eab884608af1bb7ef508ef5bd202c25e31ecece7d81766ffae6c96b518841f215bb6361bbf66f45ca6c0a1b"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c3cee1ac-1bb3-48b0-8a35-813e511d1d41/dbcba8b2e6d28886d07bec53ab509225/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-osx-x64.tar.gz",
               "hash": "da35a51180e75a238b7a4b5d1a5b7e3e33f1a1c179b40957deee98c8e01a9bfade62e2c909d2e5b377f43cf2dc78687b34b349b27b2f8f841165c3c05b3fe443"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/29c1ff6f-0156-43d4-b86c-9e7d3d99676d/d6097b452228be86bc95b995688685c2/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.exe",
               "hash": "b855a6a68dd1e4fe93348d20a7940685ab46540a4037512d99e30269a9a941c8a740f71984876b876441597e2830aff4bc2940666043a3ba565016c491f982ee"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7b9dad11-8a62-4521-9984-3a099d9ce61d/a0a1fe27a63ac76480db3281577edcef/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-arm64.zip",
               "hash": "611c04fe90746c82c4902eb75a98e6219222cd82733388b79cc81fe3c9401ed261474e92993439e06efa6eec6230604bbb05a77a0894f030ea75dc22808d1edb"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1515bcb1-1862-43c5-a86c-180b1ec9049d/c4049cf3b8eb87e40dff823573cf563d/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.exe",
               "hash": "32eee5f12a564098fe19253a50260bffaad34fd92d7a2d10612993eeef0a78fc7aee051dff9c72738091f3c38029d4579886a626541f656e090497080ffce22d"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5bb0c9db-5ddb-44e7-90d1-bf34c1ac688f/8ba52405d812250c4b31e81e94c62334/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
               "hash": "5abe780d515bf82692752d3defe6317bdd17171ddbd5aa9b769ba8f63edd713868c26b8735ba427c9f193ac0daac28c2cd87c4321565c3b2c4545b906f5c3587"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bb1317f1-6c8d-4287-b10e-618e67cff2ff/d7537c37617a5d5d56b87079a24a2a66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.exe",
               "hash": "2c3ad59a9e57b9a56aaf825f4eb23f90caffc1508c9bb5ef511865455e051fb65e2834f3ceb829931d6ee74ab81c52885c2c862d02c23a015593d6fc182030f7"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ce78ba3f-c369-408e-8026-a2318844db65/d1636d07dd075acfdaad4d80d69b6262/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.4.24267.66/dotnet-sdk-9.0.100-preview.4.24267.66-win-x86.zip",
               "hash": "ea8617ced22a2b4e0e048f3560e350cd720d5529776bd5cd5e165b139bf287624178870cdaad68e613a18122f3d2ca5e917c46ff8390a8a92631787e21a39243"
             }
           ]
@@ -4705,127 +4705,127 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/992c2b62-6318-4dc7-b7c3-994fd9f29e35/37e65e34cbe93b5389f8b779bded70f2/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
             "hash": "e156c79c3e064e0d4ba2f2cb2fe53d2d427b2c5d62641e350278b31abe53e67ecd955de296b5e35f2e5fe491082fba8e09be67e1392874756be97487ab5a7994"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bc6ae1a6-a98c-446f-8aa9-fe4bdd18412d/569b1a10883293eaa5aae3275d8a4e2f/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
             "hash": "6f457cfc870a8ea3a8f9e5cbc6b4554dd98c7380ced6f4c6f05bf918545e22937b1c446cc696125e08f964f78dacb2215c0d9e42fdd86ea1c3a4a57af199dac1"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/833d8170-3991-4523-8601-e7ff36cf254f/ff7f1cf297f4af74acadda36affcfac9/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
             "hash": "2cc4b0babc021c5cfa87ca25c1259485626b71834614f40468c6e1dac6468bba7585f2f0b373a42741be109653911fbebbac9036ace4e1f79e5b6eb8ca75b1d0"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/02b13c1e-b263-4ab2-add3-963137022042/9d5fe5a6b63936a143047fc6a466eb17/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
             "hash": "02a4e69d6a627e80b76fa6d24d5f631420a92c83763bb65392a3b34d6bb24d24e24e49cedbaaa1b835c9815da8c01d64bb17b87aea8dd9771d80c6d99d5f1ecf"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f6caec80-aaf5-494d-bf71-10761428ff24/e062b54765e468699ab0588c092cce18/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
             "hash": "ac7c5caefd2285bf9e3d6d5afb6fd99e6fc23e534635cd3300acd043c042d21e0936670515a4e5d30bb58ef9503f9765787e4ff7bda675975dec5c9d46097677"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6f889c70-8c50-44d0-9877-0d0376c031ab/d73ca2ec30f5fc3e537b16f37c029daa/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
             "hash": "ee65f640c894ac6e67589c40682b2fc215f2ab7037695589b9f92801073a0f8a8d071c3caf4608679f61e10830f02d21e916107f77b68c58e59b1f191ec8039a"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/57b0954f-d550-42af-b1b5-8c9ef5da0d58/a4c7f9677ac41fa3421050bf9822c56a/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-arm64.tar.gz",
             "hash": "2440f43ec72f5298679126527af6c1c410cc542a98ab4e0c5aca0ffda40d29b7dc52e1f1aaa869b2d5b86b7bcd80579bada8fe20d0ba9e48a64ea147ed3b4c0c"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7ccc886e-61cc-475e-9ab4-b1723078e7e4/093617db718ce4669b6a93f2d8934b1f/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-osx-x64.tar.gz",
             "hash": "614fc10a69d3c78a1b1478b1d49d1e5d7dcadb02b6edd1ece510b81075e19f6267a53c7252ee4cdba1c5df1353f17ad64a54a08459d3a3a8a4baf707e4bef7f2"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/92b6f660-9ac3-4f16-85ff-28e623f6d1d8/cc4895fbe24aeca773a1c1ad991c2d0a/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.exe",
             "hash": "6e1aa5c31257030364e9140a6626e818f18f71f6cb3f14b7ae37f72200984069ad60020029bf3824ee46d1fbbe55d97b90f6e68cbac3d4060aed972c007ff536"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/accb26be-44e1-4940-8add-d51e6c3dfdb8/6514f378b6921d8cf43deaa94d803197/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-arm64.zip",
             "hash": "412daab92de5b9eb2a27c2b2146ec4e56f422b512b4b61cba0d96e34059f59116715e4eeaae30c59c8c6c57562262ccda353a589f47e969a5d61c0d0b6119e3e"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c4862573-61c6-491e-82c5-851c6e68e50b/6685d83ef28ca605014610d2302db83d/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.exe",
             "hash": "8864e666cf561f6ad1127d1add213293e4448fa83cdd589b2ae019346f29294d1ea12cd22f4939d0989435ab3f09c7493bd2466bf99179c2693bde9be4569c3a"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a97e2ca1-2463-480b-a8d9-1ef74cbeb1b8/a817f2e44eefb42f8859ce34d4ab4d05/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x64.zip",
             "hash": "f57273459e202bf2ac7a1a2cefe7075a6400d6c8baf4da2426d76b488a5f935eb2b8ae6178c69d4b3fa252aed8b02453c2200d8f996555ac849fcb26839d8984"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c041c63a-938d-4c08-95a5-d019b64af27e/1ed28254f2a8d92e934968b77b90701a/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.exe",
             "hash": "78f5e5f81f1e5af7f89dc608c0937498f23544627e97d443b6614e982ff707ae9276f64b2aa6213f09a5efa6e103a480df3477272df8b5ff0683a5d91ed603cd"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/51f63e30-95a8-4c1e-81b7-4da3b8d66c22/d56ec056ada0081cad7ffa34bc7461e7/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-9.0.0-preview.4.24267.6-win-x86.zip",
             "hash": "abd9d4c26dc916b8009d628bcb7d05d7688fd5ee2183adfca5323241b3b1a6bb299f383179659755c30197d14a33e1fb443e4acc26e0cdc79ace6e14f79dd8c7"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4345184c-9cb3-447b-8515-f577a4f80082/15e68b416144285b265fc84e11e6b54d/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm.tar.gz",
             "hash": "45bd8e7829d00f37867fbd74e3801fdf69104db7c45e8a2e579059ef02e77ba96152a1073c7ce76ec33f2d88ddbaae92ad90dc21c741ec94ffaed8ecfcea3f1b"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3241265e-62d8-4a77-aed5-ec07d829a4f9/c3beb873fd6733a0e17741681220fe1b/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-arm64.tar.gz",
             "hash": "29acf67b87c29ea9e02ba05a48052ea323494d91c6c07cda8c82cca4704b60b12683fc05e8fde803fcbf00a2810d1e9581bd90125eb748a6b556b05b55f2e236"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c4601543-9425-4a65-a7dc-890fc5031fd1/ee9980fb39cd686314d2ce281d57e9c8/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm.tar.gz",
             "hash": "016b9e5efb3dd65fdd4a27b256cee6d10ae8541e26e5446dfec5c603f585555ac49e343dbf04db44efeb6ab5f973a2fb8ec253b6331bce3f6d5ff96c9ac80e60"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e0785796-d1f1-4224-b951-be51959d2422/cb7309f3f96bb1d6c87e003f5bea97a0/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-arm64.tar.gz",
             "hash": "e7b353d80a12e91cab47d74e9d9624db5455a8cbaaf39c26e16d1f19dfda235a7598534c828c1c7d1ec8db85585aa8ee902267e9406e938bcb05eb1c97a5c81f"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5b89c4c9-b798-4eb3-a7cb-4b84f5cfccba/9cc25a4b4e004197ec7d99c53406f266/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-musl-x64.tar.gz",
             "hash": "bd6900bebedbc02cad6793f0ce25361591562118c205035821355522d1b0dd70143949377c02131d65a1bea536dc1ebcf310e4a441187b4159ac54e4be419158"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/75d03b48-e892-4ecc-bac2-94b361ec9f15/8c345c3075ad13ec8c9013e7f1d08d85/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/aspnetcore-runtime-composite-9.0.0-preview.4.24267.6-linux-x64.tar.gz",
             "hash": "4fbd2ff0a650bfc46fca485886aa53b17e78f1e4ea28ac2933429724a409b1739132d07be4da7c163a3713b73ec2448426921bf8ba8b3901d5b05998cc5a3f47"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dc7f36ba-c8ca-4dbb-9fc6-ba10ec01c36f/fd73f2c002241fec538305a8cf26c203/dotnet-hosting-9.0.0-preview.4.24267.6-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.4.24267.6/dotnet-hosting-9.0.0-preview.4.24267.6-win.exe",
             "hash": "19885f297d2f01e20b46b69c48b8a1fd02aaaa9bf44ab7ca8b7a8ae961b0147bfdff8b8a63cf2766fb6bbb8ffe3d5dac80b1efe2a12bc4a91cd798abcb09ae4d",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -4838,37 +4838,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cfbeca90-42aa-4cac-bdb6-96cd4613e5c2/4ff431cf779a7892ffb899c27c76d7e5/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.exe",
             "hash": "432e3d142eedb2a67eeeadb8d5aea906085d06540ed12cef9d3c6fdf55661024bf8b220ed8dbbefba3fbb6d23ed38916260e0ed935d97c39e92b941a74869367"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9db2ef93-4e2e-47a6-9574-f8de141e8469/57ed42a750224dc5e501833f23df7f51/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-arm64.zip",
             "hash": "18ecaf2ac89462b371e1e281c4336b00d8b1cf72ac0f7534cacd9f184423a57c330834293506c2f649df833e15c2ff7948f9e8befb8644512f962b71c0ff0f75"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a3420930-6bca-4552-9c40-adaf4abec571/5a6243eda5d7e9645afe9b6145213ec5/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.exe",
             "hash": "0f46daf2f73ad038dec2b333c5b921148102622c2897a6651d76bba8a782f0bf6e29b20139c446eddf9bcfd31106eaf42832c48db7411587988fd772f486fa9b"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d8f00-2cf0-47d5-b763-a534a8cb77b5/f4043682c3e2f1bab5c2ebf5507ed4cc/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x64.zip",
             "hash": "3f54ad4b62953d2438c1d9d55116ada0f1f98d41698a2f3b9d6baaac2e17a32186825935a4f83dc973f0c229396ecf82c2dbb255381343db3488c722f46d0eee"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/53c1b7b1-1a61-43a7-8344-1c66d8238f03/592ed2c250de13ad82ec1c34d96a6b68/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.exe",
             "hash": "d34b5653e4ccfc370a2667e5c8718a93b154e5f06e85f605b33d95186e067aad788a817ecf02858e7bf06c6f034868d89dc5974cf70f55756bded3a20cc9a549"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/43216cd1-dd9c-4dcf-b05c-9591125f0cd7/91dabb962aaf27fddc388b20dd80dc10/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.4.24267.11/windowsdesktop-runtime-9.0.0-preview.4.24267.11-win-x86.zip",
             "hash": "a5a15087e024beb729b2382af8c47ad38b08de2375eb4d49f9f5ab853725ff80325641f5bae0fa31ff9e62abb2194d648df36603c06c623d24216bd6cfbd93cc"
           }
         ]
@@ -4889,97 +4889,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/34bb1d7f-d98c-4f07-b659-d51fcfe82e40/b755a48d351c45c04645be8616dc2e2c/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm.tar.gz",
             "hash": "ccbda0ce6e8220ec83bf9fd7eba030a96d2e9567bd4bf162e4b0ccc3ce8c08b855c6ec20b15f401e6b4341464d12dae219f3716102a001672fc441a4358e3445"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41f0b5d2-d224-49ef-baba-d4f75e495f17/dbd1b290ff250e51fd5daa4f639c8e8e/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-arm64.tar.gz",
             "hash": "3f8bd80a03a63019d0c2038119a0bccfa5b1b700fc7c22565bff2e0af425fc0ca475c13b03a666aca2f954db9e53d7505db9cf984482d4a6be1d8019986324ab"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/97ddafb5-67fc-4af9-8458-8af7fb3f74b8/896be16550d107cc0e6ba54d614d760e/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm.tar.gz",
             "hash": "c5638c562451f2c2d591e51e014edb15111ab49b8a71016bca3d4095a74d9064184a3f5bdeb236fda59ad98dd730221038628c5ac6105d9a4eae6664a98abf16"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/463ffd08-51fe-4d29-b267-119349e3658b/0212b77c93920c7a6a8e688bd8b106df/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-arm64.tar.gz",
             "hash": "c8777c446cad3a37012e47625031552d517e27d32198ccb746b1544135abcf60bfc3ff7e801cfcfb72d2d8563604345e2da011fa0aa8939bacb13d8b619bea5d"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/124b82e6-f328-4c78-a3b4-f039dbf5bd70/6ac2746137c3ddefdbf5e45400d3e781/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-musl-x64.tar.gz",
             "hash": "adace7cff420fcf0e437bdfc90b6a39b703c53301b95d2fbdaab15fb4a7acc6d8a40ce6107a8c0f30230c6c8145c28e8c0f33c2ab604c6d1946d80dd8d350c48"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/28946a74-4cba-4b0d-a080-3c84b4be668e/651cbebe71762ec64bf342805e48e85f/dotnet-runtime-9.0.0-preview.3.24172.9-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-linux-x64.tar.gz",
             "hash": "244963004ced27054eb1c5473adfa7a0e249cca4def0305e81136e39d00319e5be2c77f687034df7e1f026bf92321332d8904ce93851e215e9c213da105d37db"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9e33acd8-adc5-4359-a4a9-e7c538b6ab1f/dde8a2b81d4d6beb63e201781f65f19b/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.pkg",
             "hash": "15576674976f8927fc0fb277382d536692c4426a6483189ff192a082128b9c43d03eff1a6bd7de859e991bdb8fe75421ab3c45163552ef9e7c45441a483793de"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f2a01607-d9fc-45eb-87d9-190f178f1945/2655017d0a043d97dfe292fc4e986ef0/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-osx-arm64.tar.gz",
             "hash": "20ac79faf78b8e95e73778ab8f8c238aa282d2a6ab844406968f68e946a4a8258e8f01458794a4c77ebf7c0a1e9dcc76169ecc84dabcd1fe983209f968367887"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c78a2485-5638-4936-9c47-f7811c1bc8c2/0bc4ad7a2a12f347931f29df84fd4da0/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.pkg",
             "hash": "dce9a57df606ed6b3e142aab69ac482c160ebd4be776552881ff80843ae777e13f25f160289bc1ddfa19e04446f85552de59e9d700bbc0354aa070bd99eda4e6"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3b5e0ed2-6c44-4e1d-a790-0a9b6a9cdc59/af989e13e8da69501c6ae95b9d12a1a1/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-osx-x64.tar.gz",
             "hash": "873078a50675fa576df27867231b37c7a09511893bb2f7c91f4cc1069e88ac4b6fa7c4eb439b6b39ba2522b7a3e2d2cc9fbec4e700e49402672e6358fdeaaf07"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e4d2de3d-abf3-4884-b6ff-aeaa13aa12f2/930bb09dfba48658bf899d14c09c3c86/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.exe",
             "hash": "77b0ea1bc5b722858e269ee0c61509729a3419b7da3ad6210d85e10e18d07ed2d46ef2311a1eadd077b1997f28d2cf483e3e6d34a6f56c8c4a871cdd27f77706"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d1ce7d03-9718-4b84-8c37-34730b224fc5/d58f7cbbf1fde8914d7fac169305c04d/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-arm64.zip",
             "hash": "7c51a32dc7dec38e9f923ebc43ad9d587d3bb209589124bfbd8102a2a6d155bac6cd1758bb35f6290a3e95a0abee98a83c383900fe6765f57871652d28f5691e"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c5fa8322-30ed-4a4e-8685-91bd51d5dee2/729372cb9f417afc136e4d65099103b1/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.exe",
             "hash": "9cecf9017cec09d32bed0d26e43ae00c2122380a25ef1426dc0ad3fa16f4e43e7ba071910ef56940d32540bd5053faa0a219aaa83be3b62c273f6216c3c7ab84"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6f239997-f134-489b-be36-ecc855324592/ee1ee9d2b19682384cd8d17ac9aaba19/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-x64.zip",
             "hash": "4b46ec7849a78d73ca71cb55f259bec2d320e26029b64b398bf16ea2ef14bdff2096a35fbabe929f21b5b97ae865688c5722b2b761babc09a0d53b8921434d91"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/474968ad-0fd5-4d18-884f-4122d1d01210/278c3572b1194e5d1c11732d82c5d4c1/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.exe",
             "hash": "b73bb3c6ac46fbbfb3e536f1579abaa0cf86e97001e049226dd60e3dc1be2ead8f9d825ac8775a8fa7a57786316e0c13a63931b2c2b66363da9e033e4c3b9047"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/68781d98-413c-4722-ae18-25ff088d5f34/dca7d9075327516c817df2f5ae2f428b/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.3.24172.9/dotnet-runtime-9.0.0-preview.3.24172.9-win-x86.zip",
             "hash": "5c70d0844fbd6b0178a8820f4a0f9c9204e35216ae3de5a121e29fbfbd53f23dd82978f6bdd551907578869984242c61a7dbea57bca3b6bea59c7af7ee7b7546"
           }
         ]
@@ -4999,97 +4999,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c5268ba0-1e77-4d0c-aeea-44e91f1ee161/e9ce85b34c7477cba722f397fe1271e2/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
             "hash": "76e53d9b288ed800b9087d2a3bde25481642d84f133955f57ec69a35f2ef65237c937fc1f0f60b3c2190cd6e34f3bccc71b85fb2c37a08976e82e2d761ec40d0"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/793717c7-d418-4972-b9f1-1df9bc7f9a59/f37654f223b95c31b5baa92599b72118/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
             "hash": "83c6fc2cdb8aba6d72661f2fc360147482dda7c22b69b3f0df9912efe7e0499f3c7b1d1a8577b3667ec3faf6cca99bfa887c663904847356c93e6f1e6f9917b9"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e7a43093-48b9-4ced-bf6a-3923de4b08e9/08786ae87bbb7eaa7ff4c8216194fa07/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
             "hash": "772b2af66459b4ad7cd8005a02799f7446fe7fdac97f488d7575b1d1ed2079af539420b01609da6caf0addc86bbca72e53949ba4979c31853a9d724f80756492"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dd82f0d6-9181-4f73-a0aa-c8fa9df4d5fd/dcf5c9923fd4daff0a836a2b2a84bd96/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
             "hash": "8f19023e96760e397261b1d0c765a789c01a7377b782ab8254b5f85c01048c305f8e627d796c8b6040a23ed12eefdd544200167bcb32871efe0c627359f3e7d4"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/944ea319-8239-427a-a7aa-948cfa852c8a/ac946e77eac62fc4130f79d182952c89/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
             "hash": "e72027ffbeb7d5c9b8796620226ab410510ff57ad93f5e24f7a2ee281fd733daabff74a15f3dcbe04413fbd4bff0713fd298cac732eb0f71ee6c6dadf334e972"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/34c1f43d-2d16-4a44-870d-1e333148e4fd/10ee0406a349070f4e120fdef056216f/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
             "hash": "7f487d92ee3b28061ef28e013295ebdf6703721b5e2e55ae2d7b18f1ff4fa4e3e01b6a8b508723ffb22dbc8437f0693d7c07f4dd8ef113d5da8a51b3645b3422"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/788839e8-1e23-4ed2-b176-534d3c4d5899/d80c58a63108090e803c06d0b05a1b73/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
             "hash": "43d167bea8ab900ff67674bd378ba09228f105be8d8b0c4866e867611072169a7ee1aca67cd04f06294d01fba2ae2c0427553e5552de10c41fc1096df4db9e54"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0872ec6f-0e73-4caf-8381-c8004cf508a9/009b50364d70ddb4f892392593659d86/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
             "hash": "69452e7266bbccebc7acb9cec7b328f8fa1bca4b0720a27450b67c19d41ac9e8b5ca23f3da762c37769dadd0c65fcb1068b32c98b507d19cb9c5619b301f6860"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9794b13e-14f8-4fd8-baa9-265adc2c7f31/605ec6e450a81e1acfeedc06444450f9/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
             "hash": "7ae365e863a76a52b2c646bf34ca444b6ec08118edb4f52391d013c22f2fe9df1ceab75156b3c48d16d564baa02c71093b9b9e0edac01a6e2a0b311182bbe561"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f11c0612-bf78-41ae-836b-2b3c8765fdfb/feac36e69a3ca718c3c0d12dec3661b5/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
             "hash": "1c0d5a8751f36b4e2f0d2971600a6f870155dd12e0a0669951d99b1d50b8021c51a5c9df447ecd8bb53c3ceaa6f4467edc0eb357bcc8d26e272b5ea121f170f7"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b790cf13-8249-4fba-95ea-4e730138457a/c59c22cc546b7d1bac832c1000e9e9e7/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
             "hash": "ad7114b1a961db4797a733cd2823aa6a5735103290b282f1b0a3bf0917d360d8fac931d629d94ecc3f8ffac50cb6bcf4c0afdcb48b1dbc621fc59348abccf524"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8d18eaf5-8c36-4485-83e8-6c9569e25bf6/167d5db5b84f7080d1ba9098d464efea/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
             "hash": "1fb88185859896b2fc6e0e6f867b6a27cdea13aa414c8c6b606ce72b48148fd938209fb49c073316689a5bcc739443a647fa60b98b6ffedb0fd508886096b7e9"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/509db05f-a1fa-4420-a8e8-20249073f3fa/a699c2bd1b7bd10346a175117877d455/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
             "hash": "d8f49442160a7a92b617a59eaf8fdc4ca776739429f79a7dfd5da4486629a8b6df1999cf2adb3d06ae715a31a8fc3aa355329a87d2780724874afa5028688898"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b50c34cf-e50a-4e64-9bdc-cbd984d44acb/9cba57d4130ef9451e2a9ec218d2c83d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
             "hash": "55114bd014d2613aa35e91148bad263cfe0fd8499995c9641bdfff1b7c2f10c70add06c1d9c016f60fe7c4d144725154187a7c0ad4b1296f1ec32e876ae3ceed"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cb5b922d-65ac-4829-b035-2a2df6cd88f7/7623d8b2c846c77dc1dc9c2d19e1214d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
             "hash": "24bc29abc7c11988648584adbd17d9d3f8694b7b2ed622f860709a680f7eee97b12de34470c78a9718383cc33ee8934d19e3193475a6a7f304b65cdb02468f33"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5ff67d85-1737-499a-b12d-274b4d7ae73e/5b3dba505826bcff95607e5b0185770f/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
             "hash": "e240c2ebfa0089b95077f297748988b9c1cfd662fc39616b225c479f810dbe7ffafc91c5c3faf7cdf633be2660e1aee3d201209122cc30a9a66be21273197741"
           }
         ]
@@ -5110,97 +5110,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c5268ba0-1e77-4d0c-aeea-44e91f1ee161/e9ce85b34c7477cba722f397fe1271e2/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm.tar.gz",
               "hash": "76e53d9b288ed800b9087d2a3bde25481642d84f133955f57ec69a35f2ef65237c937fc1f0f60b3c2190cd6e34f3bccc71b85fb2c37a08976e82e2d761ec40d0"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/793717c7-d418-4972-b9f1-1df9bc7f9a59/f37654f223b95c31b5baa92599b72118/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-arm64.tar.gz",
               "hash": "83c6fc2cdb8aba6d72661f2fc360147482dda7c22b69b3f0df9912efe7e0499f3c7b1d1a8577b3667ec3faf6cca99bfa887c663904847356c93e6f1e6f9917b9"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e7a43093-48b9-4ced-bf6a-3923de4b08e9/08786ae87bbb7eaa7ff4c8216194fa07/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm.tar.gz",
               "hash": "772b2af66459b4ad7cd8005a02799f7446fe7fdac97f488d7575b1d1ed2079af539420b01609da6caf0addc86bbca72e53949ba4979c31853a9d724f80756492"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/dd82f0d6-9181-4f73-a0aa-c8fa9df4d5fd/dcf5c9923fd4daff0a836a2b2a84bd96/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-arm64.tar.gz",
               "hash": "8f19023e96760e397261b1d0c765a789c01a7377b782ab8254b5f85c01048c305f8e627d796c8b6040a23ed12eefdd544200167bcb32871efe0c627359f3e7d4"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/944ea319-8239-427a-a7aa-948cfa852c8a/ac946e77eac62fc4130f79d182952c89/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-musl-x64.tar.gz",
               "hash": "e72027ffbeb7d5c9b8796620226ab410510ff57ad93f5e24f7a2ee281fd733daabff74a15f3dcbe04413fbd4bff0713fd298cac732eb0f71ee6c6dadf334e972"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/34c1f43d-2d16-4a44-870d-1e333148e4fd/10ee0406a349070f4e120fdef056216f/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-linux-x64.tar.gz",
               "hash": "7f487d92ee3b28061ef28e013295ebdf6703721b5e2e55ae2d7b18f1ff4fa4e3e01b6a8b508723ffb22dbc8437f0693d7c07f4dd8ef113d5da8a51b3645b3422"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/788839e8-1e23-4ed2-b176-534d3c4d5899/d80c58a63108090e803c06d0b05a1b73/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.pkg",
               "hash": "43d167bea8ab900ff67674bd378ba09228f105be8d8b0c4866e867611072169a7ee1aca67cd04f06294d01fba2ae2c0427553e5552de10c41fc1096df4db9e54"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0872ec6f-0e73-4caf-8381-c8004cf508a9/009b50364d70ddb4f892392593659d86/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-arm64.tar.gz",
               "hash": "69452e7266bbccebc7acb9cec7b328f8fa1bca4b0720a27450b67c19d41ac9e8b5ca23f3da762c37769dadd0c65fcb1068b32c98b507d19cb9c5619b301f6860"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9794b13e-14f8-4fd8-baa9-265adc2c7f31/605ec6e450a81e1acfeedc06444450f9/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.pkg",
               "hash": "7ae365e863a76a52b2c646bf34ca444b6ec08118edb4f52391d013c22f2fe9df1ceab75156b3c48d16d564baa02c71093b9b9e0edac01a6e2a0b311182bbe561"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f11c0612-bf78-41ae-836b-2b3c8765fdfb/feac36e69a3ca718c3c0d12dec3661b5/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-osx-x64.tar.gz",
               "hash": "1c0d5a8751f36b4e2f0d2971600a6f870155dd12e0a0669951d99b1d50b8021c51a5c9df447ecd8bb53c3ceaa6f4467edc0eb357bcc8d26e272b5ea121f170f7"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b790cf13-8249-4fba-95ea-4e730138457a/c59c22cc546b7d1bac832c1000e9e9e7/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.exe",
               "hash": "ad7114b1a961db4797a733cd2823aa6a5735103290b282f1b0a3bf0917d360d8fac931d629d94ecc3f8ffac50cb6bcf4c0afdcb48b1dbc621fc59348abccf524"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8d18eaf5-8c36-4485-83e8-6c9569e25bf6/167d5db5b84f7080d1ba9098d464efea/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-arm64.zip",
               "hash": "1fb88185859896b2fc6e0e6f867b6a27cdea13aa414c8c6b606ce72b48148fd938209fb49c073316689a5bcc739443a647fa60b98b6ffedb0fd508886096b7e9"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/509db05f-a1fa-4420-a8e8-20249073f3fa/a699c2bd1b7bd10346a175117877d455/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.exe",
               "hash": "d8f49442160a7a92b617a59eaf8fdc4ca776739429f79a7dfd5da4486629a8b6df1999cf2adb3d06ae715a31a8fc3aa355329a87d2780724874afa5028688898"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b50c34cf-e50a-4e64-9bdc-cbd984d44acb/9cba57d4130ef9451e2a9ec218d2c83d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
               "hash": "55114bd014d2613aa35e91148bad263cfe0fd8499995c9641bdfff1b7c2f10c70add06c1d9c016f60fe7c4d144725154187a7c0ad4b1296f1ec32e876ae3ceed"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/cb5b922d-65ac-4829-b035-2a2df6cd88f7/7623d8b2c846c77dc1dc9c2d19e1214d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.exe",
               "hash": "24bc29abc7c11988648584adbd17d9d3f8694b7b2ed622f860709a680f7eee97b12de34470c78a9718383cc33ee8934d19e3193475a6a7f304b65cdb02468f33"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5ff67d85-1737-499a-b12d-274b4d7ae73e/5b3dba505826bcff95607e5b0185770f/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.3.24204.13/dotnet-sdk-9.0.100-preview.3.24204.13-win-x86.zip",
               "hash": "e240c2ebfa0089b95077f297748988b9c1cfd662fc39616b225c479f810dbe7ffafc91c5c3faf7cdf633be2660e1aee3d201209122cc30a9a66be21273197741"
             }
           ]
@@ -5217,121 +5217,121 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/889f7855-0c73-459e-a02f-eafa99a8e500/586101e88960a4424001143dc71b5d90/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
             "hash": "ad4540890752e278406a7a731705251e9e803100ea8784f3ea9ab499ae24bdf3fa09456b324834953775f5edea019a3e80c608d9ebfc7de0cb2ff430a0234e3c"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b7eb8865-5ff1-493d-b2f2-add90226b29d/901cff3eca56382d9bd7ca0f7e0087e7/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
             "hash": "e484d1530bb8462f5956d50b0055407a5b697f176f43a8e97b26d80c0507f9373b950f962a5144f7876e4c699b2fd29a63eeda71b090fb80c4885750d73cc42a"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d568896f-9f13-4dfa-a486-20e54d717c16/8daa58ccb02ea0003b54c10f6c0a3785/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
             "hash": "70700a6ac11a4a4e192e8d536d7dbe746aa2b209fbe5522a9bb6b09988b1d40019d03327a1e79917f04a8008581b685f7b6fc925750ffc6e0de4877955ebbad8"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ca2b4853-a3a8-4b0b-be76-f3f9dfb7e34d/7574a7679a38e6dadf61a0c5e4bf5ce3/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
             "hash": "6011b173f4f31ad942f4911623b1b0175e03c160ea55b2d50c454bc0a921ab3f35a5ad2f822590ccab5ea3470ba0f5ac9a617386e4538f82b235ff68e46ab6a9"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/382eb79b-f802-4b3f-b6c0-7efcefff5aab/ed7c9079ae9a02d84c126c4ebf5097f4/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
             "hash": "8e6c42872a062f50e25432e0945a18ff4508d708983f004bfcb619c76d5e13b5dd0653cffc5931ec7834d1d7db174566b4d9d00016c838f98b351d821e012334"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/37747dcd-c967-4c91-8928-959b32b706bc/2cb1cf0735fcea5d7eadda52bd5a6cc2/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
             "hash": "319f2700c3a954a1e6e0dd01b45c18dfe7d3728fe175b82cbdbdd928c2f64c5fc6f53b7c44f753cf59fb7c32649fab95f0245e5077ae3f607b8f59b5e9cd417d"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5b68ce5e-aea0-47de-bdfd-5a0eb0e9b1a8/67b0d4863b14455f45b2ff1a916bcd6c/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-arm64.tar.gz",
             "hash": "c216b72b3ed028cc49ac5e6c50612b77eaadb7834e21a4ef89bce346c7eb1e55bcaced48131ba68ed00d381ea0321501e9b9a0cddff088dd6ff96d5b04be6e6c"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0b4dddc0-6afc-47c6-a878-4ef939e4f46e/70f229cbcc2f968e7dd3cf53bc7132be/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-osx-x64.tar.gz",
             "hash": "6f2f4b7ad18311259864f1fe2b2ab4b78e60e035213951eed77f9fcd41488bd9f1a6360bad348af130e3984cffb7e7d7b16406c5ae2bdbd4e75a6eb28924cb68"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/daccd7a8-ee29-4398-9c0f-53ee52a8348e/dff56958bb98da605699647134b3fa60/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-arm64.zip",
             "hash": "023e2058f0f036c07ae383505305b4e46ea1be75bc5204be9d0ac864f88fa6d126e7ffeb158635c717e98a1b1f7e42b69dd44a5fe8ad4f17a332141ca91f1c8f"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0dd6eca2-4194-4784-b60e-5def59f82a53/7c5bbe6d6c403261ed81c9a0fbe8354f/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.exe",
             "hash": "3e2949483b1453bf0edea37eda3395f8c582c56fab65a4a315ed84e53b6ab9acda27764332911abbb16cf49c3b7844024a7235cba58f3c12f44643dccf45f768"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3982a9e-ef26-4506-a03e-b7f492df4e5f/677debf2487991af87442a9b07ae2466/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x64.zip",
             "hash": "6e3d9ff40c04eb382ce4d3603892733e43c58c47472c571efdc12e8be7f52a338fa46659137c9320fecaae4288ce81ca6f41a5bec32e73511b9014ebca7a4c99"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5c3f1910-1f0b-49ef-917f-e438af26f069/658cc32133053424f78e9cf4c2ac8475/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.exe",
             "hash": "b1e8df9ed48bdc53c03a309ffd58c5aa91f999067258f7e905573011a57f93b3b406a829dfe2f760d6fe68fb5cc8b347812b9a01b3e9722de08a2cda0bda94fc"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fb3609f3-44c7-4591-9095-db37485716c3/49c7db163acfaac6cf65884ab93a5ddd/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-9.0.0-preview.3.24172.13-win-x86.zip",
             "hash": "501f5353a720e0e4a976c4cae5875da7ccb7a5cc9c93343f732bc182ac0a457f6cea8ba2edc33a7665849d558c213e3ffbb16b85110c61d47b776487da4b35b0"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/97290bb1-9a86-47e0-ad8a-8027c080999e/ac2621ad5bced59e859c6a4b1468a87f/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm.tar.gz",
             "hash": "a6958b10bb735875670bb280b6187f963b65fa2a02f49848096b2a6c06526a39accefbf362394d6cb82d5cce65eb1819762365c7114cd7b7748908f814fdebca"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f787be98-8e32-4356-94cf-afdbfc89807c/908078a68902b7db3419cdfe66aa28cc/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-arm64.tar.gz",
             "hash": "88edee0dbe7c16409674db0442b5098a92d9d22f2d6e4d8bf27e44a6415f38023bab96174d45a33a9bfdcb88bf896ba6acfb36b6f7fec7323dbb18e472bebdc1"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e5c76b43-b251-4796-9ca7-a060e73372a4/da95c6e26f9c56ea5dd9a0ffeb45d986/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm.tar.gz",
             "hash": "370274b311ae9671f2aeb38b313b05cdbc6b04eeb96146ad82ab7b3b9e65fa2d2fbc03f4343026c4fb81106fa97fbfaaaf933127c8ae9bfc9c91fe6aa3c6786a"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/55bdb213-5027-4ef3-b23f-4833298c2312/896cd4a98a5b29100519c5f8bac55ad9/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-arm64.tar.gz",
             "hash": "cf1432c021e7e639d1eefc18f7feeb0c2a11ebec19dddf3e101903d7a3171b1b9415270e8b4086a19f86ffe2a1cb6ec4e73c391ac3040caaf9dd32b2f8d06136"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d86383e0-8ba1-4bbc-b79a-b51906336d40/ae0a563e8efd2a8f73eaf2985909565b/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-musl-x64.tar.gz",
             "hash": "f6861aa3ef052d5a4140ce771cee2cd62c07256043581ff06e601d8d4f95a344bf90c86fbf22ec55d9a130e4b205b18e7711af3dba7a03e1741f2abd02f74f58"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/35d8c84e-43ba-4a6d-8151-ca2b2cefdbeb/46e265a8e72808dc3f82990d13beb955/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/aspnetcore-runtime-composite-9.0.0-preview.3.24172.13-linux-x64.tar.gz",
             "hash": "7a4b00241a2a91cf7dd3ca391b4f64edefc4179c351eeb0aa260c27680510be71b4fbc1f07ac7682208c73e879a40fdf3943b5cdf58456d7a4763665e46e8258"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f28df469-8a85-4d55-9c4c-957b8c79a7d0/902f993af8ee3aaaf646bc55c4cf668f/dotnet-hosting-9.0.0-preview.3.24172.13-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.3.24172.13/dotnet-hosting-9.0.0-preview.3.24172.13-win.exe",
             "hash": "bf6f9cbe3dea1e45f7fe831d9a8ccbb46f744c479f22449908e328a388d8517f5f38caac5cd8345166279b79f653a040399a85f18f75da63d983199ddd1ca340",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -5344,37 +5344,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/505f54ed-7158-4708-8111-b3cac859e452/28d77d115e8c3179b0752d7a1fe89dcc/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.exe",
             "hash": "4b15257cd6b655483677a1b842b011ca6cc3937ae6ee3ee7873fdc99197911618d7049480ebf43642ca4eb65a43edc322f6ec62f0c20759406b0f95376d586b5"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b4dbf836-975c-4413-9319-b3e40f633fd1/668ed496071d38cf29863e60a8f5a263/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-arm64.zip",
             "hash": "0552d7553ec1a44d215d41bace840366e93530ff352a51988c297bd13bac4dfb09759473878de199e92aa8dda6323cf93b74dec1570f72b77cdec87e2b3448f6"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/678121c1-dd28-4eb9-9389-139d270d0f8c/4bc7282a6ebd29714ff7767871308a71/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.exe",
             "hash": "a0dcd0adbf301165d90085be2ef05cfdcc100224c6097a98ad056df70351f974bdf8dbc129e8927f5f473b6ccd0932288be0467d629f932c7db43a45e2b14af0"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/27d8d431-11d7-47fb-9510-2e2419f80561/e7d7a221ec27b3274b981782893fd2dc/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x64.zip",
             "hash": "58024d2eb7284a46d8393000e8d93083699fef472d9a9eedcecd17a98ad45b81636ac67fa6cda2e62c34e8a27038ff75d07de0fe5f8bc7d6e58da879777615c7"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2dbf9b41-0a0c-4ca5-8b64-e3d7f9f74048/7d5eb210b81b7357cbdf8bc7b5d54754/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.exe",
             "hash": "2e2faa1c23a40a2459670a1af10b802e6e295dc3c3ac6e5f593fcb5de756912707009bb3e8a98f2f3e07b089b984083158417a5d3d383becbc0a0aaa33ffb3b5"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ad07edbf-1cff-4e61-8273-847688e323e3/b7a65770015e2c1b7a8a4927e537f8e1/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.3.24175.3/windowsdesktop-runtime-9.0.0-preview.3.24175.3-win-x86.zip",
             "hash": "4032a8bac5d08289dcc4b124ef1e5922ed3133f5ba9ec5bdfb86203fc93787f2fe68b1231ad1ba238341ba5bdc47e0eb6309c6bab3d0d56be9bca8d135e462e6"
           }
         ]
@@ -5395,97 +5395,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b8a2b8f8-4499-450c-81e6-a54654e3e8c4/4c148cdfdce492949538fdcf478b72a5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm.tar.gz",
             "hash": "845b0a1eb3ba18637cecbe4105e6f7a26cf5e0c482177feb1570e1ec85eecb717d59ae5e189788bc4a4a4db23081c21369b8c462991fc4a426b52ddcca34b4bc"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ab7bbaf3-c61e-481d-8dbf-b0dc2bcc80f6/0467f280265fe3b33ddcd345b04cdfa1/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-arm64.tar.gz",
             "hash": "5ae4c5f4acf1465c8aba29a90aa3ee99ab47ffece9f932e9fb4de8937d05feace4c5d3b53d4b8bf226eb99de16a0aad0e71f091827651f0722261513c8a8a2e7"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/95ae0189-d474-4d1e-b47b-32999c6c9b96/aef82d9a69aa8ba7563eee2b64324dde/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm.tar.gz",
             "hash": "31ce6e4af959df846383b8ff5d7912b6f16bb8244dca675b1109153ff13298ac033b4675319eb30bbaea6dda8172cf87d0f4f5e1f3680086374fff97c41110d7"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ec450edb-1042-432e-9a15-211c3aa63f73/99dea9857c948437ebc0d18c0466f596/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-arm64.tar.gz",
             "hash": "3384c37ae4dd0b0f9eda8a4b7bbdc24ab8fd82a9fba9977408b93ef2a49c4aeca7808faf6c28fa970cd07959c6883045cd0408d3c96f52d1bfe9282dd6cf06eb"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5ee7ee86-0913-4a6e-886c-287b5c315645/49775cbe375d6544da49676b68595ad4/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-musl-x64.tar.gz",
             "hash": "192faff21e221e1211acc087a759925205ced69d47641df46495cdb508b2e9a6276b24da54c6046c6cdf5e82ca5fc3eef1febc05cdfe3459018b7c63bd764e2a"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3d7900df-fefb-4aba-8dbc-e3d755111a85/c849ddf0290aeae485414ba46ad961c3/dotnet-runtime-9.0.0-preview.2.24128.5-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-linux-x64.tar.gz",
             "hash": "6433959a75103f2f1108bbc16cfe348f9ba04fec1c8f9b6895019241bfcb7b21fab675cc13971f2c1a66b46b044a95f91e1e2b46e6e8bdd893d277906f82545a"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/943e433f-88c2-4e0b-a56d-44fba4946e1e/809ebff77cf2e17f2d9146df174fddeb/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.pkg",
             "hash": "08e482abe56ca8282f53a32ef30f078397e16118fa1fcc83eda0a08b67e052668a111cad6b9f7245db8c27051a5d26ed70b3428964f593d1cb54b754022204b8"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6401083b-8213-431e-94b3-bb1bba37d792/551aca92ab4da13513ead1e7865d57e2/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-osx-arm64.tar.gz",
             "hash": "cc7b8626cdec48427ef79f14c0919a09a3500bdc1c2933c6b5cf80886cc590ab20ccbd07bdb3a6081e47b80f372db3b4887b5276a12252887b7360a7f23e9901"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/018b25f2-3017-4750-b7d4-aa5feac985d0/46eec7638b52e3179eafe00d17e8c448/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.pkg",
             "hash": "975279950f5644c9c7889ba5b1c6c4fb836a3561b68d1a6024ceb028860350c480a53e451f7317e0cbc3ea88813319c5108a2a99a04bb61731417d81b486aa37"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8ccc8b00-80b0-48c4-9948-9adfa67f42e3/b93918f628eee154b3400fe05774d1be/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-osx-x64.tar.gz",
             "hash": "9f83d1d7dbfb8c8df1c7530fed3ddbb1571e60100954051bf07b8ee758edc600d1d988819c91711cd8b4baa05dd97f9900d1edf2ae5035ac74930a920951f380"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e34ab999-b734-4d28-9811-c850e7efa475/e8ee49da3fe00f64d7974e2a9229bdf9/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.exe",
             "hash": "e9f0e707f54b1dde058a7c47a29f3b02d2119814b3a7c752e6ef295a00ca3130e8c3d6b7a58b753c2148818d0ddf0baa335d98d0500602695a35ae16f76068a1"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1b52f101-5fc6-4de8-b929-79c152dd976d/b332a49ecbffbfecf6c175d9d0c28d2d/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-arm64.zip",
             "hash": "3f284a3ae3e14566788edf0d093f4da83e7c0024931e32b04620b73c2739bded2061e3268caf36af6490b31dc257d26f1fceac5c53b88921217f3588cb870c43"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c00df4a5-6d92-4704-ac31-ae10be42083a/41aa5cd5ebe827a4138ab662c31da899/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.exe",
             "hash": "dcb1fbdcc439c81dab9d17e60ec226bb0307e3a68c5e28683408b9b8900f6e81e9c457e6a5ff65d177e538e02514841a9d979cf017f1ff24c98513916a089c29"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/148ff15b-93e9-43a5-b9a0-19be5f5918c0/c2793ee38f227acac267234877e0bcac/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-x64.zip",
             "hash": "701283ab4dde1f23b621ae712b66e117b4d87f9dfe4aacfee0d1a0622e7b9135b54a940f132e3a59add88bae69ffad790b1acacfa03cc30f55d16572c34fd932"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cbb27466-67aa-4847-aea5-6c81d1d16dc7/a302106d0792a83c1fdfec62466fdffa/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.exe",
             "hash": "4b64d2d82c53e6f7e541c589eacbe273e4d71d22b538b4caa57a52de302613e32a1ae1d6f3312a4529ecd8ecf378411b0262e1902ae929f58ac09942894f8ec4"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7101e9b8-6446-42a8-8ef6-2a9806db83cc/338af40210ac0a98c56ddcc904f09862/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.2.24128.5/dotnet-runtime-9.0.0-preview.2.24128.5-win-x86.zip",
             "hash": "b472c78b3eb5d3762bf2cf2690efe0379a79958e34986a939f5f07b0c78950e9cbc423d072b99b31db8bf063b739434a9dc6cdae874ce64601e351474c9bd85a"
           }
         ]
@@ -5505,97 +5505,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c2602262-2aba-4921-81f0-640ec8200c5e/7eac075f28a6817086891867c5058ae2/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
             "hash": "51dde68d8cbe20e8e77fef7b940ae55158e8dbc31d219696228e82b2e4223b55a43dd2797c70101d3fcf2ca56bfd7370ff08daba5f0e457f54dbd8e171503f31"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b64ba1b3-ad10-40a2-b588-73db9ed9d99d/f772743c20f55a5a8aea3da2e1480676/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
             "hash": "1d591e504352f765a35092394719451c024a628c69efb6a10d0a5d57947c466a004243e799b46147fdf6316a23b4335b1e8fb1fc5513def1dec9f96c6c845dc7"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/daa714fa-cd09-40ef-94ef-7f7785e312d3/a0a4d29f8508ce756185f682ff1acb47/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
             "hash": "a0547586a2e1c04b1ac030637901c113abb7bcf3bfb4bb6e017d6c11ee6f5fc114dea4da57cf4f702765a0a0e5c19391623c73e9a3500d5f6713a000a9c14058"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/48c6b988-5bb3-431d-b8d8-f03a1607ae06/6d0fb991e397020332cd09deb21fee15/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
             "hash": "a56d724d388576e8e6db78c67004a7296ae33a7c2ab00d8af132d3df12398cce3f81b08a50f9094942cbab6ffa66efdd805359a5ee9189dfacbafd7478d34285"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e9eeb6eb-889b-46f6-a5b5-63d985747b66/a7aab27d12efd89d1d387727a32bc2f3/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
             "hash": "51fd7da5986f7776a602d8aa3dee1952e86ba0676c1fdb392f7d13c642bc608489a897347707267fa030355042f6873024c92583a6bb8080397427bee35f087a"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/911f82cf-0f87-46c2-8d70-44fab9a0f3c9/137ec23686722b8119bd62def8d7b117/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
             "hash": "c44df5e11791e4b22720834ed7f28102e33ab475670fa8e132d73d5dd03d8f4ed3f4a548deac67a79e06db6f776c9f632eda4503b6fdc9eef7ffb001cc9963c0"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ea918db8-961f-4b46-9457-00eddc6289e7/8c9b1472a0dd4d12702f598ac017617d/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
             "hash": "61e5819cfe28beab99b3a75425c9c0dd0afb01390170e21fdc0fc0ecd9518d20ce24d07048012e522b53d727f7bc94639f257cc6021fd1b39b57405ae6adaeb2"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/30628efc-01f0-468d-baf1-fc487e55093a/4c2bf86dbebb6c522d4d667516dc5930/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
             "hash": "1c7166a594ba6c07d0233aac44428e561e2131f1f1812cdfee75807d19f1fe53f40f9d93e88d4a478c885993424ec2ec7b9aaf8f174332f587e6ff10813680ec"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/077d24e5-df1c-40fa-8204-cd601e0b3465/44de36d04f570e120f4f47debe33b839/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
             "hash": "16d6a5e48cdce9e5e529c5572032d02213136b5b028a06a86c72c32765a87b30aaa62381bdde4f810e5b1ad7ab07103386002b6447bb8186888604794da7faed"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5d2259a0-cb6e-4079-96fa-e0de6f0448c5/9b299e3cc15adf6153c28c24cba35fef/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
             "hash": "a5a02f596e3976e65650d6a780903a755d4d700491c670b4f3c2f167224da632b98ad03ab7a087dc18561c5cc3ae6a3be78d5c6ca2f7312c7d7c417d909a481a"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b9e31f8c-0bf0-4895-9c79-8baffc8530ef/b2db38465ee04fecbad4a970422681c2/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
             "hash": "86ec1715eb1373d22ea3ea49021c537484b481c03ce6a82df9ae81d911f5de28a8878f78871db66bc407d65bb84cc1ffe0099928a177ebab50910b6f6bbe1290"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41c79f6f-30d8-4b2f-a15a-c098084dc78b/e46437cd6d1bca934eeba50a70a33bf7/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
             "hash": "c8d0ff7e90b6799f352ea69cbff376e7efd201ae5593d6199145225afb2caa920480191be2bdff1c364ade02e89fc157e06cd944f761ff3af0b08b4009b1c28f"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e120265e-8b49-4faf-ae33-7828bbec8375/8d607b56fb4d92f8c456eff315d3d687/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
             "hash": "7ea7ea590d222d84ab7326ff120a40b45364a01c386c881ea7efabfb869237b789743b0829b791895613d7f4f2584c411f38150f319bdc5fa3f2b9ee7e5b3bd2"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1e952733-b58e-4d72-808b-4b6cafec490e/04fbd6374d14a95bebdf500b47e12098/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
             "hash": "83dcc6aee85e332993ad57b041e22c09c1ca946fc7befed54bc451ae0c2d2ec16b818d2323589a8a150cd2ef90239e990bbb2390d5ded458a4904be0052fa364"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/af6eaf7a-e53e-4787-a61d-74cdb048b2c0/81cdad4a45ebaebf4881ae1a5a944c49/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
             "hash": "1ff5e7be6fe1a1a436be343553d12066ea8e94b1d80b5ed7d2979f3d2eadf3c5c7e2da5727be2d12cc6ad1d831562172fae4dc55d5a84075b00891ce8395126c"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/db55584c-9ba6-42d4-a946-545993e2ec07/a5ccf36a2217b8476337d2ad5f547b87/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
             "hash": "5c1b310ff5543d7416850d2044c4584f4a2286676b7cd05c32f505b95959bc66968f334cae1b35c852937cf289160f97f4129e15f5e5e220ab1d6c5bf61f1fd2"
           }
         ]
@@ -5616,97 +5616,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c2602262-2aba-4921-81f0-640ec8200c5e/7eac075f28a6817086891867c5058ae2/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm.tar.gz",
               "hash": "51dde68d8cbe20e8e77fef7b940ae55158e8dbc31d219696228e82b2e4223b55a43dd2797c70101d3fcf2ca56bfd7370ff08daba5f0e457f54dbd8e171503f31"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b64ba1b3-ad10-40a2-b588-73db9ed9d99d/f772743c20f55a5a8aea3da2e1480676/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-arm64.tar.gz",
               "hash": "1d591e504352f765a35092394719451c024a628c69efb6a10d0a5d57947c466a004243e799b46147fdf6316a23b4335b1e8fb1fc5513def1dec9f96c6c845dc7"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/daa714fa-cd09-40ef-94ef-7f7785e312d3/a0a4d29f8508ce756185f682ff1acb47/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm.tar.gz",
               "hash": "a0547586a2e1c04b1ac030637901c113abb7bcf3bfb4bb6e017d6c11ee6f5fc114dea4da57cf4f702765a0a0e5c19391623c73e9a3500d5f6713a000a9c14058"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/48c6b988-5bb3-431d-b8d8-f03a1607ae06/6d0fb991e397020332cd09deb21fee15/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-arm64.tar.gz",
               "hash": "a56d724d388576e8e6db78c67004a7296ae33a7c2ab00d8af132d3df12398cce3f81b08a50f9094942cbab6ffa66efdd805359a5ee9189dfacbafd7478d34285"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e9eeb6eb-889b-46f6-a5b5-63d985747b66/a7aab27d12efd89d1d387727a32bc2f3/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-musl-x64.tar.gz",
               "hash": "51fd7da5986f7776a602d8aa3dee1952e86ba0676c1fdb392f7d13c642bc608489a897347707267fa030355042f6873024c92583a6bb8080397427bee35f087a"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/911f82cf-0f87-46c2-8d70-44fab9a0f3c9/137ec23686722b8119bd62def8d7b117/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-linux-x64.tar.gz",
               "hash": "c44df5e11791e4b22720834ed7f28102e33ab475670fa8e132d73d5dd03d8f4ed3f4a548deac67a79e06db6f776c9f632eda4503b6fdc9eef7ffb001cc9963c0"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ea918db8-961f-4b46-9457-00eddc6289e7/8c9b1472a0dd4d12702f598ac017617d/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.pkg",
               "hash": "61e5819cfe28beab99b3a75425c9c0dd0afb01390170e21fdc0fc0ecd9518d20ce24d07048012e522b53d727f7bc94639f257cc6021fd1b39b57405ae6adaeb2"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/30628efc-01f0-468d-baf1-fc487e55093a/4c2bf86dbebb6c522d4d667516dc5930/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-arm64.tar.gz",
               "hash": "1c7166a594ba6c07d0233aac44428e561e2131f1f1812cdfee75807d19f1fe53f40f9d93e88d4a478c885993424ec2ec7b9aaf8f174332f587e6ff10813680ec"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/077d24e5-df1c-40fa-8204-cd601e0b3465/44de36d04f570e120f4f47debe33b839/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.pkg",
               "hash": "16d6a5e48cdce9e5e529c5572032d02213136b5b028a06a86c72c32765a87b30aaa62381bdde4f810e5b1ad7ab07103386002b6447bb8186888604794da7faed"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5d2259a0-cb6e-4079-96fa-e0de6f0448c5/9b299e3cc15adf6153c28c24cba35fef/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-osx-x64.tar.gz",
               "hash": "a5a02f596e3976e65650d6a780903a755d4d700491c670b4f3c2f167224da632b98ad03ab7a087dc18561c5cc3ae6a3be78d5c6ca2f7312c7d7c417d909a481a"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b9e31f8c-0bf0-4895-9c79-8baffc8530ef/b2db38465ee04fecbad4a970422681c2/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.exe",
               "hash": "86ec1715eb1373d22ea3ea49021c537484b481c03ce6a82df9ae81d911f5de28a8878f78871db66bc407d65bb84cc1ffe0099928a177ebab50910b6f6bbe1290"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/41c79f6f-30d8-4b2f-a15a-c098084dc78b/e46437cd6d1bca934eeba50a70a33bf7/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-arm64.zip",
               "hash": "c8d0ff7e90b6799f352ea69cbff376e7efd201ae5593d6199145225afb2caa920480191be2bdff1c364ade02e89fc157e06cd944f761ff3af0b08b4009b1c28f"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e120265e-8b49-4faf-ae33-7828bbec8375/8d607b56fb4d92f8c456eff315d3d687/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.exe",
               "hash": "7ea7ea590d222d84ab7326ff120a40b45364a01c386c881ea7efabfb869237b789743b0829b791895613d7f4f2584c411f38150f319bdc5fa3f2b9ee7e5b3bd2"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1e952733-b58e-4d72-808b-4b6cafec490e/04fbd6374d14a95bebdf500b47e12098/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
               "hash": "83dcc6aee85e332993ad57b041e22c09c1ca946fc7befed54bc451ae0c2d2ec16b818d2323589a8a150cd2ef90239e990bbb2390d5ded458a4904be0052fa364"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/af6eaf7a-e53e-4787-a61d-74cdb048b2c0/81cdad4a45ebaebf4881ae1a5a944c49/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.exe",
               "hash": "1ff5e7be6fe1a1a436be343553d12066ea8e94b1d80b5ed7d2979f3d2eadf3c5c7e2da5727be2d12cc6ad1d831562172fae4dc55d5a84075b00891ce8395126c"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/db55584c-9ba6-42d4-a946-545993e2ec07/a5ccf36a2217b8476337d2ad5f547b87/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.2.24157.14/dotnet-sdk-9.0.100-preview.2.24157.14-win-x86.zip",
               "hash": "5c1b310ff5543d7416850d2044c4584f4a2286676b7cd05c32f505b95959bc66968f334cae1b35c852937cf289160f97f4129e15f5e5e220ab1d6c5bf61f1fd2"
             }
           ]
@@ -5723,121 +5723,121 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/69ca0164-e58a-4777-b1e9-0bd15a372b40/51284f988bdd4dc653eea820484a071c/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
             "hash": "f1dd7f9d7a9faa408c081e869804f7b2a54d8a03d8cb3ac4378e0a015ce87e05ad0963684fb9f8369ba0860eceb9f8cd2774e92740564e96858a62b2a5d62b03"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cb8d7d43-e403-44b3-9ee8-477a947f3e6b/3e38a543b6b9144e0fed12cf18eae7f9/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
             "hash": "6f7a5575d02197f1908c56d580f0a9049f393ae68a4ad4b73935e981d9c6766e028463d2828d3ba0aeb4049237516fee2e116196e790948fefd65436ea804f35"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/97bcbe77-6b0f-44f7-9a01-a3110308bcf8/469574afbddd9432bf1f4b9f9078c919/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
             "hash": "db34cb136e1bd5e3722e9dae9029cbb5bcaeb8f563e02e39ff51daa5b51ef4435cac60d77197da30753b79af45e2efd6aba7f75a02fe766859ecd863fe7da2c1"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/948610d8-af3c-4c0c-84f1-65cf3b9bfbad/226982b96d52f4147bcd36d9a2133cad/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
             "hash": "1158514625f2284a38a528b6182d98137ae7228512995723015d57c3a3e1e81436f87d18eb2b9d864398b609373bf4212a20943db97d5fb1acb29b0fcbc9b8e3"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/59a764e6-bc1a-4aba-95d3-15e94a3aba0b/18f5fd10635db63df24fc2592f7cf65b/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
             "hash": "6454787598b68f4402012057d1019d21f16df83b763c56b55557c0d45d2dc66a161dc41aa46a1b6324950315484fea5b7a5c8089f08cd69501d79c5f5fbf961c"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e3e81a61-4493-433a-ac40-ce2bceb3370d/ce1c59a7054d200dd24a7e4987666b8c/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
             "hash": "9d836edc539ace64ef8fa883bdfc881d89f4cf30d048640246dae9d54e46e79f2e82ebcdf366c1b69017d86d1bf1496acef5d56c3133297ea0bddb2df2eb4523"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f27cd5d-334b-4dfe-8876-33186210815a/2752edc7662b603b734219e4fee20ba0/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-arm64.tar.gz",
             "hash": "81b5860e68e9e660a535568f96d8058ab6f98dd6b0a8305e3e3358ee721da610c08baf0b59a52d7e30184c39784ab18544f9328a55d8490d400d07be734059a4"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dbbdbf43-8860-4aae-b1aa-57d44f976cc8/f4f6c6c4a740de95a332ed2c693d1d6f/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-osx-x64.tar.gz",
             "hash": "c0c37a504f8c3113c90b8108f1f784fbb61387475e3eab37d303c49f627e06034ef6e917ee9c780e910cbf565c20050173f240f215fdead4fabb1f3795f3ac08"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/049903fc-4c2d-4236-85cd-87951ea9de7f/0f0aec1fb155fa09f61ed86cd26b6b6e/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-arm64.zip",
             "hash": "513afe42770fbab74e7d5746587d5f4859f95ed801954e6a16fad6b5e6cc681d1fb40822764f38140ba7b74aa71ef42c502f0fe65abe0a5010d8d5b3b8d73e4e"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c2a880ed-96d2-4060-9132-5343b8fdb539/dda51332250362edb5c59047e925f556/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.exe",
             "hash": "0b55ba24806ba6337aa95e26b64ee5d3d4b1feb00ba0993dbcaadb03e17e0544ceeec0a4cfad82b97ec0b9454219d421d5ba12b1e4cfaeac12ddbee81f59091d"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/872b0c60-bd0a-4fed-a744-b265f13fff25/160c69de96951aed473bdb0570352322/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x64.zip",
             "hash": "cdb4a42761d729bf68ca94414f85c9543bd46e8954680b37b66db15c26135def215933a2fbd38b231302f7ea4f6407a4290d00a25c5f8d7d58e780e55052c3dd"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cbf688a5-c777-476d-a47d-6b532848fd71/5034e38cef71b22c4d0a6fcd19db9840/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.exe",
             "hash": "b9b8bbf176c545fa2b1e2765c8eb6ea632c9acf27d15f6e54f22451b3982c115af027a5a957fa37a9e762c41dc2fdc9c0a3ec22933dfc7effa5c468cb9e29e84"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f46c914-c6ec-437e-8769-81a5c7d372e4/e3e5847261a6b71742a74fb47331d20f/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-9.0.0-preview.2.24128.4-win-x86.zip",
             "hash": "8f6e89659b3d641f3fe64f417023d8c3bd587eebc343c8cf478a44d945e79a039c2fef828484764ab43cfd30e5b3bc50c17b81590b2f6f1000b3ccf4e8a15ab3"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1b3ae66-ed5f-46db-a1da-a3aa6f379a10/449d2758801ca01a21baa296edebf9d4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm.tar.gz",
             "hash": "725a370e508db4b4be0b4e6cb1ba1070316877a6950bbfcbe0fad76dfcc8bf12cbe987a4ce3787a48eeeccd37c04189d3fa517f1ceeb78ad92fbb30e326819ce"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c3651a71-c7b5-445c-aa96-fbb473513f68/d23dc7326deba60db789acec02afd4b2/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-arm64.tar.gz",
             "hash": "ae20e3cabb39e4cb91cd3678f85290e89162d2007316719ca408093b9c8d5772a443926abac1cd909405d6a58b81ec0e96b8d00fc076c699081965e1d1e90b4f"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dd404332-ec4e-4d97-9cd9-007d9d185904/3e1e4ce502178d132adf8f68904c9002/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm.tar.gz",
             "hash": "de45c5866d477bc2685f3a9d6ebdd08e3cb7effc37df896fb1a10c5ab9dd95cc120e49e9d95930c078f9f8b7262ed567b85cb752ee93b236193eb3e90fc49657"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4f59418a-e794-4cbd-83ba-28caf49ffab6/895663c4eb1a594f37015a79d5a6c57a/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-arm64.tar.gz",
             "hash": "4030c12b8efd49a254a53454bae20407f3fdfba39c8ecf637ef9581b8cdb98b792d904d0be641561237b47f7daf83281b15e473b81a43c0f1052e6f42011f92a"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f8b9b876-af92-4182-9eeb-075f9c10903b/780b103d20efe7b3aa0b5baea30c93c5/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-musl-x64.tar.gz",
             "hash": "18987fc174b6f52c65537e91a60d9590af3fee05c3f83b248abcbd17b8988996d79eeaefedbc0c42a2b9a815ce28c6babf4dbf3d3202fcf30bff28262ae22514"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/285f7beb-77ed-41d2-88df-9b13831a8a6e/5ec67e65df1f9c869af24fdcbe43bd60/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/aspnetcore-runtime-composite-9.0.0-preview.2.24128.4-linux-x64.tar.gz",
             "hash": "80e47ec27e40c11cce232b033c0fa961f3262eed9cb6743768d164af7fb5243e10464a7607fa1fffb4217446f5716382dfd836e7c8c5a118df6da4ac6203e689"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bab2ec4f-c930-44be-9b7d-38b9f837b3af/5ad4812b54c7588622b9eb10fd0de616/dotnet-hosting-9.0.0-preview.2.24128.4-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.2.24128.4/dotnet-hosting-9.0.0-preview.2.24128.4-win.exe",
             "hash": "a959ade3fa01e191bf8b03adc89247a1a45374d354e3c27db06927e8e692d8368974e918ecf27a1a0bcd2020f2f11212d878d64a389f907345d053aa79b65449",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -5850,37 +5850,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7636b226-87e1-4d09-b758-c71b375b1bcc/ae993e6825615dfe90ec796c3fea0bad/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.exe",
             "hash": "9bc150443a0358f44a9891c23d8dde0f05717291d91ef1458093426023621122cb23cafb3543d8969a99dd02dbd16238816034517dc9aa0c9ccf5d4164a447b2"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5b6ce66b-ad59-445d-a46d-b94fc74e665d/90a22ecdb847711b7b765310b63e01ad/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-arm64.zip",
             "hash": "8cb6cb9edf27ea32bd67164d108d8ce15e9850e5e1d9cadef427e273fc895a84484a081f5162c6ea693bf94d5ac751432ab78c25be4ea09cfda30335d6f8838f"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/860c2219-3f1f-4948-925a-1d463ae23801/092fdd99190bf61c37eaea1b5b034305/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.exe",
             "hash": "5cd41db47e7e52f62b8f2f0f312224117ec83c4fb27af08e5bdb9d560efaa58863c36a0c5a46d3acfe971bcb983a14af659579503cf53c9b4900054b5c3c2f70"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cc5408ce-a9da-458c-ba58-65fd4dfb47ea/57a22113ce6b45f0880f391efb953cdd/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x64.zip",
             "hash": "faf7c80e268b50d6eb36b27e4c3f0bc85361bfdcb6f58bb4d421c319f65e648c8960b3f501c968e0b321b83b84658faa311117ca20ff5756525cb5a056c0f6a5"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9914baa5-6682-45df-8dfd-6098376d0ee6/4b7d697197ddb6929f00778759f09275/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.exe",
             "hash": "c7bd9a824c7594099d4d26759dbb181d49698cee8b35bb46d72fc88a09989b3b49d110058a40c1fc237f925a98e47b071e29396b68fb67a09c61a9fe4e391003"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2d3eae09-04af-41ad-8072-ba414988dd87/a725bb2c98fd8a56412e4c1a9e61fa98/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.2.24128.10/windowsdesktop-runtime-9.0.0-preview.2.24128.10-win-x86.zip",
             "hash": "559103fd16447f5f279d3174cfe2efb1d31215c175134a099df3653c5debeb37781fb98000444f918840bd3273fb0eabba58b5f1b172310e2078b4a7b213a710"
           }
         ]
@@ -5901,97 +5901,97 @@
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f59acd9f-cbed-4483-acde-2b42d1abac59/b6edd8e417a12e04849dded2c6143869/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm.tar.gz",
             "hash": "8f5e104562dd8ecbe87433896ba7bdd48400f28f41d0ffebe39d160adb6f0f600dcd327acd653d6c8a6dd13f3b375784290f17fd129e2f20bf307ccdbc4ba285"
           },
           {
             "name": "dotnet-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7d911f96-acdc-4f5f-b283-cae6d6439bfd/f9e1c8d283ffd1d2e40346926a9c37bc/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-arm64.tar.gz",
             "hash": "265b7bf094730be765bdaadec3215c1a7c51bff6fb18bb51cff383473e32d1ba821b6d046e0f7fa864400dc5cb68e35943057f5b6ae6e8c411375fc15fdbaf3c"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d4e427bc-0a0f-4bd1-ae1f-79dfcb59ca8e/2c2ea76fdbbe8eb67029013741abc7c8/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm.tar.gz",
             "hash": "7e8d46ae5668cc13011b9b579f71f27fa5c5feb93be2f6ee3541e75a163bb9f82d5e7b41cd5290e964d1ce7644ffdb9832d1570d7d795821cfd8c12f029e5d74"
           },
           {
             "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d8daea8a-5a9d-4570-a860-cc9512946d66/bec3eb14bf7e22a3f99e21f6de8f5a7d/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-arm64.tar.gz",
             "hash": "9e5a8dac01bc070758fb07788ec693a2b1c98be2d8aa1036d70e778c024df93d5a9299a4198514b7a8712143de47af6ce830d059350ba8686c760c6a37a8811d"
           },
           {
             "name": "dotnet-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fe51f8fc-c30d-42ee-ae0b-e4866193c392/c8cecc468809fb235223f77dd19a0bfc/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-musl-x64.tar.gz",
             "hash": "f6a42522f3bbf59e58e28f3b5ce0bdd2b81e5f0aa9634ea4be7221145853925c221bdf04988e9e7364efd578c665f5136af55edc2eb9e2b276877ccd92235d80"
           },
           {
             "name": "dotnet-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5bcb417b-0de3-461c-9ce2-a9ddd5df1aff/73e36aaa7c2e381724a2adac149eb376/dotnet-runtime-9.0.0-preview.1.24080.9-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-linux-x64.tar.gz",
             "hash": "68f0b89227c8e0b3239477409708c1b0c5cc7d80afd6661dc2150946c66e2130cf560c2471609f0fd063f01ca1d8e72f74beec45ecb519cf58f1cdc434615054"
           },
           {
             "name": "dotnet-runtime-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/00b22eac-00df-4aaa-9d9c-cb709afc7727/30b1bd396e681d1e7a5e0a2d034243a7/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.pkg",
             "hash": "011963caf28e5fdd3a92b11732dffddf532f6c97ac5525682c32fc8ed3cb542f82aafdaa4020eef673f1b466533e2fdb133dab9334cff51840f45601c27a1a77"
           },
           {
             "name": "dotnet-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/079214b6-0ce6-4d6f-a0ac-9bd9072dad0f/14b558eb20224c345f78ea80f7029e11/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-osx-arm64.tar.gz",
             "hash": "63bf6a57f61c4dcf4e0cdcedb8ff6c76cb702a95d4e0033f17b4cd2a3e800e73ab16c401fb098416404ea5716c725c175f9422250b2a8816c08eed2702cd38e5"
           },
           {
             "name": "dotnet-runtime-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a33892b-8d4c-4a35-831d-537ae7361c96/381e7d9f93758fbe2ffbda88927fdda5/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.pkg",
             "hash": "d4cc85c39b4c287471784a61410458bc2078f44cf07146ea24ae11a8e96944297133802972de80623ac7aff10e57289628e1cd5cc9a64ac2fa3effec2b369418"
           },
           {
             "name": "dotnet-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0307fdd7-b398-4e90-a88b-574d853b769b/ab8938a35b03d8308a7a16331fa65cfa/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-osx-x64.tar.gz",
             "hash": "f644ce6ee158bd86a4aba21bdd955a3aebb0367b5af618b6e77dc85922bc790b9c33b572606a15f566b2729a90923f66a933159124e803494105a695c890b775"
           },
           {
             "name": "dotnet-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/57abc76c-46c8-4a76-b28d-108a097203dd/5796bd89648367c97adab3dbbc1ed1c2/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.exe",
             "hash": "6027f09e7bd4612fe9cd1ac2550d0663cb80d63cec1a41cbd4a9f502d14c77ed83f83e3e47b87da28ce0820e894a0539624939d09e9363d52f2218696dc685e5"
           },
           {
             "name": "dotnet-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6714615d-e422-4037-845a-c51a7cb7fd1c/f2efed74b142bcb681209cd5ca1f333b/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-arm64.zip",
             "hash": "3a800156e1680f46a0cdeeb60b780ee56e3150c52f1c6e9b440eb30529f2bc36dd928c51afd495396f8f4a7c1998e52168fedd2a1205ca0f7ccda2d880d12a4d"
           },
           {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a160565d-c481-4d36-b6df-e708b3273914/b31aaffa739731821684023da81c3b06/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.exe",
             "hash": "a535447c840aa27e21b69de7172f225ae5e3bea3ed632b81372a4cd20919a2ca4c6ae7c3963648bdb98d458fb204c5c5af3e85e0b44c8b5b803c1b3e4d8e791e"
           },
           {
             "name": "dotnet-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4f93597e-2697-4e50-a232-aa4d7c025ee4/4f35240f9b922d5b77f5c426e52c6e70/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-x64.zip",
             "hash": "a417238c10646dac5ff47663b34d05ed51e96e224aa1f29dc2de03a96c273d72dbd3c890a36b728fc01d0a3d6ae50804ade78c9f29310cdab49dcecf8e0e6ad8"
           },
           {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/292f3bdc-8f10-43cc-9f54-a2740ea4f8e3/3aaa99d7befd139d2e5ac8c4b1fa6707/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.exe",
             "hash": "70f677e2171a2773a0b0dafd0deffce9bdbf97692e34d2032163ea21645394becb71afdeda332edd0f558dc7e7080ed4e4a695f2ee32aa3866e8d7b81ef919a2"
           },
           {
             "name": "dotnet-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ae7b1529-8508-4202-be55-911ff8373186/b657e9299262515b194ecd8e95948b4d/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.0-preview.1.24080.9/dotnet-runtime-9.0.0-preview.1.24080.9-win-x86.zip",
             "hash": "be777abcd6300a3628ea3a154d0c62fae0c4142f3a5e9c4eda5d315d4716014dd42cddc9cac25c2fccddb106bade516f30805584e07c086f2d3fc9a171135dfb"
           }
         ]
@@ -6011,97 +6011,97 @@
           {
             "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f5e9fc40-e56c-4276-bcf8-3ecf80f7c1a7/94900c87e4529a89ac71d164665088c7/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
             "hash": "fa14b4545688097f490b9730a9063a3f7e7b779fd57a4bee43e61ef6f61c6aa5ba33ae5e1c8e0bc13dd060709d3eebbd04b044e06a9a70eecc73243db4107086"
           },
           {
             "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e8743929-2c7b-4410-88f5-5f247040b498/ff454c589dc8d5dd9cb42e0950f34a69/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
             "hash": "b7c29e4e4baf2d2ba7b29fc5a080df708c5a915e6fb1ce2ff93ffc8f18e7725fae5d569ab1349ef4b067d05d00886a17c8d1a95e211602db1ee5da820b5edefd"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4cf1722b-252e-4b66-a292-8aa97fdd0fec/7bc384770059a0348e4024d8b6489f3f/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
             "hash": "821f7e1387a50b27c9fcad1e1955cc6aeb4012a0d1cef7273f882409ca18a42d97fe3fcad18eb141e8dd91afc16fa698a720763e4be6d7054af9c4e9104b43fd"
           },
           {
             "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9fba65ff-def6-44cf-9230-1973c6a150a4/230b5ce3ae290ce5b10ed748b4f16dfc/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
             "hash": "93a0126c76bcd054a7119fb5e51b64980b130f55850d006d77ed4dd3a5f9ec79bfe49c0160c2c4dd58a01226c7264081f36b594e4b2d5c8d18a400ab57b86460"
           },
           {
             "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/744e137c-6902-426e-a494-1ec7bc71a8eb/c5a6d2c3d3c4e57c10da28992e34617a/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
             "hash": "7b44faba92fcc228477dce2ecd3311f0d6b68c30f082ff020472b07fc2615aa0e591da9185667a172a6f708192c6610e6c20594f79cee8e1a046515ffbb8e26b"
           },
           {
             "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f51b05d4-bc43-4290-9b33-aaa212edbba6/e10559d91242409faf5c37cb529de8f3/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
             "hash": "e176126d9a12075d91a0ad2b4dd50021a564258742d86560bd216ac36482c763087bd8affc68fe9a8d3c46f61f864bc2c7c2e455739d21614516c4f73fd281fd"
           },
           {
             "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5f6fd-0b74-407c-a3cf-52792d76415f/53c4911d66ce7a8757c9d10c2c4d6414/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
             "hash": "5375987c0a02eb33d820802ec9c76acb14ccecf1a35df1f894bf7e362e1400a8b48dad628267b65d8bda29850f1a70ff4cc0960cd57cd61dc7f155e155bc9de6"
           },
           {
             "name": "dotnet-sdk-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cd991bbf-8952-4bd1-83d4-33eb1a810939/3662095e14f91f43c2b3a7e6c55666fa/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
             "hash": "901835cfc277c626d38c7a2bc1a6704115d240812631cd32f4b51833b41ddcd3a4a169a1bbda42a9446eb33b2337f6a8c6410bc3d1bae557c8898d427e2fc8c1"
           },
           {
             "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5c78b512-56ef-49a1-b181-96ca60917c06/f6ad92dac6791efabedd862a495e7d4b/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
             "hash": "8254d65d65ef1bc038255e651ad962bc15249b2f5a760c31e628fa342f3a2bfd2dfd2aa96f1125cf8318d60e8ec99cb7a51dab1d780e606b4f3d47c2b7159f96"
           },
           {
             "name": "dotnet-sdk-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9956af63-be37-43be-a854-01f3a95e12fe/60d97a3f4f53b33376b8df055a14cf39/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
             "hash": "90c6709c54c0f9f4d7100bbf9c3b8136b6468617034c23f6a60dc17092e311539d54b741e149b70f1b6a6e2c6be0aacc948d4c72abac724f47d5ea05e02a2939"
           },
           {
             "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/224503be-904d-4735-a447-b180b5a90c88/c267d21bd55b3108a226b0b458f02ab7/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
             "hash": "99c61acc8bf757793fa2a08eb29afcf3e365bf285fde929c58ce774424294570c26609468cc94f89d891f0c42769041d6ad9c6c759a0665727dba16288dd2f64"
           },
           {
             "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/019706df-7545-4e5c-a8e0-1cd8ed308eca/eb7fe6847f4d9be5870ee0ea172d5025/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
             "hash": "38bc46731201d5796d7a7ee30446fc35f2c225a75c978b896e7b6b09c7d537b22f991acbd413f6352df39cb8e69d94634b085968256377d83843527e55268d0d"
           },
           {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bb120bd7-6656-4ebf-9efc-87dbbbd2f344/ef7cb2cf73d9a740c2af0b4ca9c2266e/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
             "hash": "82dfbbe479df411c0a177459ed9af55c373561e5b23dfcd09eb1ba713764e0800519dc2b50138108520bb772c8aec696c31f99c85674cb7c7d7b999292668d31"
           },
           {
             "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4c55bc67-e478-4fdc-abe3-08b8dd64f4e4/9cf46c3018f477a93a8498850e6c122b/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
             "hash": "a993f0a23dee43f43e51509094f385379183ae916ee04f891927bc2398fd3645bfd866d0960c9d0ccf11f7878856dd7317298a6e5ec6a17dd7f32fb3890855a9"
           },
           {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/351f70a4-7eda-44e7-9e3b-44ee92e2b678/92d69c8dc447e2870f95ec535c3edf83/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
             "hash": "9ee4c1da97526bffda9c1ad58e609bbbcad324dcb4e24b1cdd30f1feb0b37333e326b95ae08706e56f52c12ee20556151b13d7d5c04a0283f3420659c706ac63"
           },
           {
             "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2a5790bb-b57d-4c34-bbf9-d93a589bc065/0456e1a4bd06579fccf6fb776dfa5dc6/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
             "hash": "1ea49121eebc8ad47dae4148bdda7ee9ca17f65f49af9a0ce39d42dfa3916ac4d8430d7d0c0c7f466f15fc0fdd844b891635e743ca4782571cdde76828f7d236"
           }
         ]
@@ -6122,97 +6122,97 @@
             {
               "name": "dotnet-sdk-linux-arm.tar.gz",
               "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f5e9fc40-e56c-4276-bcf8-3ecf80f7c1a7/94900c87e4529a89ac71d164665088c7/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm.tar.gz",
               "hash": "fa14b4545688097f490b9730a9063a3f7e7b779fd57a4bee43e61ef6f61c6aa5ba33ae5e1c8e0bc13dd060709d3eebbd04b044e06a9a70eecc73243db4107086"
             },
             {
               "name": "dotnet-sdk-linux-arm64.tar.gz",
               "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e8743929-2c7b-4410-88f5-5f247040b498/ff454c589dc8d5dd9cb42e0950f34a69/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-arm64.tar.gz",
               "hash": "b7c29e4e4baf2d2ba7b29fc5a080df708c5a915e6fb1ce2ff93ffc8f18e7725fae5d569ab1349ef4b067d05d00886a17c8d1a95e211602db1ee5da820b5edefd"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm.tar.gz",
               "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4cf1722b-252e-4b66-a292-8aa97fdd0fec/7bc384770059a0348e4024d8b6489f3f/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm.tar.gz",
               "hash": "821f7e1387a50b27c9fcad1e1955cc6aeb4012a0d1cef7273f882409ca18a42d97fe3fcad18eb141e8dd91afc16fa698a720763e4be6d7054af9c4e9104b43fd"
             },
             {
               "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
               "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9fba65ff-def6-44cf-9230-1973c6a150a4/230b5ce3ae290ce5b10ed748b4f16dfc/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-arm64.tar.gz",
               "hash": "93a0126c76bcd054a7119fb5e51b64980b130f55850d006d77ed4dd3a5f9ec79bfe49c0160c2c4dd58a01226c7264081f36b594e4b2d5c8d18a400ab57b86460"
             },
             {
               "name": "dotnet-sdk-linux-musl-x64.tar.gz",
               "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/744e137c-6902-426e-a494-1ec7bc71a8eb/c5a6d2c3d3c4e57c10da28992e34617a/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-musl-x64.tar.gz",
               "hash": "7b44faba92fcc228477dce2ecd3311f0d6b68c30f082ff020472b07fc2615aa0e591da9185667a172a6f708192c6610e6c20594f79cee8e1a046515ffbb8e26b"
             },
             {
               "name": "dotnet-sdk-linux-x64.tar.gz",
               "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f51b05d4-bc43-4290-9b33-aaa212edbba6/e10559d91242409faf5c37cb529de8f3/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-linux-x64.tar.gz",
               "hash": "e176126d9a12075d91a0ad2b4dd50021a564258742d86560bd216ac36482c763087bd8affc68fe9a8d3c46f61f864bc2c7c2e455739d21614516c4f73fd281fd"
             },
             {
               "name": "dotnet-sdk-osx-arm64.pkg",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5f6fd-0b74-407c-a3cf-52792d76415f/53c4911d66ce7a8757c9d10c2c4d6414/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.pkg",
               "hash": "5375987c0a02eb33d820802ec9c76acb14ccecf1a35df1f894bf7e362e1400a8b48dad628267b65d8bda29850f1a70ff4cc0960cd57cd61dc7f155e155bc9de6"
             },
             {
               "name": "dotnet-sdk-osx-arm64.tar.gz",
               "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/cd991bbf-8952-4bd1-83d4-33eb1a810939/3662095e14f91f43c2b3a7e6c55666fa/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-arm64.tar.gz",
               "hash": "901835cfc277c626d38c7a2bc1a6704115d240812631cd32f4b51833b41ddcd3a4a169a1bbda42a9446eb33b2337f6a8c6410bc3d1bae557c8898d427e2fc8c1"
             },
             {
               "name": "dotnet-sdk-osx-x64.pkg",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5c78b512-56ef-49a1-b181-96ca60917c06/f6ad92dac6791efabedd862a495e7d4b/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.pkg",
               "hash": "8254d65d65ef1bc038255e651ad962bc15249b2f5a760c31e628fa342f3a2bfd2dfd2aa96f1125cf8318d60e8ec99cb7a51dab1d780e606b4f3d47c2b7159f96"
             },
             {
               "name": "dotnet-sdk-osx-x64.tar.gz",
               "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9956af63-be37-43be-a854-01f3a95e12fe/60d97a3f4f53b33376b8df055a14cf39/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-osx-x64.tar.gz",
               "hash": "90c6709c54c0f9f4d7100bbf9c3b8136b6468617034c23f6a60dc17092e311539d54b741e149b70f1b6a6e2c6be0aacc948d4c72abac724f47d5ea05e02a2939"
             },
             {
               "name": "dotnet-sdk-win-arm64.exe",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/224503be-904d-4735-a447-b180b5a90c88/c267d21bd55b3108a226b0b458f02ab7/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.exe",
               "hash": "99c61acc8bf757793fa2a08eb29afcf3e365bf285fde929c58ce774424294570c26609468cc94f89d891f0c42769041d6ad9c6c759a0665727dba16288dd2f64"
             },
             {
               "name": "dotnet-sdk-win-arm64.zip",
               "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/019706df-7545-4e5c-a8e0-1cd8ed308eca/eb7fe6847f4d9be5870ee0ea172d5025/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-arm64.zip",
               "hash": "38bc46731201d5796d7a7ee30446fc35f2c225a75c978b896e7b6b09c7d537b22f991acbd413f6352df39cb8e69d94634b085968256377d83843527e55268d0d"
             },
             {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bb120bd7-6656-4ebf-9efc-87dbbbd2f344/ef7cb2cf73d9a740c2af0b4ca9c2266e/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.exe",
               "hash": "82dfbbe479df411c0a177459ed9af55c373561e5b23dfcd09eb1ba713764e0800519dc2b50138108520bb772c8aec696c31f99c85674cb7c7d7b999292668d31"
             },
             {
               "name": "dotnet-sdk-win-x64.zip",
               "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4c55bc67-e478-4fdc-abe3-08b8dd64f4e4/9cf46c3018f477a93a8498850e6c122b/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
               "hash": "a993f0a23dee43f43e51509094f385379183ae916ee04f891927bc2398fd3645bfd866d0960c9d0ccf11f7878856dd7317298a6e5ec6a17dd7f32fb3890855a9"
             },
             {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/351f70a4-7eda-44e7-9e3b-44ee92e2b678/92d69c8dc447e2870f95ec535c3edf83/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.exe",
               "hash": "9ee4c1da97526bffda9c1ad58e609bbbcad324dcb4e24b1cdd30f1feb0b37333e326b95ae08706e56f52c12ee20556151b13d7d5c04a0283f3420659c706ac63"
             },
             {
               "name": "dotnet-sdk-win-x86.zip",
               "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2a5790bb-b57d-4c34-bbf9-d93a589bc065/0456e1a4bd06579fccf6fb776dfa5dc6/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.100-preview.1.24101.2/dotnet-sdk-9.0.100-preview.1.24101.2-win-x86.zip",
               "hash": "1ea49121eebc8ad47dae4148bdda7ee9ca17f65f49af9a0ce39d42dfa3916ac4d8430d7d0c0c7f466f15fc0fdd844b891635e743ca4782571cdde76828f7d236"
             }
           ]
@@ -6229,121 +6229,121 @@
           {
             "name": "aspnetcore-runtime-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/27ce8ce5-a12e-47d5-b075-5c6034c86c40/6280dfd63195eeb410c4b70dff2d6ba9/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
             "hash": "688c07f9d896db90a1ea863b008fff5187d50b2aef352298f3e4c16522812f3dc9be22f8bdee89abde8554e7668bb9f35d0aa4746b1fd9c42ea0aa8ef84f1f83"
           },
           {
             "name": "aspnetcore-runtime-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3f2586f3-89fd-44ad-aae2-4c241f72996f/f973c7140305733792dd25b466e37606/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
             "hash": "118967e64995d7c242738bf806928ecc52cfae3b0e0429a6951047eaf37d27bdde0adc0c6dc74e32d61b69565f7666cbfd4658396c37988e5d343debcc15bdf6"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e7783447-29c2-4866-bd77-fcc207fe2d73/a1d3af0e7af02e478e7f748011af1c48/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
             "hash": "1d322b98cb039938a735267b29f49d1bb5b024fe2fda96608de725c2419d2da3cae8f6e3e7fa2594d0d7768180ced2bc1c2da20582380aa66954e34fe0ed01ea"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/df69432f-27c5-450b-8afc-b7c9e35630d0/b5bc58a367875a214cf0c2c11ad174a9/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
             "hash": "b297d9cfa88fbd879f4e36a567b17109d5a0ac32102afdc5243c181f469f5c9beac0ec2ac776b68b7419ad9b9ddb932ef0c8f79a7cc14e6d62a491959685969c"
           },
           {
             "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d3f3a6eb-ef34-474b-944e-bed7bdb040cc/bccb1d80864eaaf576c25444525f9224/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
             "hash": "5ddef8928f7db38a3bc9fdad0d7cf8bddd8dee698ce8b72e7e7eedca5d769b70eab79ed161576ea8a5eb65806f80b27f6668f200ddd6c9425ab724074c543b03"
           },
           {
             "name": "aspnetcore-runtime-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/14b2b268-4d58-4f7b-9708-46c5a0a5b868/3cfbd27c7e2aabc0ca70f474709a4767/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
             "hash": "29bfe0b5b72608eba97151909308a67a47dc299902a46bf1a22d67bb5f8a0c87c6f4533c0c2d4679f9440f9ccccf549c434a4280c101f7633bdbdcf049c95817"
           },
           {
             "name": "aspnetcore-runtime-osx-arm64.tar.gz",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a407f4d8-183b-45c9-8153-c889c10630b9/2388fbcc5171e20d05abeb301027df2e/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-arm64.tar.gz",
             "hash": "09746054c291b10bacf3fba8ad147443fd41f42b6b04d9559281bc7d919ddc56ebe7402021997f6f24b745b3292368719cc2142d0eebba76226c5603545b6743"
           },
           {
             "name": "aspnetcore-runtime-osx-x64.tar.gz",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2e9a9af2-f1dd-467a-85f3-430f5142bf0b/6ce0853ee69a127bb767270a737f6467/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-osx-x64.tar.gz",
             "hash": "3ed80631a3ca0a4684a70fc0f17d46257a63cc71c7497c958accb4d329eff4a7c832a29c028b608798fbed0b82e2c5b7d5533c57dff2188d4142559b57341192"
           },
           {
             "name": "aspnetcore-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f942b1be-4e32-43cd-914f-24bd19b7e583/262944dd0604ab13fc39d5387c59d53d/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-arm64.zip",
             "hash": "4ef745d883f519a3949ff7479950945a6952de6c0ab10aa0d9320dc9c6578221bf7551788f17d62a2c287f5a662ea81c3b747d1a1b28184a32f7cce47f0ef4cb"
           },
           {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/427d2f8c-58f0-4ebb-b3c2-8960b88d03a2/354461a9a09d96678505e964f829df42/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.exe",
             "hash": "1644a3474e01a3b5805b341881b4450af885b043d7578360a7a0bfecb13158305d878c9624d697774e10ed5c84c976c1a7f541ecd585bd6d3d53084f6d9fb880"
           },
           {
             "name": "aspnetcore-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/188d9bb7-2cd9-48b0-ae5f-c1919ebb0750/c1c4b6c669863c4f6fb5bbe9b6498ca8/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x64.zip",
             "hash": "e8ebffbc89b516aedfab48fa8cfd9ec529437df21724b6e7f0a8b8b97eba29d274499a37fca0aaa0f7bd84ab3fb839a2ff09c6042f3abe568d4ec8191becbbd7"
           },
           {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cf9d5773-4262-4135-b8cd-10bdb1d64cf3/2999b27d44b816b58a966d74d43ca2f6/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.exe",
             "hash": "219addc5b3fc08f3e9c650171cb2804161c9a4c3a70f5367a32a2ef368a7850a8b18d232f27d5c265b323c4ccc7034f21d820558e2f05c59f8fd6f444e7c44ac"
           },
           {
             "name": "aspnetcore-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d5423ff0-60fe-4e91-b083-5aefca88610a/962fb47ce2b483795e7eb33f08a4bc46/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-9.0.0-preview.1.24081.5-win-x86.zip",
             "hash": "6e7730207fdfef400edac61ec142dd7440376699e25675d13fe05b347264f69b9a7cc3b047a8051b14c7862d144a465fe63fc9ff2a6d3c3c7a2a3cb46d1f6657"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fbb4cdaa-f4de-4297-bce0-5af6e8a8148f/90c097d5618d4dd81d8d489abce1645b/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm.tar.gz",
             "hash": "2310efa27939af7f28ff3869a640a182a3fca6374b06db98fc9cdc6a5b49b75de9904bb47bb3e15334620357662ede933b08994b35d5bc1dd5c859ca73530602"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/42ca6325-0b0c-4ee6-96c4-ac46affd2c64/20f5fc2ee183de3450cd33e06e5c8bf2/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-arm64.tar.gz",
             "hash": "1ea9bc90557a4196eecc51f8965994c6feb446c671b19236b6593a8996641410cc15f2ed6b2a7be73217ae89683664cee2af68594e3a0164306b770778d96295"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5a23389-0099-4b0c-adde-6acbee4412b9/10a484a2160790fb695c8e2eb6d34d53/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm.tar.gz",
             "hash": "6f070ba486fdc59d1717c2089f322329d28a4996d5e165ac55f7ed07dc4f014fa18efc2ab36e50fbe0959d10960a346476fede4ef4115e8972ee105fc7b777a5"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c165e81b-e915-4c10-9fd1-86e1a3eaabf6/184c4299dc0fcf3b18a8e18f989a3d6b/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-arm64.tar.gz",
             "hash": "5ef4134b9ecdc4b80bb402209fd2adba4c219d235e0f3a4d196c8d7ac0366c9fd40c6a515d1f585b3f9b3bcbeaf7bb9c41a64643ef2f065305abdd47014879c0"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/bede20f1-0e70-4a08-a1d8-df9613e7ddf3/aa55cc5fa325b264eb1cbda8eb45d8b7/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-musl-x64.tar.gz",
             "hash": "d5740881123b148f0e9b3d990f2407da9b0a4cb61e6e853c9eb709a52196dccc2e2cb8b9ee5c778fc6022fb5a45a076436020a4817089dbb67e2e126f717b342"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f7492292-937e-4ed2-aac1-1e1aee31c19b/f345f6bc48f5c073b048e2946d504041/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/aspnetcore-runtime-composite-9.0.0-preview.1.24081.5-linux-x64.tar.gz",
             "hash": "8022e4a1d37089242905ca9c4fd5f37a22136f377a170a677f1005fc8ce32d5bbc6341c0b80236d8287022533d908a4d91120bac894ab418b20a056de2e45b61"
           },
           {
             "name": "dotnet-hosting-win.exe",
             "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6728a941-7b39-44af-b75c-91769681007d/0f062452057e1f17bcf2e1af7e2a5414/dotnet-hosting-9.0.0-preview.1.24081.5-win.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.0-preview.1.24081.5/dotnet-hosting-9.0.0-preview.1.24081.5-win.exe",
             "hash": "67a972f36f9e31417e6746b9ea69fc033e945708c2e43be665239ac16f561e92960240f789d942ae886b4d4a38a49e1ed226e5b92f0eeb1e66d178c760cd4960",
             "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
           }
@@ -6356,37 +6356,37 @@
           {
             "name": "windowsdesktop-runtime-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5bcc6b35-e7e7-48b5-8cf2-277a60fc03e1/d5c4319efbf8e734f9dd11a358c03bd4/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.exe",
             "hash": "bf252da538951cce59469e1d2074d34c4b8bb04de33421c9b594c447c8d3b9e2e2cacd28e4f515ba1a2e430db18d11c70bffb07cdcb518a3d035cf88f777a768"
           },
           {
             "name": "windowsdesktop-runtime-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dc0ae26f-121d-4f63-a066-2333861699b7/45bb105bf0b9756495fe8d217f20c397/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-arm64.zip",
             "hash": "2df2ba1949621525b70767bd1230928d8d82255e58a0f28a131ae4345d32e62ceeac41f42bac119c7b60eef0f9731d4920e522a4555e5d64a34ef361ef5128de"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0c804185-7f86-4167-8703-8365d4939d72/02935dd20c741d36acb2c4eb2f2d5a21/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.exe",
             "hash": "ef2731f34d6d2e732deaa5dff36e4fc04d6c2d6f600d0faf0a8f4f662e731fb6eeb778efa2dbc287dc04bdc00fda257f194ffb7821958cd4137683feaabe9d12"
           },
           {
             "name": "windowsdesktop-runtime-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9a297cbf-b641-4026-bca8-c68293c4fa8f/05b5d48d0ab2dc0cea2271f85c027c87/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x64.zip",
             "hash": "15f93de63a9144e01528bafd169d62a0e7fa1fc5a85c4e7422a1553b79ddbbc7213488facc38d677b8fca90778c608d623f49ada121a16664d675a1d7e225d9e"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e3264b5f-c04b-427b-bf87-f9a264f53b0d/9f564a10f3af50fda2ec7ef2365b10d5/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.exe",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.exe",
             "hash": "0288cddb418da54bbc09fdf9640eaa8ea0c236e4cec8613b70c10f6a2e2f831104d68d0bbe11138ba51bf51861cfdb6fba532394e3e58a7ce255f28f7f71a474"
           },
           {
             "name": "windowsdesktop-runtime-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f0788f54-28b1-4a6d-ae86-1ead236dda97/37a05b2928ca436d0424aeb3d5ce4e4f/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.zip",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.0-preview.1.24081.3/windowsdesktop-runtime-9.0.0-preview.1.24081.3-win-x86.zip",
             "hash": "e47ae91d7bf992e9dda09519551dc2dc9f5cec7b61542961c3b8c9ca67606204ed2f212934bed8a34bf6331d095683f018bb4418fed442e5b3ead1a11b479f28"
           }
         ]


### PR DESCRIPTION
Take two. Will merge on Tuesday the 18th.

If that all goes well, will merge https://github.com/dotnet/core/pull/9724 soon after.

Users with old versions of the [.NET Install Tool extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-runtime) may break. Users must be on v2.2.8 to avoid the break. We know that most users migrate to the new extension within 24-48 hours.

- https://github.com/dotnet/core/pull/9725
- https://github.com/dotnet/vscode-dotnet-runtime/pull/2129