### PR TITLE
Update .NET SDK to version 8.0.410

### DIFF
--- a/release-notes/8.0/8.0.16/8.0.16.md
+++ b/release-notes/8.0/8.0.16/8.0.16.md
@@ -33,7 +33,7 @@ You can check your .NET SDK version by running the following command. The exampl
 
 ```console
 $ dotnet --version
-8.0.409
+8.0.410
 ```
 
 ## Docker Images


### PR DESCRIPTION
Update .NET SDK to version 8.0.410
Updated the .NET SDK from version 8.0.409 to 8.0.410.
All download links for Linux, macOS, and Windows have been
revised to point to the new SDK version.

@rbhanda @victorisr 