### PR TITLE
Improve codefence in JSON snippet

### DIFF
--- a/release-notes/10.0/preview/preview6/sdk.md
+++ b/release-notes/10.0/preview/preview6/sdk.md
@@ -93,7 +93,7 @@ dotnet clean --cli-schema
 
 Outputs:
 
-```json
+```jsonc
 {
   "name": "clean",
   "version": "10.0.100-dev",


### PR DESCRIPTION
Stops the comment being rendered like a syntax error.

https://github.com/dotnet/core/pull/9830#discussion_r2206671662