### PR TITLE
Update preview release notes

### DIFF
--- a/release-notes/9.0/README.md
+++ b/release-notes/9.0/README.md
@@ -1,14 +1,16 @@
 # .NET 9
 
-[.NET 9](https://aka.ms/dotnet/9/preview1) is a [Standard Term Support (STS)](../../release-policies.md) release and will be supported on [multiple operating systems](supported-os.md) for 18 months, from November 12th, 2024 to May 12th, 2026.
+[.NET 9](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) is a [Standard Term Support (STS)](../../release-policies.md) release and will be supported on [multiple operating systems](supported-os.md) for 18 months, from November 12th, 2024 to May 12th, 2026.
 
+- [What's New](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/overview)
 - [Downloads](https://dotnet.microsoft.com/download/dotnet/9.0)
-- [Linux Package Managers](https://learn.microsoft.com/dotnet/core/install/linux)
-- [Containers](https://hub.docker.com/_/microsoft-dotnet)
 - [Supported OSes](supported-os.md)
+- [Installation instructions](install.md)
+- [Linux Packages](https://learn.microsoft.com/dotnet/core/install/linux)
+- [Containers](https://mcr.microsoft.com/catalog?search=dotnet/&type=partial&cat=Application%20Frameworks)
 - [OS packages](./os-packages.md)
 - [Known Issues](known-issues.md)
-- [Installation instructions](install.md)
+- [Preview release notes](./preview/README.md)
 
 ## Release notes
 
@@ -19,92 +21,3 @@
 | 2024/12/10 | [9.0.200 Preview SDK](./9.0.0/9.0.200-preview.md) |
 | 2024/12/03 | [9.0.101 SDK](./9.0.0/9.0.101.md) |
 | 2024/11/12 | [9.0.0](./9.0.0/9.0.0.md) |
-| 2024/10/08 | [9.0.0 RC 2](preview/rc2/README.md) |
-| 2024/09/10 | [9.0.0 RC 1](preview/rc1/README.md) |
-| 2024/08/13 | [9.0.0 Preview 7](preview/preview7/README.md) |
-| 2024/07/09 | [9.0.0 Preview 6](preview/preview6/README.md) |
-| 2024/06/11 | [9.0.0 Preview 5](preview/preview5/README.md) |
-| 2024/05/21 | [9.0.0 Preview 4](preview/preview4/README.md) |
-| 2024/04/11 | [9.0.0 Preview 3](preview/preview3/README.md) |
-| 2024/03/12 | [9.0.0 Preview 2](preview/preview2/README.md) |
-| 2024/02/13 | [9.0.0 Preview 1](preview/preview1/README.md) |
-
-### .NET Libraries
-
-- [What's new in .NET 9 libraries](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/overview#net-libraries)
-- [RC 2](preview/rc2/libraries.md)
-- [RC 1](preview/rc1/libraries.md)
-- [Preview 7](preview/preview7/libraries.md)
-- [Preview 6](preview/preview6/libraries.md)
-- [Preview 5](preview/preview5/libraries.md)
-- [Preview 4](preview/preview4/libraries.md)
-- [Preview 3](preview/preview3/libraries.md)
-- Preview 2: No release notes
-- [Preview 1](preview/preview1/libraries.md)
-
-### .NET Runtime
-
-- [What's new in the .NET 9 runtime](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/runtime)
-- [RC 2](preview/rc2/runtime.md)
-- RC 1: No release notes
-- [Preview 7](preview/preview7/runtime.md)
-- [Preview 6](preview/preview6/runtime.md)
-- Preview 5: No release notes
-- [Preview 4](preview/preview4/runtime.md)
-- [Preview 3](preview/preview3/runtime.md)
-- [Preview 2](preview/preview2/runtime.md)
-- [Preview 1](preview/preview1/runtime.md)
-
-### .NET SDK
-
-- [What's new in the SDK for .NET 9](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/sdk)
-- [RC 2](preview/rc2/sdk.md)
-- [RC 1](preview/rc1/sdk.md)
-- [Preview 7](preview/preview7/sdk.md)
-- [Preview 6](preview/preview6/sdk.md)
-- Preview 5: No release notes
-- Preview 4: No release notes
-- [Preview 3](preview/preview3/sdk.md)
-- [Preview 2](preview/preview2/sdk.md)
-- [Preview 1](preview/preview1/sdk.md)
-
-### C\#
-
-- [What's new in C# 13](https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-13)
-- [Preview 7](preview/preview7/csharp.md)
-- [Preview 6](preview/preview6/csharp.md)
-
-### ASP.NET Core
-
-- [What's new in ASP.NET Core 9.0](https://learn.microsoft.com/aspnet/core/release-notes/aspnetcore-9.0)
-- [RC 2](preview/rc2/aspnetcore.md)
-- [RC 1](preview/rc1/aspnetcore.md)
-- [Preview 7](preview/preview7/aspnetcore.md)
-- [Preview 6](preview/preview6/aspnetcore.md)
-- [Preview 5](preview/preview5/aspnetcore.md)
-- [Preview 4](preview/preview4/aspnetcore.md)
-- [Preview 3](preview/preview3/aspnetcore.md)
-- [Preview 2](preview/preview2/aspnetcore.md)
-- [Preview 1](preview/preview1/aspnetcore.md)
-
-### .NET MAUI
-
-- [What's new in .NET MAUI for .NET 9](https://learn.microsoft.com/dotnet/maui/whats-new/dotnet-9)
-- [RC 2](preview/rc2/dotnetmaui.md)
-- [RC 1](preview/rc1/dotnetmaui.md)
-- [Preview 7](preview/preview7/dotnetmaui.md)
-- [Preview 6](preview/preview6/dotnetmaui.md)
-- [Preview 5](preview/preview5/dotnetmaui.md)
-- [Preview 4](preview/preview4/dotnetmaui.md)
-- [Preview 3](preview/preview3/dotnetmaui.md)
-- [Preview 2](preview/preview2/dotnetmaui.md)
-- [Preview 1](preview/preview1/dotnetmaui.md)
-
-### Entity Framework Core
-
-- [What's new in EF Core 9](https://learn.microsoft.com/ef/core/what-is-new/ef-core-9.0/whatsnew)
-- [Preview 5](preview/preview5/efcoreanddata.md)
-- [Preview 4](preview/preview4/efcoreanddata.md)
-- [Preview 3](preview/preview3/efcoreanddata.md)
-- [Preview 2](preview/preview2/efcoreanddata.md)
-- [Preview 1](preview/preview1/efcoreanddata.md)

--- a/release-notes/9.0/preview/README.md
+++ b/release-notes/9.0/preview/README.md
@@ -1,0 +1,17 @@
+# .NET 9 preview release notes
+
+.NET 9 preview releases were released between February and October, 2025. The first [stable release](../README.md) was published in November. Release notes included detailed information and API diffs for new features.
+
+## Release notes
+
+| Date | Release |
+| :-- | :-- |
+| 2024/10/08 | [9.0.0 RC 2](preview/rc2/README.md) |
+| 2024/09/10 | [9.0.0 RC 1](preview/rc1/README.md) |
+| 2024/08/13 | [9.0.0 Preview 7](preview/preview7/README.md) |
+| 2024/07/09 | [9.0.0 Preview 6](preview/preview6/README.md) |
+| 2024/06/11 | [9.0.0 Preview 5](preview/preview5/README.md) |
+| 2024/05/21 | [9.0.0 Preview 4](preview/preview4/README.md) |
+| 2024/04/11 | [9.0.0 Preview 3](preview/preview3/README.md) |
+| 2024/03/12 | [9.0.0 Preview 2](preview/preview2/README.md) |
+| 2024/02/13 | [9.0.0 Preview 1](preview/preview1/README.md) |

--- a/release-notes/9.0/preview/preview1/README.md
+++ b/release-notes/9.0/preview/preview1/README.md
@@ -7,12 +7,10 @@ Find more information on new features released in .NET 9 Preview 1 by browsing t
 * [Libraries](./libraries.md)
 * [Runtime](./runtime.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET Data and EF Core](./efcoreanddata.md)
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/preview2/README.md
+++ b/release-notes/9.0/preview/preview2/README.md
@@ -4,12 +4,10 @@
 
 * [Runtime](./runtime.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET Data and EF Core](./efcoreanddata.md)
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/preview3/README.md
+++ b/release-notes/9.0/preview/preview3/README.md
@@ -5,12 +5,10 @@
 * [Libraries](libraries.md)
 * [Runtime](./runtime.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET Data and EF Core](./efcoreanddata.md)
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/preview4/README.md
+++ b/release-notes/9.0/preview/preview4/README.md
@@ -4,13 +4,11 @@
 
 * [Libraries](./libraries.md)
 * [Runtime](./runtime.md)
-
-## Feature Release Notes
-
 * [.NET Data and EF Core](./efcoreanddata.md)
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
 * [WPF](./wpf.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/preview5/README.md
+++ b/release-notes/9.0/preview/preview5/README.md
@@ -3,12 +3,10 @@
 .NET 9 Preview 5 released on June 11th, 2024. Find more information on new features released in .NET 9 Preview 5 by browsing through the release notes below:
 
 * [Libraries](./libraries.md)
-
-## Feature Release Notes
-
 * [.NET Data and EF Core](./efcoreanddata.md)
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/preview6/README.md
+++ b/release-notes/9.0/preview/preview6/README.md
@@ -5,12 +5,10 @@
 * [Libraries](./libraries.md)
 * [Runtime](./runtime.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
 * [C#](./csharp.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/rc1/README.md
+++ b/release-notes/9.0/preview/rc1/README.md
@@ -4,11 +4,9 @@
 
 * [Libraries](./libraries.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 

--- a/release-notes/9.0/preview/rc2/README.md
+++ b/release-notes/9.0/preview/rc2/README.md
@@ -5,11 +5,9 @@
 * [Libraries](./libraries.md)
 * [Runtime](./runtime.md)
 * [SDK](./sdk.md)
-
-## Feature Release Notes
-
 * [.NET MAUI](./dotnetmaui.md)
 * [ASP.NET Core](./aspnetcore.md)
+* [API diff](./api-diff/README.md)
 
 ## Get Started
 


### PR DESCRIPTION
Simplified .NET 9 release notes by moving preview content to the preview folder. This was primarily done to get feedback on a new approach.