### PR TITLE
API diff between .NET 10 Preview 2 and .NET 10 Preview 3

### DIFF
--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3.md
@@ -1,0 +1,13 @@
+# API difference between .NET 10.0 Preview 2 and .NET 10.0 Preview 3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components](10.0-preview3_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Endpoints](10.0-preview3_Microsoft.AspNetCore.Components.Endpoints.md)
+* [Microsoft.AspNetCore.Http.Abstractions](10.0-preview3_Microsoft.AspNetCore.Http.Abstractions.md)
+* [Microsoft.AspNetCore.Http.Results](10.0-preview3_Microsoft.AspNetCore.Http.Results.md)
+* [Microsoft.AspNetCore.Routing](10.0-preview3_Microsoft.AspNetCore.Routing.md)
+* [Microsoft.Extensions.Caching.Memory](10.0-preview3_Microsoft.Extensions.Caching.Memory.md)
+* [System.Threading.RateLimiting](10.0-preview3_System.Threading.RateLimiting.md)
+

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Components.Endpoints.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Components.Endpoints.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Components.Endpoints
+
+```diff
+  namespace Microsoft.Extensions.DependencyInjection
+  {
++     public static class RazorComponentsRazorComponentBuilderExtensions
++     {
++         public static Microsoft.Extensions.DependencyInjection.IRazorComponentsBuilder RegisterPersistentService<TPersistentService>(this Microsoft.Extensions.DependencyInjection.IRazorComponentsBuilder builder, Microsoft.AspNetCore.Components.IComponentRenderMode renderMode);
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Components.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,35 @@
+# Microsoft.AspNetCore.Components
+
+```diff
+  namespace Microsoft.AspNetCore.Components
+  {
+      public abstract class NavigationManager
+      {
++         public event System.EventHandler<System.EventArgs> NotFoundEvent { add; remove; }
++         public virtual void NotFound();
+      }
++     public sealed class SupplyParameterFromPersistentComponentStateAttribute : Microsoft.AspNetCore.Components.CascadingParameterAttributeBase
++     {
++         public SupplyParameterFromPersistentComponentStateAttribute();
++     }
+  }
+  namespace Microsoft.AspNetCore.Components.Infrastructure
+  {
+      public class ComponentStatePersistenceManager
+      {
++         public ComponentStatePersistenceManager(Microsoft.Extensions.Logging.ILogger<Microsoft.AspNetCore.Components.Infrastructure.ComponentStatePersistenceManager> logger, System.IServiceProvider serviceProvider);
++         public void SetPlatformRenderMode(Microsoft.AspNetCore.Components.IComponentRenderMode renderMode);
+      }
++     public static class RegisterPersistentComponentStateServiceCollectionExtensions
++     {
++         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddPersistentServiceRegistration<TService>(Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.AspNetCore.Components.IComponentRenderMode componentRenderMode);
++     }
+  }
+  namespace Microsoft.Extensions.DependencyInjection
+  {
++     public static class SupplyParameterFromPersistentComponentStateProviderServiceCollectionExtensions
++     {
++         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddSupplyValueFromPersistentComponentStateProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Http.Abstractions.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Http.Abstractions.md
@@ -1,0 +1,64 @@
+# Microsoft.AspNetCore.Http.Abstractions
+
+```diff
+  namespace Microsoft.AspNetCore.Http.Metadata
+  {
++     public interface IDisableValidationMetadata
++     {
++     }
+  }
++ namespace Microsoft.AspNetCore.Http.Validation
++ {
++     public interface IValidatableInfo
++     {
++     }
++     public interface IValidatableInfoResolver
++     {
++     }
++     public abstract class ValidatableParameterInfo : Microsoft.AspNetCore.Http.Validation.IValidatableInfo
++     {
++         protected ValidatableParameterInfo(System.Type parameterType, string name, string displayName);
++         protected abstract System.ComponentModel.DataAnnotations.ValidationAttribute[] GetValidationAttributes();
++         public virtual System.Threading.Tasks.Task ValidateAsync(object? value, Microsoft.AspNetCore.Http.Validation.ValidateContext context, System.Threading.CancellationToken cancellationToken);
++     }
++     public abstract class ValidatablePropertyInfo : Microsoft.AspNetCore.Http.Validation.IValidatableInfo
++     {
++         protected ValidatablePropertyInfo(System.Type declaringType, System.Type propertyType, string name, string displayName);
++         protected abstract System.ComponentModel.DataAnnotations.ValidationAttribute[] GetValidationAttributes();
++         public virtual System.Threading.Tasks.Task ValidateAsync(object? value, Microsoft.AspNetCore.Http.Validation.ValidateContext context, System.Threading.CancellationToken cancellationToken);
++     }
++     public sealed class ValidatableTypeAttribute
++     {
++         public ValidatableTypeAttribute();
++     }
++     public abstract class ValidatableTypeInfo : Microsoft.AspNetCore.Http.Validation.IValidatableInfo
++     {
++         protected ValidatableTypeInfo(System.Type type, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo> members);
++         public virtual System.Threading.Tasks.Task ValidateAsync(object? value, Microsoft.AspNetCore.Http.Validation.ValidateContext context, System.Threading.CancellationToken cancellationToken);
++     }
++     public sealed class ValidateContext
++     {
++         public ValidateContext();
++         public int CurrentDepth { get; set; }
++         public string CurrentValidationPath { get; set; }
++         public System.ComponentModel.DataAnnotations.ValidationContext? ValidationContext { get; set; }
++         public System.Collections.Generic.Dictionary<string, string[]>? ValidationErrors { get; set; }
++         public required Microsoft.AspNetCore.Http.Validation.ValidationOptions ValidationOptions { get; set; }
++     }
++     public class ValidationOptions
++     {
++         public ValidationOptions();
++         public bool TryGetValidatableParameterInfo(System.Reflection.ParameterInfo parameterInfo, out Microsoft.AspNetCore.Http.Validation.IValidatableInfo? validatableInfo);
++         public bool TryGetValidatableTypeInfo(System.Type type, out Microsoft.AspNetCore.Http.Validation.IValidatableInfo? validatableTypeInfo);
++         public int MaxDepth { get; set; }
++         public System.Collections.Generic.IList<Microsoft.AspNetCore.Http.Validation.IValidatableInfoResolver> Resolvers { get; }
++     }
++ }
++ namespace Microsoft.Extensions.DependencyInjection
++ {
++     public static class ValidationServiceCollectionExtensions
++     {
++         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Http.Validation.ValidationOptions>? configureOptions = null);
++     }
++ }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Http.Results.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Http.Results.md
@@ -1,0 +1,27 @@
+# Microsoft.AspNetCore.Http.Results
+
+```diff
+  namespace Microsoft.AspNetCore.Http
+  {
+      public static class Results
+      {
++         public static Microsoft.AspNetCore.Http.IResult ServerSentEvents(System.Collections.Generic.IAsyncEnumerable<string> values, string? eventType = null);
++         public static Microsoft.AspNetCore.Http.IResult ServerSentEvents<T>(System.Collections.Generic.IAsyncEnumerable<T> values, string? eventType = null);
++         public static Microsoft.AspNetCore.Http.IResult ServerSentEvents<T>(System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<T>> values);
+      }
+      public static class TypedResults
+      {
++         public static Microsoft.AspNetCore.Http.HttpResults.ServerSentEventsResult<string> ServerSentEvents(System.Collections.Generic.IAsyncEnumerable<string> values, string? eventType = null);
++         public static Microsoft.AspNetCore.Http.HttpResults.ServerSentEventsResult<T> ServerSentEvents<T>(System.Collections.Generic.IAsyncEnumerable<T> values, string? eventType = null);
++         public static Microsoft.AspNetCore.Http.HttpResults.ServerSentEventsResult<T> ServerSentEvents<T>(System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<T>> values);
+      }
+  }
+  namespace Microsoft.AspNetCore.Http.HttpResults
+  {
++     public sealed class ServerSentEventsResult<T> : Microsoft.AspNetCore.Http.IResult, Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider, Microsoft.AspNetCore.Http.IStatusCodeHttpResult
++     {
++         public System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext);
++ public System.Nullable<int> StatusCode { get; }
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Routing.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.AspNetCore.Routing.md
@@ -1,0 +1,12 @@
+# Microsoft.AspNetCore.Routing
+
+```diff
+  namespace Microsoft.AspNetCore.Builder
+  {
++     public static class ValidationEndpointConventionBuilderExtensions
++     {
++         public static TBuilder DisableValidation<TBuilder>(this TBuilder builder)
++             where TBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder;
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.Extensions.Caching.Memory.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_Microsoft.Extensions.Caching.Memory.md
@@ -1,0 +1,12 @@
+# Microsoft.Extensions.Caching.Memory
+
+```diff
+  namespace Microsoft.Extensions.Caching.Memory
+  {
+      public class MemoryCache : Microsoft.Extensions.Caching.Memory.IMemoryCache
+      {
++         public bool TryGetValue(System.ReadOnlySpan<char> key, out object? value);
++         public bool? TryGetValue<TItem>(System.ReadOnlySpan<char> key, out TItem? value);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_System.Threading.RateLimiting.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.AspNetCore.App/10.0-preview3_System.Threading.RateLimiting.md
@@ -1,0 +1,11 @@
+# System.Threading.RateLimiting
+
+```diff
+  namespace System.Threading.RateLimiting
+  {
+      public abstract class RateLimiter
+      {
++         public static System.Threading.RateLimiting.RateLimiter CreateChained(params System.Threading.RateLimiting.RateLimiter[] limiters);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3.md
@@ -1,0 +1,17 @@
+# API difference between .NET 10.0 Preview 2 and .NET 10.0 Preview 3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.ComponentModel.Annotations](10.0-preview3_System.ComponentModel.Annotations.md)
+* [System.Diagnostics.DiagnosticSource](10.0-preview3_System.Diagnostics.DiagnosticSource.md)
+* [System.Formats.Asn1](10.0-preview3_System.Formats.Asn1.md)
+* [System.Memory](10.0-preview3_System.Memory.md)
+* [System.Net.Primitives](10.0-preview3_System.Net.Primitives.md)
+* [System.Net.Security](10.0-preview3_System.Net.Security.md)
+* [System.Net.ServerSentEvents](10.0-preview3_System.Net.ServerSentEvents.md)
+* [System.Runtime](10.0-preview3_System.Runtime.md)
+* [System.Security.Claims](10.0-preview3_System.Security.Claims.md)
+* [System.Security.Cryptography](10.0-preview3_System.Security.Cryptography.md)
+* [System.Threading](10.0-preview3_System.Threading.md)
+

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.ComponentModel.Annotations.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.ComponentModel.Annotations.md
@@ -1,0 +1,35 @@
+# System.ComponentModel.Annotations
+
+```diff
+  namespace System.ComponentModel.DataAnnotations
+  {
+      public sealed class ValidationContext : System.IServiceProvider
+      {
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public ValidationContext(object instance, System.Collections.Generic.IDictionary<object, object?>? items);
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public ValidationContext(object instance, System.IServiceProvider? serviceProvider, System.Collections.Generic.IDictionary<object, object?>? items);
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public ValidationContext(object instance);
++         public ValidationContext(object instance, string displayName, System.IServiceProvider? serviceProvider, System.Collections.Generic.IDictionary<object, object?>? items);
+      }
+      public static class Validator
+      {
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public static bool TryValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, bool validateAllProperties);
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public static bool TryValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults);
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public static void ValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, bool validateAllProperties);
+-         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of instance cannot be statically discovered and the Type's properties can be trimmed.")]
++         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+          public static void ValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Diagnostics.DiagnosticSource.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Diagnostics.DiagnosticSource.md
@@ -1,0 +1,31 @@
+# System.Diagnostics.DiagnosticSource
+
+```diff
+  namespace System.Diagnostics
+  {
+      public sealed class ActivitySource : System.IDisposable
+      {
++         public ActivitySource(System.Diagnostics.ActivitySourceOptions options);
++         public string? TelemetrySchemaUrl { get; }
+      }
++     public class ActivitySourceOptions
++     {
++         public ActivitySourceOptions(string name);
++         public string Name { get; set; }
++         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? Tags { get; set; }
++         public string? TelemetrySchemaUrl { get; set; }
++         public string? Version { get; set; }
++     }
+  }
+  namespace System.Diagnostics.Metrics
+  {
+      public class Meter : System.IDisposable
+      {
++         public string? TelemetrySchemaUrl { get; }
+      }
+      public class MeterOptions
+      {
++         public string? TelemetrySchemaUrl { get; set; }
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Formats.Asn1.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Formats.Asn1.md
@@ -1,0 +1,11 @@
+# System.Formats.Asn1
+
+```diff
+  namespace System.Formats.Asn1
+  {
+      public sealed class AsnWriter
+      {
++         public void Encode<TState>(TState state, System.Action<TState, System.ReadOnlySpan<byte>> encodeCallback);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Memory.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Memory.md
@@ -1,0 +1,23 @@
+# System.Memory
+
+```diff
+  namespace System
+  {
+      public static class MemoryExtensions
+      {
++         public static int CountAny<T>(this System.ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values)
++             where T : System.IEquatable<T>?;
++         public static int CountAny<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values, System.Collections.Generic.IEqualityComparer<T>? comparer = null);
++         public static int CountAny<T>(this System.ReadOnlySpan<T> span, params scoped System.ReadOnlySpan<T> values)
++             where T : System.IEquatable<T>?;
++         public static void ReplaceAny<T>(this System.ReadOnlySpan<T> source, System.Span<T> destination, System.Buffers.SearchValues<T> values, T newValue)
++             where T : System.IEquatable<T>?;
++         public static void ReplaceAny<T>(this System.Span<T> span, System.Buffers.SearchValues<T> values, T newValue)
++             where T : System.IEquatable<T>?;
++         public static void ReplaceAnyExcept<T>(this System.ReadOnlySpan<T> source, System.Span<T> destination, System.Buffers.SearchValues<T> values, T newValue)
++             where T : System.IEquatable<T>?;
++         public static void ReplaceAnyExcept<T>(this System.Span<T> span, System.Buffers.SearchValues<T> values, T newValue)
++             where T : System.IEquatable<T>?;
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.Primitives.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.Primitives.md
@@ -1,0 +1,22 @@
+# System.Net.Primitives
+
+```diff
+  namespace System.Security.Authentication
+  {
+-     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+      public enum CipherAlgorithmType
+      {
+      }
+-     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+      public enum ExchangeAlgorithmType
+      {
+      }
+-     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++     [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+      public enum HashAlgorithmType
+      {
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.Security.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.Security.md
@@ -1,0 +1,28 @@
+# System.Net.Security
+
+```diff
+  namespace System.Net.Security
+  {
+      public class SslStream : System.Net.Security.AuthenticatedStream
+      {
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual System.Security.Authentication.CipherAlgorithmType CipherAlgorithm { get; }
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual int CipherStrength { get; }
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual System.Security.Authentication.HashAlgorithmType HashAlgorithm { get; }
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual int HashStrength { get; }
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual System.Security.Authentication.ExchangeAlgorithmType KeyExchangeAlgorithm { get; }
+-         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
++         [System.ObsoleteAttribute("KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead.", DiagnosticId = "SYSLIB0058", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public virtual int KeyExchangeStrength { get; }
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.ServerSentEvents.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Net.ServerSentEvents.md
@@ -1,0 +1,34 @@
+# System.Net.ServerSentEvents
+
+```diff
++ namespace System.Net.ServerSentEvents
++ {
++     public static class SseFormatter
++     {
++         public static System.Threading.Tasks.Task WriteAsync(System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<string>> source, System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task WriteAsync<T>(System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<T>> source, System.IO.Stream destination, System.Action<System.Net.ServerSentEvents.SseItem<T>, System.Buffers.IBufferWriter<byte>> itemFormatter, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++     }
++     public readonly struct SseItem<T>
++     {
++         public SseItem(T data, string? eventType = null);
++         public T Data { get; }
++         public string? EventId { get; init; }
++         public string EventType { get; }
++         public System.TimeSpan? ReconnectionInterval { get; init; }
++     }
++     public delegate T SseItemParser<out T>(string eventType, System.ReadOnlySpan<byte> data);
++     public static class SseParser
++     {
++         public const string EventTypeDefault = "message";
++         public static System.Net.ServerSentEvents.SseParser<string> Create(System.IO.Stream sseStream);
++         public static System.Net.ServerSentEvents.SseParser<T> Create<T>(System.IO.Stream sseStream, System.Net.ServerSentEvents.SseItemParser<T> itemParser);
++     }
++     public sealed class SseParser<T>
++     {
++         public System.Collections.Generic.IEnumerable<System.Net.ServerSentEvents.SseItem<T>> Enumerate();
++         public System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<T>> EnumerateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++ public string LastEventId { get; }
++         public System.TimeSpan ReconnectionInterval { get; }
++     }
++ }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Runtime.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Runtime.md
@@ -1,0 +1,81 @@
+# System.Runtime
+
+```diff
+  namespace System
+  {
+      public class Random
+      {
++         public string GetHexString(int stringLength, bool lowercase = false);
++         public void GetHexString(System.Span<char> destination, bool lowercase = false);
++         public string GetString(System.ReadOnlySpan<char> choices, int length);
+      }
+  }
+  namespace System.Runtime.CompilerServices
+  {
+      public sealed class ConditionalWeakTable<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable where TKey : class where TValue : class
+      {
++         public bool Remove(TKey key, out TValue value);
+      }
+      public ref struct DefaultInterpolatedStringHandler
+      {
++         public void Clear();
++         public System.ReadOnlySpan<char> Text { get; }
+      }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(10)]
++     public struct InlineArray10<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(11)]
++     public struct InlineArray11<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(12)]
++     public struct InlineArray12<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(13)]
++     public struct InlineArray13<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(14)]
++     public struct InlineArray14<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(15)]
++     public struct InlineArray15<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(2)]
++     public struct InlineArray2<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(3)]
++     public struct InlineArray3<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(4)]
++     public struct InlineArray4<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(5)]
++     public struct InlineArray5<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(6)]
++     public struct InlineArray6<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(7)]
++     public struct InlineArray7<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(8)]
++     public struct InlineArray8<T>
++     {
++     }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(9)]
++     public struct InlineArray9<T>
++     {
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Claims.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Claims.md
@@ -1,0 +1,12 @@
+# System.Security.Claims
+
+```diff
+  namespace System.Security.Claims
+  {
+      public class ClaimsPrincipal : System.Security.Principal.IPrincipal
+      {
+-         public static System.Func<System.Security.Claims.ClaimsPrincipal> ClaimsPrincipalSelector { get; set; }
++         public static System.Func<System.Security.Claims.ClaimsPrincipal?>? ClaimsPrincipalSelector { get; set; }
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Cryptography.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Cryptography.md
@@ -34,6 +34,9 @@
       }
 +     public enum Pkcs12ExportPbeParameters
 +     {
++         Default = 0,
++         Pkcs12TripleDesSha1 = 1,
++         Pbes2Aes256Sha256 = 2,
 +     }
   }
 ```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Cryptography.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Security.Cryptography.md
@@ -1,0 +1,39 @@
+# System.Security.Cryptography
+
+```diff
+  namespace System.Security.Cryptography
+  {
+      public abstract class SymmetricAlgorithm : System.IDisposable
+      {
++         public void SetKey(System.ReadOnlySpan<byte> key);
++         protected virtual void SetKeyCore(System.ReadOnlySpan<byte> key);
+      }
+  }
+  namespace System.Security.Cryptography.X509Certificates
+  {
+      public sealed class PublicKey
+      {
+-         public PublicKey(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedData parameters, System.Security.Cryptography.AsnEncodedData keyValue);
++         public PublicKey(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedData? parameters, System.Security.Cryptography.AsnEncodedData keyValue);
+-         public System.Security.Cryptography.AsnEncodedData EncodedParameters { get; }
++         public System.Security.Cryptography.AsnEncodedData? EncodedParameters { get; }
+      }
+      public class X509Certificate : System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+      {
+-         public virtual byte[] GetKeyAlgorithmParameters();
++         public virtual byte[]? GetKeyAlgorithmParameters();
+-         public virtual string GetKeyAlgorithmParametersString();
++         public virtual string? GetKeyAlgorithmParametersString();
++         public byte[] ExportPkcs12(System.Security.Cryptography.PbeParameters exportParameters, string? password);
++         public byte[] ExportPkcs12(System.Security.Cryptography.X509Certificates.Pkcs12ExportPbeParameters exportParameters, string? password);
+      }
+      public class X509Certificate2Collection : System.Security.Cryptography.X509Certificates.X509CertificateCollection, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable
+      {
++         public byte[] ExportPkcs12(System.Security.Cryptography.PbeParameters exportParameters, string? password);
++         public byte[] ExportPkcs12(System.Security.Cryptography.X509Certificates.Pkcs12ExportPbeParameters exportParameters, string? password);
+      }
++     public enum Pkcs12ExportPbeParameters
++     {
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Threading.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.NETCore.App/10.0-preview3_System.Threading.md
@@ -1,0 +1,38 @@
+# System.Threading
+
+```diff
+  namespace System.Threading
+  {
+      public class EventWaitHandle : System.Threading.WaitHandle
+      {
++         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode, string? name, System.Threading.NamedWaitHandleOptions options, out bool createdNew);
++         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode, string? name, System.Threading.NamedWaitHandleOptions options);
++         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
++         public static System.Threading.EventWaitHandle OpenExisting(string name, System.Threading.NamedWaitHandleOptions options);
++         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
++         public static bool TryOpenExisting(string name, System.Threading.NamedWaitHandleOptions options, out System.Threading.EventWaitHandle? result);
+      }
+      public sealed class Mutex : System.Threading.WaitHandle
+      {
++         public Mutex(bool initiallyOwned, string? name, System.Threading.NamedWaitHandleOptions options, out bool createdNew);
++         public Mutex(bool initiallyOwned, string? name, System.Threading.NamedWaitHandleOptions options);
++         public Mutex(string? name, System.Threading.NamedWaitHandleOptions options);
++         public static System.Threading.Mutex OpenExisting(string name, System.Threading.NamedWaitHandleOptions options);
++         public static bool TryOpenExisting(string name, System.Threading.NamedWaitHandleOptions options, out System.Threading.Mutex? result);
+      }
+      public sealed class Semaphore : System.Threading.WaitHandle
+      {
++         public Semaphore(int initialCount, int maximumCount, string? name, System.Threading.NamedWaitHandleOptions options, out bool createdNew);
++         public Semaphore(int initialCount, int maximumCount, string? name, System.Threading.NamedWaitHandleOptions options);
++         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
++         public static System.Threading.Semaphore OpenExisting(string name, System.Threading.NamedWaitHandleOptions options);
++         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
++         public static bool TryOpenExisting(string name, System.Threading.NamedWaitHandleOptions options, out System.Threading.Semaphore? result);
+      }
++     public struct NamedWaitHandleOptions
++     {
++         public bool CurrentSessionOnly { get; set; }
++         public bool CurrentUserOnly { get; set; }
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3.md
@@ -1,0 +1,8 @@
+# API difference between .NET 10.0 Preview 2 and .NET 10.0 Preview 3
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Windows.Forms](10.0-preview3_System.Windows.Forms.md)
+* [System.Windows.Forms.Design](10.0-preview3_System.Windows.Forms.Design.md)
+

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_System.Windows.Forms.Design.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_System.Windows.Forms.Design.md
@@ -1,0 +1,28 @@
+# System.Windows.Forms.Design
+
+```diff
+  namespace System.ComponentModel.Design
+  {
+      public class DesignerActionMethodItem : System.ComponentModel.Design.DesignerActionItem
+      {
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, bool includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, bool includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description, bool includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description) : base(default(string?), default(string?), default(string?));
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category) : base(default(string?), default(string?), default(string?));
+-         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName) : base(default(string?), default(string?), default(string?));
+-         public virtual bool IncludeAsDesignerVerb { get; }
++         public virtual bool? IncludeAsDesignerVerb { get; }
+-         public virtual string MemberName { get; }
++         public virtual string? MemberName { get; }
+-         public System.ComponentModel.IComponent RelatedComponent { get; set; }
++         public System.ComponentModel.IComponent? RelatedComponent { get; set; }
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName, bool? includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName, string? category, bool? includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName, string? category, string? description, bool? includeAsDesignerVerb) : base(default(string?), default(string?), default(string?));
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName, string? category, string? description) : base(default(string?), default(string?), default(string?));
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName, string? category) : base(default(string?), default(string?), default(string?));
++         public DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList? actionList, string? memberName, string? displayName) : base(default(string?), default(string?), default(string?));
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_System.Windows.Forms.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_System.Windows.Forms.md
@@ -1,0 +1,24 @@
+# System.Windows.Forms
+
+```diff
+  namespace System.Windows.Forms
+  {
+      public class DataObject : System.Windows.Forms.ITypedDataObject, System.Windows.Forms.IDataObject
+      {
+-         public void SetDataAsJson<T>(string format, bool autoConvert, T data);
+      }
+      public class ErrorProvider
+      {
+-         protected override void Dispose(bool disposing);
+-         public int BlinkRate { get; set; }
++         public int? BlinkRate { get; set; }
+-         public System.Windows.Forms.ErrorBlinkStyle BlinkStyle { get; set; }
++         public System.Windows.Forms.ErrorBlinkStyle? BlinkStyle { get; set; }
+-         public bool HasErrors { get; }
++         public bool? HasErrors { get; }
+-         public virtual bool RightToLeft { get; set; }
++         public virtual bool? RightToLeft { get; set; }
++         protected override void Dispose(bool? disposing);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview3/api-diff/README.md
+++ b/release-notes/10.0/preview/preview3/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 10.0 Preview 3 API Changes
+
+The following API changes were made in .NET 10.0 Preview 3:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/10.0-preview3.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/10.0-preview3.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/10.0-preview3.md)


### PR DESCRIPTION
Repo area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @Tanya-Solyanik @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffschwMSFT @jeffhandley @karelz @ericstj @stephentoub @SamMonoRT 

Libraries area owners:
- System.ComponentModel.DataAnnotations @dotnet/area-system-componentmodel-dataannotations 
- System.Diagnostics @dotnet/area-system-diagnostics 
- System.Formats.Asn1 @dotnet/area-system-formats-asn1 
- System.Memory @dotnet/area-system-memory 
- System.Net @dotnet/ncl 
- System.Runtime @dotnet/area-system-runtime 
- System.Security @dotnet/area-system-security 
- System.Threading @kouvel @mangod9

-----

## New tool to generate diffs!

I have an open PR with the new tool we'll be using from now on to generate these API diffs: https://github.com/dotnet/sdk/pull/46425

If you see any bugs, or if you don't see any APIs that should've showed up, **please let me know**.

Main differences with the old tool:

- It uses Roslyn instead of Cci.
- It has unit tests.
- The files are being generated by assembly, not by namespace. So for example, you might find System.Runtime.CompilerServices under the System.Runtime file.
- Events now show their `add` and `remove` accessors.
- Might show some attributes that we weren't showing before in Api Diffs. Let me know if you don't want them shown and I'll exclude them.