### PR TITLE
fix releases index channel 2.2 security

### DIFF
--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -126,7 +126,7 @@
       "channel-version": "2.2",
       "latest-release": "2.2.8",
       "latest-release-date": "2019-11-19",
-      "security": true,
+      "security": false,
       "latest-runtime": "2.2.8",
       "latest-sdk": "2.2.207",
       "product": ".NET Core",


### PR DESCRIPTION
I found a mismatch between releases-index.json and releases.json for channel 2.2, mismatch in a field "security".
Found during development of https://github.com/dotnet/release/issues/1346 which will be used for synchronizing GitHub releases.json with CDN and this sync process also validates that values in releases-index.json match with values in the latest release in releases.json.
I believe this `security` should be `false` as there is a statement ".NET Core 2.2.8 release carries only non-security fixes."  in a linked release notes [2.2.8.md](https://github.com/dotnet/core/blob/main/release-notes/2.2/2.2.8/2.2.8.md).
I know there won't be any updates of channel 2.2 info, but good to have this consistency I hope (otherwise I have to have some special exclusions in the sync tool).