### PR TITLE
Remove references to Debian 13 Trixie container images

### DIFF
--- a/release-notes/10.0/preview/preview1/containers.md
+++ b/release-notes/10.0/preview/preview1/containers.md
@@ -3,35 +3,21 @@
 .NET 10 Preview 1 includes the following updates for container images:
 
 - [`10.0-preview` tags use Ubuntu 24.04](#100-preview-tags-use-ubuntu-2404)
-- [Debian images use Debian 13 "Trixie"](#debian-images-use-debian-13-trixie)
 - [Ubuntu Chiseled images now contain the Chisel manifest](#ubuntu-chiseled-images-now-contain-the-chisel-manifest)
 
 ## `10.0-preview` tags use Ubuntu 24.04
 
 The default OS for .NET tags has been changed from Debian to Ubuntu.
 This applies to all .NET tags that do not explicitly specify an OS.
-Debian images are still produced and supported.
-They can be referenced using the `-trixie-slim` suffix.
 
 - `docker pull mcr.microsoft.com/dotnet/sdk:10.0-preview` - Refers to Ubuntu 24.04 "Noble Numbat"
-- `docker pull mcr.microsoft.com/dotnet/sdk:10.0-preview-noble` - Refers to Ubuntu 24.04 "Noble Numbat"
-- `docker pull mcr.microsoft.com/dotnet/sdk:10.0-preview-trixie-slim` - Refers to Debian 13 "Trixie"
+- `docker pull mcr.microsoft.com/dotnet/sdk:10.0-preview-noble` - Also refers to Ubuntu 24.04 "Noble Numbat"
 
 For more information, see:
 
+- [Platforms for .NET 10 container images](https://github.com/dotnet/dotnet-docker/discussions/6539)
 - [.NET containers supported platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
 - [Proposal: Switch to Ubuntu for .NET convenience tags (dotnet/dotnet-docker#5709)](https://github.com/dotnet/dotnet-docker/discussions/5709)
-
-## Debian images use Debian 13 "Trixie"
-
-New images for Debian 13 "Trixie" have been added for .NET 10.
-
-See [dotnet/core#9652](https://github.com/dotnet/core/issues/9652) for more context.
-
-- `docker pull mcr.microsoft.com/dotnet/sdk:10.0-preview-trixie-slim`
-- `docker pull mcr.microsoft.com/dotnet/aspnet:10.0-preview-trixie-slim`
-- `docker pull mcr.microsoft.com/dotnet/runtime:10.0-preview-trixie-slim`
-- `docker pull mcr.microsoft.com/dotnet/runtime-deps:10.0-preview-trixie-slim`
 
 ## Ubuntu Chiseled images now contain the Chisel manifest
 

--- a/release-notes/10.0/preview/preview2/containers.md
+++ b/release-notes/10.0/preview/preview2/containers.md
@@ -22,7 +22,6 @@ The following images have been added to the `dotnet/sdk` repo:
 - `10.0-noble-preview-aot` (Also tagged as `10.0-preview-aot`)
 - `10.0-preview-alpine-aot`
 - `10.0-preview-azurelinux3.0-aot`
-- `10.0-preview-trixie-aot`
 
 For more information, see:
 


### PR DESCRIPTION
Context: We no longer plan to ship Debian 13 "Trixie" images for .NET 10.

- https://github.com/dotnet/dotnet-docker/issues/6526
- https://github.com/dotnet/dotnet-docker/discussions/6539
