### PR TITLE
API diff between .NET 10 Preview 3 and .NET 10 Preview 4

### DIFF
--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4.md
@@ -1,0 +1,12 @@
+# API difference between .NET 10.0 Preview 3 and .NET 10.0 Preview 4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [Microsoft.AspNetCore.Components](10.0-preview4_Microsoft.AspNetCore.Components.md)
+* [Microsoft.AspNetCore.Components.Web](10.0-preview4_Microsoft.AspNetCore.Components.Web.md)
+* [Microsoft.AspNetCore.Server.HttpSys](10.0-preview4_Microsoft.AspNetCore.Server.HttpSys.md)
+* [Microsoft.Extensions.Logging](10.0-preview4_Microsoft.Extensions.Logging.md)
+* [Microsoft.Extensions.Logging.Abstractions](10.0-preview4_Microsoft.Extensions.Logging.Abstractions.md)
+* [Microsoft.JSInterop](10.0-preview4_Microsoft.JSInterop.md)
+

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Components.Web.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Components.Web.md
@@ -1,0 +1,19 @@
+# Microsoft.AspNetCore.Components.Web
+
+```diff
+  namespace Microsoft.AspNetCore.Components.Routing
+  {
+      public class NavLink : Microsoft.AspNetCore.Components.ComponentBase
+      {
+-         protected virtual bool ShouldMatch(string currentUriAbsolute);
++         protected virtual bool ShouldMatch(string uriAbsolute);
+      }
+  }
+  namespace Microsoft.AspNetCore.Components.Web.Internal
+  {
+      public interface IInternalWebJSInProcessRuntime
+      {
++         string InvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Components.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Components.md
@@ -1,0 +1,32 @@
+# Microsoft.AspNetCore.Components
+
+```diff
+  namespace Microsoft.AspNetCore.Components
+  {
+      public abstract class NavigationManager
+      {
+-         public event System.EventHandler<System.EventArgs> NotFoundEvent { add; remove; }
+-         public virtual void NotFound();
++         public void NotFound();
++         public event System.EventHandler<Microsoft.AspNetCore.Components.Routing.NotFoundEventArgs> OnNotFound { add; remove; }
+      }
+  }
+  namespace Microsoft.AspNetCore.Components.RenderTree
+  {
+      public abstract class Renderer
+      {
++         protected virtual void SignalRendererToFinishRendering();
+      }
+  }
+  namespace Microsoft.AspNetCore.Components.Routing
+  {
+      public interface IHostEnvironmentNavigationManager
+      {
++         void Initialize(string baseUri, string uri, System.Func<string, System.Threading.Tasks.Task> onNavigateTo);
+      }
++     public sealed class NotFoundEventArgs
++     {
++         public NotFoundEventArgs();
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Server.HttpSys.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.AspNetCore.Server.HttpSys.md
@@ -1,0 +1,11 @@
+# Microsoft.AspNetCore.Server.HttpSys
+
+```diff
+  namespace Microsoft.AspNetCore.Server.HttpSys
+  {
+      public class HttpSysOptions
+      {
++         public System.Action<Microsoft.AspNetCore.Http.Features.IFeatureCollection, System.ReadOnlySpan<byte>> TlsClientHelloBytesCallback { get; set; }
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.Extensions.Logging.Abstractions.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.Extensions.Logging.Abstractions.md
@@ -1,0 +1,12 @@
+# Microsoft.Extensions.Logging.Abstractions
+
+```diff
+  namespace Microsoft.Extensions.Logging
+  {
++     public class ProviderAliasAttribute
++     {
++         public ProviderAliasAttribute(string alias);
++         public string Alias { get; }
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.Extensions.Logging.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.Extensions.Logging.md
@@ -1,0 +1,12 @@
+# Microsoft.Extensions.Logging
+
+```diff
+  namespace Microsoft.Extensions.Logging
+  {
+-     public class ProviderAliasAttribute
+-     {
+-         public ProviderAliasAttribute(string alias);
+-         public string Alias { get; }
+-     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.JSInterop.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/10.0-preview4_Microsoft.JSInterop.md
@@ -1,0 +1,104 @@
+# Microsoft.JSInterop
+
+```diff
+  namespace Microsoft.JSInterop
+  {
+      public interface IJSInProcessObjectReference : Microsoft.JSInterop.IJSObjectReference
+      {
++         TValue GetValue<TValue>(string identifier);
++         Microsoft.JSInterop.IJSInProcessObjectReference InvokeNew(string identifier, object?[]? args);
++         void SetValue<TValue>(string identifier, TValue value);
+      }
+      public interface IJSInProcessRuntime : Microsoft.JSInterop.IJSRuntime
+      {
++         TValue GetValue<TValue>(string identifier);
++         Microsoft.JSInterop.IJSInProcessObjectReference InvokeNew(string identifier, params object?[]? args);
++         void SetValue<TValue>(string identifier, TValue value);
+      }
+      public interface IJSObjectReference
+      {
++         System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier, System.Threading.CancellationToken cancellationToken);
++         System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier);
++         System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, object?[]? args);
++         System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value, System.Threading.CancellationToken cancellationToken);
++         System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value);
+      }
+      public interface IJSRuntime
+      {
++         System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier, System.Threading.CancellationToken cancellationToken);
++         System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier);
++         System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, object?[]? args);
++         System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value, System.Threading.CancellationToken cancellationToken);
++         System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value);
+      }
+      public abstract class JSInProcessRuntime : Microsoft.JSInterop.JSRuntime, Microsoft.JSInterop.IJSInProcessRuntime, Microsoft.JSInterop.IJSRuntime
+      {
++         public TValue GetValue<TValue>(string identifier);
++         protected abstract string? InvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo? invocationInfo);
++         public Microsoft.JSInterop.IJSInProcessObjectReference InvokeNew(string identifier, params object?[]? args);
++         public void SetValue<TValue>(string identifier, TValue value);
+      }
+      public static class JSObjectReferenceExtensions
+      {
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference jsObjectReference, string identifier, params object?[]? args);
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference jsObjectReference, string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference jsObjectReference, string identifier, System.TimeSpan timeout, object?[]? args);
+      }
+      public abstract class JSRuntime : Microsoft.JSInterop.IJSRuntime
+      {
++         protected abstract void BeginInvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo);
++         public System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier, System.Threading.CancellationToken cancellationToken);
++         public System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier);
++         public System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, object?[]? args);
++         public System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         public System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value, System.Threading.CancellationToken cancellationToken);
++         public System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value);
+      }
+      public static class JSRuntimeExtensions
+      {
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSRuntime jsRuntime, string identifier, params object?[]? args);
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSRuntime jsRuntime, string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         public static System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(this Microsoft.JSInterop.IJSRuntime jsRuntime, string identifier, System.TimeSpan timeout, object?[]? args);
+      }
+  }
+  namespace Microsoft.JSInterop.Implementation
+  {
+      public class JSInProcessObjectReference : Microsoft.JSInterop.Implementation.JSObjectReference, Microsoft.JSInterop.IJSInProcessObjectReference, Microsoft.JSInterop.IJSObjectReference
+      {
++         public TValue GetValue<TValue>(string identifier);
++         public Microsoft.JSInterop.IJSInProcessObjectReference InvokeNew(string identifier, object?[]? args);
++         public void SetValue<TValue>(string identifier, TValue value);
+      }
+      public class JSObjectReference : Microsoft.JSInterop.IJSObjectReference
+      {
++         public System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier, System.Threading.CancellationToken cancellationToken);
++         public System.Threading.Tasks.ValueTask<TValue> GetValueAsync<TValue>(string identifier);
++         public System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, object?[]? args);
++         public System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference> InvokeNewAsync(string identifier, System.Threading.CancellationToken cancellationToken, object?[]? args);
++         public System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value, System.Threading.CancellationToken cancellationToken);
++         public System.Threading.Tasks.ValueTask SetValueAsync<TValue>(string identifier, TValue value);
+      }
+  }
+  namespace Microsoft.JSInterop.Infrastructure
+  {
++     public sealed class JSCallType
++     {
++ public const Microsoft.JSInterop.Infrastructure.JSCallType FunctionCall = 1;
++         public const Microsoft.JSInterop.Infrastructure.JSCallType GetValue = 3;
++         public const Microsoft.JSInterop.Infrastructure.JSCallType NewCall = 2;
++         public const Microsoft.JSInterop.Infrastructure.JSCallType SetValue = 4;
++         public int value__;
++     }
++     public sealed class JSInvocationInfo
++     {
++ public required string ArgsJson { get; init; }
++         public required long AsyncHandle { get; init; }
++         public required Microsoft.JSInterop.Infrastructure.JSCallType CallType { get; init; }
++         public required string Identifier { get; init; }
++         public required Microsoft.JSInterop.JSCallResultType ResultType { get; init; }
++         public required long TargetInstanceId { get; init; }
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4.md
@@ -1,0 +1,16 @@
+# API difference between .NET 10.0 Preview 3 and .NET 10.0 Preview 4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [System.Collections.Immutable](10.0-preview4_System.Collections.Immutable.md)
+* [System.Diagnostics.DiagnosticSource](10.0-preview4_System.Diagnostics.DiagnosticSource.md)
+* [System.IO.Compression](10.0-preview4_System.IO.Compression.md)
+* [System.IO.Compression.ZipFile](10.0-preview4_System.IO.Compression.ZipFile.md)
+* [System.Linq.Queryable](10.0-preview4_System.Linq.Queryable.md)
+* [System.Memory](10.0-preview4_System.Memory.md)
+* [System.Runtime](10.0-preview4_System.Runtime.md)
+* [System.Runtime.InteropServices](10.0-preview4_System.Runtime.InteropServices.md)
+* [System.Runtime.Intrinsics](10.0-preview4_System.Runtime.Intrinsics.md)
+* [System.Security.Cryptography](10.0-preview4_System.Security.Cryptography.md)
+

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Collections.Immutable.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Collections.Immutable.md
@@ -1,0 +1,12 @@
+# System.Collections.Immutable
+
+```diff
+  namespace System.Collections.Frozen
+  {
+      public static class FrozenDictionary
+      {
++         public static System.Collections.Frozen.FrozenDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey>? comparer, params scoped System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<TKey, TValue>> source);
++         public static System.Collections.Frozen.FrozenDictionary<TKey, TValue> Create<TKey, TValue>(params scoped System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<TKey, TValue>> source);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Diagnostics.DiagnosticSource.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Diagnostics.DiagnosticSource.md
@@ -1,0 +1,12 @@
+# System.Diagnostics.DiagnosticSource
+
+```diff
+  namespace System.Diagnostics
+  {
+      public abstract class DistributedContextPropagator
+      {
++         public static System.Diagnostics.DistributedContextPropagator CreatePreW3CPropagator();
++         public static System.Diagnostics.DistributedContextPropagator CreateW3CPropagator();
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.IO.Compression.ZipFile.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.IO.Compression.ZipFile.md
@@ -1,0 +1,36 @@
+# System.IO.Compression.ZipFile
+
+```diff
+  namespace System.IO.Compression
+  {
+      public static class ZipFile
+      {
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, System.IO.Stream destination, System.IO.Compression.CompressionLevel compressionLevel, bool includeBaseDirectory, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, System.IO.Stream destination, System.IO.Compression.CompressionLevel compressionLevel, bool includeBaseDirectory, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, System.IO.Compression.CompressionLevel compressionLevel, bool includeBaseDirectory, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, System.IO.Compression.CompressionLevel compressionLevel, bool includeBaseDirectory, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(System.IO.Stream source, string destinationDirectoryName, bool overwriteFiles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(System.IO.Stream source, string destinationDirectoryName, System.Text.Encoding? entryNameEncoding, bool overwriteFiles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(System.IO.Stream source, string destinationDirectoryName, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(System.IO.Stream source, string destinationDirectoryName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, bool overwriteFiles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, System.Text.Encoding? entryNameEncoding, bool overwriteFiles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchive> OpenAsync(string archiveFileName, System.IO.Compression.ZipArchiveMode mode, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchive> OpenAsync(string archiveFileName, System.IO.Compression.ZipArchiveMode mode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchive> OpenReadAsync(string archiveFileName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+      }
+      public static class ZipFileExtensions
+      {
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchiveEntry> CreateEntryFromFileAsync(this System.IO.Compression.ZipArchive destination, string sourceFileName, string entryName, System.IO.Compression.CompressionLevel compressionLevel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchiveEntry> CreateEntryFromFileAsync(this System.IO.Compression.ZipArchive destination, string sourceFileName, string entryName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(this System.IO.Compression.ZipArchive source, string destinationDirectoryName, bool overwriteFiles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToDirectoryAsync(this System.IO.Compression.ZipArchive source, string destinationDirectoryName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToFileAsync(this System.IO.Compression.ZipArchiveEntry source, string destinationFileName, bool overwrite, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public static System.Threading.Tasks.Task ExtractToFileAsync(this System.IO.Compression.ZipArchiveEntry source, string destinationFileName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.IO.Compression.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.IO.Compression.md
@@ -1,0 +1,17 @@
+# System.IO.Compression
+
+```diff
+  namespace System.IO.Compression
+  {
+      public class ZipArchive : System.IAsyncDisposable, System.IDisposable
+      {
++         public static System.Threading.Tasks.Task<System.IO.Compression.ZipArchive> CreateAsync(System.IO.Stream stream, System.IO.Compression.ZipArchiveMode mode, bool leaveOpen, System.Text.Encoding? entryNameEncoding, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
++         public System.Threading.Tasks.ValueTask DisposeAsync();
++         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore();
+      }
+      public class ZipArchiveEntry
+      {
++         public System.Threading.Tasks.Task<System.IO.Stream> OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Linq.Queryable.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Linq.Queryable.md
@@ -1,0 +1,18 @@
+# System.Linq.Queryable
+
+```diff
+  namespace System.Linq
+  {
+      public static class Queryable
+      {
++         [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(-1)]
++         [System.ObsoleteAttribute("The Queryable MinBy and MaxBy taking an IComparer<TSource> are obsolete. Use the new ones that take an IComparer<TKey>.", DiagnosticId = "SYSLIB0061", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public static TSource? MaxBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector, System.Collections.Generic.IComparer<TSource>? comparer);
++         [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(-1)]
++         [System.ObsoleteAttribute("The Queryable MinBy and MaxBy taking an IComparer<TSource> are obsolete. Use the new ones that take an IComparer<TKey>.", DiagnosticId = "SYSLIB0061", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+          public static TSource? MinBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector, System.Collections.Generic.IComparer<TSource>? comparer);
++         public static TSource? MaxBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector, System.Collections.Generic.IComparer<TKey>? comparer);
++         public static TSource? MinBy<TSource, TKey>(this System.Linq.IQueryable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, TKey>> keySelector, System.Collections.Generic.IComparer<TKey>? comparer);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Memory.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Memory.md
@@ -1,0 +1,15 @@
+# System.Memory
+
+```diff
+  namespace System
+  {
+      public static class MemoryExtensions
+      {
+          public ref struct SpanSplitEnumerator<T>
+            where T : System.IEquatable<T>
+          {
++             public System.ReadOnlySpan<T> Source { get; }
+          }
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.InteropServices.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.InteropServices.md
@@ -1,0 +1,25 @@
+# System.Runtime.InteropServices
+
+```diff
+  namespace System.Runtime.InteropServices
+  {
++     public sealed class TypeMapAssemblyTargetAttribute<TTypeMapGroup> : System.Attribute
++     {
++         public TypeMapAssemblyTargetAttribute(string assemblyName);
++     }
++     public sealed class TypeMapAssociationAttribute<TTypeMapGroup> : System.Attribute
++     {
++         public TypeMapAssociationAttribute(System.Type source, System.Type proxy);
++     }
++     public sealed class TypeMapAttribute<TTypeMapGroup> : System.Attribute
++     {
++         public TypeMapAttribute(string value, System.Type target, System.Type trimTarget);
++         public TypeMapAttribute(string value, System.Type target);
++     }
++     public static class TypeMapping
++     {
++         public static System.Collections.Generic.IReadOnlyDictionary<string, System.Type> GetOrCreateExternalTypeMapping<TTypeMapGroup>();
++         public static System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Type> GetOrCreateProxyTypeMapping<TTypeMapGroup>();
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.Intrinsics.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.Intrinsics.md
@@ -1,0 +1,71 @@
+# System.Runtime.Intrinsics
+
+```diff
+  namespace System.Runtime.Intrinsics
+  {
+      public static class Vector128
+      {
++         public static System.Runtime.Intrinsics.Vector128<byte> ShuffleNative(System.Runtime.Intrinsics.Vector128<byte> vector, System.Runtime.Intrinsics.Vector128<byte> indices);
++         public static System.Runtime.Intrinsics.Vector128<double> ShuffleNative(System.Runtime.Intrinsics.Vector128<double> vector, System.Runtime.Intrinsics.Vector128<long> indices);
++         public static System.Runtime.Intrinsics.Vector128<short> ShuffleNative(System.Runtime.Intrinsics.Vector128<short> vector, System.Runtime.Intrinsics.Vector128<short> indices);
++         public static System.Runtime.Intrinsics.Vector128<int> ShuffleNative(System.Runtime.Intrinsics.Vector128<int> vector, System.Runtime.Intrinsics.Vector128<int> indices);
++         public static System.Runtime.Intrinsics.Vector128<long> ShuffleNative(System.Runtime.Intrinsics.Vector128<long> vector, System.Runtime.Intrinsics.Vector128<long> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector128<sbyte> ShuffleNative(System.Runtime.Intrinsics.Vector128<sbyte> vector, System.Runtime.Intrinsics.Vector128<sbyte> indices);
++         public static System.Runtime.Intrinsics.Vector128<float> ShuffleNative(System.Runtime.Intrinsics.Vector128<float> vector, System.Runtime.Intrinsics.Vector128<int> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector128<ushort> ShuffleNative(System.Runtime.Intrinsics.Vector128<ushort> vector, System.Runtime.Intrinsics.Vector128<ushort> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector128<uint> ShuffleNative(System.Runtime.Intrinsics.Vector128<uint> vector, System.Runtime.Intrinsics.Vector128<uint> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector128<ulong> ShuffleNative(System.Runtime.Intrinsics.Vector128<ulong> vector, System.Runtime.Intrinsics.Vector128<ulong> indices);
+      }
+      public static class Vector256
+      {
++         public static System.Runtime.Intrinsics.Vector256<byte> ShuffleNative(System.Runtime.Intrinsics.Vector256<byte> vector, System.Runtime.Intrinsics.Vector256<byte> indices);
++         public static System.Runtime.Intrinsics.Vector256<double> ShuffleNative(System.Runtime.Intrinsics.Vector256<double> vector, System.Runtime.Intrinsics.Vector256<long> indices);
++         public static System.Runtime.Intrinsics.Vector256<short> ShuffleNative(System.Runtime.Intrinsics.Vector256<short> vector, System.Runtime.Intrinsics.Vector256<short> indices);
++         public static System.Runtime.Intrinsics.Vector256<int> ShuffleNative(System.Runtime.Intrinsics.Vector256<int> vector, System.Runtime.Intrinsics.Vector256<int> indices);
++         public static System.Runtime.Intrinsics.Vector256<long> ShuffleNative(System.Runtime.Intrinsics.Vector256<long> vector, System.Runtime.Intrinsics.Vector256<long> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector256<sbyte> ShuffleNative(System.Runtime.Intrinsics.Vector256<sbyte> vector, System.Runtime.Intrinsics.Vector256<sbyte> indices);
++         public static System.Runtime.Intrinsics.Vector256<float> ShuffleNative(System.Runtime.Intrinsics.Vector256<float> vector, System.Runtime.Intrinsics.Vector256<int> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector256<ushort> ShuffleNative(System.Runtime.Intrinsics.Vector256<ushort> vector, System.Runtime.Intrinsics.Vector256<ushort> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector256<uint> ShuffleNative(System.Runtime.Intrinsics.Vector256<uint> vector, System.Runtime.Intrinsics.Vector256<uint> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector256<ulong> ShuffleNative(System.Runtime.Intrinsics.Vector256<ulong> vector, System.Runtime.Intrinsics.Vector256<ulong> indices);
+      }
+      public static class Vector512
+      {
++         public static System.Runtime.Intrinsics.Vector512<byte> ShuffleNative(System.Runtime.Intrinsics.Vector512<byte> vector, System.Runtime.Intrinsics.Vector512<byte> indices);
++         public static System.Runtime.Intrinsics.Vector512<double> ShuffleNative(System.Runtime.Intrinsics.Vector512<double> vector, System.Runtime.Intrinsics.Vector512<long> indices);
++         public static System.Runtime.Intrinsics.Vector512<short> ShuffleNative(System.Runtime.Intrinsics.Vector512<short> vector, System.Runtime.Intrinsics.Vector512<short> indices);
++         public static System.Runtime.Intrinsics.Vector512<int> ShuffleNative(System.Runtime.Intrinsics.Vector512<int> vector, System.Runtime.Intrinsics.Vector512<int> indices);
++         public static System.Runtime.Intrinsics.Vector512<long> ShuffleNative(System.Runtime.Intrinsics.Vector512<long> vector, System.Runtime.Intrinsics.Vector512<long> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector512<sbyte> ShuffleNative(System.Runtime.Intrinsics.Vector512<sbyte> vector, System.Runtime.Intrinsics.Vector512<sbyte> indices);
++         public static System.Runtime.Intrinsics.Vector512<float> ShuffleNative(System.Runtime.Intrinsics.Vector512<float> vector, System.Runtime.Intrinsics.Vector512<int> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector512<ushort> ShuffleNative(System.Runtime.Intrinsics.Vector512<ushort> vector, System.Runtime.Intrinsics.Vector512<ushort> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector512<uint> ShuffleNative(System.Runtime.Intrinsics.Vector512<uint> vector, System.Runtime.Intrinsics.Vector512<uint> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector512<ulong> ShuffleNative(System.Runtime.Intrinsics.Vector512<ulong> vector, System.Runtime.Intrinsics.Vector512<ulong> indices);
+      }
+      public static class Vector64
+      {
++         public static System.Runtime.Intrinsics.Vector64<byte> ShuffleNative(System.Runtime.Intrinsics.Vector64<byte> vector, System.Runtime.Intrinsics.Vector64<byte> indices);
++         public static System.Runtime.Intrinsics.Vector64<short> ShuffleNative(System.Runtime.Intrinsics.Vector64<short> vector, System.Runtime.Intrinsics.Vector64<short> indices);
++         public static System.Runtime.Intrinsics.Vector64<int> ShuffleNative(System.Runtime.Intrinsics.Vector64<int> vector, System.Runtime.Intrinsics.Vector64<int> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector64<sbyte> ShuffleNative(System.Runtime.Intrinsics.Vector64<sbyte> vector, System.Runtime.Intrinsics.Vector64<sbyte> indices);
++         public static System.Runtime.Intrinsics.Vector64<float> ShuffleNative(System.Runtime.Intrinsics.Vector64<float> vector, System.Runtime.Intrinsics.Vector64<int> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector64<ushort> ShuffleNative(System.Runtime.Intrinsics.Vector64<ushort> vector, System.Runtime.Intrinsics.Vector64<ushort> indices);
++         [System.CLSCompliantAttribute(false)]
++         public static System.Runtime.Intrinsics.Vector64<uint> ShuffleNative(System.Runtime.Intrinsics.Vector64<uint> vector, System.Runtime.Intrinsics.Vector64<uint> indices);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Runtime.md
@@ -1,0 +1,23 @@
+# System.Runtime
+
+```diff
+  namespace System.Runtime.CompilerServices
+  {
+      public static class Unsafe
+      {
+-         public static unsafe void* AsPointer<T>(ref T value);
++         public static unsafe void* AsPointer<T>(ref readonly T value);
+      }
++     [System.Runtime.CompilerServices.InlineArrayAttribute(16)]
++     public struct InlineArray16<T>
++     {
++     }
+  }
+  namespace System.Runtime.ExceptionServices
+  {
+      public static class ExceptionHandling
+      {
++         public static void RaiseAppDomainUnhandledExceptionEvent(object exception);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Security.Cryptography.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.NETCore.App/10.0-preview4_System.Security.Cryptography.md
@@ -1,0 +1,295 @@
+# System.Security.Cryptography
+
+```diff
+  namespace System.Security.Cryptography
+  {
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public abstract class MLDsa : System.IDisposable
++     {
++         protected MLDsa(System.Security.Cryptography.MLDsaAlgorithm algorithm);
++         public void Dispose();
++         protected virtual void Dispose(bool disposing);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public int ExportMLDsaPrivateSeed(System.Span<byte> destination);
++         protected abstract void ExportMLDsaPrivateSeedCore(System.Span<byte> destination);
++         public int ExportMLDsaPublicKey(System.Span<byte> destination);
++         protected abstract void ExportMLDsaPublicKeyCore(System.Span<byte> destination);
++         public int ExportMLDsaSecretKey(System.Span<byte> destination);
++         protected abstract void ExportMLDsaSecretKeyCore(System.Span<byte> destination);
++         public byte[] ExportPkcs8PrivateKey();
++         public string ExportPkcs8PrivateKeyPem();
++         public byte[] ExportSubjectPublicKeyInfo();
++         public string ExportSubjectPublicKeyInfoPem();
++         public static System.Security.Cryptography.MLDsa GenerateKey(System.Security.Cryptography.MLDsaAlgorithm algorithm);
++         public static System.Security.Cryptography.MLDsa ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes);
++         public static System.Security.Cryptography.MLDsa ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password);
++         public static System.Security.Cryptography.MLDsa ImportFromPem(System.ReadOnlySpan<char> source);
++         public static System.Security.Cryptography.MLDsa ImportMLDsaPrivateSeed(System.Security.Cryptography.MLDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportMLDsaPublicKey(System.Security.Cryptography.MLDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportMLDsaSecretKey(System.Security.Cryptography.MLDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLDsa ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source);
++         public int SignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>));
++         protected abstract void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination);
++         protected void ThrowIfDisposed();
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten);
++         public bool VerifyData(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> signature, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>));
++         protected abstract bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature);
++         public System.Security.Cryptography.MLDsaAlgorithm Algorithm { get; }
++         public static bool IsSupported { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class MLDsaAlgorithm
++     {
++ public static System.Security.Cryptography.MLDsaAlgorithm MLDsa44 { get; }
++         public static System.Security.Cryptography.MLDsaAlgorithm MLDsa65 { get; }
++         public static System.Security.Cryptography.MLDsaAlgorithm MLDsa87 { get; }
++         public string Name { get; }
++         public int PrivateSeedSizeInBytes { get; }
++         public int PublicKeySizeInBytes { get; }
++         public int SecretKeySizeInBytes { get; }
++         public int SignatureSizeInBytes { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class MLDsaOpenSsl : System.Security.Cryptography.MLDsa
++     {
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("osx")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
++         public MLDsaOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) : base(default(System.Security.Cryptography.MLDsaAlgorithm)!);
++         protected override void Dispose(bool disposing);
++         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle();
++         protected override void ExportMLDsaPrivateSeedCore(System.Span<byte> destination);
++         protected override void ExportMLDsaPublicKeyCore(System.Span<byte> destination);
++         protected override void ExportMLDsaSecretKeyCore(System.Span<byte> destination);
++         protected override void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination);
++         protected override bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature);
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public abstract class MLKem : System.IDisposable
++     {
++         protected MLKem(System.Security.Cryptography.MLKemAlgorithm algorithm);
++         public byte[] Decapsulate(byte[] ciphertext);
++         public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
++         protected abstract void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
++         public void Dispose();
++         protected virtual void Dispose(bool disposing);
++         public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret);
++         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
++         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
++         public byte[] ExportDecapsulationKey();
++         public void ExportDecapsulationKey(System.Span<byte> destination);
++         protected abstract void ExportDecapsulationKeyCore(System.Span<byte> destination);
++         public byte[] ExportEncapsulationKey();
++         public void ExportEncapsulationKey(System.Span<byte> destination);
++         protected abstract void ExportEncapsulationKeyCore(System.Span<byte> destination);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(string password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportPkcs8PrivateKey();
++         public string ExportPkcs8PrivateKeyPem();
++         public byte[] ExportPrivateSeed();
++         public void ExportPrivateSeed(System.Span<byte> destination);
++         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);
++         public byte[] ExportSubjectPublicKeyInfo();
++         public string ExportSubjectPublicKeyInfoPem();
++         public static System.Security.Cryptography.MLKem GenerateKey(System.Security.Cryptography.MLKemAlgorithm algorithm);
++         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source);
++         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source);
++         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(string password, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes);
++         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password);
++         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes);
++         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(string source, string password);
++         public static System.Security.Cryptography.MLKem ImportFromPem(System.ReadOnlySpan<char> source);
++         public static System.Security.Cryptography.MLKem ImportFromPem(string source);
++         public static System.Security.Cryptography.MLKem ImportPkcs8PrivateKey(byte[] source);
++         public static System.Security.Cryptography.MLKem ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source);
++         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(byte[] source);
++         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source);
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten);
++         protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten);
++         public System.Security.Cryptography.MLKemAlgorithm Algorithm { get; }
++         public static bool IsSupported { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class MLKemAlgorithm : System.IEquatable<System.Security.Cryptography.MLKemAlgorithm>
++     {
++         public override bool Equals(object? obj);
++         public bool Equals(System.Security.Cryptography.MLKemAlgorithm? other);
++         public override int GetHashCode();
++         public static bool operator ==(System.Security.Cryptography.MLKemAlgorithm? left, System.Security.Cryptography.MLKemAlgorithm? right);
++         public static bool operator !=(System.Security.Cryptography.MLKemAlgorithm? left, System.Security.Cryptography.MLKemAlgorithm? right);
++ public int CiphertextSizeInBytes { get; }
++         public int DecapsulationKeySizeInBytes { get; }
++         public int EncapsulationKeySizeInBytes { get; }
++         public static System.Security.Cryptography.MLKemAlgorithm MLKem1024 { get; }
++         public static System.Security.Cryptography.MLKemAlgorithm MLKem512 { get; }
++         public static System.Security.Cryptography.MLKemAlgorithm MLKem768 { get; }
++         public string Name { get; }
++         public int PrivateSeedSizeInBytes { get; }
++         public int SharedSecretSizeInBytes { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class MLKemOpenSsl : System.Security.Cryptography.MLKem
++     {
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("osx")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
++         public MLKemOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) : base(default(System.Security.Cryptography.MLKemAlgorithm)!);
++         protected override void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
++         protected override void Dispose(bool disposing);
++         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle();
++         protected override void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
++         protected override void ExportDecapsulationKeyCore(System.Span<byte> destination);
++         protected override void ExportEncapsulationKeyCore(System.Span<byte> destination);
++         protected override void ExportPrivateSeedCore(System.Span<byte> destination);
++         protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public abstract class SlhDsa : System.IDisposable
++     {
++         protected SlhDsa(System.Security.Cryptography.SlhDsaAlgorithm algorithm);
++         public void Dispose();
++         protected virtual void Dispose(bool disposing);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters);
++         public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters);
++         public byte[] ExportPkcs8PrivateKey();
++         public string ExportPkcs8PrivateKeyPem();
++         public int ExportSlhDsaPublicKey(System.Span<byte> destination);
++         protected abstract void ExportSlhDsaPublicKeyCore(System.Span<byte> destination);
++         public int ExportSlhDsaSecretKey(System.Span<byte> destination);
++         protected abstract void ExportSlhDsaSecretKeyCore(System.Span<byte> destination);
++         public byte[] ExportSubjectPublicKeyInfo();
++         public string ExportSubjectPublicKeyInfoPem();
++         public static System.Security.Cryptography.SlhDsa GenerateKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm);
++         public static System.Security.Cryptography.SlhDsa ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.SlhDsa ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.SlhDsa ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes);
++         public static System.Security.Cryptography.SlhDsa ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password);
++         public static System.Security.Cryptography.SlhDsa ImportFromPem(System.ReadOnlySpan<char> source);
++         public static System.Security.Cryptography.SlhDsa ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.SlhDsa ImportSlhDsaPublicKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.SlhDsa ImportSlhDsaSecretKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source);
++         public static System.Security.Cryptography.SlhDsa ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source);
++         public int SignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>));
++         protected abstract void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination);
++         protected void ThrowIfDisposed();
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten);
++         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten);
++         public bool VerifyData(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> signature, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>));
++         protected abstract bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature);
++         public System.Security.Cryptography.SlhDsaAlgorithm Algorithm { get; }
++         public static bool IsSupported { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class SlhDsaAlgorithm
++     {
++ public string Name { get; }
++         public int PublicKeySizeInBytes { get; }
++         public int SecretKeySizeInBytes { get; }
++         public int SignatureSizeInBytes { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_128f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_128s { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_192f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_192s { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_256f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_256s { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake128f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake128s { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake192f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake192s { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake256f { get; }
++         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaShake256s { get; }
++     }
++     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++     public sealed class SlhDsaOpenSsl : System.Security.Cryptography.SlhDsa
++     {
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("osx")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
++         public SlhDsaOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) : base(default(System.Security.Cryptography.SlhDsaAlgorithm)!);
++         protected override void Dispose(bool disposing);
++         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle();
++         protected override void ExportSlhDsaPublicKeyCore(System.Span<byte> destination);
++         protected override void ExportSlhDsaSecretKeyCore(System.Span<byte> destination);
++         protected override void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination);
++         protected override bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature);
++     }
+  }
+  namespace System.Security.Cryptography.X509Certificates
+  {
+      public sealed class CertificateRequest
+      {
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.MLDsa key);
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public CertificateRequest(string subjectName, System.Security.Cryptography.MLDsa key);
+      }
+      public sealed class PublicKey
+      {
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public PublicKey(System.Security.Cryptography.MLKem key);
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
++         public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey();
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
++         public System.Security.Cryptography.MLKem? GetMLKemPublicKey();
+      }
+      public class X509Certificate2 : System.Security.Cryptography.X509Certificates.X509Certificate
+      {
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.MLDsa privateKey);
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.MLKem privateKey);
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.MLDsa? GetMLDsaPrivateKey();
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey();
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.MLKem? GetMLKemPrivateKey();
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public System.Security.Cryptography.MLKem? GetMLKemPublicKey();
+      }
+      public abstract class X509SignatureGenerator
+      {
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
++         public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForMLDsa(System.Security.Cryptography.MLDsa key);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4.md
@@ -1,0 +1,9 @@
+# API difference between .NET 10.0 Preview 3 and .NET 10.0 Preview 4
+
+API listing follows standard diff formatting.
+Lines preceded by a '+' are additions and a '-' indicates removal.
+
+* [PresentationCore](10.0-preview4_PresentationCore.md)
+* [PresentationFramework](10.0-preview4_PresentationFramework.md)
+* [System.Windows.Forms](10.0-preview4_System.Windows.Forms.md)
+

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_PresentationCore.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_PresentationCore.md
@@ -1,0 +1,58 @@
+# PresentationCore
+
+```diff
+  namespace System.Windows
+  {
+      public static class Clipboard
+      {
+-         public static System.IO.Stream GetAudioStream();
++         public static System.IO.Stream? GetAudioStream();
+-         public static object GetData(string format);
++         public static object? GetData(string format);
+-         public static System.Windows.IDataObject GetDataObject();
++         public static System.Windows.IDataObject? GetDataObject();
+-         public static System.Windows.Media.Imaging.BitmapSource GetImage();
++         public static System.Windows.Media.Imaging.BitmapSource? GetImage();
++         public static void SetDataAsJson<T>(string format, T data);
++         public static bool TryGetData<T>(string format, out T data);
++         public static bool TryGetData<T>(string format, System.Func<System.Reflection.Metadata.TypeName, System.Type?> resolver, out T data);
+      }
+      public sealed class DataObject : System.Windows.IDataObject, System.Windows.ITypedDataObject
+      {
+-         public object GetData(string format, bool autoConvert);
++         public object? GetData(string format, bool autoConvert);
+-         public object GetData(string format);
++         public object? GetData(string format);
+-         public object GetData(System.Type format);
++         public object? GetData(System.Type format);
+-         public void SetData(object data);
+-         public void SetData(string format, object data, bool autoConvert);
+-         public void SetData(string format, object data);
+-         public void SetData(System.Type format, object data);
++         public void SetData(object? data);
++         public void SetData(string format, object? data, bool autoConvert);
++         public void SetData(string format, object? data);
++         public void SetData(System.Type format, object? data);
++         public void SetDataAsJson<T>(T data);
++         public void SetDataAsJson<T>(string format, T data);
++         public bool TryGetData<T>(out T data);
++         public bool TryGetData<T>(string format, out T data);
++         public bool TryGetData<T>(string format, bool autoConvert, out T data);
++         public bool TryGetData<T>(string format, System.Func<System.Reflection.Metadata.TypeName, System.Type?> resolver, bool autoConvert, out T data);
+      }
++     public static class DataObjectExtensions
++     {
++         public static bool TryGetData<T>(this System.Windows.IDataObject dataObject, out T data);
++         public static bool TryGetData<T>(this System.Windows.IDataObject dataObject, string format, out T data);
++         public static bool TryGetData<T>(this System.Windows.IDataObject dataObject, string format, bool autoConvert, out T data);
++         public static bool TryGetData<T>(this System.Windows.IDataObject dataObject, string format, System.Func<System.Reflection.Metadata.TypeName, System.Type> resolver, bool autoConvert, out T data);
++     }
++     public interface ITypedDataObject : System.Windows.IDataObject
++     {
++         bool TryGetData<T>(out T data);
++         bool TryGetData<T>(string format, out T data);
++         bool TryGetData<T>(string format, bool autoConvert, out T data);
++         bool TryGetData<T>(string format, System.Func<System.Reflection.Metadata.TypeName, System.Type> resolver, bool autoConvert, out T data);
++     }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_PresentationFramework.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_PresentationFramework.md
@@ -1,0 +1,21 @@
+# PresentationFramework
+
+```diff
+  namespace System.Windows
+  {
+      public sealed class MessageBoxButton
+      {
++ public const System.Windows.MessageBoxButton AbortRetryIgnore = 2;
++         public const System.Windows.MessageBoxButton CancelTryContinue = 6;
++         public const System.Windows.MessageBoxButton RetryCancel = 5;
+      }
+      public sealed class MessageBoxResult
+      {
++ public const System.Windows.MessageBoxResult Abort = 3;
++         public const System.Windows.MessageBoxResult Continue = 11;
++         public const System.Windows.MessageBoxResult Ignore = 5;
++         public const System.Windows.MessageBoxResult Retry = 4;
++         public const System.Windows.MessageBoxResult TryAgain = 10;
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_System.Windows.Forms.md
+++ b/release-notes/10.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/10.0-preview4_System.Windows.Forms.md
@@ -1,0 +1,11 @@
+# System.Windows.Forms
+
+```diff
+  namespace System.Windows.Forms
+  {
+      public static class Clipboard
+      {
++         public static bool TryGetData<T>(out T data);
+      }
+  }
+```

--- a/release-notes/10.0/preview/preview4/api-diff/README.md
+++ b/release-notes/10.0/preview/preview4/api-diff/README.md
@@ -1,0 +1,7 @@
+# .NET 10.0 Preview 4 API Changes
+
+The following API changes were made in .NET 10.0 Preview 4:
+
+- [Microsoft.NETCore.App](./Microsoft.NETCore.App/10.0-preview4.md)
+- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/10.0-preview4.md)
+- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/10.0-preview4.md)


### PR DESCRIPTION
Repo area owners:

- ASP.NET - @dotnet/aspnet-api-review 
- WinForms - @merriemcgaw @Tanya-Solyanik @JeremyKuhne
- WPF - @singhashish-wpf and @pchaurasia14
- Libraries - @artl93 @jeffschwMSFT @jeffhandley @karelz @ericstj @stephentoub @SamMonoRT 

Libraries area owners:

- System.Collections @dotnet/area-system-collections 
- System.Diagnostics @dotnet/area-system-diagnostics 
- System.IO.Compression @dotnet/area-system-io-compression 
- System.Linq @dotnet/area-system-linq 
- System.Memory @dotnet/area-system-memory 
- System.Runtime @dotnet/area-system-runtime 
- System.Runtime.InteropServices @dotnet/interop-contrib 
- System.Runtime.Intrinsics @dotnet/area-system-runtime-intrinsics 
- System.Security.Cryptography @dotnet/area-system-security 

-----

## New tool to generate diffs

If you see any bugs, or if you don't see any APIs that should've showed up, **please let me know**. Main differences with the old tool:

- It uses Roslyn instead of Cci.
- It has unit tests.
- The files are being generated by assembly, not by namespace. So for example, you might find System.Runtime.CompilerServices under the System.Runtime file.
- Events now show their `add` and `remove` accessors.
- Might show some attributes that we weren't showing before in Api Diffs. Let me know if you don't want them shown and I'll exclude them.