### PR TITLE
Add missing cve-id

### DIFF
--- a/release-notes/9.0/releases.json
+++ b/release-notes/9.0/releases.json
@@ -15,6 +15,7 @@
       "security": true,
       "cve-list": [
         {
+          "cve-id": "CVE-2025-26682",
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-26682"
         }
       ],


### PR DESCRIPTION
The `cve-id` property is missing from the 9.0.4 release.
