### PR TITLE
docs(Net9-preview): Correct Year number in the net9 preview release notes

### DIFF
--- a/release-notes/9.0/preview/README.md
+++ b/release-notes/9.0/preview/README.md
@@ -1,6 +1,6 @@
 # .NET 9 preview release notes
 
-.NET 9 preview releases were released between February and October, 2025. The first [stable release](../README.md) was published in November. Release notes included detailed information and API diffs for new features.
+.NET 9 preview releases were released between February and October, 2024. The first [stable release](../README.md) was published in November. Release notes included detailed information and API diffs for new features.
 
 ## Release notes
 


### PR DESCRIPTION
Currently its stating 2025, but seeing the reality and the table below, this has to be 2024

Closes: #9939