### PR TITLE
Fix .NET 10 preview 3 version numbers

### DIFF
--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -14,7 +14,7 @@
       "security": false,
       "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview3/10.0.0-preview.3.md",
       "runtime": {
-        "version": "10.0.0-preview.3",
+        "version": "10.0.0-preview.3.25171.5",
         "version-display": "10.0.0-preview.3",
         "vs-version": "",
         "vs-mac-version": "",
@@ -430,7 +430,7 @@
         }
       ],
       "aspnetcore-runtime": {
-        "version": "10.0.0-preview.3",
+        "version": "10.0.0-preview.3.25172.1",
         "version-display": "10.0.0-preview.3",
         "version-aspnetcoremodule": [
           "20.0.25082.0"
@@ -663,7 +663,7 @@
         ]
       },
       "windowsdesktop": {
-        "version": "10.0.0-preview.3",
+        "version": "10.0.0-preview.3.25174.1",
         "version-display": "10.0.0-preview.3",
         "files": [
           {


### PR DESCRIPTION
Fix `version` being the same as `version-display`, instead of the actual version.