### PR TITLE
Update .NET 10 P7 release date in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the home of .NET [release notes](./release-notes/README.md) and [news
 
 |  Version  | Release Date | Release type | Support phase | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- | :-- |
-| [.NET 10.0](release-notes/10.0/README.md) | November 11, 2025 | [LTS][policies] | Preview | [10.0.0-preview.7][10.0.0-preview.7] | TBD |
+| [.NET 10.0](release-notes/10.0/README.md) | August 12, 2025 | [LTS][policies] | Preview | [10.0.0-preview.7][10.0.0-preview.7] | TBD |
 | [.NET 9.0](release-notes/9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | Active | [9.0.8][9.0.8] | May 12, 2026 |
 | [.NET 8.0](release-notes/8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | Active | [8.0.19][8.0.19] | November 10, 2026 |
 


### PR DESCRIPTION
This pull request updates the release date for .NET 10.0 in the `README.md` file to reflect the new planned release schedule.

- Documentation update:
  * Changed the release date for `.NET 10.0` from November 11, 2025 to August 12, 2025 in the release table in `README.md`.