### PR TITLE
Fix latest-runtime for .NET 10

### DIFF
--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -319,9 +319,9 @@
         ]
       },
       "sdks": [
-        {
+          "version": "10.0.100-preview.3.25201.16",
           "version-display": "10.0.100-preview.3",
-          "runtime-version": "10.0.0-preview.3.25171.5",
+          "version-display": "10.0.100-preview.3",
           "runtime-version": "10.0.0-preview.3.25171.5",
 
           "vs-version": "",

--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -2,7 +2,7 @@
   "channel-version": "10.0",
   "latest-release": "10.0.0-preview.3",
   "latest-release-date": "2025-04-10",
-  "latest-runtime": "10.0.0-preview.3",
+  "latest-runtime": "10.0.0-preview.3.25171.5",
   "latest-sdk": "10.0.100-preview.3.25201.16",
   "support-phase": "preview",
   "release-type": "lts",

--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -320,8 +320,8 @@
       },
       "sdks": [
         {
-          "version": "10.0.100-preview.3.25201.16",
-          "runtime-version": "10.0.0-preview.3.25171.5",
+          "version-display": "10.0.100-preview.3",
+          "runtime-version": "10.0.0-preview.3.25171.5",
           "runtime-version": "10.0.0-preview.3.25171.5",
 
           "vs-version": "",

--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -210,7 +210,7 @@
       "sdk": {
         "version": "10.0.100-preview.3.25201.16",
         "version-display": "10.0.100-preview.3",
-        "runtime-version": "10.0.0-preview.3",
+        "runtime-version": "10.0.0-preview.3.25171.5",
         "vs-version": "",
         "vs-mac-version": "",
         "vs-support": "",
@@ -321,7 +321,7 @@
         {
           "version": "10.0.100-preview.3.25201.16",
           "version-display": "10.0.100-preview.3",
-          "runtime-version": "10.0.0-preview.3",
+          "runtime-version": "10.0.0-preview.3.25171.5",
           "vs-version": "",
           "vs-mac-version": "",
           "vs-support": "",

--- a/release-notes/10.0/releases.json
+++ b/release-notes/10.0/releases.json
@@ -211,6 +211,7 @@
         "version": "10.0.100-preview.3.25201.16",
         "version-display": "10.0.100-preview.3",
         "runtime-version": "10.0.0-preview.3.25171.5",
+
         "vs-version": "",
         "vs-mac-version": "",
         "vs-support": "",
@@ -320,8 +321,9 @@
       "sdks": [
         {
           "version": "10.0.100-preview.3.25201.16",
-          "version-display": "10.0.100-preview.3",
           "runtime-version": "10.0.0-preview.3.25171.5",
+          "runtime-version": "10.0.0-preview.3.25171.5",
+
           "vs-version": "",
           "vs-mac-version": "",
           "vs-support": "",


### PR DESCRIPTION
Fix `latest-runtime` to use the full version for the runtime.

Missed from #9850.
