### PR TITLE
Releases json updates fix

### DIFF
--- a/release-notes/10.0/preview/preview1/release.json
+++ b/release-notes/10.0/preview/preview1/release.json
@@ -1,0 +1,515 @@
+{
+  "channel-version": "10.0",
+  "release": {
+    "release-date": "2024-02-25",
+    "release-version": "10.0.0-preview.1",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/10.0.0-preview.1.md",
+    "runtime": {
+      "version": "10.0.0-preview.1.25080.5",
+      "version-display": "10.0.0-preview.1",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-arm.tar.gz",
+          "hash": "8e91e965eace3ac1b472f8d9d2cba51537606cb0ae9b2245dde7f2f9d95f8660800cb609a7152b3efeb1e01663070c80454e6180890ccb81d6533fcc891d124e"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-arm64.tar.gz",
+          "hash": "840d229fc19322093ed5a18c123b5a322e92cad26926bdb709ee382076864a9e89a4dd0ecc13e5e48542b1732ebd19ba65cad1c1b63b94268d38e78bbe6b6b75"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-musl-arm.tar.gz",
+          "hash": "b907d97484966266c26732fbb6141ebb914be822589fedad26add9680ad6e0dc7d0068507241c0fbae124a9f4a9571838080387e21de81833fc7399be1bdd688"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-musl-arm64.tar.gz",
+          "hash": "2cc3f7715ef6d9986db73376bcbe7c6cdbb9f7a58b43e7be051c2ed457f7efc248a3c4dc87738467ad99a82ca385eea53ebc8af11c18900f5f980c8b76d9a475"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-musl-x64.tar.gz",
+          "hash": "93638a5e766b5859ae58ec3ba5dd81a60a0e6e2e4265d09b1bd71e42987216def1e94aa1c398e33d20baf6b7c021818cee111173b5771ff0ce2bcf56cc964c01"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-linux-x64.tar.gz",
+          "hash": "b704dfed083d3623024ee96ea6cb8ff6d5d7e1d6f43a27b1b4750a89193f64a966a3211b71f9e77bc7601532db992df38c34d1d1542f060082ae010d532437aa"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-osx-arm64.pkg",
+          "hash": "240c3edb434f3dc4472922306b4f840f45f2730d6fa2e06c1a5b9371f3f2e5d8800efc98a78170ac628b42a2f12af15f903c4543fec834d7c7b174f1eeee7c5e"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-osx-arm64.tar.gz",
+          "hash": "74ea61c16a06f86c6788d46c4d75726f6dd57fbe4c4593eff52a8b1472fdf805abe61830873fd3ef4178a75238f7dcfdf787b71e39a8415ed0f6ce04c4ba1e40"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-osx-x64.pkg",
+          "hash": "8a80455efde8ef4c0dc1c7f0ec5ba5062daacf91a43b575ab8e5fc2585245212e4f9c178e1702de21f6d9bf66e3181171552e960ab59cdb2e474d207036ef86c"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-osx-x64.tar.gz",
+          "hash": "6ea1da47b60e5361964fff79b9fa3dccc087c9773d342c34def7ee898eaf6de9f46da66644847d981615dedf39698610f850dd64f209bd4410e055f50b3b7e09"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-arm64.exe",
+          "hash": "638af12d1f69479bf47751c6127d2e599ae5d305b83c6c892c4e7fe9d7e1a50b91272898a425280f9c7f2237234cd9d13d014310bea5c05ca7621119db34ee97"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-arm64.zip",
+          "hash": "a9431c593af26ba07bca7cbfee79959e0103aae5ef2918e57890a5674416d8244e6a7c31a7d8b2da7c6224d1e2abc8d1cbd49255767aaa9edfc44f2b2c6d5a6e"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-x64.exe",
+          "hash": "51b3ae834a5498f5eaf508bc6f7de02460d43737baa3ef494367946875516adb1a08d74a7d8f353249c1e92a6f86be4dc09da2acf3777d2975157cf20d4da4b6"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-x64.zip",
+          "hash": "70067ab2024b104502393066b7f321a580ba99d95608ea67945b5705b487bd614bc0f1ea0653d23e257763fdbdf2fa5351ddc8734a60c6400ca15ad806ba07e7"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-x86.exe",
+          "hash": "8398d338f02981bc79f6dc8ffe834d7bd6a922862ab2d7e74094a4372d189419503040879f696db14ebc19ba2f06dcfbd215164b4538947477ee2b7b5dc0d6fa"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-runtime-10.0.0-preview.1.25080.5-win-x86.zip",
+          "hash": "2764e0d40d5bf5cdab623d6ec1fcabc3f065f6e44a06f9fa464f0d761638497a8cf455f52feb145588abb8b1b83898453b14afff9e20e7a3518574e69bb63cf2"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "10.0.100-preview.1.25120.13",
+      "version-display": "10.0.100-preview.1",
+      "runtime-version": "10.0.0-preview.1.25080.5",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "vs-support": "",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-arm.tar.gz",
+          "hash": "d3a76713855026bcb131b97596750e26a43180be9f875811208a3b1b7d88c81e96cc769e97df4c7397a3baace3098f848a8345df6560703ace765db8b21092d8"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-arm64.tar.gz",
+          "hash": "645b618ab7fbcce38f82b2ca9a5fab6b11742dc9ca53f4bb65654dbe8385e1789aed034162436af998c59e418b5031607e71856dc38848717a74f8f3292e0c4b"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-arm.tar.gz",
+          "hash": "361c46feb05350d07c969c88cc1a821152cb21535d544817c7bac54914b84d526e3e5aa642fb9cc5dc331ef008bb205138841ad222ec3b9a06b8d08741fae95d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-arm64.tar.gz",
+          "hash": "916807107cdee561f530d393d80c1fc3be55099436f324ef03d2a92792b3cab7df9fc3ccc87c58aad5520232f807de2c4258af4a24eb13715c360cdcf54efa3e"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-x64.tar.gz",
+          "hash": "35a2ce93ba7f39a08fd177118aa0ccfe8c90055b8df98d3e1340644a91c3ea90afc0201bffb0ceb54882313fdd9d3ab01ac23d6f8ccb3ef0670a1af825cd3257"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-x64.tar.gz",
+          "hash": "98687cb89859fe1847a0cae6c752ce2309231e5ef26ee5285893a5b5794fbfd51ddf8510deb5f700ea298ceffd9cbc0f9f26c9c7b4d90044a82bdd2b98abfcc4"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-arm64.pkg",
+          "hash": "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-arm64.tar.gz",
+          "hash": "5e98db2acaacfb3e91ab56fd369a422587060cd4cdf3b6411bc5214d59b985142c459f650ea6b63b6af8f1fffd2f5e39d685b17950814a8b131e57b30e1c2f48"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-x64.pkg",
+          "hash": "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-x64.tar.gz",
+          "hash": "5f60bd5a013e59cfb674b7d2e9333b4e88d8bc8645e8d18cca751e356286986f371d9f217675f703c85c515159e0f74ef54d60e5c7f717c1ee469a7684a57f5d"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-arm64.exe",
+          "hash": "0a676d984d6b67e4cf8b7bc540c777fd50a0b70a3cfc66cdc22719f2b6d9802e66d9fc7bba7388745e8340a92c9a990b00576bcf008bf04f1848f380f563ad5b"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-arm64.zip",
+          "hash": "42bc6fa5fb394801925eff1f296f33deebcbb9e0d506c2a7cbd345b38bbc0f26244df16fc999be62c6ea3b10ec50910650a548d500de3ce87cfcbc9d269a5794"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x64.exe",
+          "hash": "cf6f4f097b15488bc027171f16a15a11eca65b0aba4630e998026ebdd8501757f8b68f6be6cde16b333c35392394f8f8c0dc5b4aac4b0df7609376cc6ba151c8"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x64.zip",
+          "hash": "f574e68dbb4214679a123f2527fe0478c7a7d2ca6900c81e2cfec03984421a894d8e1304a5683f077185b71b4491ed12d449636620f96b640156aa251f4a6a53"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x86.exe",
+          "hash": "ae9f4b1b82c5be882e6c112e146e20d50f8fcd6e700263088be2ede90638a62ccd2dbb3c72407abaab636c0478b7a77fe85e60671463dd31e1aa864f33820a6f"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x86.zip",
+          "hash": "5cb4fbc77bcce3cb6ab158e24d6f10697baedaf236b55fc1b80691ba094820ac4c0b57d8c66af33fa68076f06aa3a679a3383fd095775521a6d13fd0faa59cc4"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "10.0.100-preview.1.25120.13",
+        "version-display": "10.0.100-preview.1",
+        "runtime-version": "10.0.0-preview.1.25080.5",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-arm.tar.gz",
+            "hash": "d3a76713855026bcb131b97596750e26a43180be9f875811208a3b1b7d88c81e96cc769e97df4c7397a3baace3098f848a8345df6560703ace765db8b21092d8"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-arm64.tar.gz",
+            "hash": "645b618ab7fbcce38f82b2ca9a5fab6b11742dc9ca53f4bb65654dbe8385e1789aed034162436af998c59e418b5031607e71856dc38848717a74f8f3292e0c4b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-arm.tar.gz",
+            "hash": "361c46feb05350d07c969c88cc1a821152cb21535d544817c7bac54914b84d526e3e5aa642fb9cc5dc331ef008bb205138841ad222ec3b9a06b8d08741fae95d"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-arm64.tar.gz",
+            "hash": "916807107cdee561f530d393d80c1fc3be55099436f324ef03d2a92792b3cab7df9fc3ccc87c58aad5520232f807de2c4258af4a24eb13715c360cdcf54efa3e"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-musl-x64.tar.gz",
+            "hash": "35a2ce93ba7f39a08fd177118aa0ccfe8c90055b8df98d3e1340644a91c3ea90afc0201bffb0ceb54882313fdd9d3ab01ac23d6f8ccb3ef0670a1af825cd3257"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-linux-x64.tar.gz",
+            "hash": "98687cb89859fe1847a0cae6c752ce2309231e5ef26ee5285893a5b5794fbfd51ddf8510deb5f700ea298ceffd9cbc0f9f26c9c7b4d90044a82bdd2b98abfcc4"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-arm64.pkg",
+            "hash": "14f83d81cbafcc572a70100037c677911368970e4b20dd471d69595813b688615577b393cb4f8579b284493341b7642ad2f2d00171dd9d1d40d35e886e2ed2dc"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-arm64.tar.gz",
+            "hash": "5e98db2acaacfb3e91ab56fd369a422587060cd4cdf3b6411bc5214d59b985142c459f650ea6b63b6af8f1fffd2f5e39d685b17950814a8b131e57b30e1c2f48"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-x64.pkg",
+            "hash": "29900a2b93424661ba0300671be017629ca5c5183cdddbeaecae2666f8a5ea6c26e415b7f2286a6644efa27523ebb0f61080b9fad82f85dc9c648344af36268d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-osx-x64.tar.gz",
+            "hash": "5f60bd5a013e59cfb674b7d2e9333b4e88d8bc8645e8d18cca751e356286986f371d9f217675f703c85c515159e0f74ef54d60e5c7f717c1ee469a7684a57f5d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-arm64.exe",
+            "hash": "0a676d984d6b67e4cf8b7bc540c777fd50a0b70a3cfc66cdc22719f2b6d9802e66d9fc7bba7388745e8340a92c9a990b00576bcf008bf04f1848f380f563ad5b"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-arm64.zip",
+            "hash": "42bc6fa5fb394801925eff1f296f33deebcbb9e0d506c2a7cbd345b38bbc0f26244df16fc999be62c6ea3b10ec50910650a548d500de3ce87cfcbc9d269a5794"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x64.exe",
+            "hash": "cf6f4f097b15488bc027171f16a15a11eca65b0aba4630e998026ebdd8501757f8b68f6be6cde16b333c35392394f8f8c0dc5b4aac4b0df7609376cc6ba151c8"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x64.zip",
+            "hash": "f574e68dbb4214679a123f2527fe0478c7a7d2ca6900c81e2cfec03984421a894d8e1304a5683f077185b71b4491ed12d449636620f96b640156aa251f4a6a53"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x86.exe",
+            "hash": "ae9f4b1b82c5be882e6c112e146e20d50f8fcd6e700263088be2ede90638a62ccd2dbb3c72407abaab636c0478b7a77fe85e60671463dd31e1aa864f33820a6f"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-sdk-10.0.100-preview.1.25120.13-win-x86.zip",
+            "hash": "5cb4fbc77bcce3cb6ab158e24d6f10697baedaf236b55fc1b80691ba094820ac4c0b57d8c66af33fa68076f06aa3a679a3383fd095775521a6d13fd0faa59cc4"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "10.0.0-preview.1.25120.3",
+      "version-display": "10.0.0-preview.1",
+      "version-aspnetcoremodule": [
+        "20.0.25051.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-arm.tar.gz",
+          "hash": "253c3e18705954121c843d367e3b2cbb8ffc46649f2e0db255b35833163e5dec6b5df41c4970102281af68cf8d912222db168de39e2171af39b0cc163bc17eb7"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-arm64.tar.gz",
+          "hash": "4f996f48fd215b63b84daf24a4ab08dd5b6877dab6bef0e6c35ec945152b6e5b22dcba9d50ac1198d5876313f0bcd0c800aa5a8cc83ec7647e77466f74dac22e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-musl-arm.tar.gz",
+          "hash": "465797b3b8d1552e9a46092481f1c816827bf01c532cb8b7aae110870a4ec9f12500adb91edafbcbbf1ae46338a4851845d56de21274d5c6c2b6ccb395d9514f"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-musl-arm64.tar.gz",
+          "hash": "7709a4a05a0e56a4a585089051159db840c0a8d3072bb936076b1c70c89c2f1a0b54783e64d762a2d0dd61b6bb5144dbacad567ba46992196c41014a51badccf"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-musl-x64.tar.gz",
+          "hash": "015564ad968b0916f122aaebcc71bd6800ac480179cb7423dca45450b9e61d271207a86be5a7cc0c1628b1e7fa4906133819d47beaa180ca75c04101afcee9b8"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-linux-x64.tar.gz",
+          "hash": "bf5d4f5c1dfa63e937f4d0e6b800283437a3df5c55b2e426c3efb0b8dc9794ba704f5d4468acc130f0f3b81ace3e3d46ee11945bbc5f34bbd29d7b54c36630fc"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-osx-arm64.tar.gz",
+          "hash": "43b24242a57da6735bef26f4a039aa1c9bc7971f4d2d8ba28a8c019da133207f180d672144e4e122e274a7da11c65ef8932e9544d673d506b9e25ec1de740616"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-osx-x64.tar.gz",
+          "hash": "5833bd67f1c7e2b16a3bacab66c94c20a3cee2ed9619c7954e6be164b802438eef602d4adaf057a13c729b6e357ff29e923c4be16b852836132848b90c22ed62"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-arm64.exe",
+          "hash": "3b9c557b748b0cc8f0a9b73e0d19a3300049f4adb01e859ffe4d45c7aee81800dfbe43b779755fb51c16c1b1d005e9ef26f0f63226a241567ac5b552bcc8e5c3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-arm64.zip",
+          "hash": "388de23c5d88946f343ea885510faf6ab629dfccbf8fc3db13d516df154d876b55c2b6faf31cbca50910c6ab2802cdc633d92ec57f33d5bb9cba97ca9ef7d95b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-x64.exe",
+          "hash": "836b26c38e372af0d89b54c449874f56f253a36185c77ee1cd7d81225d0bbab3e842949268b047f8b73563bcbee84e1ec386c754b271ded9f090f8445e332cf5"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-x64.zip",
+          "hash": "a5e5c941ad8b831c31fe623d0d3675bb9e1b4c1a442a5890061b83ff874e0c106e87fa18394873798c193de8ce0146c90d5903e98c0926929614b15ffdde2f12"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-x86.exe",
+          "hash": "243fb5db98556388120a7213c2950cd9a3a6e87d2c64df29a415f2d6b5f0f76fefbbf032b8f06edc932073503b792d396c36471bed676de2e48da975abff9942"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-10.0.0-preview.1.25120.3-win-x86.zip",
+          "hash": "12ba1b42491c7327358671429bed97ecd1483ad248c2a60c0402e9c29946ca5b38746c8fe006ec683ec7a33efdf8870e4955b122ce39d7bb62febaf5baa93fb3"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-arm.tar.gz",
+          "hash": "35b67d2a31281e8ed8a6194d661e78410b5b2c8c552b0568fd24133e108978f5e31f6f7bdd21424cc0b324d1750b0f0b56a066c78694f446749048a6a10aea1e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-arm64.tar.gz",
+          "hash": "c6dd0af60294bfc9a0de1cf39b859a5cae2c9c54a5ef7182fc4d140bf1b9ab2aee0f117865792dff98fb892a7e9006b6cdc299e0b4c531a7188a9b04d23787fa"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-musl-arm.tar.gz",
+          "hash": "31ced448fa58247f0653e178e1205afadf4ee85ea8bc6db59a5d71db7d60ebb0ef9b771ca39ac7e3c7faeba37eb4995c23446550d4f5aed2441ce1508ed3a36b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-musl-arm64.tar.gz",
+          "hash": "631cab0c707240409314e515f65ea7cc67e4be5234fd5d2042f119bcd54ebfa582e4e4bca77501f12f66b7efda5f66cd5dcc390a6561ae85005b6849f5c61afb"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-musl-x64.tar.gz",
+          "hash": "ce56388e2cf567bbae78be9e63b7bac5a5f00202357f60c3b68d98d09b5fcc2ae281811cf163192e51a3bce0f3e655927438346a5648b9dfcf85c360993d71d7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/aspnetcore-runtime-composite-10.0.0-preview.1.25120.3-linux-x64.tar.gz",
+          "hash": "a9771a74c99e5c4e878e9371e00ed84b243c057ece276209d51d32538fe8db621e4af4245d92a4015b6f071f7b4f8c15a78593f8f8cf089d94012e2def4d10f7"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/dotnet-hosting-10.0.0-preview.1.25120.3-win.exe",
+          "hash": "a417fde9b7e1d143408d74b8a92999337221b2042c558e83e0fba34f8706ed024b3208ffd4b4125ea4e1821d8fffc46b47425a016b272e18fe415c724831f525",
+          "akams": "https://aka.ms/dotnetcore-10-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "10.0.0-preview.1.25080.4",
+      "version-display": "10.0.0-preview.1",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-arm64.exe",
+          "hash": "f052ba22d9737c5cc00035ec6484bd0210e53837b2bc07e6bac08627d00213a8aad225912fd163425961d8fdc4ee5ddce0e7cab577e81ba5c79b546ded58eb9f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-arm64.zip",
+          "hash": "e47be4dee94ac62bcc43389c6e7542002c280c694bb3780b9e67d0255f8701f238ff76f81bb5604b4df3ade478dedcf53a8ef56d9a2f1547e2c23b862a17cb4f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-x64.exe",
+          "hash": "796ac79ed66d15cb4f0151645f2e424a60d41d034f6ac647515a93390a9c7d814fe6691c6a209957a14a296f499f0912f744a3fde7e7cc47855f624b8801439b"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-x64.zip",
+          "hash": "0b89790cda0d425771d2a8159bf4db768e5931892392af163ffd34fa494dce1dc22f025efb799a513b77e7a2172a5012bf9211b35d2a9e755bc39c326f487c15"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-x86.exe",
+          "hash": "985a3919b9a31cc74e8a8f448800406ae008b6b512b08b081bc88eb595f3c1a0caff4c65e316023a4cb538d52d4daea440326cbdbc9004d99e2b4b602a78d684"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://dotnet1pgallery.blob.core.windows.net/dotnet/private/10.0/10.0.0-preview.1/windowsdesktop-runtime-10.0.0-preview.1.25080.4-win-x86.zip",
+          "hash": "608b95683025ca023714ef07c5c6006f34eb01f161517a51039e08210be9d36fcaa1508c03fa63758ffabc1f13de55b902ff0c5032a3753a0e555b84c9e1ad6e"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/10.0/preview/preview2/release.json
+++ b/release-notes/10.0/preview/preview2/release.json
@@ -1,0 +1,515 @@
+{
+  "channel-version": "10.0",
+  "release": {
+    "release-date": "2025-03-18",
+    "release-version": "10.0.0-preview.2",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview2/10.0.0-preview.2.md",
+    "runtime": {
+      "version": "10.0.0-preview.2.25163.2",
+      "version-display": "10.0.0-preview.2",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-arm.tar.gz",
+          "hash": "fe8af0c9ac3d39e559155950cecbfa27450521f8e5faa446438de3dcc8c4bf51fb135323cac3ba5bb045fc13423776ae66ae4ed9d6a0df331e959a0ed34179a4"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-arm64.tar.gz",
+          "hash": "05ca5a0212600fa2c79c3526c673822d79ed8965e513263eea904f2d09fcdf423058321961bc930fdb90814ee41ef42545a3b27c081cc9731ee4602c514879c5"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-musl-arm.tar.gz",
+          "hash": "1298d446e8cb27768dbdd512576cdd6526dad29a7676ee748bc92fa64430760cdbe817ca6c62c4872ab2008b845580d4709571a59c6c3f332650acaee8643546"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-musl-arm64.tar.gz",
+          "hash": "63cc61a5bd53b1327fd67d57b04841c0a8e7950b5d531fc7890352e56aa2a09b083a808cc8b9be1afd424264371d51fc3329791fdc0479888ceefadda52e2723"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-musl-x64.tar.gz",
+          "hash": "d91bfb5839b30377d09849511c8668230be51fae0d05e07d761297da40c994d800de5ce6fc5f7307cbdf5cf6e7fa7dd720ecab8354ec9436c662cd4fe14851dd"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-linux-x64.tar.gz",
+          "hash": "a64cccc9809fa5b2f4ccb178964bffa92b849c43dd2b2c3981d753e73f2b05a2b6e189a8c2a50fc67652badf66963313444c08ea22e4cd18fe8797049571341e"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-osx-arm64.pkg",
+          "hash": "d3493cefce4b9c7157fc2da2cdb6aab8d29510b37d3ebee06ce92eee42b8ed0d899b88c8b4590141aa5e061f2365073cb084b26ff073ba1a42d2d38dc09d0368"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-osx-arm64.tar.gz",
+          "hash": "349b2a9f34dfcd1ab819484ee09cc32ef61c31629a9520256d643916e4bd5d1384f3cbaf8d0316bde8c90cd8eeac61a170cc486be3960b9512ac79e567ee54b5"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-osx-x64.pkg",
+          "hash": "7dddafcbfae1b6e54e63ee1d3bc5879631fb86fd2d8bcd8d2b5389ce1326c9caa10393d7e5002039faf20099d6c10d9fe1f10c9aeba8e7e06db8269d23890a2b"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-osx-x64.tar.gz",
+          "hash": "a398deecaf401781cadec919f4876aa914d93c38f081a9c1f1b850e2ebfe4952919f90abd723d8faa5cf37a149b281e391742ba8e73613e2b1e4276755d8d81e"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-arm64.exe",
+          "hash": "63f9ff8aea8a268a831fc05de6442bf504186b469f24cbd488e4613971f5311d6426e10bc1b67aef5c907261e38c8ef244ab76eeec0c643048a9bd1ed74fbace"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-arm64.zip",
+          "hash": "fe0f3c1e53ae995d01d6985760b0e519faf7b55b944508a87a1a5d4498517c7e502a2591b36b0aeec91b8c836ddce4fa5479c98ab9a536505bfc2048febdc028"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-x64.exe",
+          "hash": "f17c15095f3b630fd63d4de390ddd0afcd5629ce7a0629f64cbfede0de9f37433ec435a2b99a26038113a3c5916c3958178886ce21010ad75e4900457c8d7a67"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-x64.zip",
+          "hash": "db4f2e6cbf3729461a1232f4f9ffe625c177691082fc06707d12da1fd72e5b1bbf4516bd31fd675ee4eeaeac01bce42030ecc97edf12e36ad721c60ec31f06ad"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-x86.exe",
+          "hash": "9efc3b62710e35fb2bdf9928d5ca98800eeeb7b5d393b14def887914687e18e4920d95caa2f02340b73c75afd6b76a7867942a0d2c8135201ea67b37ddde5ef5"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.2/dotnet-runtime-10.0.0-preview.2.25163.2-win-x86.zip",
+          "hash": "bfdb644c6cdf29e5cec6da558264dc9956c246161ede16922747dc4e42b18b45bf8c5d474ed01155d67cdbf21096a4b339c5561f90e3ba98a8f15052ee95683c"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "10.0.100-preview.2.25164.34",
+      "version-display": "10.0.100-preview.2",
+      "runtime-version": "10.0.0-preview.2.25163.2",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "vs-support": "",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-arm.tar.gz",
+          "hash": "084168b2296a549fcba190d69cd565cc48efa5ea30cbfe61b5bed9e415acae43a416b53dd8e5bf16a598beeed1b0ba96dbb7bc554a2e0e2ce00c7634a1a5a1f0"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-arm64.tar.gz",
+          "hash": "0491381366f50d6a2211f925f5c5b2e1364f3b3a45076c706dacd3afa6856dd95efb6bacccc8874718bde37439e77614ff2bfd580c3c2e97737d42db311db5e6"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-arm.tar.gz",
+          "hash": "82cfc7fa9a6491e6258adf33eb81b0bcb1b69f5960d631bfbd1e9cb59e0b5550c2ffd2620461e46430d1215b8cca097a67ac215e0f7a9c965800d307a5bb8d70"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-arm64.tar.gz",
+          "hash": "c1419b713d5511835ffe6e61effe1782af5a8429fabd517d3d840d219752265681cb1a7a15a1f06b6c5a890dd50e7461b3b0eeea0a24d5c2066bfaf3d52eec42"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-x64.tar.gz",
+          "hash": "789876535ef56669dbfe6391378fcf40dc2b8f4adf137bddb8b358a23403ecafe5bdbcbb0c7715cfb0d26ed061adb20520ad1ab12505f964dc808b2b102f6594"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-x64.tar.gz",
+          "hash": "664e5618827c4f9e5d5150cd7ed7f8c4044f85ae7be8dc779a8d8634dcc962b59e7317a9533e57b2683334b1304f7b66e59b5e68e1a501147ac14e1f22f46bc4"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-arm64.pkg",
+          "hash": "f65538d7b650de4670cef8ab0f7fa3c7775782686ee174589f98e78296bb1c0adfac7ba3cbf700a75db36af8143bf250c21e9cbdeb9968ff0ccc7f894e4b6a73"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-arm64.tar.gz",
+          "hash": "55ec928ac50b0b34783871a7d8662aadbf9443cb9217b905fc447e6b46de179a6222bfdfc25a6bdd3e80bb8227bcddf088b41e61d5a5d1e6ab931fc8237d5a8d"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-x64.pkg",
+          "hash": "2f516e1dda0cd9f4ebb90fe0f3b2f30751d130252b6927a1178275a81008b00c870c6f48d978886d82fcfb1246f8e2184672669f4a93db18061037f3493c8b08"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-x64.tar.gz",
+          "hash": "cc573dc0f9d84620f0c90dd74f0538e797a597daed2365c2f311a162b0fbd92d031a697c89c806adba8ac223c3e3f3719de6d2243ea044646c62cbb8ba182873"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-arm64.exe",
+          "hash": "ecbf9153c56c8bbdccad88a86a8de578ba0a12a17b28c1e40c0b13a5ef673dae292629b98625dc8ffa8c1856829525437b8972b3be4414e3115335b36c3c937c"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-arm64.zip",
+          "hash": "bec80096e4d0d2fbc6e97317eddb9ce84582056b77767bf9cb771cec76039547141100bde33e7fccceb88fda56a32e810041f84ee7a17e7bc4cd92d215001bbb"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x64.exe",
+          "hash": "e70b3967716954ddb6cd766d72604039465dbf9693fcafd260e6dcf5fddcdda0ec97a499c9450953861814340445b3f24c7ded879a869c1b7be61c8b69852c1c"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x64.zip",
+          "hash": "a8aa6371149103c3fda2cb29972aa9343b2d6a3e3ecdbbb7e8b123c1aab1c9ed25f12408a59db3d7661316bb0f13261b1a353140f420e366bc61c5b7aaaabc1d"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x86.exe",
+          "hash": "25fbc7a782ec0f8927f8d2475a497f46a3b61f4873cdce43356b6a934351c0d0e7370b2064a607106ae3071f505345db45996feb2b34efed18446b56f7abc8bc"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x86.zip",
+          "hash": "70e416497327a7dcf478551d7fc12daa980750ff31f53770c4d89ca8efca086221c6dd441c31c14d0117f834750b6b15ed0c5380be4112597a645fa3d7a26a06"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "10.0.100-preview.2.25164.34",
+        "version-display": "10.0.100-preview.2",
+        "runtime-version": "10.0.0-preview.2.25163.2",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-arm.tar.gz",
+            "hash": "084168b2296a549fcba190d69cd565cc48efa5ea30cbfe61b5bed9e415acae43a416b53dd8e5bf16a598beeed1b0ba96dbb7bc554a2e0e2ce00c7634a1a5a1f0"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-arm64.tar.gz",
+            "hash": "0491381366f50d6a2211f925f5c5b2e1364f3b3a45076c706dacd3afa6856dd95efb6bacccc8874718bde37439e77614ff2bfd580c3c2e97737d42db311db5e6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-arm.tar.gz",
+            "hash": "82cfc7fa9a6491e6258adf33eb81b0bcb1b69f5960d631bfbd1e9cb59e0b5550c2ffd2620461e46430d1215b8cca097a67ac215e0f7a9c965800d307a5bb8d70"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-arm64.tar.gz",
+            "hash": "c1419b713d5511835ffe6e61effe1782af5a8429fabd517d3d840d219752265681cb1a7a15a1f06b6c5a890dd50e7461b3b0eeea0a24d5c2066bfaf3d52eec42"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-musl-x64.tar.gz",
+            "hash": "789876535ef56669dbfe6391378fcf40dc2b8f4adf137bddb8b358a23403ecafe5bdbcbb0c7715cfb0d26ed061adb20520ad1ab12505f964dc808b2b102f6594"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-linux-x64.tar.gz",
+            "hash": "664e5618827c4f9e5d5150cd7ed7f8c4044f85ae7be8dc779a8d8634dcc962b59e7317a9533e57b2683334b1304f7b66e59b5e68e1a501147ac14e1f22f46bc4"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-arm64.pkg",
+            "hash": "f65538d7b650de4670cef8ab0f7fa3c7775782686ee174589f98e78296bb1c0adfac7ba3cbf700a75db36af8143bf250c21e9cbdeb9968ff0ccc7f894e4b6a73"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-arm64.tar.gz",
+            "hash": "55ec928ac50b0b34783871a7d8662aadbf9443cb9217b905fc447e6b46de179a6222bfdfc25a6bdd3e80bb8227bcddf088b41e61d5a5d1e6ab931fc8237d5a8d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-x64.pkg",
+            "hash": "2f516e1dda0cd9f4ebb90fe0f3b2f30751d130252b6927a1178275a81008b00c870c6f48d978886d82fcfb1246f8e2184672669f4a93db18061037f3493c8b08"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-osx-x64.tar.gz",
+            "hash": "cc573dc0f9d84620f0c90dd74f0538e797a597daed2365c2f311a162b0fbd92d031a697c89c806adba8ac223c3e3f3719de6d2243ea044646c62cbb8ba182873"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-arm64.exe",
+            "hash": "ecbf9153c56c8bbdccad88a86a8de578ba0a12a17b28c1e40c0b13a5ef673dae292629b98625dc8ffa8c1856829525437b8972b3be4414e3115335b36c3c937c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-arm64.zip",
+            "hash": "bec80096e4d0d2fbc6e97317eddb9ce84582056b77767bf9cb771cec76039547141100bde33e7fccceb88fda56a32e810041f84ee7a17e7bc4cd92d215001bbb"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x64.exe",
+            "hash": "e70b3967716954ddb6cd766d72604039465dbf9693fcafd260e6dcf5fddcdda0ec97a499c9450953861814340445b3f24c7ded879a869c1b7be61c8b69852c1c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x64.zip",
+            "hash": "a8aa6371149103c3fda2cb29972aa9343b2d6a3e3ecdbbb7e8b123c1aab1c9ed25f12408a59db3d7661316bb0f13261b1a353140f420e366bc61c5b7aaaabc1d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x86.exe",
+            "hash": "25fbc7a782ec0f8927f8d2475a497f46a3b61f4873cdce43356b6a934351c0d0e7370b2064a607106ae3071f505345db45996feb2b34efed18446b56f7abc8bc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25164.34/dotnet-sdk-10.0.100-preview.2.25164.34-win-x86.zip",
+            "hash": "70e416497327a7dcf478551d7fc12daa980750ff31f53770c4d89ca8efca086221c6dd441c31c14d0117f834750b6b15ed0c5380be4112597a645fa3d7a26a06"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "10.0.0-preview.2.25164.1",
+      "version-display": "10.0.0-preview.2",
+      "version-aspnetcoremodule": [
+        "20.0.25073.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-arm.tar.gz",
+          "hash": "ceebf19085159175e60004dba88e4698237c0708df5dd63b225177c70c91df6be110a46e9ee693001e27933050d8637cfc8b739d1e510d09dca562031c866ccc"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-arm64.tar.gz",
+          "hash": "2161e53f30413f27be9a81a7aedace12ad523d9e68b35d6a051e417701d238b1353569e227845aa76a9c889b7ecd1b5e7bafd3a678e2bf29438dae540e970d0a"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-musl-arm.tar.gz",
+          "hash": "eb7ce0764cc88ba00bdc957b98b81105734da5964232996faeaa84e4f132b665c3177636a0a2794d2b7a01e37d963e92d59bbe6a6ee3717a01e8054d7440d48c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-musl-arm64.tar.gz",
+          "hash": "cdc179232b5688ef07993d7a78c5481f256f8cefe816fc913e38408fadec9b5f010a90628d6fd04d12e18ccc351b6252a566176154a111df6b6da14309aa0d41"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-musl-x64.tar.gz",
+          "hash": "793e3a3c49c221e8543850858b273f6f20dfd81cd831525f34d6be2a1cee5494bad210c73cc072d947c93fc820ff2ad709b0a22462bf3fe2c923319e00784d19"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-linux-x64.tar.gz",
+          "hash": "de14dab978133b9ec979d371c5fbd01e78b106cc330c168d6216ec8a97b0ccfeeb0d4f44386187499760db603483dc0016279dc4cb3f94bfb042cc63d25296fa"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-osx-arm64.tar.gz",
+          "hash": "9e4e6dc4aa1947fde24bd79f6e2d91c43dfe13307cc2037f83e8048dff795645db0439684e750dd6f9cec304899e5e7b2b5f4d961309345d0f6e32a84d00fb7e"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-osx-x64.tar.gz",
+          "hash": "e8994167755eca3bb691f4314da6b702217d285ac58fa8740ecb657a9ae21478a341aae21174023910a784e2683e536df5458953c48cd881c651e22847be8b30"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-arm64.exe",
+          "hash": "e2fa4aa600bf718eb4eff165ada0496899314dbbfa89431e8390ee8fc6b2dc3b28dc6012e599f888aef8ec64a94603e9fc272890bbf7847d9d7cd530178b23aa"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-arm64.zip",
+          "hash": "76cf96e0604f211151cf28d432190e261e3d37b747c79ff7899a459016c6519aefca75545496ad0985e2b7ba796cf233eadb66e076c4f9b91e160fd153c6ec47"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-x64.exe",
+          "hash": "9868ad7ad3f9a9be4d0cf155c519be771001d79ce35afb2926657686e968ad9e81d06ef415f42fbdd48c593a282393eccf2bb56e60ebc8dc18d3e382b6208968"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-x64.zip",
+          "hash": "cc69e8227cbe6e231b0b30db1e236b3b559f267d5cbd3cdc7b68b670951ed5cd1f0957b8717c983e1eb2d5270c669e91abe5fcba787837828692737e0803ec17"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-x86.exe",
+          "hash": "9f3b6b5152733fdafd770a1c719c2a13de78963c24badafcc36c3fd9e742c46b79ed07fc0da8e6dc0cfa00e76b243545dd91521322a50236c3811075a1d7e866"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-10.0.0-preview.2.25164.1-win-x86.zip",
+          "hash": "3ea9d72807f9b8e4fff82f8fcb82ea508ad898a9b354ddedab4013f3d97cb9748dd2458540d043ebb4c181a66a4cf62aa9f8c73cf529cf8fe7e0a381d8e0cbc9"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-arm.tar.gz",
+          "hash": "0bf0a4000ce39a0028243ee24edac150494762af0a9693d9d0c8d59fb9ae5a5112f64aa3a633cafed511ba8dd8a8ab14a46b1045fb32038014eb22637fd9c891"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-arm64.tar.gz",
+          "hash": "9ac02fe1e18d987abc7137fe061f76b852c47489705c4c57fd63e9245763d412ab243e724e090ae23d0a1e9cbc09ee92e97224ab73682c27e25538c470aa367e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-musl-arm.tar.gz",
+          "hash": "1437e56479078514d0ad1b5b8459f19dd4f282939ebb546e0888f12fdba9a182c41b75e1a762377923edcefc968d315bec3c4201c34132348c895d1fabc2ce26"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-musl-arm64.tar.gz",
+          "hash": "c65448c47260671074782f6d4e4a9daf8db47233c9322647cbc1200f0d9167644e8d6a89a66333266010403537b45f7fc66ef9a7f61b9a4329fe8facea906d15"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-musl-x64.tar.gz",
+          "hash": "07d0cff245177cecd10c4548b0468589a2c45d27427bfe60a50772fb2766a51a322d383780cc7cf18e628e311a127fee49972fdcde5b6d65290bbf4e8a317046"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/aspnetcore-runtime-composite-10.0.0-preview.2.25164.1-linux-x64.tar.gz",
+          "hash": "d67bc54f97d832ad06fd18269ddad48126cc0eee66b7f924158289e23983a01f9f1e48e09bbbe54ebef9499feafccd4116daa27621f7a3df0021c80de99fd2b8"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.2/dotnet-hosting-10.0.0-preview.2.25164.1-win.exe",
+          "hash": "32c3ff68d5fd6e6f850ffe846edb16d94f15ecbe015ddcc76175b4907eef4982fc613744dda63e1365e93352fedc57372297228caa829cb75e5de7d5c6c368bf",
+          "akams": "https://aka.ms/dotnetcore-10-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "10.0.0-preview.2.25163.3",
+      "version-display": "10.0.0-preview.2",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-arm64.exe",
+          "hash": "d9d635d79b5dcd7bb6deeec3b1b37d1b846b3f2d774479100b112a1458efbd6311466962851d10935cf085f6bad70da9bdf2a99efe4a59ef2eafd8f0fd4e16a8"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-arm64.zip",
+          "hash": "c037eb951cb2e5fdd49164bd2b53e574c5e2aa73654ce26b7c456e8b824f56be4003112197104f9092dd25d4b31a13af8d56855d3d7140e70b645edc735bae08"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-x64.exe",
+          "hash": "9300bb03f852c1a152cc01066331b3ec85da91eb1d7cd4cf326f5c30f13d4b94bec68bfc1e1f003478815dbac9837be0cc23fa78b471ae79e9ab318dbb39e4db"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-x64.zip",
+          "hash": "85a44e2dcfaad52582666e6e198aea68856a3c2f2982c0df008e457ce80f4abd1f34c3bfac9c6476e126247bd6a8f6a5085a9dd43db600b6c97bc9630f9cb432"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-x86.exe",
+          "hash": "797b3ced6cab54f5c52e5f610b9becaeebfb514821f4d2bfca01498790c9df9601a50fde0532f16dba3fcbb0f262a612e6c5a57a843e613c33b46b3b9a5f7b7a"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.2/windowsdesktop-runtime-10.0.0-preview.2.25163.3-win-x86.zip",
+          "hash": "b0b795119c9a9ff1ff82651eba9e118d72adce2aea5ed7b39365b789ae4dcd97173fb52eb2df3e8917a3cf2fb0277581868d8f6e4776ea2f84c0a2f56c6aec5a"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/10.0/preview/preview3/release.json
+++ b/release-notes/10.0/preview/preview3/release.json
@@ -1,0 +1,700 @@
+{
+  "channel-version": "10.0",
+  "release": {
+    "release-date": "2025-04-10",
+    "release-version": "10.0.0-preview.3",
+    "security": false,
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview3/10.0.0-preview.3.md",
+    "runtime": {
+      "version": "10.0.0-preview.3",
+      "version-display": "10.0.0-preview.3",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-apphost-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-arm.tar.gz",
+          "hash": "c28b6d9d293ed96c5306ccf38f854763d1a9888247b8e824cbd4cab91948333f5150fa303d283074c23a4d5c14ea851b0aeb9ca011c211ecbafb7d7e122ab080"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-arm64.tar.gz",
+          "hash": "68e5f33442ed13528d57802763d75f15b2f93462645192aff609670edc6529d2f550f6235346292835ac3f7624af1bc5c713808151baae4055d8f5c13c106420"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-arm64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-bionic-arm64.tar.gz",
+          "hash": "a2d49acdeffe3a39795ab5e672e1f5103758349b373f76afac65cc271889dfd81f3e0d0b9ffa49b7ec8ecc829ce07d36612f80bdbe85b0bbaf4a5ea4188f92d4"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-x64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-bionic-x64.tar.gz",
+          "hash": "d6f0518537bdec561aa332b136ead3240f8b066a41152f50057bbcecf3e298d897058db6da55f56638a4876aa59472c63e8d1b8dbe3a1dc47c547d12fa794644"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-musl-arm.tar.gz",
+          "hash": "d84f7ef0a2f87ac281523d1cc0fb3d8d504c1d24cfeb8d1d0778695bb7197e3769975bcf4980c99d01154242f89b603584ce10e39677c8c8378311802c093914"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-musl-arm64.tar.gz",
+          "hash": "cd5298d10162b00881bcd0568440161296a6c9e08a0320707959df70c5d0372585e9c3ffd1ff56b922d04bc0db47ac657daf72ada2e5adaac79e3dee6605b26b"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-musl-x64.tar.gz",
+          "hash": "b6b354f292e85c2d99e2aa0ee1c8b2e35973e3f76a921c57a839c04c0e44d9c31a21ed0e735ee5918d398494bb8752da4a0e3e4aa29817af87ce207ca55767a8"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-linux-x64.tar.gz",
+          "hash": "b997a1b0c0ac1445e1d61b02a010d5bc8525ad298bb6f0c85cfa4c578387596364ef7d8151f5736cbec20f0b25bfa52cd55391c0e01055715d6f23f6b2d7331b"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-osx-arm64.tar.gz",
+          "hash": "0aee07fc58bc2a9bd640e9a438b3c9adf28372a0b396dc73049e34d0f03a8c0e26cb7eab6058a5508edfa7200ed7853c543ce51cce78a8cb1ad8ecb5d7ed3feb"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-osx-x64.tar.gz",
+          "hash": "37a9126f23f194b891e86d273c01ce247b87250e387bd245397fe4dde6dcf59c5b3fec7516017de3b1efdeb75c84080133526e4657dc57768622afa72f5c895d"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-win-arm64.zip",
+          "hash": "fecd488d5b2b551db07100fb442055c4c7c82b1fe71f6801201f805c5d8978e081dc8507aa4a52701c77e98e43ffd345ce43454782998f06ca5c0807c2c9ec94"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-win-x64.zip",
+          "hash": "6e817d1967e007ba1dc63358344686316509218983328e03a095b0d6a0112d269097b23043dc5867e28ce961574070459382e4204fc106b158ed18ab4c3e2d11"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-apphost-pack-10.0.0-preview.3.25171.5-win-x86.zip",
+          "hash": "bdb648e9b2f409cf41151da07619f30812853361c85f23dd9ac1de03616457f6bb0eb9b952bf6fbc220844eaade1fc0331cfa93f2f36e1f2bce89c41ab8c07e1"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-arm.tar.gz",
+          "hash": "8e690259454a540c0c16258bed659c0a26640d2a4f4ba7e194e2807e4597e267564fc0c9b7892805a4fa8e010219de3d2229a1026e08189f0f1eca059a3a9ee6"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-arm64.tar.gz",
+          "hash": "a6a59432c12ac1964957ca09f78e15e0b2d6435d9b70ba13b6bc23ec99c9523e81e23297fe28297fa723caff4a5d2159a0cab50470de623e8172245d4343f1f6"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-arm64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-bionic-arm64.tar.gz",
+          "hash": "4da2db5a27f28ced921edf9f9bbb7a5bb99553c9e6dd81cf49ef32e1e153fc91fc038eae19bcc8ed604ec82e6e41e38019ef8c585b8da9be4b54b545db53a1cd"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-x64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-bionic-x64.tar.gz",
+          "hash": "7cb67ef172548f403e75258881c8feea10382cb028d0255d14c252102152f4a48c75ee60b37794f444bd1ea3a8dac7b9008392bbcce8b92a0070b7ea4a71075f"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-musl-arm.tar.gz",
+          "hash": "978895a7639f0c1b0860eb3c293226553e4eaeea5ba7039aa5df0eb57284657a2255e601c65a40e25d5248383884b05cd401d3472cf60934a65726007cc1de4a"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-musl-arm64.tar.gz",
+          "hash": "7532ab4d168ad7ca86fdca46db3f9447b9ece86688fdc011d4597e4a68aedaa4b3af0079c2f92f4ab2a546e7ab6ecf525dc69ef4c11d032c84c29738c7a62ada"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-musl-x64.tar.gz",
+          "hash": "26914a60143fa394d1f238d4da335ae5869696899b31da9b1f537df96e2f4b1862cdab11ea2e550dae9a19817ee3679aaa0e4db9656cebe5143b8513090dfee7"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-linux-x64.tar.gz",
+          "hash": "4e9bd2bdd54124c95dd62bcf96a5feea095617d73f132cfcc8332d15a9a8366c03bfe55d02e7409ea8ee3d35da1eb0e98390b9ec3fc86e928c6706c535fe67fa"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-osx-arm64.pkg",
+          "hash": "c1f2f39a11e672cf962162523f3c60ebe0426542a310b0a901ca63d990f82406d78d107b32b2fb54f9762bd6381f4a19c55dfeda1c6bb94d55a37e8317850a51"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-osx-arm64.tar.gz",
+          "hash": "cc02fd234c012c863d8725d88b6d302b214fb98d0171572915aa6dfe324881340f77b71cc81b53fc062d2893675bb399771bae05dd2d10f544aa2fa9d691e441"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-osx-x64.pkg",
+          "hash": "ed67fff1cf144bee3640007d3eef1afc69e7231847cf2cb519417615687540f6435dd9fee893088278fb371d06acf1e62f115a98c091c17d3235cafc1af4f669"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-osx-x64.tar.gz",
+          "hash": "8a9e97bb551ba3a2493043db6d55faa29c0756d8f5e1a8960617941d01941a8eb3297bda3ae0165c586569c51f2adda01d5009559900f50cbd4b9e59eeeda327"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-arm64.exe",
+          "hash": "4acb5933fb71ea8efc0dbbdeb2b645f9a5fc05f78a7b4c79918aae01be8e45cdcb656b72d84606de505b805fe3bfe5029801b80b2c5adb8d77e86053e56dfbfc"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-arm64.zip",
+          "hash": "1a537b66cdb3eccdc22dea97da2672417059cf6246d473c717df5a434521bcf2c2291bec323649fe1979fdb00c4a2790dbbd8495efcd7cdb0037fe7ed8e8dd89"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-x64.exe",
+          "hash": "ba6808a34f8808ad7e85eb41d9ff29dbc2677656b5c5211ee48eb9ded2036d37a567a2332e1e1938c57063c804150a81e1e1630fa579702a6cd98b2f507484fb"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-x64.zip",
+          "hash": "586e24e04ada25753dad5bea6f9302771ffb08d6a0d8be998b68ab66a28d665b6fa82c2935c4a50e9030e6baff6ba052ac43144e93c720e64cec852de125c89b"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-x86.exe",
+          "hash": "a7f493398cdeafa10d30e46843fcc7aae18af426b832c07e3ef7e70703e1c0fc390d83788f964f2efab7a7eff1a8d3c75b17be68729f0e8d9bab171284be45f7"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.3/dotnet-runtime-10.0.0-preview.3.25171.5-win-x86.zip",
+          "hash": "d0e832bd8a2f40c430bb11b78ab3b96af607787db28ed5a847455acc732091627f350bcea7da0b8367befebaef5d8f00e8e3945216a9f7aadddffd33c55af3dd"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "10.0.100-preview.3.25201.16",
+      "version-display": "10.0.100-preview.3",
+      "runtime-version": "10.0.0-preview.3",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "vs-support": "",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "17.13",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-arm.tar.gz",
+          "hash": "9409d8a906bae261b22f272cc80a1b41b8be7726437708815944e232396f0f889b874df37b3c28e6158002d2ae578f36c808d7670622a9f5cb9242df66fffc5c"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-arm64.tar.gz",
+          "hash": "9e1f7ddd98d468f937b74469397b1fc1238c4174b94dc5a78e61c6984359f594dcfd0c248e502ebda165ec6100198ebb797b1da08be47320ce926612318b65ea"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-arm.tar.gz",
+          "hash": "a7ababbe1bd3d4b8534199f872357ceb2f5f0a7da1f4bff9a929ba799f8c8e6b0018048524e8c760cd4a15d8f99972e993b5e728592602040a905f06884efd44"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-arm64.tar.gz",
+          "hash": "9057e97006f99e4fff1cc0a688443c469cfc25739aaeb752d8be5aea6b494eb49419d954339d58380e89fcb5628a424f967cdc6112b8d14357dca07f9f160d5f"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-x64.tar.gz",
+          "hash": "5443a2e09eaccf29d0dc92330a4899140627a7901e79d13d76b9d5d249a96137552831236d214932cd3c6ac56bc437fabe7b173029661fb5d061064a06e5671e"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-x64.tar.gz",
+          "hash": "aaad778cc80f5e5f023cbdab47af67703214a7a1900d12782f5d956f8623de1bd3801026727fbb5ecf84fbc885185daad92832b47da3b6514a45aa56fa971156"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-arm64.pkg",
+          "hash": "accdc73b5f4649fd03ae49e15dcad39cc0740fb27f0f6ca8df6d1d9d01b0398e33f09188cb0f9ecd17389b6b63db4b03eb82f42faf0f2567cb045c189d62dabb"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-arm64.tar.gz",
+          "hash": "b38a6ef7c6568ea5e2fd6cbd893a8e05dd158e5f21a4245b39b22bee0231033869c6c2bf576c76260c9fa633a1f0ef1d88b3e5e9cd1cf879b5ea45e9aa6600dc"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-x64.pkg",
+          "hash": "3954f8b9da6d61b04d23d8ac004ba6312a5688dafacb760fa9423a923946c4d52c4b26f08a6b5d8e28bc9f70d8c6fc9e736b129179a6a7b0e9f48ecbc351ffaa"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-x64.tar.gz",
+          "hash": "6a9c6634176027252fbd6cc3ddd10a5eeb1e40268f58aa725ec50ea94ef87362bfb154ff1f12584792b1f956710ff8070421d9f86a4638d2b392ef09910a5944"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-arm64.exe",
+          "hash": "92bed682016c91ac75b4f9cc4f6a1e48bc93b7b5abbf8b6af9c3fbb4fb166ee86c0ac3ac4dfdc7f707ef62000ecffcbd77fd13dfccd2a8567465b73b3fbc7a2a"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-arm64.zip",
+          "hash": "17889797c279519c3e98c909c2dc6952bcd15c1a7c5c2d915d87e1c8b544319262ddf7acaf80f71833f8371b8ad58b3eeaf3a32a3815fae1897585eea1154c06"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x64.exe",
+          "hash": "848a3355da9555293964e15d0d08d11964106dededb9dd5356d899e235c325a0322d16526addd40f45badaf49997f51de874a3d6a15da9a3ff07c8cbe746c342"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x64.zip",
+          "hash": "fb45e1d0cc4ceab81da28ef70543bae460cd85a37eab4ec3301dccbf7a0bdec7e29bed3cc533ee466fa8c978f2f4215fdddedde8b0da3113ae1af51e1d27417e"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x86.exe",
+          "hash": "11255c0fc31648bfb2cceff3c590e974159f3603316cb79163fdc08d74abe6fd4c269160176c1fd7dec4aa52304d447bd618af880880eed804e4e6d920767bf5"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x86.zip",
+          "hash": "1df2edfb8a4ed469ae34c16c3d5552e51077205149474817d7b6764c8a17f53684f08cfec19d1687d7d061b204fe5fcb2098728a9e2656abdead67222196a7c7"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "10.0.100-preview.3.25201.16",
+        "version-display": "10.0.100-preview.3",
+        "runtime-version": "10.0.0-preview.3",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "17.13",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-arm.tar.gz",
+            "hash": "9409d8a906bae261b22f272cc80a1b41b8be7726437708815944e232396f0f889b874df37b3c28e6158002d2ae578f36c808d7670622a9f5cb9242df66fffc5c"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-arm64.tar.gz",
+            "hash": "9e1f7ddd98d468f937b74469397b1fc1238c4174b94dc5a78e61c6984359f594dcfd0c248e502ebda165ec6100198ebb797b1da08be47320ce926612318b65ea"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-arm.tar.gz",
+            "hash": "a7ababbe1bd3d4b8534199f872357ceb2f5f0a7da1f4bff9a929ba799f8c8e6b0018048524e8c760cd4a15d8f99972e993b5e728592602040a905f06884efd44"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-arm64.tar.gz",
+            "hash": "9057e97006f99e4fff1cc0a688443c469cfc25739aaeb752d8be5aea6b494eb49419d954339d58380e89fcb5628a424f967cdc6112b8d14357dca07f9f160d5f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-musl-x64.tar.gz",
+            "hash": "5443a2e09eaccf29d0dc92330a4899140627a7901e79d13d76b9d5d249a96137552831236d214932cd3c6ac56bc437fabe7b173029661fb5d061064a06e5671e"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-linux-x64.tar.gz",
+            "hash": "aaad778cc80f5e5f023cbdab47af67703214a7a1900d12782f5d956f8623de1bd3801026727fbb5ecf84fbc885185daad92832b47da3b6514a45aa56fa971156"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-arm64.pkg",
+            "hash": "accdc73b5f4649fd03ae49e15dcad39cc0740fb27f0f6ca8df6d1d9d01b0398e33f09188cb0f9ecd17389b6b63db4b03eb82f42faf0f2567cb045c189d62dabb"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-arm64.tar.gz",
+            "hash": "b38a6ef7c6568ea5e2fd6cbd893a8e05dd158e5f21a4245b39b22bee0231033869c6c2bf576c76260c9fa633a1f0ef1d88b3e5e9cd1cf879b5ea45e9aa6600dc"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-x64.pkg",
+            "hash": "3954f8b9da6d61b04d23d8ac004ba6312a5688dafacb760fa9423a923946c4d52c4b26f08a6b5d8e28bc9f70d8c6fc9e736b129179a6a7b0e9f48ecbc351ffaa"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-osx-x64.tar.gz",
+            "hash": "6a9c6634176027252fbd6cc3ddd10a5eeb1e40268f58aa725ec50ea94ef87362bfb154ff1f12584792b1f956710ff8070421d9f86a4638d2b392ef09910a5944"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-arm64.exe",
+            "hash": "92bed682016c91ac75b4f9cc4f6a1e48bc93b7b5abbf8b6af9c3fbb4fb166ee86c0ac3ac4dfdc7f707ef62000ecffcbd77fd13dfccd2a8567465b73b3fbc7a2a"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-arm64.zip",
+            "hash": "17889797c279519c3e98c909c2dc6952bcd15c1a7c5c2d915d87e1c8b544319262ddf7acaf80f71833f8371b8ad58b3eeaf3a32a3815fae1897585eea1154c06"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x64.exe",
+            "hash": "848a3355da9555293964e15d0d08d11964106dededb9dd5356d899e235c325a0322d16526addd40f45badaf49997f51de874a3d6a15da9a3ff07c8cbe746c342"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x64.zip",
+            "hash": "fb45e1d0cc4ceab81da28ef70543bae460cd85a37eab4ec3301dccbf7a0bdec7e29bed3cc533ee466fa8c978f2f4215fdddedde8b0da3113ae1af51e1d27417e"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x86.exe",
+            "hash": "11255c0fc31648bfb2cceff3c590e974159f3603316cb79163fdc08d74abe6fd4c269160176c1fd7dec4aa52304d447bd618af880880eed804e4e6d920767bf5"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x86.zip",
+            "hash": "1df2edfb8a4ed469ae34c16c3d5552e51077205149474817d7b6764c8a17f53684f08cfec19d1687d7d061b204fe5fcb2098728a9e2656abdead67222196a7c7"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "10.0.0-preview.3",
+      "version-display": "10.0.0-preview.3",
+      "version-aspnetcoremodule": [
+        "20.0.25082.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-arm.tar.gz",
+          "hash": "f9c3a4655924604e4e4ed4365333d09442ac1135ca195e0f82374999159f4e67d0b3ef07edb60d87a4d2f1dfa2e0b1df4e49fc79f9dd248677aea9db623d9144"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-arm64.tar.gz",
+          "hash": "48568aa8a3fd431a6775c90f26754136c87b89dea9e07b304101bd8c6dc4961f1436fa5a0316f7e9535198a978636caf7425f9b7aae003b53a95a1e14a01b450"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-musl-arm.tar.gz",
+          "hash": "f1b06e651590ba866dc312da08a85b4b3e4c8d71a1dce9d5719e1e86f5d7ad646913dead9552d74eeedd7cb70a349d10fd54c77dbc9ad09b34327f739fc45092"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-musl-arm64.tar.gz",
+          "hash": "8decf0ecf5dab0c1d09832c3419c08cb6ba027fc1713f0a17ab7a61b89369867dafabaf1704340e0db81753b65aa63e131b75969fe7d7ee58e01c8854c6cba6b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-musl-x64.tar.gz",
+          "hash": "6fc6432cda03745448e4152c06d737bd8bfa4356e2b38a0b48619f2b6ff75ff1d1f66f72449c643224ca7f04c505efe1af35e0e66dd311e5edfb34ac6599e58d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-linux-x64.tar.gz",
+          "hash": "592e78f23d0eeec3fe21d3885d6b4b2ce65538e6a987d9d4094dd5acfc98351eaa8441845d53bc0cdc1d49f3b4c1e6a93a0ddacd44bd5c7f50a01eeae76247f4"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-osx-arm64.tar.gz",
+          "hash": "23fe9a7fe626ee9f0acdf64842fbb6bcdf81d6b4ef97037bc12de3cdf6a6ae7fdd218373487ce185b83fb9af5146188b1368d5eee82bdf59b089908c7b032ad2"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-osx-x64.tar.gz",
+          "hash": "ca5680ec83add53dd9c261d3b4a9aa3a2353a168889aff6216300ea76b760bd4246058a2ba28f562aa822302f4c522c7c5b4b1499e13eb1851d9dd1566f3977b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-arm64.exe",
+          "hash": "ec8765b4d545c6dc52348895d362ba9be6db83e4f1d2da836e7c4fe02a7cc8a0f0901ab2437b322cf5ce5947d1fd975ee76357a1a9ec7e9c82610e14ce9ba4b9"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-arm64.zip",
+          "hash": "fe23d4b8ad4e58fe8ef4785bf1f73d91deb72ed31db094cb30a588f3d3fde2525d05ef024ee220422e0835710e917a020b0e87232bf4fd75334e67b0c555bad5"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-x64.exe",
+          "hash": "ac51127107942feba162a0ff14efb19a39be744028beb83aca2b1fdf7c25bac77586a06bb57b10a6a124923e8df5465953edc84262bf52feaf101a1b05b7b4e9"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-x64.zip",
+          "hash": "0bcda427a08422bda3d0331b99742fd076abee2e22c994dcd4b4a84534f3e6080dbb63a69b415b8a0a5681d34be38b80366addbf3a5446fc25faca9e2a88eb8e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-x86.exe",
+          "hash": "e510c6e419b5977290b2ca8462f411f18a20b7168388e6677401f6889041595123082e0a91bbeb9d8f02e5241f37b8955d783795f1b9baef745e3ab4c5a9de80"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-10.0.0-preview.3.25172.1-win-x86.zip",
+          "hash": "090cc1df01eac271750e2407eea6d8adb555ab1083527401282af69a86bc252a91c68cadad455b43fda9b306df146e8056cb25c5ea66b3e6f0e90408924e4a58"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-arm.tar.gz",
+          "hash": "27d233ea2fa4855880f8dc87a99b5123c4afef986904ca7827125c6e4e86c858f0bedaef82a78bcb8fb61b5015403d78bb649e371bff8b7830140973141a89aa"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-arm64.tar.gz",
+          "hash": "a0e24eec757d9bf02cd918bf48a5e5c8c8ae5afe10df153cc2f9373e24d552f7b4385ea825638ab348537903368e9a3832abe5df241384629e558d88ac8cf676"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-musl-arm.tar.gz",
+          "hash": "37319b3e7962a1e1092bf875feaf04d6f6c0fbda2f04e86c0add572883d70ab8a0b4284bb7255bfa08c1115303eee4f0cbcf9feca495775a1c1f9111e392f463"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-musl-arm64.tar.gz",
+          "hash": "ffa0fb15fd3a1c48c16501862d0891c2971cfe4861b0c09a1cbec86f44c3b703482b953102e44913991b6df5deece7960f27fa18cab4a2924f3d7887770f9e37"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-musl-x64.tar.gz",
+          "hash": "b0f26f74125cc91e7612de53d41c6b845fb3a10c261eb9e717d20e267fc0332ebdb77be7c592d15b34ffa623b5c5622263d4ab81460a547dc9a602baa4f49832"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-linux-x64.tar.gz",
+          "hash": "55cca3c587e789137305ed3d6aed34915b53ba4d36000f1e5368e85ad2250d3b206db9c979bfb01b244baf9da85f3fc325a7cb5ce8905250299cbdddbcddea21"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-osx-arm64.tar.gz",
+          "hash": "317cc1cc61e65b009c8143baec0844a679509b32fbf13715faed4142c52aa1ca80c334f48aa1aefe86b461252265f648a766e872b11243eb24b248973206bea6"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-osx-x64.tar.gz",
+          "hash": "d5851f026d61dac87626de5246c0fc9114a84f2a4cc75a9211d6d74e4c4918ce1cd39bc91c182a3499d4c9cab994a680708d4273d149881ee70045a92ac76e21"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-win-arm64.zip",
+          "hash": "a2b61b0fc31800e6eab96b78c74d9e60bdb5128a3639523905b97686f59491be0db44a514bb8113c7b9be91220470720e9443c179040952a29ca18f74e39c1f8"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-win-x64.zip",
+          "hash": "7d77304e8e99f929c4e5661f240210b41b196bbde71a829f7b7d4e5ee25676d7c63891deb56ae5405580ae81ac763e259a4ae9d77c3b5518d865d65e3e7a5b20"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-runtime-composite-10.0.0-preview.3.25172.1-win-x86.zip",
+          "hash": "bb6b940b7a70100557c5861b70085cdb661d4fde03ad7339ced37279fc2d0178c542d8463d22abcf119cc77334203911ad7f89cb79a71d98f1491c56555f97af"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-arm.tar.gz",
+          "hash": "c72bee489cf35bb776a74db282700a994a76575847e1c475707e331c9e0941ccd1b55dfeac8dc7d63b699b82118564113cf8a7dff2ad2227b1bbb9f5b7d2d2ba"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-arm64.tar.gz",
+          "hash": "1166181c34da505b02d7d1242c0dfe3198c427b73c119b63f5a3fb408bfbd0a2e1b996cd6f0be4cb1104992bd84c1ec777913990c8f07277a204d60c0734160c"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-musl-arm.tar.gz",
+          "hash": "48ec5076dd9d22c3d52a638109fb85c35f1de0f2e215d63c72a628dbc0c816ba9567079afbc599ba812b0e541920d158717e94333c5b0c54bb8d2ced89d292e3"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-musl-arm64.tar.gz",
+          "hash": "88eb1a8dd59bc92664508f2515bb73d922274efbd11f0e6ef71578ab135728453dc2ba8259f70c077683aa7a5e3475d94e86d1b2ea1c8c6520c97eec4890a02c"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-musl-x64.tar.gz",
+          "hash": "2854fc7fb51edfd9896dfaed0fae9a86fcf0310554cc36167eb614ab0d7d90abb7df9d9704863eb0be234d53db7b02793a50c11adc181e013c819be4e5aef5a6"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-linux-x64.tar.gz",
+          "hash": "237f27e22d5ec4dc923fc5bccac326f03c680174a53e365aa3fb6f63f3993cdc6ec70236e8559a3696393db0dc1459047c669a16090d27b0be83a3c0f6718c13"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-osx-arm64.tar.gz",
+          "hash": "6c431c18714cf4bf00b6560eae2b4f58f65fc1f1d1feb20a119b66481346e815c463274fbfe22577c55683e87364eeefa816bb6a9963215ad87f917caba3d5e7"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-osx-x64.tar.gz",
+          "hash": "ae48cce52954ef14f3117de041080adc16985638ddd2d7aac6c135b30717425d10b5ec43f7b4cc189c8aca00f1d16109f10af7c66628324e830ddd0cfc8b088b"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-win-arm64.zip",
+          "hash": "5bd2ec084c22c5d9d793805fe4150de91e57cd9e54dcb399f7cce004888f3126c2d994eb5e5ba577fb4af837a122ab2d065fed82c717b660832257a3eef32e53"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-win-x64.zip",
+          "hash": "833288807dee18f8fa41a04906007212e83ed3a33c44ce386abc8b1009772c0ac7a429d6750160b67017d357f9ac331144f5cc8e2cb422a9096ccd14d2c2fe13"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/aspnetcore-targeting-pack-10.0.0-preview.3.25172.1-win-x86.zip",
+          "hash": "3fb64cb2c399a5bc9a1874932b685217fb0320282779183bf3e0274d3316e16fa0ffe0c0309773e80b817338f058baa51d1353d98be5400c0cae6bcff4da82b6"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.3/dotnet-hosting-10.0.0-preview.3.25172.1-win.exe",
+          "hash": "08aa4c6bf1e014a6d6140b1e51c2ef3a444a87f0bb669d10f3438604b9d7a7d7fb56db5befc8c4a29edf90e1cbeb39e62fe272d99316350ca49cea4f1fcd8796",
+          "akams": "https://aka.ms/dotnetcore-10-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "10.0.0-preview.3",
+      "version-display": "10.0.0-preview.3",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-arm64.exe",
+          "hash": "7420fc8b532723d95277f97676800c6fabbe27ec674c8593c87cddbefcb39fe76561631839d0623774ddb7bed5b75eca06d2d6fd01124d996a519964d1825512"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-arm64.zip",
+          "hash": "9e8aa5501715957f21995153780b737c9b3e48ff619328ec63383658c9040f000a89ce70054a5b6d5d892dc7331cff45758411905266b96be6e7ea1a845e01ba"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-x64.exe",
+          "hash": "535a275a0b9aa19bac39dcc4d463fe6c66ad7b1b9e2a002eef3999526c7cb03b6d6308093342f6b7ebf0dd5a91f75ae90e79f2a78825180e5f3c7763f23267a0"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-x64.zip",
+          "hash": "81ff1f3343fbee94713ca123882a968562948b6a7bacfba843ee0764a00967f73d17e64e326176e68e608037a9e4d60ee7f2bf7f0c87321294ac166f13fa3d3e"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-x86.exe",
+          "hash": "fd267202f3de8dacdd0b789c80e5300132030ef058cd7b22b4b7e24e1388c3eb607479cb4c24ccd86c724e5fc96d4466251fde53233aa4d5c88348f74c861a3d"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.3/windowsdesktop-runtime-10.0.0-preview.3.25174.1-win-x86.zip",
+          "hash": "26f4f66b6d479718e50a9dbe2ef2ec00f21187c6949687d3b4e2837107a5ec98b4b269d5ded0c8f7e69401b900cf0a4097bed80b0c96854e2fd4e684ff0a3419"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/10.0/preview/preview4/release.json
+++ b/release-notes/10.0/preview/preview4/release.json
@@ -1,0 +1,699 @@
+{
+  "channel-version": "10.0",
+  "release": {
+    "release-date": "2025-05-13",
+    "release-version": "10.0.0-preview.4",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview4/10.0.0-preview.4.md",
+    "runtime": {
+      "version": "10.0.0-preview.4.25258.110",
+      "version-display": "10.0.0-preview.4",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-apphost-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "d5115b0e54b487c83fd4b66504da7c31522d4b6fe72044ef0bbf8b7362b39f538658d309f6b99289091ee3a13c10f9d63abce8bbefbeb5dfb2cba1ef382cdd2c"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "1a42d330b310f79f6e153fcef38d4cfc6aab65ebc42bd8ba3c1e58a813e6ee2e3c9e947fb7356b6224efc7d71405526ca314f49ae7c280f78f5e4f2599a42c08"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-arm64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-bionic-arm64.tar.gz",
+          "hash": "8ea0d014f7aa4c8b91ccb060cd2f7123d90be0cca967252bbacb09fecbed93be450fa13bb3004d2d08f8fdb674cc6da57c25847f6f49e1b342c8465ccf068e5e"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-x64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-bionic-x64.tar.gz",
+          "hash": "f193737f5aa908c02e65f3a7cbf5cfa18ddb0d047b87e237410f74fb64f0adc3a866c28b2c0115b84f641a88afa7fd1c10a38804eba1461e9db724a6cd295246"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "38724dcfcc683e66a3539c49bed1215b8e7a69246aff91f40cdf61ad93afd5e51f30f209fb6c5ca70cf31f33d55285917c8270c613b5a4f76968ce1045da6f9e"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "1d893ee5ca41523547e9e37ef4894c3a89e36d7d0d8a06a2f9ab9b4d167ab92db8b8b121071f634ea5e52f9caa5b20468592b7ec823ace4d0e4b21abaf968e34"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "86234118a59adad350db86bd81cf2720f8b41b8de5cfd405f103789e43fd7593ffe3f77a1c2ad7cc1e5be08ffd412d25c0a1828e3ea325dc8e597a9cdea96c21"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "cb259beebf484a240846940bf2e3e2a047788eab8059afbaa27518b2f5b09bba284049c97ddf9a15bf1e8d9c170f7ff0917e8b4fe7196ed5d9acb8b843fb4d02"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "7e66852c9ad6505f1b70bd5a531b3ae1b52033af24139c7357fa63d7b2ba16cec427cddbcb2757ff117773f47345d633a08e4756f14b37a626214b5d8f51f1db"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "1d103e6f01a47c2d98d36f7b01ddabcb400ea6cd645ab8c18a3471e2e147983b16039fa884ed054079c30f4fcf1c9acd6ee8813bc19c404beb6ed6a089429389"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "e4e331b5e9d662e323d0c00515571d13a3b7ea2dda9d91065d501a1e715d337ed6d9735af723a871f54be7262460c9b9d272c7a2786ab70e400273f59ce002ad"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "b6b131e1babea7975fddd6d92d1d37526e06cc8f314ef68c9e92b57dabc878f1bbfbc9d87c4409ec315d8b74f30fdd0f09f18b401aa17d78043b1e8a77636325"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-apphost-pack-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "e0141bdf479ad12ddd4896d155752908f44a186a75191b3343f3969bea354fc6a44eac1e39af9c3b4791be0c6ebd7389b1ef576f99f345010d0993f09fb1876e"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "403d9c733139895e3ea6269f054a5324df870baeb5a6fe3bb74fa0bae62254962df49025c01b162085e8c633c89b4b2c8403780f0e322d7889d5da16c186ca2a"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "06af523d810d3afc311a83830e1ac03b01b36fbfc93ece395ee954ecb238ae5aafd403f330332870ea314f2b569f2474c721c12c78d162b1bf2b5fd075d6c231"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-arm64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-bionic-arm64.tar.gz",
+          "hash": "66b9492b51b107fb1572141b0951fd43c0104b5f7ab90245d086c2a5e1dc1c87d038b65417f58a5cadb52547c894262b4dc2e8b01f25dc49ed289fe0241ec6d7"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-x64.tar.gz",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-bionic-x64.tar.gz",
+          "hash": "f8f2c3a986c5b6498e7dcd7d62e2351a289af990574eeedb00d15a71cd2852b85ab79eb54049ee9851f73eaab964fb0f252e76707019a950656f20b56a9772e1"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "95ba53d99a5faf1e666747bacc19f593011ffd6b6941ff46ec9002b7757591855738a065885af67099d9abe6d29d3623350557cac4337fa59908988788d42fce"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "6e2d053f3c22e4f60df2eaee9a36b7b2dd5c68e5fc0d03c4d4e51f9b5157a5abfadeb0a2a0af480cc65c3eea3d5fa78d4dba2cf3abbe74eccc06f6485e1d0915"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "43987a916ab6f92e39307ec05d10e50e23c727a7436a14272ba86062b76f89ff4e288341f1e26d6e996e4b61f2006aac37eb700f3c2300c9ff27c3b6e9f882a2"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "1902b230b1f200fec7762a14b1c7e140172a155bd8312d5338ea290c9507a61be3ed7dc7995e5769e9e0f55b11dfe2ee7585a654e6f4b4464e59415463ce7ade"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-osx-arm64.pkg",
+          "hash": "95b322b963df61e7b4a61ffa353d8b21182c75478a284e07924c86e4986fa2a5cc5bc35be072f6d282a9d8a3c8630083ad5df5e38afc961340d1865f4b046eba"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "3aa02f829a824c8e36aece53c747acc6fa4129938af04fe305e3df7ae0666df172b60a687841a0f98d89d142644f5ed42fa14d31a13a0e7de141f9c0cfe9a658"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-osx-x64.pkg",
+          "hash": "1b25f378949dc0d8b1136b01eab8e1394bfe32b414432144dfe2df9e106c5eb52b856ada3d905f67f2ebfd822cc3c14de452d52ba2ad5700006403789fe30a68"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "3717d3249bb8778ce3696801ed57115b552b204c0480d3afbeb8e6fa3f17b9f4ea89b7b4154e3abdf5827ea11c3b63d7e291e7620b48e0b5a9a31d116c0594bc"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-arm64.exe",
+          "hash": "dbf94215389639365fbca47b383320647555589bfdbcb73eb31dddad40ffbebbe2b136cf07077f8e2fb37d89b136dddb3cda64a8746faabd05f9f3efe7c06179"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "677929369caa6211ac317ae98fbfb44de2eb5fbed7fb99d9091fe88f77cf2d9d32fd9b52b16288bda3f3324daf062c7ccac3710b2c1c9f8e363728af02376e58"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-x64.exe",
+          "hash": "4074a801ccf0839647b4a00e26e1b3f85b1dc779716c78039454bcda33217b724d7e20c02e254bd949eee2fcefd7dc9e5533797e815abba0007173ae0e7fad4a"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "e8b57e093218b91cc75bff6ef929e9de890c79ce8bc71d3d3bfe6a0cfbdc23cd6902c36b7052cff3f3c4f52f6f7841acaf43d2b514a4bb672fb6129626bfc8da"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-x86.exe",
+          "hash": "8e7e77bc51f4ec5688e5701f846ec519f600fdc20d9f60005293fe911a4e78e59e7612aee8d23f755740d8c4d60415208395f4e323a0c22f66b4ab5a2cebd1f3"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.4.25258.110/dotnet-runtime-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "6234f55a4525e300778260ea6721baa1e657f1837697d98030f9fb88959728a28521c061659f7ce03d93b2ba8063260508076ef3e7b8b582e6211386c39eff8d"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "10.0.100-preview.4.25258.110",
+      "version-display": "10.0.100-preview.4",
+      "runtime-version": "10.0.0-preview.4.25258.110",
+      "vs-version": "17.14",
+      "vs-mac-version": "",
+      "vs-support": "Visual Studio 2022 (v17.14)",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "0d4279a0b35853ce619a2341fe3c2375f15fafdfc67d48a85ca6c1d7212e7bf098cfebfe48455daef98ada9357fc5835b07ffb3c549234654dac39fed864cc91"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "38c25fa1f4335907a5e58210b343b1bed0b4444ef94a336558d70bab3f2763ffd786155e66640fc08fd9fd949bf061c4f69451fab9c0a6f134e0104a440cf972"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "8a714da3e87b21d8d81b709a7b8e401f1ae0f7be3bacb9829fb84de29b48c6e7355050018accc72f642dd395e8ebc08f9987deb9140eda8ba3f1a6cbe41138ec"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "0ef193341f450a17996e479e42e69087d700473589f0d8dccc1f4e8072f104cf83e065e38361f9fdcad84cc816aab0b807b82b242b6f67858cde592725e42aef"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "78c54bcc822dfebf1d4972387e594ff7bbc3d70a02609393f4d93ae90e2cbcefa00abc16a5d7fef8202446aa9057deb9194efbe2df83c078c2a2b9ba61fd9422"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "889788370618955f2fb10005aa66a1e617d52c8cd01783d7819e4368ed5c60b9541adf126fe7e307b764c0f0f283a4f209c0d2017d992da4432b671b73765b44"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-arm64.pkg",
+          "hash": "258abd5a6ec4f81109e056693a379239f8ba5556e1257518bd4f2dac6ffd53a447bc2d980edd5bdc3a12b8d6e969727a623d1b5f0eda2ad1ebffcd75fc483681"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "b3e02d8f01786e89bc4f8de711e6edae97b979e27097b2673aa51cc5124306853325edc9be899eba4ba81b67692cd81e4c7ba388a15f85ceeba0404f1bdc92a1"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-x64.pkg",
+          "hash": "5703352dd15952ec30cd5b96882ff22f4db6ee23cef8773d796411eb33e8c4562cc8779eeceda40c2112907b838e46d786f1289c3c75c42f733e8977e62c6e4b"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "5b8b066612c4dd09e3955734cdffbba703ce6e03d40f688b4b1367980b08407ae07b234f5219f2225ec2db6d81eddd02c4afba64ae10ac31882a71b60117539e"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-arm64.exe",
+          "hash": "f5b6eb2b923ae8419073bef4b4d6846c60c73d7172017c06bc67cce8b6360954882af9a0e09de2c6be32604242f6878168029599507f08e0db7b250655ce63ba"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-arm64.zip",
+          "hash": "a2a7725d794e592dd0965682ab920e7b691bf387cc7b7c526eca367604734e4e2b3022e7f09ebda3fe7a2d1682894a230b83d9ea7920665d5bb12c159c38e50e"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x64.exe",
+          "hash": "d79646bbfdee7f86250efb63934d5d9876d1934ba52fe2694ae4feed383fe1667f6c49f2435ab5b5430e22669caf0e9c821d3a1c90e075017c62085a34249e52"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x64.zip",
+          "hash": "266d9f25c196bada1c73af596ebe1605ef0e4527d66aafbe0209f597c78d3cc9bed3a87fddcdc0c3d4a757adb108f71487ee2374a79278e688a9f12093a5131f"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x86.exe",
+          "hash": "39277ae3e55f7d59b8e083d172fa1b74ffbe1e33ac3a147137a6b390a6edd8b42b80b504522a4374f4e7a89b63f44faf22a76d0cf52e294bd699eda0aa838693"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x86.zip",
+          "hash": "3d30f45ad988cf9612aadb64c3a326462279adb7a28996bf77143c75310ec1bec1fa3fb6a23bbc832333201fb27169a0ee2afdc0ef9dba6c93a23bf76710a746"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "10.0.100-preview.4.25258.110",
+        "version-display": "10.0.100-preview.4",
+        "runtime-version": "10.0.0-preview.4.25258.110",
+        "vs-version": "17.14",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2022 (v17.14)",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "16.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-arm.tar.gz",
+            "hash": "0d4279a0b35853ce619a2341fe3c2375f15fafdfc67d48a85ca6c1d7212e7bf098cfebfe48455daef98ada9357fc5835b07ffb3c549234654dac39fed864cc91"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-arm64.tar.gz",
+            "hash": "38c25fa1f4335907a5e58210b343b1bed0b4444ef94a336558d70bab3f2763ffd786155e66640fc08fd9fd949bf061c4f69451fab9c0a6f134e0104a440cf972"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-arm.tar.gz",
+            "hash": "8a714da3e87b21d8d81b709a7b8e401f1ae0f7be3bacb9829fb84de29b48c6e7355050018accc72f642dd395e8ebc08f9987deb9140eda8ba3f1a6cbe41138ec"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-arm64.tar.gz",
+            "hash": "0ef193341f450a17996e479e42e69087d700473589f0d8dccc1f4e8072f104cf83e065e38361f9fdcad84cc816aab0b807b82b242b6f67858cde592725e42aef"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-musl-x64.tar.gz",
+            "hash": "78c54bcc822dfebf1d4972387e594ff7bbc3d70a02609393f4d93ae90e2cbcefa00abc16a5d7fef8202446aa9057deb9194efbe2df83c078c2a2b9ba61fd9422"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-linux-x64.tar.gz",
+            "hash": "889788370618955f2fb10005aa66a1e617d52c8cd01783d7819e4368ed5c60b9541adf126fe7e307b764c0f0f283a4f209c0d2017d992da4432b671b73765b44"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-arm64.pkg",
+            "hash": "258abd5a6ec4f81109e056693a379239f8ba5556e1257518bd4f2dac6ffd53a447bc2d980edd5bdc3a12b8d6e969727a623d1b5f0eda2ad1ebffcd75fc483681"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-arm64.tar.gz",
+            "hash": "b3e02d8f01786e89bc4f8de711e6edae97b979e27097b2673aa51cc5124306853325edc9be899eba4ba81b67692cd81e4c7ba388a15f85ceeba0404f1bdc92a1"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-x64.pkg",
+            "hash": "5703352dd15952ec30cd5b96882ff22f4db6ee23cef8773d796411eb33e8c4562cc8779eeceda40c2112907b838e46d786f1289c3c75c42f733e8977e62c6e4b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-osx-x64.tar.gz",
+            "hash": "5b8b066612c4dd09e3955734cdffbba703ce6e03d40f688b4b1367980b08407ae07b234f5219f2225ec2db6d81eddd02c4afba64ae10ac31882a71b60117539e"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-arm64.exe",
+            "hash": "f5b6eb2b923ae8419073bef4b4d6846c60c73d7172017c06bc67cce8b6360954882af9a0e09de2c6be32604242f6878168029599507f08e0db7b250655ce63ba"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-arm64.zip",
+            "hash": "a2a7725d794e592dd0965682ab920e7b691bf387cc7b7c526eca367604734e4e2b3022e7f09ebda3fe7a2d1682894a230b83d9ea7920665d5bb12c159c38e50e"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x64.exe",
+            "hash": "d79646bbfdee7f86250efb63934d5d9876d1934ba52fe2694ae4feed383fe1667f6c49f2435ab5b5430e22669caf0e9c821d3a1c90e075017c62085a34249e52"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x64.zip",
+            "hash": "266d9f25c196bada1c73af596ebe1605ef0e4527d66aafbe0209f597c78d3cc9bed3a87fddcdc0c3d4a757adb108f71487ee2374a79278e688a9f12093a5131f"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x86.exe",
+            "hash": "39277ae3e55f7d59b8e083d172fa1b74ffbe1e33ac3a147137a6b390a6edd8b42b80b504522a4374f4e7a89b63f44faf22a76d0cf52e294bd699eda0aa838693"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x86.zip",
+            "hash": "3d30f45ad988cf9612aadb64c3a326462279adb7a28996bf77143c75310ec1bec1fa3fb6a23bbc832333201fb27169a0ee2afdc0ef9dba6c93a23bf76710a746"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "10.0.0-preview.4.25258.110",
+      "version-display": "10.0.0-preview.4",
+      "version-aspnetcoremodule": [],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "64c4359a8d35ac15312ad844587dee1d227f207d3c9ba16edf50c6706f93a29d0b8d3388bd17547491652f1423a67bfbf42c4c7ae880afbe420615e529babf75"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "7c56bc04dd5515291fc29a944e501ce276b722aa78e3c679188cb9fe33fbe063c21b04efd0fcbba61013dd73914e7a4b438626a816c0b6f9cf7f097646a6d208"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "d6b6e4f2f548b0de2ba48c85a55de60675243d91b9e433aa2c4c036679aeb814236f9cf4f38509da5d471352a3845a830e1e02e5bc5e971acdb841567285626d"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "92070419e0df1ec95d92900a14984fd1226da604e815460853fea6186be9b03a8bf4e0c79b243812ac54f35f293cd247b478f1bd896c3b653cb526808cce797c"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "a23f36e5b2ee6d1533b8770a9b1b90b8053bed2c613489d3b5ca298f4553d0cdc79ad9f5080058a1ce868c7c83ebf4727de379e757aee45dc07def528e55eeea"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "0fa8d60bdc3f63df49b5f3fe5cdda13713a3f9bea3e7c150480543f2b7c3b3871f4278fc042d6f850434146950c4934606c848f4b077be69ae4357ace36b7075"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "71a4c1494e7fd576fef11c5c92fcd0ecd921fe042f496704a55a96ffa5145d7938c6c435090e285d8ffe150c311f3ed67f75b1c1e3d192db9429f34f5301fddc"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "5aa0689b4df534c2225b78170e2b52e8ba88b5c243e655f0ab1c58a11357022f7c7d7fb418cf145d7d82613d3a3b290d68a59a34d5fe33221c6d878719b30502"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-arm64.exe",
+          "hash": "9a4ab672e0c5a6c600d6fd5c1ad4e2838ce24f95cbc7ff8720c1542647a7b42505b108d6e38d4b6b6c4630fd4ae208c25b13f8050f6e77814bbda917636514b3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "17d0d35b085cd8bce4f30d29be29bfea341789580fea60f6dc09673060e1c4b1f5f3056a7c03bf465f978528f1e9e020f7c7c93d5d3fe9c4d6f6b14a11edff10"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-x64.exe",
+          "hash": "a01fd598de7202dc0bc379f16108a828587115ac36be19e1214e00edd44f2d5bb7706b2ce582baaa41c947e8ad8699b356ea405b5ed277fe36d0a26eb157c142"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "db68461f744a623a62fd63d230e5c9fa160c220013a46b23d436fad18927c0f349432cdeb6c9e115db5ed8311dc82891bd81f2958d7d6773c4ba84c92ad0e7fc"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-x86.exe",
+          "hash": "a94cf1c01a3c764da6e0dcdc6a86fd21fe80c9f0f4bdf7962f7ecd39d2598bb1c5597a3933c15808c5beea5caa3871698e818aebbe50278e0f8fdb70ecbbaf55"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "da426ac0f9f5f07094f38155c75c0b22887ab6b14725aecbd7bb12e529b815b61ac13fb05ea093f0a8f281e2997e05b8f71522c996c901c7d05f464cdd5e52b5"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "177a931c53532a4d5881775b0670405bd23ff12102c8f7c55f83a5a5db04c3d326e78eb6e86626a19f0a771067af3e23147c8bfd19bef56f21a44827bdd67a63"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "9b1eb0c1ce649bbc74900c459fff67d91379bacf84b95d1ad207feee9baa1fbd56b3bb264a9a8c073415e5f878805754e371c48e36e71fdd9041fe68ce733125"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "fbeeb4b715588e1f480a42fe799c248e3b9cf90aa5bc04dea9506d17d65f0fa9e5db8fde779bdc9231ef8d0bf947a7182c3b2164e3367eda443b04ccaf5bbbaf"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "4fbd593865854e0e69c271871cc4db3dcf33a244c35810c1a3c2ad42db37a92aeb628fa3e8db37f503dc27c332d108e60f3f312304cc6aa696d857ebeb200cb5"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "eeb47521e7d68d0e964da20cc318bc578ac3aae85340d870a29ea0e9d1e77b5ddc2b722d15e42c5b15b080eda21d8f3a1708630bf942d55e3c3288a117a91a3e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "8318d32f748348c1a5d56823a6733b3bb31558734c8f91dfe8189c8475953a64ee2c2698a1bf5e007e07054f16f797dfe2dfa463f61f69c877714589b51972c7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "ad9a40cde11dfb7135f4e47f0f611920eacca6067598d82251c74de7cb9685d5d4960f299c784016d4267ec854e0aaa58a7ffd5f46498b4ea90487e29895c09e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "99f8600261ae2fd49be181e8d181a386b6694c5eeeee15839c845bfbfeff987e999f88aeda37360350090ea9635507d8bb3f871f86c59a5df1a722520aa42592"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "ea788a61e314aa8912adedd2e9c8dfac306be701f917d2fec64ead0e63caf6dfbcb765dbc3f56f6d5b7e757d55326979b70b3725d02598df9ee7b6e1bf26a151"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "4b04f92244740e89615ef8e19975b51d8f87f879517850fb0037d90400952d8e2442e4679dfa246a9aa7239f5b417e15b59dd3fadafe05b63536df17354b91a9"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-runtime-composite-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "cf95339751f7156ac19e5323b59cb5a38683236c0f5874fe03b21f695f92f6b9bcfb0f07b0823edcc1b8297019f84bab465e985792e168ff8d208e07f76bd45a"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-arm.tar.gz",
+          "hash": "d5f31468d42c495ca46bc6bad75a65b3412f18a108f2ce42ccacfd0c364e257a21c1a6ef1186f5d3d96b70712905cc108835cada43437bc0c42ebb026f30c31b"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-arm64.tar.gz",
+          "hash": "528202289d982da003d68fb8e07883f2e490b49de0d9e05c84ae568feb59e4f667d45959d3b2c22a875f4c8d2491dad62a834394c03e153f0c849b7e8c823a0a"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-musl-arm.tar.gz",
+          "hash": "932813c81d4805ad18727d1b362d0a97a946ab34bc56ddf540dab53f438aa470aff79f57ad8fb5744dd0495dc6deefba6d1d10bb47863612265831e06d2ba62f"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-musl-arm64.tar.gz",
+          "hash": "000fae4aca4bce7b2f2692233cabc94c87970826eaef4523d6ac969d0eaba46f1cc0fab939f323f298cb9a954ab4f651e8bea1df171a8ddc3b2d671698201829"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-musl-x64.tar.gz",
+          "hash": "427a9e64e585ddaf852b2b54cd6831fb610665dde71a826a95915436c0b0a42ea513a11bc03cb42e7c653187c72be98aee7575417afe52d93bbb827da88ef333"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-linux-x64.tar.gz",
+          "hash": "79b0ff89da667252420c57e2c515983433bd738aa6eda8e06773569bb463be7d896c7417587a9d2e713860a3c100d94d88fe87bee8c44272fa3bf4638fd7adef"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-osx-arm64.tar.gz",
+          "hash": "051ad55c690422bdff1cd3e6936f5e58c90c1c2e6a41dc4466cf4f6debe74e3dca68790ff97efda76362e54d93a35797ee36b5a24f7b5bfc8c2a7088259e479e"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-osx-x64.tar.gz",
+          "hash": "48cdf253c8a6687af3b8cb0461d189a8d91b299af47ece3dd91206c98f4b7e86861abcbeff458f27128aa4a049fa507b4e73843461e1485528d7dce7c82f0b86"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "6236dfc25233ca8f55543e6b723899bc94d9ef9cf125d20393c28b2b5c3255518f6e4d85e710ee45ec3c2b023cb3eca0d0203439645ffe1d8e22bd3c948e71bc"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "56e4f21f8a51c58eb6052183927f61c8d538e2e27bb4dd10d1bee0f4fea07f69874d8237d761afba9c8bd172f7c8e1877f92d26ec2fb89532221493369be5155"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/aspnetcore-targeting-pack-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "1e6d06385e6fc7837e648a02243d9fd45491e12e2847a2ca1a339c648ee7c23b506bf0c94d641053377a2fe3275c3288d78758e130db7f5f1b155a8031f9fde8"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.4.25258.110/dotnet-hosting-10.0.0-preview.4.25258.110-win.exe",
+          "hash": "2b4084f7a291f67d0c73fab697a26d25afef3ba3ceadb14292096743e77f07d7663d20703485c3097ef2bf86f89f855f69c6c75377f87545db525a44037a8b3a",
+          "akams": "https://aka.ms/dotnetcore-10-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "10.0.0-preview.4.25258.110",
+      "version-display": "10.0.0-preview.4",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-arm64.exe",
+          "hash": "c23d2116db598a7d06248f55b7550ecdea4e7762bdc68fd73036b1e93935646dae81ddfc4ecf56da38a01c8e38aa3b9f8f96f4e7f30861d1c8c00660fabd79f8"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-arm64.zip",
+          "hash": "390163e50818cdbb4699c2834c56e230935e3dc160c4976c2676cc97d1ab9f62cd35f6e5f2ff466241cb37a0d8e68143ef3c753b18c8c4341c73aa99e6c598bf"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-x64.exe",
+          "hash": "4a5fbb9ca28733487eeffb64d8e83c9cca20a76d7f443c46a9cb36fb21c58f66a8effca936435b60ef834f647c197aeaf5ae5aefcc406b51c0ae2c31be902012"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-x64.zip",
+          "hash": "03b37d335cb34c455c317499e29c39d571929e8d4e699fcef371f4c30c7617ccd28621225f171614fb5ff4370988f46f00ea244501e7d38335d4ff22258f0263"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-x86.exe",
+          "hash": "566fc2a08954d4dcac7b5c79f23fe40242c84d4b56da5af2ba7147cfcda54991634b26b59c2c6cdc6a5ce095b80d51166ad820ca1c7cfb198438fc64050527ea"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.4.25258.110/windowsdesktop-runtime-10.0.0-preview.4.25258.110-win-x86.zip",
+          "hash": "a5c6b2684079c33ee13bdbd331d8e4e56c0aa80be685f88181f7c1408a5be4eab4339b824bb319166079c563e90ca976fb10f698434e30883716f04749b54ee7"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/10.0/preview/preview5/release.json
+++ b/release-notes/10.0/preview/preview5/release.json
@@ -1,0 +1,699 @@
+{
+  "channel-version": "10.0",
+  "release": {
+    "release-date": "2025-06-10",
+    "release-version": "10.0.0-preview.5",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview5/10.0.0-preview.5.md",
+    "runtime": {
+      "version": "10.0.0-preview.5.25277.114",
+      "version-display": "10.0.0-preview.5",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-apphost-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "A6E028A341A62E8D6439626BF888D572F991A12CD80A1A2D8CD6EFDA9C9F104ED19125C5B11CB8EF505B75B9129294A42237740D310005AB7F0D72CE35CB77CC"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "44FAD100DF0564153855A76A964B21FE30C7DC26C5610138FCB2827F13FE7D669E53E4F511A3D16292593DC01589D80F8A34A4C007FFC5257732161DAC4EACC6"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-arm64.tar.gz",
+          "rid": "linux-bionic-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-bionic-arm64.tar.gz",
+          "hash": "E31CC0034F38AC94FCE1A12DB067053BA8DA900C113195BDACC79D5767BF1937E5179B7D1523ED46141622A51DD693CA18D7AC69328DF6E9A5754DE4A1E2EB41"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-bionic-x64.tar.gz",
+          "rid": "linux-bionic-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-bionic-x64.tar.gz",
+          "hash": "B987D31E0C2F0933239B523AEDDC820AC42CCF2D611EF095DCD6A39CE9C4501F7D6419987B314405E46E9B572FDAC026BB5E2F2E7BEBDF280FE3F56D0B41C971"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "8EE1926711F970B6692CBFFD2050BD3FBCD225C411475A154006BD94CA34E7B09BED8B023DDA399148BF01FA37B893BA17863BCFDD4F14F8CCA636EF0A4C6E2B"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "207B84A7911F5F194A7558F35A4E13482B85EDEE587ECB93E4A42690CB14284C0EA2EC89F9D96F2D1A19B7A0A8411B6D9CBB7543BA2CF2A5277DB74AAF125360"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "DEE31F80B1B1ED6ADDA70CE58AF96183EDA2A8FFF5B2AADC7CEB70E3C9914C132C6FB2405984E241BAC1973DFE1E4403E5E695D4E67A326BD1D9D68F03DC9EB5"
+        },
+        {
+          "name": "dotnet-apphost-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "6A71DCCAA3997E2CCDC5A506C8473B24A2702C8874AF27C983F6F787B857B9EE53E2F3C6EBA3DB75D423B1F57ADF9D6053AF9C1FF07C1EB25C8340DA6041E41E"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "AB849707CEE617BF314CE68C09E8D8C9AF3B2B9DE4D64405C3AA3FBF875C9510E1E7A22649B0B0285BC1FAA0EAD426F3F79D159463530002011DC5929100B52D"
+        },
+        {
+          "name": "dotnet-apphost-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "2E28F36C3FFB64730EB8B8DE5D5764ECE16613C818FE377A0E7DDBEBC6C07900C9D0B289DBA4D3494EFE07FCCB21F227BE0CA807C10BE18B954B0EE1FDF43F0B"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "9082BDF83AB098B2C94C2676A0849C528A2D8DACE34E32621B04ADC460D9289B3BE5D94A5C424ABFB9B290BA59F4380A06AA41FBB8F0B2F99B4CF2A15D70C2E5"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "1E71509F540A4B92B17ABADBAC1CF74B6E8E8044FCCF1D6E6F941506BA56F9084F2114FA4B994832667A20ADBE5D71CF57462433C36833D44EB4469675D27B79"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-apphost-pack-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "515F0CE92E16FCEA513A56D91D0F72BF35A2D1AAC97C3BBE6A1A19E734062A3EBDC189EC00407F188537AC80C66D009A6F5C50AB27CA99AA6FEC60005652E915"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "D9294D0AA4A224E1A76AB08684D827580841B45A0D96953C317EF4FD3858C08524455B302734F76ED7D5C940B212FD116F7A5F1317F7A4463AADBEC910989AEE"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "9AE24D6528C30242F537F2D3E3AD89B87EBE47BAD441FD6730DF5264D135A63705721B67F434E2251809013B25ADB2E3734D650E233E6C871C579D713240A650"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-arm64.tar.gz",
+          "rid": "linux-bionic-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-bionic-arm64.tar.gz",
+          "hash": "340827A3C4893DC492CC8C084B3F1CA2A386BDC252B4174DD34EA12A778D43298107B0E060E4592C6B77C98B328359EFEFC3C4EA61111984392037A93950D2D6"
+        },
+        {
+          "name": "dotnet-runtime-linux-bionic-x64.tar.gz",
+          "rid": "linux-bionic-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-bionic-x64.tar.gz",
+          "hash": "D0104F8B1333AE62A7B3BB64B27A313FEE343AA23C7D8B845DCA47DF570B0BC2CB0E101025F92136A82E5B99D57A7BFCFBB7EFC793C02D572A7004DE606F3C42"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "37B38B5CA69E2CBBDDCFAF4D7C2D1F652E56368F3C4BCA842C8CD81FA108A25AFBF5A9AC85856363EA6E0E10C85CEC03CFF57E641690EDDDF0938F17D379DE32"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "10F5A4F743D8795688FAB1B9E736CD76E04BECB5A56903D9607CD7694C81A0AACEE948FA511BE463E7D719EF8AAA9CCD9099EF2A6A0F15D955D238CE0919FC9C"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "716B01559B44320C124459C461DC9BE7A2391B680EC9BA46A22F77A737EB93C4E3323A73B1138DDD1574DCC50934C82ADF7ABE792D6BBD953B8AEA790619941F"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "EC21EFF51B0F8B9E7C9C00B6CC9E9CDD810997C9D2C1987042C48CDD6BF6E40C2552ACBFCDA405C56B3CE7DE52B3A20E6B91F068C6E4BD101B896C302A32B5F2"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-osx-arm64.pkg",
+          "hash": "3867EFE2B96768D785CF74849F8A0816EA6DB24D4A0452D560FD1A1F5CF741BD0428BF4B60488909C055C8E02C84E1A2AED30ED7616242002F52C9BE11E7766F"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "8B950FDF099F34022CBB11AE2E736FA36D3CD7E117230971230EB3E0CDB3D33F36B43F87EE6F8C0767C56E6619066667BCFC8E267A6F416965B9C37B0C92152F"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-osx-x64.pkg",
+          "hash": "05BEBFAB82BF512D806DCC9E5F478E7D03C426E5A889C55279A846F89A307CADB3B5948F31DE17C1D7F3A827B91956C3656487E3FA85C31A742E6BF72E7B74B6"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "B8607F688ECF06CF9FB295045383D7565BC2C9057E790F7716A2AC2D056C9AF6B5A3D642D82A1BF4F82727E0B6F6B066C72E2C54ED969FC5ADEA38841D88408C"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-arm64.exe",
+          "hash": "55D6B893B179DEFC422FF581A1356B6AAB9E37B233FB244902C320C490EF6F1D2ECB4EBEF129A80C1E1DD1113DB45FDE7F469F5BB230A56E68C3A3029DF254B7"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "8F29BA0D38827EB30A0CE0A3A6FBAC2BB82F1EBF417B0C41B234F2DECB063E87AC9BF28B198F7DC162C1A2DBCAE0C9ED11D5B9245A8BF2C85FAE245442AB6F2F"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-x64.exe",
+          "hash": "C8B6764DD8D080A3AAE07A2DC7452B70578B8921864C356418F8002A4F912FB381B5C7921F2E5EFF8A7065BA27F1694E1EF838ED072EF2B0FEB88958D1F9AEF3"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "9A2E9FAC1424CD7E50624466E410D3DDA7F97EFFD6F4F96BE2B08961A1929A48169B84243555622AC015D6BCFFE8E953B86F68DA6FB9A66DED5F72EC1E362021"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-x86.exe",
+          "hash": "AB5C8169FBB774E7A177648D17AAA9F037E163FDB6E52D9D5FDF2EC62A6B04857DECEE3E2AC2EA7983C4E5A65EDD7CE157DF3DBE5EDCD6EE8E054F699C62CF22"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.0-preview.5.25277.114/dotnet-runtime-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "64AF1C5917CDB077EB1909F8ED62AD2E8BFB3BE0B9B01612F85203D614F5F15F03B7802D6676967025AADAE3202909634B6FFE29EC28640D84827F0717B19517"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "10.0.100-preview.5.25277.114",
+      "version-display": "10.0.100-preview.5",
+      "runtime-version": "10.0.0-preview.5.25277.114",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "vs-support": "",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "17.13",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "1BB72EBACF090A3FC34DD1311AD634E4FB00EA452320AA68D62ABBF83121518B5AE42B9C1895FB804F55CFACEC78095CAF23C0CCF44D0076912C7E3A5A001786"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "E99F03858BAFFA1B41E67EB6291B7E9EB68FC8926409794D4416982092B7E80356E5547BE779B774216C1EC7AEE236B6474567CB7C0D815ECD19EBC71B07F971"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "DE43CB81692591FF6508A9BEE19107FE03E6551633F03FD617CF29A14E5142DBDCAED9DED406A7E839F39D8D0FB4B6AA1749C2C925B63C93CC1567420679B0C1"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "C5085C53974ABB9949A774EE613BB22CAA22BB510883296AA5E0CF9590F4F13BE0E2E7074E4054F9B1BF09D20D08F2FF223594495E956FBEEAE85C508C7F1596"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "B9E48F0C1B8B233F0BED18EFD84DC35B3DFF4F6C84052C9CCA40FC701A34D1D86744DEAC0F155C91CEBC3E54276170AD0B51DA7A8E73E597A7D3D24672608C18"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "4EF3BC177BBAA7BA38CEB78CF0109BACCEA1F4432CD8C52E3D78B237CD5A92BD660E926774036A2FCB51175F48FFEBC8A65DCA56BB905BC8ED4F2ECFD8C15C79"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-arm64.pkg",
+          "hash": "2BC0BEB4636989819A008ECEDA33237E623B11579F72BBCEB3569F96656719BAD0FF70E6DA72D1C247D31795F49380EAEFAA2FFBADD0CB154B89458AE86C750B"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "185A3E341B928BA1B218FB769FB0D8CFD7162C567CCD46928FFCE74D6069BA0C491E44E9062855335283A747E995AF44529EB6FCE06D3C09C5C9B0A622C39360"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-x64.pkg",
+          "hash": "DA59DF0ABFBD51BD1BFF48F4383C5A11C6B1470B7173D6F4F953AE161030E9AA19ECCBFA10CAC88BAAA85AB6AF682C1E1456C8B6CFEBACF20ED0C77F504B355F"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "CAF70EBAF1182FD803E60A05F2F793AB6F6902EC365BD94B09902679709FB2AEF6122A03256DB4D3936F33B98F64623E8EDA0C64CF8AE902829C23E745987148"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-arm64.exe",
+          "hash": "AC896689007910E927751A6EF6AE801F368FEC53D69D2B95495860374E9C85C72906B9CD66B85C1B07DB42AD6C0D54BFE19D1CFC9070937C630B63B3B316AE41"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-arm64.zip",
+          "hash": "67FF83BFFEDD09D513636A870247DA9157096DC22FB30D1E7DE3D4C7268892396B89542D2C7F7593EB154F3E1CF54CECC754640585F5081AA44AB2B6C8DEFDFE"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x64.exe",
+          "hash": "A831E4853315517ED6AE917E892D5F4FED15D1398FA69B5A6F4790827AD1EA81E9E0290939C6F7C5A91126A8F0A7DF885ECF1BE5105E5B5A9301786C00F6A74D"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x64.zip",
+          "hash": "E54A15F594474DD9902AEBCB99C3EC0963D7E4DCD73935DADE6E70D726BCC21410DEA104CA699F19D8CAEB4D3E82EE52F8F373102D4E46F5E9121CACF9DC53CF"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x86.exe",
+          "hash": "3CF01D32DA05DD5A8880863974EE1A0E20BAA3A8E8162B69A76B23CDAC092389BBB30208545B7E05D7C2039628A866B7F153745F7FDDA8FAE36C33C383B1C305"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x86.zip",
+          "hash": "BEC0FC40E823827F6F6691AF1CD7FEBFC7045A2F36DD60FA551CAF1CC191FF9B51F640CEDD39CBDC873A94D7501F0D93E6A4023B64B048E67873D46C0FA115A9"
+        }
+      ]
+    },
+    "sdks": [
+      {
+        "version": "10.0.100-preview.5.25277.114",
+        "version-display": "10.0.100-preview.5",
+        "runtime-version": "10.0.0-preview.5.25277.114",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "17.13",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-arm.tar.gz",
+            "hash": "1BB72EBACF090A3FC34DD1311AD634E4FB00EA452320AA68D62ABBF83121518B5AE42B9C1895FB804F55CFACEC78095CAF23C0CCF44D0076912C7E3A5A001786"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-arm64.tar.gz",
+            "hash": "E99F03858BAFFA1B41E67EB6291B7E9EB68FC8926409794D4416982092B7E80356E5547BE779B774216C1EC7AEE236B6474567CB7C0D815ECD19EBC71B07F971"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-arm.tar.gz",
+            "hash": "DE43CB81692591FF6508A9BEE19107FE03E6551633F03FD617CF29A14E5142DBDCAED9DED406A7E839F39D8D0FB4B6AA1749C2C925B63C93CC1567420679B0C1"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-arm64.tar.gz",
+            "hash": "C5085C53974ABB9949A774EE613BB22CAA22BB510883296AA5E0CF9590F4F13BE0E2E7074E4054F9B1BF09D20D08F2FF223594495E956FBEEAE85C508C7F1596"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-musl-x64.tar.gz",
+            "hash": "B9E48F0C1B8B233F0BED18EFD84DC35B3DFF4F6C84052C9CCA40FC701A34D1D86744DEAC0F155C91CEBC3E54276170AD0B51DA7A8E73E597A7D3D24672608C18"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-linux-x64.tar.gz",
+            "hash": "4EF3BC177BBAA7BA38CEB78CF0109BACCEA1F4432CD8C52E3D78B237CD5A92BD660E926774036A2FCB51175F48FFEBC8A65DCA56BB905BC8ED4F2ECFD8C15C79"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-arm64.pkg",
+            "hash": "2BC0BEB4636989819A008ECEDA33237E623B11579F72BBCEB3569F96656719BAD0FF70E6DA72D1C247D31795F49380EAEFAA2FFBADD0CB154B89458AE86C750B"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-arm64.tar.gz",
+            "hash": "185A3E341B928BA1B218FB769FB0D8CFD7162C567CCD46928FFCE74D6069BA0C491E44E9062855335283A747E995AF44529EB6FCE06D3C09C5C9B0A622C39360"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-x64.pkg",
+            "hash": "DA59DF0ABFBD51BD1BFF48F4383C5A11C6B1470B7173D6F4F953AE161030E9AA19ECCBFA10CAC88BAAA85AB6AF682C1E1456C8B6CFEBACF20ED0C77F504B355F"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-osx-x64.tar.gz",
+            "hash": "CAF70EBAF1182FD803E60A05F2F793AB6F6902EC365BD94B09902679709FB2AEF6122A03256DB4D3936F33B98F64623E8EDA0C64CF8AE902829C23E745987148"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-arm64.exe",
+            "hash": "AC896689007910E927751A6EF6AE801F368FEC53D69D2B95495860374E9C85C72906B9CD66B85C1B07DB42AD6C0D54BFE19D1CFC9070937C630B63B3B316AE41"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-arm64.zip",
+            "hash": "67FF83BFFEDD09D513636A870247DA9157096DC22FB30D1E7DE3D4C7268892396B89542D2C7F7593EB154F3E1CF54CECC754640585F5081AA44AB2B6C8DEFDFE"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x64.exe",
+            "hash": "A831E4853315517ED6AE917E892D5F4FED15D1398FA69B5A6F4790827AD1EA81E9E0290939C6F7C5A91126A8F0A7DF885ECF1BE5105E5B5A9301786C00F6A74D"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x64.zip",
+            "hash": "E54A15F594474DD9902AEBCB99C3EC0963D7E4DCD73935DADE6E70D726BCC21410DEA104CA699F19D8CAEB4D3E82EE52F8F373102D4E46F5E9121CACF9DC53CF"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x86.exe",
+            "hash": "3CF01D32DA05DD5A8880863974EE1A0E20BAA3A8E8162B69A76B23CDAC092389BBB30208545B7E05D7C2039628A866B7F153745F7FDDA8FAE36C33C383B1C305"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x86.zip",
+            "hash": "BEC0FC40E823827F6F6691AF1CD7FEBFC7045A2F36DD60FA551CAF1CC191FF9B51F640CEDD39CBDC873A94D7501F0D93E6A4023B64B048E67873D46C0FA115A9"
+          }
+        ]
+      }
+    ],
+    "aspnetcore-runtime": {
+      "version": "10.0.0-preview.5.25277.114",
+      "version-display": "10.0.0-preview.5",
+      "version-aspnetcoremodule": [],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "0830203BBDA5F1BE678E59BF08E4CBF6C0DA52C9809D026004BA2EF0EA0FD6A3088C8F025D7A92C6619B0FB586E07056F7495A26D5FD537CAE09AB71CA816E1D"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "AC99EBEC4E7ABD660A27317D37DA56AE1FA8E9EBDBF4A88FE5F9BE58E1F4D7E8F05BEC32D5E902C0FDD1E9D9E250CDB49448266682010E4CF7F4640F9699B9F1"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "789EC6DCB6805ED709F03FACD19E2CF04FAEB88408E2436BC7E7E76EB65F273402F4714CEE60C6B08FD9B59138BFF43B805965D1D5C5BA585BEAE71E5FFB8B4D"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "B06D62A7C5300C4A7FC795438180E27C127E971578F8F874C8C6D733BE2B645EFB59B633D88F6658CA34DBCBC8B689675CB3651A612598204FC2A5BAE41D361D"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "C998983DB2CD5E8BA3703900873929D93F0FF8C6A51B465A27035972BA77F0C19A72D3CB8542DDB32FECD1E76BA3971627391A2E00F5A9FE1DF7CE648392D317"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "6E69A85F7E18B8EEBB5F99A7E8099DB2FA5DA34BCF078BECBB123C0863D4BE7B4252C7CFC6B21B9585F4F800C058A12CAE55EF2A63B9BEA886CA3D1D8A0EC113"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "623B5A293F98DD35D305F311281792A1ABD9CE557F31A6673943F20B928E6EA918076AD8F21983EC5148206BFA4C0898EE8D926DF94925838CCE11AEAF6A5524"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "231667EDCF6E734240C0A8F40EBB428E7B5685C5185BA1FA50D5F5072ED86533F9E94B69551C8BF6C16DA4DE4DFD4980E6AC25F104A1CC1518A792399BF2268D"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-arm64.exe",
+          "hash": "CCBFDA165F7B43F1D32EF6EA907D322EFCB320EBE946666C7B390CA133FEB9D5C6BA384058B2FA5EE5830F17A2A02BDA8DC811575CF4A1F40DE97CE5C5AA9953"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "30EA875D0F445EA7A08E10884A36D10C4B14E8BAABF2D709F042FF9ABD72CFFF4B13BDAA2EDBAFC4E1EC5E9F969572B226A99C9EA0F65C2EDB62BA968B6C6C21"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-x64.exe",
+          "hash": "E0828789A0AC2920967604CF859CA008A753897B91FD9F6C954C61DF28B10C5DE89C498732B68F691BF2090A2C7E045AFFDA14CC4E3B17C2FD0D08C320752097"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "FE9D46066F394BF11D172E847A90038F0B42951CD06960D153822C158666E13DEF904DCD7A900B1CD43F2888AAB94E90405CCB0552E7D707FBFC0278E6314DF0"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-x86.exe",
+          "hash": "EB89B1AAC4B49C9CB64FF75A21D0D245BE0F31774CDE88AE0842F65B88F56B9022E5D5D8907F0188B8B91AE39C1A6175B4ADB35C7C16EF8D8B29DF67E2F50FE1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "D746F85FA7E6361A15F85A5114A7BB5C4D076529B175DB2BDE8D6D53A7006C707DF5CCEE9B7A555D45A9B5EE3E6B84FBF5CC29AD9C57C0E30DA97D52B4BC46B7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "E0023293584C9DF783F1CCB4A8368FE9DAB128BC42B469CAF883E52A6AFDF0C216F001BE0A9E383C537DFD5F31B8106944936784E5D74193D77E50EB08D453A7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "2160222CFBD063F1EF109D94C629A2D2236263922927ACCB30BF38FF1F853F69651FA33DF5C96AA2AC037C2D6AEF7A107347F7E40EA3681EEFBCCEC7D06D1D1C"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "A012AB79894CAF198FE725825C6973C818B0F5CCB6BA7D0F306B6741FD488E39A5E3D1DFD90FF5D2B100714D2F1F2262B59C97C1D360406D37431B109F483C42"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "246F726E68BEACCEB8B96177663BB2D6B00153ED51BFE591234F5F59F9C8E50B4DF3C8E8084C52D81FF144D47FB78BD7C40E7C9BDD51B7DD4EE51AA5ED462F30"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "197D5A9C080743A7CE1F3547BD7A3D7ABCE2A1F66796416FABDD01630BB127033004013EAB1CFB8CDEB1F80C62FE18FB858E13FD32388D2B48EA291A42C9C6F1"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "390EDF8B930F1AD580F555E3F795E6F0568BFAC09433661C6D04D80E7DD6615F8438C2301CD55DAEAB9766722E40EC94C7B442CBB0C6AAF82C501A55D3224EC2"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "01CB563E953CF0D7DA687D8B976B79A5BFF4FC5ED48971E1D271B6EA3294E31EE0FA916A77AA991A526D0F9B40FBB19CC73D42053A5735733E09C0A86F74A482"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "687ED68AD0AD1D41BFA58C938428DC7EE5C3A89ABC28310B5E5E126EFB02A73654AD743F4B495C69D834D717ED4F6BB5D136C3E778130F5F1F99433885F2AB68"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "6D54359F7546E295685EF87E3FB5C230AD2DFDB106657E7F098CEF0D077B880E70CF76FD863879A5576C7530BFDD8AD841C57C3EB940BE2F019D606C1B651AD2"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "96E0E11FBE520A4E15874C07B4CF61799EEA4084B14AC158C6852922E1897A826B17A5640F60D827E599722953B4070A0E2EF55FD10A3AEB6604D4528F61CF5A"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-runtime-composite-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "F18FCC0C88A11F6EC96E9F8B6C31E1ABC7FBF98FD42E8754B158C0385DDEC762EBB4C62D66DD2B65AAE1A5A78B01FEF8839E77F0BDD38767C7B1DCC762FEFDEE"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-arm.tar.gz",
+          "hash": "7AFE535FD96C9AE6A1B9C034E2447E117F700B85D8E96EED6F727C79799B8B265D8C101AACB5582673D48B13DFA519F065D6AC830BAA7581A63F68749180A914"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-arm64.tar.gz",
+          "hash": "A6F7AB98963E2EA694FF6CDC3AC2A95E1AC70A1A51B74D6A4040D59DAE1C71999F67DC9565F390B22EFC88F8BB13BBA94F295C78B6939ECF1F69CCAAFDC6DE23"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-musl-arm.tar.gz",
+          "hash": "0C65D01FE4E253FCC628D5710C78B6D27686D20FCE24A10904870C86FE2CB7C720B1E7439AA3BB75E74011400E3DF8DF4414E07A7E5239F6552803808FD4B857"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-musl-arm64.tar.gz",
+          "hash": "98D53983BF534D71935B6D63621411F3EB2A956AACF8C32E397A31BBD85E2FBD6DD3E9DC0E2E779E2581E72EA04B9935C1725448DB363104FDD2B9D14FCD71A8"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-musl-x64.tar.gz",
+          "hash": "71400A85B86198F362EC47A3003873EA16B8F5EE394D1280EA863265EE4F9012AE7217834A972E466BA619F62E5577D43B8AC54AB916071AACF2060548DEF8D2"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-linux-x64.tar.gz",
+          "hash": "9EED70BF765947ACC19342A5B564A60AB96542DEF4A93A83F263317159F80602BB28E9D9BBF26DE53643ADBB0B934752D2C44503EF60020CF68BF514C5831989"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-osx-arm64.tar.gz",
+          "hash": "F78680057C875DBEDBDA253E87EEB5F6AD25016B1013C62087987B798BA13BFBE55E9557C34F0C43869526B282F34276249412F4560461D7639D1A11B19CC7EB"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-osx-x64.tar.gz",
+          "hash": "A4F2CEEFCE7ED17612B45F738E363C967C427E56EFDD8394A1546063C1C94DF6B3AFE9EF88E01D18944ADF2C54BB1CA597D0CCF9BFF33BF374F5E0DC44236120"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "10E180B1F80563AFC5A281E75B0D716D5D38EFAB2CAFBB3E569A6004A43EDA528A7D4A003543AFF8C389F794BE1C324F8779166A726C11484ED3989EF7AF5EB7"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "C597E119C158FCD872DF4CFA83827722777B232C6232948DE041D53AFE0303124C46F7EC6ABB741EF9DD1AB82D513D7A0B227AE7C3703F77AE9446DB17E9AB68"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/aspnetcore-targeting-pack-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "330560CC24E0C51F255FE59CD0D1D79E03776D86803DA5637CD5CB5E5F4BE23987F92D7E4F1887B6CCE89BBCA93A3255328DE02CEF41E7DF6A3A53672F88F7F8"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.0-preview.5.25277.114/dotnet-hosting-10.0.0-preview.5.25277.114-win.exe",
+          "hash": "928C153F8C3D5F65FDFEF71975E6B8F630A4910BCC8B78202C125DB0F4CC06279A7BEF8F3E2B5FC5BA8FE8712B67C992C33AC65F869F794B7C8D5B3E0B0A12E8",
+          "akams": "https://aka.ms/dotnetcore-10-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "10.0.0-preview.5.25277.114",
+      "version-display": "10.0.0-preview.5",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-arm64.exe",
+          "hash": "26A7F7461474DB196EFBB6F0D14F888E6FEC74841B097C96E70B0696AEBCEF075E4F9EABCB351064C25CD2EE77BC2E0F57530A31CA6E1CADFB49073E1ABA0E34"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-arm64.zip",
+          "hash": "BFB19FB4A3AC9C3ECC27B8A9F3392C8ADE2768AF153979F1FCC1D20C4D643B89AAC47B4436AEDA9B92163A234AA12F5576CA32268D37E0D07A7EDC2DFD4C683C"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-x64.exe",
+          "hash": "AB613396EC8344449B115611494FAE3470EFE6472CDA363EF104B4A698FAF7591A3343E379F57A020C035453835EE899B3BE4F7A5CFB22361A8E8965BC0A438A"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-x64.zip",
+          "hash": "A4680A1C746F771654F5C61109DC33001961C595B6974466C7E29CA172664522193D4A1BF3981EFC1B7765202C8B979439789073ED7613E4D39BC3FEDCD39140"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-x86.exe",
+          "hash": "85780B5FCCF23C405C7B419C72FF36CACFE43D6CA6B767319B48C877613783F4BAFB2F1F0F19975BDE66F6ACA1D465D555A94E8FA6F305C8108C3BC7A1634E4E"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/10.0.0-preview.5.25277.114/windowsdesktop-runtime-10.0.0-preview.5.25277.114-win-x86.zip",
+          "hash": "C4A9F08C7ED3BD7C164AA8E2BD47DAA6EB7E34E385B289AD7B7047E77F7B3FA940A236A72B081ACB1B684E6195189051CF89991F7A78D17926B7AEA1FC99CA32"
+        }
+      ]
+    }
+  }
+}

--- a/release-notes/10.0/preview/preview6/release.json
+++ b/release-notes/10.0/preview/preview6/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "10.0",
-  "release-date": "2025-07-15",
-  "release-version": "10.0.0-preview.6.25358.103",
-  "security": false,
   "release": {
     "release-date": "2025-07-15",
     "release-version": "10.0.0-preview.6",

--- a/release-notes/8.0/8.0.0/release.json
+++ b/release-notes/8.0/8.0.0/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2023-11-14",
-  "release-version": "8.0.0",
-  "security": true,
   "release": {
     "release-date": "2023-11-14",
     "release-version": "8.0.0",

--- a/release-notes/8.0/8.0.1/release.json
+++ b/release-notes/8.0/8.0.1/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-01-09",
-  "release-version": "8.0.1",
-  "security": true,
   "release": {
     "release-date": "2024-01-09",
     "release-version": "8.0.1",

--- a/release-notes/8.0/8.0.10/release.json
+++ b/release-notes/8.0/8.0.10/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-10-08",
-  "release-version": "8.0.10",
-  "security": true,
   "release":     {
     "release-date": "2024-10-08",
     "release-version": "8.0.10",

--- a/release-notes/8.0/8.0.11/release.json
+++ b/release-notes/8.0/8.0.11/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-11-12",
-  "release-version": "8.0.11",
-  "security": true,
   "release":        {
     "release-date": "2024-11-12",
     "release-version": "8.0.11",

--- a/release-notes/8.0/8.0.12/release.json
+++ b/release-notes/8.0/8.0.12/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-01-14",
-  "release-version": "8.0.12",
-  "security": true,
   "release": {
     "release-date": "2025-01-14",
     "release-version": "8.0.12",

--- a/release-notes/8.0/8.0.13/release.json
+++ b/release-notes/8.0/8.0.13/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-02-11",
-  "release-version": "8.0.13",
-  "security": false,
   "release":  {
     "release-date": "2025-02-11",
     "release-version": "8.0.13",

--- a/release-notes/8.0/8.0.14/release.json
+++ b/release-notes/8.0/8.0.14/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-03-11",
-  "release-version": "8.0.14",
-  "security": true,
   "release":      
   {
     "release-date": "2025-03-11",

--- a/release-notes/8.0/8.0.15/release.json
+++ b/release-notes/8.0/8.0.15/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-04-08",
-  "release-version": "8.0.15",
-  "security": true,
   "release":      
   {
     "release-date": "2025-04-08",

--- a/release-notes/8.0/8.0.16/release.json
+++ b/release-notes/8.0/8.0.16/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-05-22",
-  "release-version": "8.0.16",
-  "security": true,
   "release": 
   {
     "release-date": "2025-05-22",

--- a/release-notes/8.0/8.0.17/release.json
+++ b/release-notes/8.0/8.0.17/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-06-10",
-  "release-version": "8.0.17",
-  "security": true,
   "release": 
   {
     "release-date": "2025-06-10",

--- a/release-notes/8.0/8.0.18/release.json
+++ b/release-notes/8.0/8.0.18/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-07-08",
-  "release-version": "8.0.18",
-  "security": false,
   "release": 
   {
     "release-date": "2025-07-08",

--- a/release-notes/8.0/8.0.19/release.json
+++ b/release-notes/8.0/8.0.19/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2025-08-05",
-  "release-version": "8.0.19",
-  "security": false,
   "release": 
     {
       "release-date": "2025-08-05",

--- a/release-notes/8.0/8.0.2/release.json
+++ b/release-notes/8.0/8.0.2/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-02-13",
-  "release-version": "8.0.2",
-  "security": true,
   "release": {
     "release-date": "2024-02-13",
     "release-version": "8.0.2",

--- a/release-notes/8.0/8.0.3/release.json
+++ b/release-notes/8.0/8.0.3/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-03-12",
-  "release-version": "8.0.3",
-  "security": true,
   "release": {
     "release-date": "2024-03-12",
     "release-version": "8.0.3",

--- a/release-notes/8.0/8.0.4/release.json
+++ b/release-notes/8.0/8.0.4/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-04-09",
-  "release-version": "8.0.4",
-  "security": true,
   "release": {
     "release-date": "2024-04-09",
     "release-version": "8.0.4",

--- a/release-notes/8.0/8.0.5/release.json
+++ b/release-notes/8.0/8.0.5/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-05-14",
-  "release-version": "8.0.5",
-  "security": true,
   "release": {
     "release-date": "2024-05-14",
     "release-version": "8.0.5",

--- a/release-notes/8.0/8.0.6/release.json
+++ b/release-notes/8.0/8.0.6/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-06-11",
-  "release-version": "8.0.6",
-  "security": true,
   "release": {
     "release-date": "2024-06-11",
     "release-version": "8.0.6",

--- a/release-notes/8.0/8.0.7/release.json
+++ b/release-notes/8.0/8.0.7/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-07-09",
-  "release-version": "8.0.7",
-  "security": true,
   "release": {
     "release-date": "2024-07-09",
     "release-version": "8.0.7",

--- a/release-notes/8.0/8.0.8/release.json
+++ b/release-notes/8.0/8.0.8/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "8.0",
-  "release-date": "2024-09-24",
-  "release-version": "8.0.8",
-  "security": true,
   "release": {
     "release-date": "2024-09-24",
     "release-version": "8.0.8",

--- a/release-notes/9.0/9.0.0/release.json
+++ b/release-notes/9.0/9.0.0/release.json
@@ -1,129 +1,234 @@
 {
   "channel-version": "9.0",
-  "release-date": "2024-12-03",
-  "release-version": "9.0.0",
-  "security": true,
-  "releases": [
-    {
-      "release-date": "2024-12-03",
-      "release-version": "9.0.0",
-      "security": true,
-      "cve-list": [
+  "release": {
+    "release-date": "2024-12-03",
+    "release-version": "9.0.0",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2024-43498",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43498"
+      },
+      {
+        "cve-id": "CVE-2024-43499",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43499"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.0/9.0.0.md",
+    "runtime": {
+      "version": "9.0.0",
+      "version-display": "9.0.0",
+      "vs-version": "17.12",
+      "vs-mac-version": "",
+      "files": [
         {
-          "cve-id": "CVE-2024-43498",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43498"
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8f639af4-29e2-474e-ad2d-ad1845c09e21/d6a1fac24aa5bed41dcc8c35017a44f4/dotnet-runtime-9.0.0-linux-arm.tar.gz",
+          "hash": "fab552df6d884090aba1f658c8812b5369e9bea17e6a1f905145cde512772b57db5d5cf586c6c2b7f2e56a8cb83c206f0cf7594bcf42d32844b8103538bd883f"
         },
         {
-          "cve-id": "CVE-2024-43499",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43499"
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3ae34de0-5928-47c4-9abb-e0b8f795c256/1ea2ed5a50af003121ebf32cb218258e/dotnet-runtime-9.0.0-linux-arm64.tar.gz",
+          "hash": "4f9c2dd544af0b8540c16352b9f01f75f828b8e4e084057a300a4dec652fb3d6532906cdd4246399cc13f16b571b17575812ec2f9c297e27bbed678baf4b2fde"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f2566d5b-8b22-460e-86fa-94388974ab09/a4ae7832d06be1e5ef0b55ecc22b1ad1/dotnet-runtime-9.0.0-linux-musl-arm.tar.gz",
+          "hash": "97dc1ddcac177d73b517d651326ec484eac52501c506c8c837c3f9ceaf476ddf929ccece9b6dc2c0a4e7d378576fd73930a8835814690631a560642527335b33"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/51a64e2f-043f-460b-a048-ea79617d9a06/b3274372b27c70fc4da62cc994890f8d/dotnet-runtime-9.0.0-linux-musl-arm64.tar.gz",
+          "hash": "33523364d9310b75d9819a4866b120c03b9ef7946bd3646b15930e37ff1e211de294c8a94b4ad6c1c0f7d291cb70601a4188e396d4252f5767a36a6dbe68502a"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53729aa8-9540-4ddc-ad77-4b7126b36b30/5156249a151c4d334c19c89bb63b940d/dotnet-runtime-9.0.0-linux-musl-x64.tar.gz",
+          "hash": "9c33d73a898fa9b4e84ae1844468b69086979f7c2c8ea6b32db0fea62a4014513cea0619025f9edb23e67ab4ae4e2f2725d1d9bb892858bba7dfe8ed17aee799"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/282bb881-c2ae-4250-b814-b362745073bd/6e15021d23f704c0d457c820a69a3de6/dotnet-runtime-9.0.0-linux-x64.tar.gz",
+          "hash": "5176bd68637646cd36fce7a88f83effe1065fb075e6d4a46b8be3c33d5a8394740577f0ed4f8b4fb13fa69fe83b229eb55ab7f45caac90849bf0392a670ed5af"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a129df43-9d92-421f-9d63-eb9a8218e16a/9533b915759dcbe7cbd2fb0bed4d1ba2/dotnet-runtime-9.0.0-osx-arm64.pkg",
+          "hash": "e0de96a405b00f68922ecc02db7bf52b9ddaf6f3491b7d7cf821e2ee6074e870cb282aecf9fb3d13519cfc07bb0eeff94551791ceaa4a031596bc5bb13cde41d"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/013e0f03-e1e4-4f97-a5cc-e6504f684620/0c0ea6a0c124d87027d8ff6abeb7b697/dotnet-runtime-9.0.0-osx-arm64.tar.gz",
+          "hash": "66c487ae2f5fc24d5baafdfb4286e23737664bd3efc181abc31cf5ded60dc22e4ba1791744a506da343e6034b1fcda2dee761d9e71229945a177b7508ba6ddb6"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c36c7ef4-59b3-40e5-ae06-798b485fc007/579afa87e7f72dc6af44bc96aa6c2477/dotnet-runtime-9.0.0-osx-x64.pkg",
+          "hash": "7fadb1f8a039efe22f66498919c58d4d8f24e6b75bb1035d15edc997229d3c52e4d66ec972ad61b846bbeea99e7228ee21185cac9b36cc0819426f2e429ba9c6"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4be484a1-a095-48cf-8407-cae1d3dcc944/9f373dc1d85022e004df3ac1071ace59/dotnet-runtime-9.0.0-osx-x64.tar.gz",
+          "hash": "1ebd6a97ab744fe752068639d676b145960d820501c792751404507e8d82cd9268d7e239c437f9de73b08141c3b693bb24eeb3cf3baf30e3bf33b460bb95d4b0"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1736a901-4535-42e5-9cf8-4d1d07699b45/f7dc8e4cf85bf579170043799e356e9e/dotnet-runtime-9.0.0-win-arm64.exe",
+          "hash": "7ac11f3b388170ddf8d2248aa719bffd1202f3946a1bcf0701bdd8988d030d0ea2cd321eb2e6150e30bc0444a8af0b5a9ad5db3ac58b15f4338ce34193ba470a"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cfecd946-5932-496c-a2b6-ba3c99318f24/4a5b2d8e244b4db3db110ff5751ed35b/dotnet-runtime-9.0.0-win-arm64.zip",
+          "hash": "4f33049397341e8302fd01ece043fdd1935a7dbd75007ec5739ce5eb5c205cac4bc1399550907f71f2e4b218e40297a89bf5d605882f5544c4deec37f9b0d026"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/99bd07c2-c95c-44dc-9d47-36d3b18df240/bdf26c62f69c1b783687c1dce83ccf7a/dotnet-runtime-9.0.0-win-x64.exe",
+          "hash": "97334bbe82e2d6db090279b178d0bdfb1d675e0fcd9ca0c951bbcac05598b0424f66eb74599eb8d1a6790699a931974924f79815941944f440a261dce2cd9ca1"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fed1ee33-4574-4d89-85b5-3b8d7762b56a/432725cb9d6d235424768defea5ce6ee/dotnet-runtime-9.0.0-win-x64.zip",
+          "hash": "23ae6ce34fe1271a5a48675a9cb7ed728af4be4014a7ee4a6a60a84fc23e55b50a5cafd7ec20197bd73ee47901e4239e0c4cd8fd0f5deeb34cc3da1de3960e46"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0e89cce9-dc02-423c-a657-0c2b421edf21/af2e916785775fe7e023b953af404db5/dotnet-runtime-9.0.0-win-x86.exe",
+          "hash": "7d744cedfc81f911b51ac05741a77953a18d1415bc7c1667fd8fa8e89b4a0df597046f25a82a960bf65e7e7fe453edf87aacc25abd6bb05d0b289adedd6b2ab1"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/73b2d717-c521-47cf-857e-e353f05f3b83/db5484cdaef7f85c94b484fbeb42299d/dotnet-runtime-9.0.0-win-x86.zip",
+          "hash": "dc345e64174a9bec4bf9c27d6a80c946aec3a418a7ac42e2ed9c20737c014cb0b1dbce3bd33eb6cce211ebf60ddcb0e13e1d60051017e4c0c11bd6ab4fda1c80"
         }
-      ],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.0/9.0.0.md",
-      "runtime": {
-        "version": "9.0.0",
-        "version-display": "9.0.0",
-        "vs-version": "17.12",
-        "vs-mac-version": "",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8f639af4-29e2-474e-ad2d-ad1845c09e21/d6a1fac24aa5bed41dcc8c35017a44f4/dotnet-runtime-9.0.0-linux-arm.tar.gz",
-            "hash": "fab552df6d884090aba1f658c8812b5369e9bea17e6a1f905145cde512772b57db5d5cf586c6c2b7f2e56a8cb83c206f0cf7594bcf42d32844b8103538bd883f"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3ae34de0-5928-47c4-9abb-e0b8f795c256/1ea2ed5a50af003121ebf32cb218258e/dotnet-runtime-9.0.0-linux-arm64.tar.gz",
-            "hash": "4f9c2dd544af0b8540c16352b9f01f75f828b8e4e084057a300a4dec652fb3d6532906cdd4246399cc13f16b571b17575812ec2f9c297e27bbed678baf4b2fde"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f2566d5b-8b22-460e-86fa-94388974ab09/a4ae7832d06be1e5ef0b55ecc22b1ad1/dotnet-runtime-9.0.0-linux-musl-arm.tar.gz",
-            "hash": "97dc1ddcac177d73b517d651326ec484eac52501c506c8c837c3f9ceaf476ddf929ccece9b6dc2c0a4e7d378576fd73930a8835814690631a560642527335b33"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/51a64e2f-043f-460b-a048-ea79617d9a06/b3274372b27c70fc4da62cc994890f8d/dotnet-runtime-9.0.0-linux-musl-arm64.tar.gz",
-            "hash": "33523364d9310b75d9819a4866b120c03b9ef7946bd3646b15930e37ff1e211de294c8a94b4ad6c1c0f7d291cb70601a4188e396d4252f5767a36a6dbe68502a"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/53729aa8-9540-4ddc-ad77-4b7126b36b30/5156249a151c4d334c19c89bb63b940d/dotnet-runtime-9.0.0-linux-musl-x64.tar.gz",
-            "hash": "9c33d73a898fa9b4e84ae1844468b69086979f7c2c8ea6b32db0fea62a4014513cea0619025f9edb23e67ab4ae4e2f2725d1d9bb892858bba7dfe8ed17aee799"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/282bb881-c2ae-4250-b814-b362745073bd/6e15021d23f704c0d457c820a69a3de6/dotnet-runtime-9.0.0-linux-x64.tar.gz",
-            "hash": "5176bd68637646cd36fce7a88f83effe1065fb075e6d4a46b8be3c33d5a8394740577f0ed4f8b4fb13fa69fe83b229eb55ab7f45caac90849bf0392a670ed5af"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.pkg",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a129df43-9d92-421f-9d63-eb9a8218e16a/9533b915759dcbe7cbd2fb0bed4d1ba2/dotnet-runtime-9.0.0-osx-arm64.pkg",
-            "hash": "e0de96a405b00f68922ecc02db7bf52b9ddaf6f3491b7d7cf821e2ee6074e870cb282aecf9fb3d13519cfc07bb0eeff94551791ceaa4a031596bc5bb13cde41d"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/013e0f03-e1e4-4f97-a5cc-e6504f684620/0c0ea6a0c124d87027d8ff6abeb7b697/dotnet-runtime-9.0.0-osx-arm64.tar.gz",
-            "hash": "66c487ae2f5fc24d5baafdfb4286e23737664bd3efc181abc31cf5ded60dc22e4ba1791744a506da343e6034b1fcda2dee761d9e71229945a177b7508ba6ddb6"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c36c7ef4-59b3-40e5-ae06-798b485fc007/579afa87e7f72dc6af44bc96aa6c2477/dotnet-runtime-9.0.0-osx-x64.pkg",
-            "hash": "7fadb1f8a039efe22f66498919c58d4d8f24e6b75bb1035d15edc997229d3c52e4d66ec972ad61b846bbeea99e7228ee21185cac9b36cc0819426f2e429ba9c6"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4be484a1-a095-48cf-8407-cae1d3dcc944/9f373dc1d85022e004df3ac1071ace59/dotnet-runtime-9.0.0-osx-x64.tar.gz",
-            "hash": "1ebd6a97ab744fe752068639d676b145960d820501c792751404507e8d82cd9268d7e239c437f9de73b08141c3b693bb24eeb3cf3baf30e3bf33b460bb95d4b0"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/1736a901-4535-42e5-9cf8-4d1d07699b45/f7dc8e4cf85bf579170043799e356e9e/dotnet-runtime-9.0.0-win-arm64.exe",
-            "hash": "7ac11f3b388170ddf8d2248aa719bffd1202f3946a1bcf0701bdd8988d030d0ea2cd321eb2e6150e30bc0444a8af0b5a9ad5db3ac58b15f4338ce34193ba470a"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cfecd946-5932-496c-a2b6-ba3c99318f24/4a5b2d8e244b4db3db110ff5751ed35b/dotnet-runtime-9.0.0-win-arm64.zip",
-            "hash": "4f33049397341e8302fd01ece043fdd1935a7dbd75007ec5739ce5eb5c205cac4bc1399550907f71f2e4b218e40297a89bf5d605882f5544c4deec37f9b0d026"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/99bd07c2-c95c-44dc-9d47-36d3b18df240/bdf26c62f69c1b783687c1dce83ccf7a/dotnet-runtime-9.0.0-win-x64.exe",
-            "hash": "97334bbe82e2d6db090279b178d0bdfb1d675e0fcd9ca0c951bbcac05598b0424f66eb74599eb8d1a6790699a931974924f79815941944f440a261dce2cd9ca1"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fed1ee33-4574-4d89-85b5-3b8d7762b56a/432725cb9d6d235424768defea5ce6ee/dotnet-runtime-9.0.0-win-x64.zip",
-            "hash": "23ae6ce34fe1271a5a48675a9cb7ed728af4be4014a7ee4a6a60a84fc23e55b50a5cafd7ec20197bd73ee47901e4239e0c4cd8fd0f5deeb34cc3da1de3960e46"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e89cce9-dc02-423c-a657-0c2b421edf21/af2e916785775fe7e023b953af404db5/dotnet-runtime-9.0.0-win-x86.exe",
-            "hash": "7d744cedfc81f911b51ac05741a77953a18d1415bc7c1667fd8fa8e89b4a0df597046f25a82a960bf65e7e7fe453edf87aacc25abd6bb05d0b289adedd6b2ab1"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/73b2d717-c521-47cf-857e-e353f05f3b83/db5484cdaef7f85c94b484fbeb42299d/dotnet-runtime-9.0.0-win-x86.zip",
-            "hash": "dc345e64174a9bec4bf9c27d6a80c946aec3a418a7ac42e2ed9c20737c014cb0b1dbce3bd33eb6cce211ebf60ddcb0e13e1d60051017e4c0c11bd6ab4fda1c80"
-          }
-        ]
-      },
-      "sdk": {
+      ]
+    },
+    "sdk": {
+      "version": "9.0.101",
+      "version-display": "9.0.101",
+      "runtime-version": "9.0.0",
+      "vs-version": "17.12.3",
+      "vs-support": "Visual Studio 2022 (v17.12)",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fa0fa6b6-8db2-441e-a393-2dd2f5c841b9/19b664790a03e20ce4069449eaa74b21/dotnet-sdk-9.0.101-linux-arm.tar.gz",
+          "hash": "cdf8989d02e4a6aa21e68081e956318c94c601583a757d5eb433919ebe7fa518f207aa0f58a09ee28cf95f445c486386c229de69891433a4a29145ef596aa1a4"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/93a7156d-01ef-40a1-b6e9-bbe7602f7e8b/3c93e90c63b494972c44f073e15bfc26/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
+          "hash": "c5f9c17dded5101cb4b65ad1033ae4d82fc5b04303bdce4eb61a6dc47efa84202bd726d05caf117e536a01bd78ad773b8d23cbf43bc655e5eb9912b12078e0b1"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5528c94e-1708-4291-917f-c9b693df3389/b851b22328c11e88f9fb61ea3e18582f/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
+          "hash": "7e6560e69b83b9e64961e91155f8585421c3a2ce76897871d386492c623e9280f66f2284dc49362bc38739e48172523ce54b2269524437394ea3e908728a0118"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a8f1d5c7-c724-451c-8659-fe6ea4e72ea8/1c90dea91c1e117b96198bdccdc0b594/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
+          "hash": "6a6d6a6d6dfbdacb48374c0ac9bdb1c93781f3970c8778b0bee1f159a22b00176868264e605331fef833cb9fed829b4ffd414276d0d1140a8b0e257195c2f374"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/73c11b94-0188-458f-b599-f7591718fc28/c44e21ffbf353b50ef88a76122e89e24/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
+          "hash": "3f4e14fb7b52dfb57b1e31cb5973e6e0a338f7f030f12b3082d3b55f12f9587ddf4926a7c5fcf86b7671397e44f8e5c20fb949d70e9a7dd0dc27be73a548dffc"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d74fd2dd-3384-4952-924b-f5d492326e35/e91d8295d4cbe82ba3501e411d78c9b8/dotnet-sdk-9.0.101-linux-x64.tar.gz",
+          "hash": "91b37efd64242e5f1f3c2025d183eb34e17f3a9271c5602f29ddf794845eee103723ef955ed869788ebf5a731e8ddc69328799c92c64cb118e1328d259a6ad01"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/00630dd1-1470-4f65-9238-a9262d170a29/86e0e51d908e9b12b017423c2f915998/dotnet-sdk-9.0.101-osx-arm64.pkg",
+          "hash": "52f0efce397b2e3ab182a98e7bc69967143399c8ec512687f7893cf5ed85784a9b1ce181980827c6fe0a8866755eece4ef4aafc01d10048f01117164b186782b"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6707b71c-f95b-46b9-a4f8-067922291242/93d5be41bfa39461c47bae856a8ad93c/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
+          "hash": "c6608ed280e5a76c46ce8f9b06b8c7014c7bdb54a9795c4585deb8e057db4d524037e4e82f9caf32444eede427c9cb5fdbb722508f389ef89a864f0bbae4766a"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1fec6f64-0d7f-4b39-acd1-e9e2701a6b1d/b7b6246d0c20cfe703c6c88ffdbb081e/dotnet-sdk-9.0.101-osx-x64.pkg",
+          "hash": "3d5567891ceed07837d7f00bd81dd5dc73accd2e007b6adc12218bd5ce9f7d5563e64ede3e49bf96a532d282ca764a72b9ca4d8cf9aa8ab1764e9b4fa55a59e1"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/330381bd-72dc-47ba-b5fb-884bd8b0bb44/8f1eef9415fc29a806fbf80a54e28c0e/dotnet-sdk-9.0.101-osx-x64.tar.gz",
+          "hash": "0c13e3081348dd2bcf2e0c6b84bc375f806550f6c389b1fca61767ad6b9004300af7272de199358f32afef295513ba5ec43f5f8614d12437bb884be8eca4de01"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4d9233cf-ec91-49d9-919c-0ac0070e1bad/f0c3580e34ac9c4afd2197785a11521e/dotnet-sdk-9.0.101-win-arm64.exe",
+          "hash": "d09cb91e49313e7ae891d28c8fc7841b2a92cfcc3f610b249b9ef81230615335daa30ad210d9db6942ac1d02d446c8d1cf9d7cab0daff543221bb4e6697cd3db"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4b0e6d09-25eb-4e69-a3d7-9da8f20b939a/8b1bec15740a22f5a255d2570376c802/dotnet-sdk-9.0.101-win-arm64.zip",
+          "hash": "a14fec6786c28523795f98c074ca8da972860134e3549f5be20c1bf41a0b8b946f3ea1251196c356d4d869591a333203401d08323ba9e498fe8e6a5bde1e3011"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/38e45a81-a6a4-4a37-a986-bc46be78db16/33e64c0966ebdf0088d1a2b6597f62e5/dotnet-sdk-9.0.101-win-x64.exe",
+          "hash": "6c1899452dc855698ccc2a9928301352e5700e7829f0d42a1e567b51f08089affc67801ba7cd49d7e45b4a4dcb79cba54561163d64c27c3f36108737b3bf9f62"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/43fd03f0-72f4-43a9-9f33-15933d232447/d8576131aa13a6eda440cf7217ad2add/dotnet-sdk-9.0.101-win-x64.zip",
+          "hash": "53f16be2079ed85d230a6c98fa9220046930ca0eaaf1f928b63cfae9fd9a0a5ad87c60c07833ee16dedfa582ce5d9ae68b5b4292aec56fd44203fe9e7bcfba92"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/838bc4f1-96ee-43f9-8e47-2dc2656590c0/15cbe313b18ccbeffdb61cff66f5ef26/dotnet-sdk-9.0.101-win-x86.exe",
+          "hash": "14d22475bf0d13b01d36f472353239de0351454f3b570d0629f6003aab55032ff575fae237e20d2e9e3d45a9f6a884c6d1330e025ebcf22a8e19d68d7f64c149"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a5fc9a9-c8b4-43d5-8314-0f757968f1a2/c355d463e19e329572d04514a8116188/dotnet-sdk-9.0.101-win-x86.zip",
+          "hash": "c04a7c2601d2d21678f2f9833973bf9b687156520044f13d7092c77331f6e29fcad808443d6001aec1f76233990e523aeaf3516b0084603a848da934f3e78d6d"
+        }
+      ]
+    },
+    "sdks": [
+      {
         "version": "9.0.101",
         "version-display": "9.0.101",
         "runtime-version": "9.0.0",
@@ -231,403 +336,293 @@
           }
         ]
       },
-      "sdks": [
-        {
-          "version": "9.0.101",
-          "version-display": "9.0.101",
-          "runtime-version": "9.0.0",
-          "vs-version": "17.12.3",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "16.9",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fa0fa6b6-8db2-441e-a393-2dd2f5c841b9/19b664790a03e20ce4069449eaa74b21/dotnet-sdk-9.0.101-linux-arm.tar.gz",
-              "hash": "cdf8989d02e4a6aa21e68081e956318c94c601583a757d5eb433919ebe7fa518f207aa0f58a09ee28cf95f445c486386c229de69891433a4a29145ef596aa1a4"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/93a7156d-01ef-40a1-b6e9-bbe7602f7e8b/3c93e90c63b494972c44f073e15bfc26/dotnet-sdk-9.0.101-linux-arm64.tar.gz",
-              "hash": "c5f9c17dded5101cb4b65ad1033ae4d82fc5b04303bdce4eb61a6dc47efa84202bd726d05caf117e536a01bd78ad773b8d23cbf43bc655e5eb9912b12078e0b1"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5528c94e-1708-4291-917f-c9b693df3389/b851b22328c11e88f9fb61ea3e18582f/dotnet-sdk-9.0.101-linux-musl-arm.tar.gz",
-              "hash": "7e6560e69b83b9e64961e91155f8585421c3a2ce76897871d386492c623e9280f66f2284dc49362bc38739e48172523ce54b2269524437394ea3e908728a0118"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a8f1d5c7-c724-451c-8659-fe6ea4e72ea8/1c90dea91c1e117b96198bdccdc0b594/dotnet-sdk-9.0.101-linux-musl-arm64.tar.gz",
-              "hash": "6a6d6a6d6dfbdacb48374c0ac9bdb1c93781f3970c8778b0bee1f159a22b00176868264e605331fef833cb9fed829b4ffd414276d0d1140a8b0e257195c2f374"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/73c11b94-0188-458f-b599-f7591718fc28/c44e21ffbf353b50ef88a76122e89e24/dotnet-sdk-9.0.101-linux-musl-x64.tar.gz",
-              "hash": "3f4e14fb7b52dfb57b1e31cb5973e6e0a338f7f030f12b3082d3b55f12f9587ddf4926a7c5fcf86b7671397e44f8e5c20fb949d70e9a7dd0dc27be73a548dffc"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d74fd2dd-3384-4952-924b-f5d492326e35/e91d8295d4cbe82ba3501e411d78c9b8/dotnet-sdk-9.0.101-linux-x64.tar.gz",
-              "hash": "91b37efd64242e5f1f3c2025d183eb34e17f3a9271c5602f29ddf794845eee103723ef955ed869788ebf5a731e8ddc69328799c92c64cb118e1328d259a6ad01"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/00630dd1-1470-4f65-9238-a9262d170a29/86e0e51d908e9b12b017423c2f915998/dotnet-sdk-9.0.101-osx-arm64.pkg",
-              "hash": "52f0efce397b2e3ab182a98e7bc69967143399c8ec512687f7893cf5ed85784a9b1ce181980827c6fe0a8866755eece4ef4aafc01d10048f01117164b186782b"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6707b71c-f95b-46b9-a4f8-067922291242/93d5be41bfa39461c47bae856a8ad93c/dotnet-sdk-9.0.101-osx-arm64.tar.gz",
-              "hash": "c6608ed280e5a76c46ce8f9b06b8c7014c7bdb54a9795c4585deb8e057db4d524037e4e82f9caf32444eede427c9cb5fdbb722508f389ef89a864f0bbae4766a"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1fec6f64-0d7f-4b39-acd1-e9e2701a6b1d/b7b6246d0c20cfe703c6c88ffdbb081e/dotnet-sdk-9.0.101-osx-x64.pkg",
-              "hash": "3d5567891ceed07837d7f00bd81dd5dc73accd2e007b6adc12218bd5ce9f7d5563e64ede3e49bf96a532d282ca764a72b9ca4d8cf9aa8ab1764e9b4fa55a59e1"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/330381bd-72dc-47ba-b5fb-884bd8b0bb44/8f1eef9415fc29a806fbf80a54e28c0e/dotnet-sdk-9.0.101-osx-x64.tar.gz",
-              "hash": "0c13e3081348dd2bcf2e0c6b84bc375f806550f6c389b1fca61767ad6b9004300af7272de199358f32afef295513ba5ec43f5f8614d12437bb884be8eca4de01"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4d9233cf-ec91-49d9-919c-0ac0070e1bad/f0c3580e34ac9c4afd2197785a11521e/dotnet-sdk-9.0.101-win-arm64.exe",
-              "hash": "d09cb91e49313e7ae891d28c8fc7841b2a92cfcc3f610b249b9ef81230615335daa30ad210d9db6942ac1d02d446c8d1cf9d7cab0daff543221bb4e6697cd3db"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4b0e6d09-25eb-4e69-a3d7-9da8f20b939a/8b1bec15740a22f5a255d2570376c802/dotnet-sdk-9.0.101-win-arm64.zip",
-              "hash": "a14fec6786c28523795f98c074ca8da972860134e3549f5be20c1bf41a0b8b946f3ea1251196c356d4d869591a333203401d08323ba9e498fe8e6a5bde1e3011"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/38e45a81-a6a4-4a37-a986-bc46be78db16/33e64c0966ebdf0088d1a2b6597f62e5/dotnet-sdk-9.0.101-win-x64.exe",
-              "hash": "6c1899452dc855698ccc2a9928301352e5700e7829f0d42a1e567b51f08089affc67801ba7cd49d7e45b4a4dcb79cba54561163d64c27c3f36108737b3bf9f62"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/43fd03f0-72f4-43a9-9f33-15933d232447/d8576131aa13a6eda440cf7217ad2add/dotnet-sdk-9.0.101-win-x64.zip",
-              "hash": "53f16be2079ed85d230a6c98fa9220046930ca0eaaf1f928b63cfae9fd9a0a5ad87c60c07833ee16dedfa582ce5d9ae68b5b4292aec56fd44203fe9e7bcfba92"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/838bc4f1-96ee-43f9-8e47-2dc2656590c0/15cbe313b18ccbeffdb61cff66f5ef26/dotnet-sdk-9.0.101-win-x86.exe",
-              "hash": "14d22475bf0d13b01d36f472353239de0351454f3b570d0629f6003aab55032ff575fae237e20d2e9e3d45a9f6a884c6d1330e025ebcf22a8e19d68d7f64c149"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5a5fc9a9-c8b4-43d5-8314-0f757968f1a2/c355d463e19e329572d04514a8116188/dotnet-sdk-9.0.101-win-x86.zip",
-              "hash": "c04a7c2601d2d21678f2f9833973bf9b687156520044f13d7092c77331f6e29fcad808443d6001aec1f76233990e523aeaf3516b0084603a848da934f3e78d6d"
-            }
-          ]
-        },
-        {
-          "version": "9.0.100",
-          "version-display": "9.0.100",
-          "runtime-version": "9.0.0",
-          "vs-version": "17.12",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "16.9",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/526d93c5-bae2-4cfc-a9cf-b2d28d7b5c98/17c926df21958999f74992973837d261/dotnet-sdk-9.0.100-linux-arm.tar.gz",
-              "hash": "de06e89e559bc763ff6773bcf852d915ec47f2d89f4e7065ba0800da99ab56357f31437391a77d7096e405f63318625b0cb074f6b410036fbe906fce7f3794e8"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6f79d99b-dc38-4c44-a549-32329419bb9f/a411ec38fb374e3a4676647b236ba021/dotnet-sdk-9.0.100-linux-arm64.tar.gz",
-              "hash": "684450e6d1f7c711fffdbf32a2b86a932d17a51f4742bd27a4289e319c5b24f6743553fc7e0ad1c7163e448ed5c40cd1ecf4198b2e681acc4622d8e6193a5cf2"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c77904f4-57f5-46cf-bf99-d0dd1e4b9b3b/d7b454d3500c1a930b38e39a916aa38f/dotnet-sdk-9.0.100-linux-musl-arm.tar.gz",
-              "hash": "b0920f80e866a7603cea628a1130df003bc5d7818275c8a5882a31c6e4e29f07322fc5cfd87333893e4131bd96130fb2384d008cbad704022c89267d52686e07"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ca5a82b7-704c-4405-bde2-4bde4b932d2e/0332e51e8d339cbc0410079f911205f3/dotnet-sdk-9.0.100-linux-musl-arm64.tar.gz",
-              "hash": "dae06d007327f6f53f50cb3a2884b93cd2fcbb73c756a8ac5ff673617f9bdf00093932f3a83652211fc2eeb57c271078644ef5c28a42897d8397f76d0e89586d"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/404c65f4-7595-4792-85ab-e26084ebb5cf/db570cf4dc8d0a61270243c61fbdf619/dotnet-sdk-9.0.100-linux-musl-x64.tar.gz",
-              "hash": "e2032e6b4ed99adb3a92b7e041ea895ee09c6ed2455a1f68e55ed53bd613c8c20ef4aa5c434393bb5fdbc2f5635a83067f77451fe2fd3febcee264fe077acdaa"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/308f16a9-2ecf-4a42-b8bb-c1233de985fd/be6e87045ab21935bd8bb98ce69026c4/dotnet-sdk-9.0.100-linux-x64.tar.gz",
-              "hash": "7f69bda047de1f952286be330a5e858171ded952d1aa24169e62212f90a27149e63b636c88ad313a6e3ec860da31f8c547ff4ab6808103a070f7fb26ba99c1c7"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2787e86a-6efe-4c4d-a3d1-8fd8c302c639/d386f92a6b2b819cb11cc0382dc98bc7/dotnet-sdk-9.0.100-osx-arm64.pkg",
-              "hash": "91cadc95a2dc8674a8e1fd5a8a54a6e1f4adaf1a364365e79ff69457079f5be3d0fd254325924a7c94bac531b84752bb17bb37e206b12b5b7bd43c9526ded9c7"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4569c514-16ac-49fc-ac41-4416f547c249/851fb0aa9b2a8bdcb0d1d9f9493a952e/dotnet-sdk-9.0.100-osx-arm64.tar.gz",
-              "hash": "94dfa49652195a884f06d06ceb23ef6f7d7380fe0c4015b96e8f950b57a9558711fba61128710f9c8de0081dd91af48a90f7bd0f8b90038aeb5aeb24fb6724ff"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ce4a7dd7-1baa-45b1-a447-76cac8d50218/128808a7422ca2e0ae37901d7c78cd53/dotnet-sdk-9.0.100-osx-x64.pkg",
-              "hash": "b51da89b449bda3fe81e9be2356473536558ba7cfdd5c60adb765b215c437c7d753f1dd60468e519dcac859a64edaba3078b473891b95b3d4f744e55f47ff080"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/cab5bf72-f0c7-46c7-a8f2-074f71e4b6ca/a14ec2fc3b6fd32d47b4293994ab3c61/dotnet-sdk-9.0.100-osx-x64.tar.gz",
-              "hash": "59ef320289796abbdc573036d0d1b4aa1919c83140b7a363174abd68be5cc0252741546a21d46c201586331f5f9211787bd19b5381b902f3bd7c226220344ae9"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/19ebb0b1-8f0c-4b8b-b5d6-ec835e2ce02c/a10305403c47790226ec809cea0d4251/dotnet-sdk-9.0.100-win-arm64.exe",
-              "hash": "071c44e59d4b7b58e9d0e5c8752229e5b3d6cd5bc1fe9f1f06409fa36392ef969f93e0faa0fd437c5fb8f5e525719f1b4fcd664d38c9f386b0cee1103b23adc3"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c44bc697-44f3-4367-b40c-7bd6196039fa/742da26e7cb9b91bdb83361d44429883/dotnet-sdk-9.0.100-win-arm64.zip",
-              "hash": "8e22602df5ea84a0a4234dc677d5ac3b9c077c7cfdaf8257e281fadb864ed245a38e1b93a058b3d0eedeafc6a7598d6b0ed621855f5d672ac4a72077d6c60d70"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.100-win-x64.exe",
-              "hash": "a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c5650c11-6944-488c-9192-cbab3c199deb/059197c7e46969164e752eec107fbea1/dotnet-sdk-9.0.100-win-x64.zip",
-              "hash": "fdc42c1b339335b3b9470401f731af4bdeca64c0c2aedf6ffda831eba0b18869f9a83855994bd9806644aeaa31e7086a9ced23319e45d66cf1a055c9f9cbb47f"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9ac55860-8ff9-4506-b005-d88df3092c01/bd204d9ae6b3ca66dab904f1169729a3/dotnet-sdk-9.0.100-win-x86.exe",
-              "hash": "854053f68672d922740e82849b7608ecdf63019fbcaee5970aac097a33b743f76df281e64b298c0bf138d0043aa01b3cd9627199f7fcb6a523210d6ad086a90d"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/d7af32e6-aaec-4fcd-aabe-0d927fa73a6d/80bbc4143ee82e40b8b4341795e92f4e/dotnet-sdk-9.0.100-win-x86.zip",
-              "hash": "5d624181cfa8a440b359645293f3508f5c9e162e0e8c14a646b13f5e5474f93d03d3813fd4c9640497b109d3917bb7f52d7fcf829f50af7fee8c55834f13a5e3"
-            }
-          ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "9.0.0",
-        "version-display": "9.0.0",
-        "version-aspnetcoremodule": [
-          "19.0.24303.0"
-        ],
-        "vs-version": "",
+      {
+        "version": "9.0.100",
+        "version-display": "9.0.100",
+        "runtime-version": "9.0.0",
+        "vs-version": "17.12",
+        "vs-support": "Visual Studio 2022 (v17.12)",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "16.9",
         "files": [
           {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/84aa8e86-c6a1-4562-84f3-828e836ef26c/96772a224b9ff3be8904b63f37d7cf63/aspnetcore-runtime-9.0.0-linux-arm.tar.gz",
-            "hash": "f711af1fd17f6976d98609feba32dbc8b027e3b851439ab0d5a68082ba6fa87ee3888cfd8cdd368b90fc3b3710220be2de9864ab50297e3797adc4bcbaab7e99"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/526d93c5-bae2-4cfc-a9cf-b2d28d7b5c98/17c926df21958999f74992973837d261/dotnet-sdk-9.0.100-linux-arm.tar.gz",
+            "hash": "de06e89e559bc763ff6773bcf852d915ec47f2d89f4e7065ba0800da99ab56357f31437391a77d7096e405f63318625b0cb074f6b410036fbe906fce7f3794e8"
           },
           {
-            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b2029a3e-c67e-4905-ad1f-08b164322520/bd68ea0b77f12df21b935da338fdaf25/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz",
-            "hash": "d5df4b549a59c8b9b2bcee5e0ffa9fde81fc3df74b299ab49820af6bc0ccfb89eec3714ea558ffcdd2a16821a4d1ecdcc64e9981804978ee3ff1d444b8125681"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6f79d99b-dc38-4c44-a549-32329419bb9f/a411ec38fb374e3a4676647b236ba021/dotnet-sdk-9.0.100-linux-arm64.tar.gz",
+            "hash": "684450e6d1f7c711fffdbf32a2b86a932d17a51f4742bd27a4289e319c5b24f6743553fc7e0ad1c7163e448ed5c40cd1ecf4198b2e681acc4622d8e6193a5cf2"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/59a041e1-921e-405e-8092-95333f80f9ca/63e83e3feb70e05ca05ed5db3c579be2/aspnetcore-runtime-9.0.0-linux-musl-arm.tar.gz",
-            "hash": "9558c873308ce275a367643d953271ac8877e0c3535fc1717cef013ec37f42177f013dd875a12719bf9d1c1533b51592cb8f87195d1e398e528ee5d0b04f7c1e"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c77904f4-57f5-46cf-bf99-d0dd1e4b9b3b/d7b454d3500c1a930b38e39a916aa38f/dotnet-sdk-9.0.100-linux-musl-arm.tar.gz",
+            "hash": "b0920f80e866a7603cea628a1130df003bc5d7818275c8a5882a31c6e4e29f07322fc5cfd87333893e4131bd96130fb2384d008cbad704022c89267d52686e07"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e137f557-83cb-4f55-b1c8-e5f59ccd3cba/b8ba6f2ab96d0961757b71b00c201f31/aspnetcore-runtime-9.0.0-linux-musl-arm64.tar.gz",
-            "hash": "fb5255619fa0c1082020b750789e86936cc1a07b9e321297e3af336af3b7f75d425c20fae9f4dd9d76c0b04d444e1e6dd15fd545feec0f6a9137a64701ad4633"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca5a82b7-704c-4405-bde2-4bde4b932d2e/0332e51e8d339cbc0410079f911205f3/dotnet-sdk-9.0.100-linux-musl-arm64.tar.gz",
+            "hash": "dae06d007327f6f53f50cb3a2884b93cd2fcbb73c756a8ac5ff673617f9bdf00093932f3a83652211fc2eeb57c271078644ef5c28a42897d8397f76d0e89586d"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/86d7a513-fe71-4f37-b9ec-fdcf5566cce8/e72574fc82d7496c73a61f411d967d8e/aspnetcore-runtime-9.0.0-linux-musl-x64.tar.gz",
-            "hash": "09e3709664f099b4116f8a2aac4b365247d11d0d19ecae262949de38fa9d41cc6c521a67e5b1ffecd63c610c1e9b41459bfb18f62b9d9d3b5176e3856e9ad35b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/404c65f4-7595-4792-85ab-e26084ebb5cf/db570cf4dc8d0a61270243c61fbdf619/dotnet-sdk-9.0.100-linux-musl-x64.tar.gz",
+            "hash": "e2032e6b4ed99adb3a92b7e041ea895ee09c6ed2455a1f68e55ed53bd613c8c20ef4aa5c434393bb5fdbc2f5635a83067f77451fe2fd3febcee264fe077acdaa"
           },
           {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e4791376-b70d-431f-bd98-5397c876b946/64ffc29a4edc8fd70b151c2963b38b09/aspnetcore-runtime-9.0.0-linux-x64.tar.gz",
-            "hash": "1a81023f119dd5e5b0f9d87b0e3c42df89824b9fcb73192a4670cc2c67358cd018a7c9c965245c7883de468bda88c81d64a21c60f9bc68a6559d76f32d34ce96"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/308f16a9-2ecf-4a42-b8bb-c1233de985fd/be6e87045ab21935bd8bb98ce69026c4/dotnet-sdk-9.0.100-linux-x64.tar.gz",
+            "hash": "7f69bda047de1f952286be330a5e858171ded952d1aa24169e62212f90a27149e63b636c88ad313a6e3ec860da31f8c547ff4ab6808103a070f7fb26ba99c1c7"
           },
           {
-            "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a9c3126c-91ab-4ab1-bc0a-e6bbeee7a786/3f848ed6f804c50f3a4c24599361e0eb/aspnetcore-runtime-9.0.0-osx-arm64.tar.gz",
-            "hash": "4aa3037e5b8b723f69d59ea733780dcecb5c8e17af924d945b369237bffad6a6a11cefbfb6db5cfb2e1f281e2385ac88e8253120b1a52f4db93186084f230f51"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2787e86a-6efe-4c4d-a3d1-8fd8c302c639/d386f92a6b2b819cb11cc0382dc98bc7/dotnet-sdk-9.0.100-osx-arm64.pkg",
+            "hash": "91cadc95a2dc8674a8e1fd5a8a54a6e1f4adaf1a364365e79ff69457079f5be3d0fd254325924a7c94bac531b84752bb17bb37e206b12b5b7bd43c9526ded9c7"
           },
           {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4569c514-16ac-49fc-ac41-4416f547c249/851fb0aa9b2a8bdcb0d1d9f9493a952e/dotnet-sdk-9.0.100-osx-arm64.tar.gz",
+            "hash": "94dfa49652195a884f06d06ceb23ef6f7d7380fe0c4015b96e8f950b57a9558711fba61128710f9c8de0081dd91af48a90f7bd0f8b90038aeb5aeb24fb6724ff"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b3d48d74-e9f8-4b6c-9ef7-6f5729873f21/2139bfd7650c0fd8ddce3195ada43ae8/aspnetcore-runtime-9.0.0-osx-x64.tar.gz",
-            "hash": "ea778a7aa7eecd2c46c38b187119e0afdb02532743550a4bdbc56a9125e328a089c16af74c3ffe649263f456ef26f5fc3b932f4d1f76d36a47cb419f203c6587"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ce4a7dd7-1baa-45b1-a447-76cac8d50218/128808a7422ca2e0ae37901d7c78cd53/dotnet-sdk-9.0.100-osx-x64.pkg",
+            "hash": "b51da89b449bda3fe81e9be2356473536558ba7cfdd5c60adb765b215c437c7d753f1dd60468e519dcac859a64edaba3078b473891b95b3d4f744e55f47ff080"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.exe",
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cab5bf72-f0c7-46c7-a8f2-074f71e4b6ca/a14ec2fc3b6fd32d47b4293994ab3c61/dotnet-sdk-9.0.100-osx-x64.tar.gz",
+            "hash": "59ef320289796abbdc573036d0d1b4aa1919c83140b7a363174abd68be5cc0252741546a21d46c201586331f5f9211787bd19b5381b902f3bd7c226220344ae9"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fe012fbe-149d-4235-9d1a-81bfdefa6cc6/852e5c8a18ccb168316f66e1b2f4ac25/aspnetcore-runtime-9.0.0-win-arm64.exe",
-            "hash": "0f5290d42c8ed3b9a8168b618a8abb6ef0dd77f006339699bda8e9a182434143fecb0da4cd1b1d48cfbb8e95212c6d5b45bdd84fa77fcf3e8299671f0827c26c"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/19ebb0b1-8f0c-4b8b-b5d6-ec835e2ce02c/a10305403c47790226ec809cea0d4251/dotnet-sdk-9.0.100-win-arm64.exe",
+            "hash": "071c44e59d4b7b58e9d0e5c8752229e5b3d6cd5bc1fe9f1f06409fa36392ef969f93e0faa0fd437c5fb8f5e525719f1b4fcd664d38c9f386b0cee1103b23adc3"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.zip",
+            "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/38471b06-b719-4d02-a866-cd31eadb2d61/11b17d533d2feac0ae65f1a1be13de2f/aspnetcore-runtime-9.0.0-win-arm64.zip",
-            "hash": "6550abfc7a00c50dc90513a3ac842b6df395b9d2204ecb8268fdff18cd555c71ca490b68c126c1f2d4caf4519eaa913ec0ce5601388d3c6c221463aa8a204a4a"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c44bc697-44f3-4367-b40c-7bd6196039fa/742da26e7cb9b91bdb83361d44429883/dotnet-sdk-9.0.100-win-arm64.zip",
+            "hash": "8e22602df5ea84a0a4234dc677d5ac3b9c077c7cfdaf8257e281fadb864ed245a38e1b93a058b3d0eedeafc6a7598d6b0ed621855f5d672ac4a72077d6c60d70"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.exe",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/815e6104-b92c-4cd5-8971-cba2f685002a/37befaa217f3269a152016da80a922c1/aspnetcore-runtime-9.0.0-win-x64.exe",
-            "hash": "604b63941a063087d84d3bf92513cf3b2237faa11995b2854e25bde43181487d42f05bd084b412d0abfbec801b3c6c5dc6ae03df339c1a04bf08d86a9bf8fcfd"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.100-win-x64.exe",
+            "hash": "a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6f43674a-fedb-414d-a709-6cd21f295ed3/6d041dd6f1812d804994a7c6c45a23bf/aspnetcore-runtime-9.0.0-win-x64.zip",
-            "hash": "9c48f8b05fa2476b0afd4983e789aabc2ea951055c617c7eb9617df92da01242874c0ca8922794cce6d63799fb87540ec7560e0926f78ffd6def73f8afe508e4"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c5650c11-6944-488c-9192-cbab3c199deb/059197c7e46969164e752eec107fbea1/dotnet-sdk-9.0.100-win-x64.zip",
+            "hash": "fdc42c1b339335b3b9470401f731af4bdeca64c0c2aedf6ffda831eba0b18869f9a83855994bd9806644aeaa31e7086a9ced23319e45d66cf1a055c9f9cbb47f"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/70c1a68c-e5e4-45ef-9f2c-df1d3f195a2e/6b8e20fe1e45f886e464908cf18efd96/aspnetcore-runtime-9.0.0-win-x86.exe",
-            "hash": "ea65734b83c7443d4d702cb80a255a897a9ec4ed90e986dc681b124decd1fe6b55385e7f5beae59ff23341d9747d00cf4f8e60cf657c66243ad7e5cef9622e4b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9ac55860-8ff9-4506-b005-d88df3092c01/bd204d9ae6b3ca66dab904f1169729a3/dotnet-sdk-9.0.100-win-x86.exe",
+            "hash": "854053f68672d922740e82849b7608ecdf63019fbcaee5970aac097a33b743f76df281e64b298c0bf138d0043aa01b3cd9627199f7fcb6a523210d6ad086a90d"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.zip",
+            "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c1c22ca6-181e-4f44-ad83-5f2664694529/81c3cead48ad0e5aeeee2a83db0a64db/aspnetcore-runtime-9.0.0-win-x86.zip",
-            "hash": "c1b966542699932a3bf39e48c19a97b5d6f1513782fc8d3c94c5d6c875ccf19944bb807376570ea485dd7f04e3640c3444baa8cd449a2af43d5bba22f0a0f50e"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/005078b8-dd35-475e-a8fd-83cd63cb4438/b3cd0e81df04333b6d17cf37389d4204/aspnetcore-runtime-composite-9.0.0-linux-arm.tar.gz",
-            "hash": "49360cb623d848f32520a18f3943271b2970c5b81eb8f7f7f04986795bcf0400e224957bcbb8d4a9e92e75a9f60b222818bfd748442d95257d93ec65cc6d546b"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/66eccc6d-6fd3-4ca0-8230-d13097728962/6c9a2fa811e69ca8abb12c700bb5d392/aspnetcore-runtime-composite-9.0.0-linux-arm64.tar.gz",
-            "hash": "e7bd3d2a51957d9174bde49ed5be141534261cddd5908881e86d56c2f8ac2c207f29d91af2df387b2c6daa9091436a7c998564ea36c3f2d29e74de0b552e1339"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7c960cd9-c2f1-49f0-bd92-25488c910e5c/1d00f01ed028462b5a38f4f15ad32980/aspnetcore-runtime-composite-9.0.0-linux-musl-arm.tar.gz",
-            "hash": "106457de6f34a2996923a77589e841815239a760382ee525c3b714f9e6f65039d8555a5e371aaad0e89c02f9dfa5bb267cac22fbc1cd383f696facebe5b34a97"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d95f7f9f-da8b-4316-8e7c-13b8172761c3/b6b990bd12f755bfced7f16fabebec06/aspnetcore-runtime-composite-9.0.0-linux-musl-arm64.tar.gz",
-            "hash": "24354dcba020e0bdbf0da867e1a3cb3c45ce214cf7dcab4d1be966c0bcba8d1701605e7681e9adf093c5d23f96574d077ca8fef9ea3d4071b7a275ab5901f86c"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/7d0c8c38-d0d3-4f99-9ddd-212a6537758d/21c6304587312c1151044e32656ce164/aspnetcore-runtime-composite-9.0.0-linux-musl-x64.tar.gz",
-            "hash": "d2f370d46fd24909015353c9488c68c526b931e3fbe5f34385a092a59ef21ebbf123ee491a896e65b3127bdd3e03349feb9c7f54e2ecf9c827d5d86da52e64d4"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3bd9050c-4605-4d8b-b4f0-2c7dbbd0ebb4/9de6d98389cd8ccb36c72cdd979a06df/aspnetcore-runtime-composite-9.0.0-linux-x64.tar.gz",
-            "hash": "7771734dd826ee714a65f7d0963f81ec061992c9848c02d335e8423a676c7d9fa7b6e2fdac72280d8e9c8df712a3f7723d3113f37d9e052f7314b06b661e4dac"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e1ae9d41-3faf-4755-ac27-b24e84eef3d1/5e3a24eb8c1a12272ea1fe126d17dfca/dotnet-hosting-9.0.0-win.exe",
-            "hash": "07857f982392d18b0aae269fb455573a3a02dce7bd6cd9fc476b514b1792430dfb793799606a7cd7afcd80813ca269abfa5427520e9b4ac589288d6de8eb1a4f",
-            "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
-          }
-        ]
-      },
-      "windowsdesktop": {
-        "version": "9.0.0",
-        "version-display": "9.0.0",
-        "files": [
-          {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b3a8a99d-5c1c-475a-ba68-4849de9ea6e9/c17f07553d7723165f98f27128fec048/windowsdesktop-runtime-9.0.0-win-arm64.exe",
-            "hash": "36ff3e8dd5f989c87a95b0220e618cb685104c74b4f7fcb553221983a804b67c6a1b57298830519dcd8f9233d78219adb3f1762716b83209326d25353c6bcb67"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/097ced3a-0b77-4867-b9ff-226d0e4a0a3d/4f21dfcbf0da3e1b127b1eb751c96098/windowsdesktop-runtime-9.0.0-win-arm64.zip",
-            "hash": "b0277fe40efd961c6853dd86dcd55f5958e6c588fdd9739d690907898f44edbce6171d43293e61792af817ebe4dabf24e8021743d52ae6ee43f98010f4d3b95b"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/685792b6-4827-4dca-a971-bce5d7905170/1bf61b02151bc56e763dc711e45f0e1e/windowsdesktop-runtime-9.0.0-win-x64.exe",
-            "hash": "e48e015327598623cac9081a556f76f4d4d74c33e35a7cecbd2989a5b2bcb6575017e922883fc841e10efdec3d9577a47ed2b036b7f431d8f8442bb1066e72ac"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d3c1e69d-79e4-4f08-a13a-75c9c36706b9/773a05ecaad2432302fc66f2dad032c2/windowsdesktop-runtime-9.0.0-win-x64.zip",
-            "hash": "b1c4a49d33cebaee3abcec44d151ba49784a5f221daaba3fc16249386fbd285a97bdd29124dc290b5615071a1f45be9bb0fd8c173626de20a0b7d2e399880d13"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8dfbde7b-c316-418d-934a-d3246253f342/69c6a35b77a4f01b95588e1df2bddf9a/windowsdesktop-runtime-9.0.0-win-x86.exe",
-            "hash": "f597d55205b776391ac1aeb56c40abf5274e6473193c4e6c48982582c135db199d8e75adba87bdacca8981752f04f596105548ab9cc267139e681c7858890543"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4da91bba-fe5a-46e6-b61f-3ff20b0cdb4e/c3e0ae8478071f337668d19bf4c22370/windowsdesktop-runtime-9.0.0-win-x86.zip",
-            "hash": "c11bbfa7bcc1dd9b165c802eba633dc8015ad5f38130b85d1b0c1bfe98546ab7326d00b98008ae324c19bd8baca94826df2ec483fc87d976749c58dad36d458d"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d7af32e6-aaec-4fcd-aabe-0d927fa73a6d/80bbc4143ee82e40b8b4341795e92f4e/dotnet-sdk-9.0.100-win-x86.zip",
+            "hash": "5d624181cfa8a440b359645293f3508f5c9e162e0e8c14a646b13f5e5474f93d03d3813fd4c9640497b109d3917bb7f52d7fcf829f50af7fee8c55834f13a5e3"
           }
         ]
       }
-    }    
-  ]
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.0",
+      "version-display": "9.0.0",
+      "version-aspnetcoremodule": [
+        "19.0.24303.0"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/84aa8e86-c6a1-4562-84f3-828e836ef26c/96772a224b9ff3be8904b63f37d7cf63/aspnetcore-runtime-9.0.0-linux-arm.tar.gz",
+          "hash": "f711af1fd17f6976d98609feba32dbc8b027e3b851439ab0d5a68082ba6fa87ee3888cfd8cdd368b90fc3b3710220be2de9864ab50297e3797adc4bcbaab7e99"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b2029a3e-c67e-4905-ad1f-08b164322520/bd68ea0b77f12df21b935da338fdaf25/aspnetcore-runtime-9.0.0-linux-arm64.tar.gz",
+          "hash": "d5df4b549a59c8b9b2bcee5e0ffa9fde81fc3df74b299ab49820af6bc0ccfb89eec3714ea558ffcdd2a16821a4d1ecdcc64e9981804978ee3ff1d444b8125681"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/59a041e1-921e-405e-8092-95333f80f9ca/63e83e3feb70e05ca05ed5db3c579be2/aspnetcore-runtime-9.0.0-linux-musl-arm.tar.gz",
+          "hash": "9558c873308ce275a367643d953271ac8877e0c3535fc1717cef013ec37f42177f013dd875a12719bf9d1c1533b51592cb8f87195d1e398e528ee5d0b04f7c1e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e137f557-83cb-4f55-b1c8-e5f59ccd3cba/b8ba6f2ab96d0961757b71b00c201f31/aspnetcore-runtime-9.0.0-linux-musl-arm64.tar.gz",
+          "hash": "fb5255619fa0c1082020b750789e86936cc1a07b9e321297e3af336af3b7f75d425c20fae9f4dd9d76c0b04d444e1e6dd15fd545feec0f6a9137a64701ad4633"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/86d7a513-fe71-4f37-b9ec-fdcf5566cce8/e72574fc82d7496c73a61f411d967d8e/aspnetcore-runtime-9.0.0-linux-musl-x64.tar.gz",
+          "hash": "09e3709664f099b4116f8a2aac4b365247d11d0d19ecae262949de38fa9d41cc6c521a67e5b1ffecd63c610c1e9b41459bfb18f62b9d9d3b5176e3856e9ad35b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4791376-b70d-431f-bd98-5397c876b946/64ffc29a4edc8fd70b151c2963b38b09/aspnetcore-runtime-9.0.0-linux-x64.tar.gz",
+          "hash": "1a81023f119dd5e5b0f9d87b0e3c42df89824b9fcb73192a4670cc2c67358cd018a7c9c965245c7883de468bda88c81d64a21c60f9bc68a6559d76f32d34ce96"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a9c3126c-91ab-4ab1-bc0a-e6bbeee7a786/3f848ed6f804c50f3a4c24599361e0eb/aspnetcore-runtime-9.0.0-osx-arm64.tar.gz",
+          "hash": "4aa3037e5b8b723f69d59ea733780dcecb5c8e17af924d945b369237bffad6a6a11cefbfb6db5cfb2e1f281e2385ac88e8253120b1a52f4db93186084f230f51"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b3d48d74-e9f8-4b6c-9ef7-6f5729873f21/2139bfd7650c0fd8ddce3195ada43ae8/aspnetcore-runtime-9.0.0-osx-x64.tar.gz",
+          "hash": "ea778a7aa7eecd2c46c38b187119e0afdb02532743550a4bdbc56a9125e328a089c16af74c3ffe649263f456ef26f5fc3b932f4d1f76d36a47cb419f203c6587"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fe012fbe-149d-4235-9d1a-81bfdefa6cc6/852e5c8a18ccb168316f66e1b2f4ac25/aspnetcore-runtime-9.0.0-win-arm64.exe",
+          "hash": "0f5290d42c8ed3b9a8168b618a8abb6ef0dd77f006339699bda8e9a182434143fecb0da4cd1b1d48cfbb8e95212c6d5b45bdd84fa77fcf3e8299671f0827c26c"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/38471b06-b719-4d02-a866-cd31eadb2d61/11b17d533d2feac0ae65f1a1be13de2f/aspnetcore-runtime-9.0.0-win-arm64.zip",
+          "hash": "6550abfc7a00c50dc90513a3ac842b6df395b9d2204ecb8268fdff18cd555c71ca490b68c126c1f2d4caf4519eaa913ec0ce5601388d3c6c221463aa8a204a4a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/815e6104-b92c-4cd5-8971-cba2f685002a/37befaa217f3269a152016da80a922c1/aspnetcore-runtime-9.0.0-win-x64.exe",
+          "hash": "604b63941a063087d84d3bf92513cf3b2237faa11995b2854e25bde43181487d42f05bd084b412d0abfbec801b3c6c5dc6ae03df339c1a04bf08d86a9bf8fcfd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f43674a-fedb-414d-a709-6cd21f295ed3/6d041dd6f1812d804994a7c6c45a23bf/aspnetcore-runtime-9.0.0-win-x64.zip",
+          "hash": "9c48f8b05fa2476b0afd4983e789aabc2ea951055c617c7eb9617df92da01242874c0ca8922794cce6d63799fb87540ec7560e0926f78ffd6def73f8afe508e4"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/70c1a68c-e5e4-45ef-9f2c-df1d3f195a2e/6b8e20fe1e45f886e464908cf18efd96/aspnetcore-runtime-9.0.0-win-x86.exe",
+          "hash": "ea65734b83c7443d4d702cb80a255a897a9ec4ed90e986dc681b124decd1fe6b55385e7f5beae59ff23341d9747d00cf4f8e60cf657c66243ad7e5cef9622e4b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c1c22ca6-181e-4f44-ad83-5f2664694529/81c3cead48ad0e5aeeee2a83db0a64db/aspnetcore-runtime-9.0.0-win-x86.zip",
+          "hash": "c1b966542699932a3bf39e48c19a97b5d6f1513782fc8d3c94c5d6c875ccf19944bb807376570ea485dd7f04e3640c3444baa8cd449a2af43d5bba22f0a0f50e"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/005078b8-dd35-475e-a8fd-83cd63cb4438/b3cd0e81df04333b6d17cf37389d4204/aspnetcore-runtime-composite-9.0.0-linux-arm.tar.gz",
+          "hash": "49360cb623d848f32520a18f3943271b2970c5b81eb8f7f7f04986795bcf0400e224957bcbb8d4a9e92e75a9f60b222818bfd748442d95257d93ec65cc6d546b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/66eccc6d-6fd3-4ca0-8230-d13097728962/6c9a2fa811e69ca8abb12c700bb5d392/aspnetcore-runtime-composite-9.0.0-linux-arm64.tar.gz",
+          "hash": "e7bd3d2a51957d9174bde49ed5be141534261cddd5908881e86d56c2f8ac2c207f29d91af2df387b2c6daa9091436a7c998564ea36c3f2d29e74de0b552e1339"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7c960cd9-c2f1-49f0-bd92-25488c910e5c/1d00f01ed028462b5a38f4f15ad32980/aspnetcore-runtime-composite-9.0.0-linux-musl-arm.tar.gz",
+          "hash": "106457de6f34a2996923a77589e841815239a760382ee525c3b714f9e6f65039d8555a5e371aaad0e89c02f9dfa5bb267cac22fbc1cd383f696facebe5b34a97"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d95f7f9f-da8b-4316-8e7c-13b8172761c3/b6b990bd12f755bfced7f16fabebec06/aspnetcore-runtime-composite-9.0.0-linux-musl-arm64.tar.gz",
+          "hash": "24354dcba020e0bdbf0da867e1a3cb3c45ce214cf7dcab4d1be966c0bcba8d1701605e7681e9adf093c5d23f96574d077ca8fef9ea3d4071b7a275ab5901f86c"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7d0c8c38-d0d3-4f99-9ddd-212a6537758d/21c6304587312c1151044e32656ce164/aspnetcore-runtime-composite-9.0.0-linux-musl-x64.tar.gz",
+          "hash": "d2f370d46fd24909015353c9488c68c526b931e3fbe5f34385a092a59ef21ebbf123ee491a896e65b3127bdd3e03349feb9c7f54e2ecf9c827d5d86da52e64d4"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3bd9050c-4605-4d8b-b4f0-2c7dbbd0ebb4/9de6d98389cd8ccb36c72cdd979a06df/aspnetcore-runtime-composite-9.0.0-linux-x64.tar.gz",
+          "hash": "7771734dd826ee714a65f7d0963f81ec061992c9848c02d335e8423a676c7d9fa7b6e2fdac72280d8e9c8df712a3f7723d3113f37d9e052f7314b06b661e4dac"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e1ae9d41-3faf-4755-ac27-b24e84eef3d1/5e3a24eb8c1a12272ea1fe126d17dfca/dotnet-hosting-9.0.0-win.exe",
+          "hash": "07857f982392d18b0aae269fb455573a3a02dce7bd6cd9fc476b514b1792430dfb793799606a7cd7afcd80813ca269abfa5427520e9b4ac589288d6de8eb1a4f",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.0",
+      "version-display": "9.0.0",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b3a8a99d-5c1c-475a-ba68-4849de9ea6e9/c17f07553d7723165f98f27128fec048/windowsdesktop-runtime-9.0.0-win-arm64.exe",
+          "hash": "36ff3e8dd5f989c87a95b0220e618cb685104c74b4f7fcb553221983a804b67c6a1b57298830519dcd8f9233d78219adb3f1762716b83209326d25353c6bcb67"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/097ced3a-0b77-4867-b9ff-226d0e4a0a3d/4f21dfcbf0da3e1b127b1eb751c96098/windowsdesktop-runtime-9.0.0-win-arm64.zip",
+          "hash": "b0277fe40efd961c6853dd86dcd55f5958e6c588fdd9739d690907898f44edbce6171d43293e61792af817ebe4dabf24e8021743d52ae6ee43f98010f4d3b95b"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/685792b6-4827-4dca-a971-bce5d7905170/1bf61b02151bc56e763dc711e45f0e1e/windowsdesktop-runtime-9.0.0-win-x64.exe",
+          "hash": "e48e015327598623cac9081a556f76f4d4d74c33e35a7cecbd2989a5b2bcb6575017e922883fc841e10efdec3d9577a47ed2b036b7f431d8f8442bb1066e72ac"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d3c1e69d-79e4-4f08-a13a-75c9c36706b9/773a05ecaad2432302fc66f2dad032c2/windowsdesktop-runtime-9.0.0-win-x64.zip",
+          "hash": "b1c4a49d33cebaee3abcec44d151ba49784a5f221daaba3fc16249386fbd285a97bdd29124dc290b5615071a1f45be9bb0fd8c173626de20a0b7d2e399880d13"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8dfbde7b-c316-418d-934a-d3246253f342/69c6a35b77a4f01b95588e1df2bddf9a/windowsdesktop-runtime-9.0.0-win-x86.exe",
+          "hash": "f597d55205b776391ac1aeb56c40abf5274e6473193c4e6c48982582c135db199d8e75adba87bdacca8981752f04f596105548ab9cc267139e681c7858890543"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4da91bba-fe5a-46e6-b61f-3ff20b0cdb4e/c3e0ae8478071f337668d19bf4c22370/windowsdesktop-runtime-9.0.0-win-x86.zip",
+          "hash": "c11bbfa7bcc1dd9b165c802eba633dc8015ad5f38130b85d1b0c1bfe98546ab7326d00b98008ae324c19bd8baca94826df2ec483fc87d976749c58dad36d458d"
+        }
+      ]
+    }
+  }
 }

--- a/release-notes/9.0/9.0.1/release.json
+++ b/release-notes/9.0/9.0.1/release.json
@@ -1,137 +1,244 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-01-14",
-  "release-version": "9.0.1",
-  "security": true,
-  "releases": [
-    {
-      "release-date": "2025-01-14",
-      "release-version": "9.0.1",
-      "security": true,
-      "cve-list": [
-        {
-          "cve-id": "CVE-2025-21171",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21171"
-        },
-        {
-          "cve-id": "CVE-2025-21172",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21172"
-        },
-        {
-          "cve-id": "CVE-2025-21176",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21176"
-        },
-        {
-          "cve-id": "CVE-2025-21173",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21173"
-        }
-      ],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.1/9.0.1.md",
-      "runtime": {
-        "version": "9.0.1",
-        "version-display": "9.0.1",
-        "vs-version": "17.12.4",
-        "vs-mac-version": "",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f8762afd-ce2a-461c-9280-0f6c377b92a7/9ca2330917e1ed7dadd5f1838b6ba44d/dotnet-runtime-9.0.1-linux-arm.tar.gz",
-            "hash": "b1cccb86da9912fcb816413718e264d899e9efc42a19fd8a6ccb8265b65ce4fe8c878d0b8d5c0633b1e0e4b2ff3ee53313a66e3f92c3b153fbdfe3044f1bcc96"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8a8a85c8-3364-42e4-a9fa-bc4d33e4a263/cb6b67c1ef5a8fd779dc43096c1f2a14/dotnet-runtime-9.0.1-linux-arm64.tar.gz",
-            "hash": "38399b6139f72ef1d836e418455494a80428bf41f3aaf2351749ff144311766487533d5a3c9bd359c189b9373f24377ae886827f45272c4019e22b594773b87b"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/391e3ee0-16aa-4294-8641-3438307e624d/d244e58fbeff1482b0f8d3aacc6cc621/dotnet-runtime-9.0.1-linux-musl-arm.tar.gz",
-            "hash": "ac8a7be3ab0895539813c1f67c33aa93ee72e2ac7f2d88ee3ca21f14479e11a4064cde9a7e15a2944222b8d7c2858ddd39de9f6c2d278b4129f5e3ba8b9c38e3"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/966184c6-ae9d-42d9-a5d6-1f14c46ffafd/fc65efc3447d3f1dced1c156742be6fa/dotnet-runtime-9.0.1-linux-musl-arm64.tar.gz",
-            "hash": "cf6865754e3c28b63bf4e73db95a2079028b9132ffc6bee4aa7af03ee15c7560a13d07260965833b43985d8b5e2f50a776ff17bf5343605b1c1bc239ddaf3c5c"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dec9d9de-effe-48df-83b1-0c83f54e4cbc/cfe914fe2e2e9edb6138ce9328051f10/dotnet-runtime-9.0.1-linux-musl-x64.tar.gz",
-            "hash": "39bc73be712afcab41425c2e42aa5098133cf9a2080f91d4c65f274c2c6bc6f812793a17f8ed6b3a5bcabde4cc5ee5be83dc9bef9d3f3b10d79d0d3f00b4b55f"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4ec0d4e4-9774-4d69-b9a2-db99ccb24a1a/b108f97029f83c8a27d041e90583ba5c/dotnet-runtime-9.0.1-linux-x64.tar.gz",
-            "hash": "d4a31944a5ab063037dca5141dbc8466d0c894b8d2560256782bdbe5a8e86585e8c4c789c40fbe51d56b3853e15adba0985bdc6ae91c85a763565316e1c3cfcb"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.pkg",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/94c702e9-6334-4f72-814b-4a26d492771e/b583daf604626c9dfeee7ab5f5bb5c14/dotnet-runtime-9.0.1-osx-arm64.pkg",
-            "hash": "8fb808f613f37cddc61c43d11c0265aa71394266db0529d1c6f806f2c79c40ebb43f6dde0f4246a0feb06da276564a2c37c9bec265950dbe61c4d16a063a4639"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5c1d13ac-90d1-4f76-bcb1-d404b1ef6748/137435417c82ec2a5a519555b93b2344/dotnet-runtime-9.0.1-osx-arm64.tar.gz",
-            "hash": "f65f650ee3c289ca092fa151a3d9cf34fea2f5426f09882c194fe71655ecaf2a681b2d508b9c7849d6c908ca679625dc48171d00580cdff7f981f0518a843c65"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e71b09a9-de09-4641-84f5-d8f0a2220874/57d2fdfabe715eccb6a38fceb712b6a2/dotnet-runtime-9.0.1-osx-x64.pkg",
-            "hash": "f9d040bf19abfc79fce730f0fb50114b8002dbafd4dfa8e5315763cc342d85c02e34637e135f26168fe809bf3fffd54bfcf2d67ec79bf43365cc4da2dc5dc4e7"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36d3662e-b23c-46cb-994c-3a46bf2b9759/2c090a2be99f96cb33a56183e747e27b/dotnet-runtime-9.0.1-osx-x64.tar.gz",
-            "hash": "b997c2c0f0350ef29ba6e865ac09ebecb1d3632e2a7561b5abe23bd0fb6abc8c0ca7388d6cf17c59ca87dd8168604ded6839a7b16cea1afbe36ca57234515e1b"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ee58a24d-2e62-468f-9349-de77065b4fcd/8c1a8bc6d3a693f73513790beb210659/dotnet-runtime-9.0.1-win-arm64.exe",
-            "hash": "3d866122fe7b560fce9d8313a37d2eb247e3e375079f456099854fdfcb5ab5c453b762ed347a48f23c56affb2d9cb9a4b92975290a6ef517fd69a6ff849a8cea"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d6ace5f4-cf28-4386-9f9a-9d756fb50763/82d2cebd4f7fc8692f5d5e16787bc1b7/dotnet-runtime-9.0.1-win-arm64.zip",
-            "hash": "2127e5064f6d446c4bf30610f48ca748eb67d6a8dcce55c22095f7e59720985339b07f64b887dd92ba5ed20bff10ce0f9fda69018da49e4cc2e30516b0769639"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/24046c49-1b56-4c1b-9c15-75c94d7a841a/d089fe00210b8113c33ea96e1e932fb7/dotnet-runtime-9.0.1-win-x64.exe",
-            "hash": "1031c5c76dbc8a5605354915a2f5e4c7b0d1a6b666ff6366589498f5b20f8a41366449dfbcb0e9181e8e79f42230a87eeb235bfd1d41b1128bf9b76bcdb4f200"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/057a1dae-2fb6-4adc-ac3f-d3f8c13926d8/6716df81f86b00a9e032134b1bab9d07/dotnet-runtime-9.0.1-win-x64.zip",
-            "hash": "30b880c3cd6c39355e92b5422e8c044a26fba1da15b4f1f8a89dc4622962c8a3537b075064c33c8493d8bbc909ae8c135a5533110080e95ef31e3407eade291f"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/21eed405-253a-4ac5-8eed-e54d36bffdaa/3692b7badff8c4311474b4511c3ab929/dotnet-runtime-9.0.1-win-x86.exe",
-            "hash": "191a9a61e8d6692b6d35a176cbcb7a9659128c646289977297744c64c98f4e18fa02751d1912e24a4450dae8ec459e7856a73271440a8abb7e9d479a23f3cdc1"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8ac967c1-7da4-4cd3-ad31-32ff01934f51/e3a1057ef293d962a3a59adc692c1c20/dotnet-runtime-9.0.1-win-x86.zip",
-            "hash": "b0914634b4b29230a000e0b00005992eb6e37094862e2d0a9e0975b366dad47455d6d26aeefe953563091f25538bf00ef9d74b8c01eca7f0ba6dd2888163b797"
-          }
-        ]
+  "release": {
+    "release-date": "2025-01-14",
+    "release-version": "9.0.1",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2025-21171",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21171"
       },
-      "sdk": {
+      {
+        "cve-id": "CVE-2025-21172",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21172"
+      },
+      {
+        "cve-id": "CVE-2025-21176",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21176"
+      },
+      {
+        "cve-id": "CVE-2025-21173",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21173"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.1/9.0.1.md",
+    "runtime": {
+      "version": "9.0.1",
+      "version-display": "9.0.1",
+      "vs-version": "17.12.4",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f8762afd-ce2a-461c-9280-0f6c377b92a7/9ca2330917e1ed7dadd5f1838b6ba44d/dotnet-runtime-9.0.1-linux-arm.tar.gz",
+          "hash": "b1cccb86da9912fcb816413718e264d899e9efc42a19fd8a6ccb8265b65ce4fe8c878d0b8d5c0633b1e0e4b2ff3ee53313a66e3f92c3b153fbdfe3044f1bcc96"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8a8a85c8-3364-42e4-a9fa-bc4d33e4a263/cb6b67c1ef5a8fd779dc43096c1f2a14/dotnet-runtime-9.0.1-linux-arm64.tar.gz",
+          "hash": "38399b6139f72ef1d836e418455494a80428bf41f3aaf2351749ff144311766487533d5a3c9bd359c189b9373f24377ae886827f45272c4019e22b594773b87b"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/391e3ee0-16aa-4294-8641-3438307e624d/d244e58fbeff1482b0f8d3aacc6cc621/dotnet-runtime-9.0.1-linux-musl-arm.tar.gz",
+          "hash": "ac8a7be3ab0895539813c1f67c33aa93ee72e2ac7f2d88ee3ca21f14479e11a4064cde9a7e15a2944222b8d7c2858ddd39de9f6c2d278b4129f5e3ba8b9c38e3"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/966184c6-ae9d-42d9-a5d6-1f14c46ffafd/fc65efc3447d3f1dced1c156742be6fa/dotnet-runtime-9.0.1-linux-musl-arm64.tar.gz",
+          "hash": "cf6865754e3c28b63bf4e73db95a2079028b9132ffc6bee4aa7af03ee15c7560a13d07260965833b43985d8b5e2f50a776ff17bf5343605b1c1bc239ddaf3c5c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dec9d9de-effe-48df-83b1-0c83f54e4cbc/cfe914fe2e2e9edb6138ce9328051f10/dotnet-runtime-9.0.1-linux-musl-x64.tar.gz",
+          "hash": "39bc73be712afcab41425c2e42aa5098133cf9a2080f91d4c65f274c2c6bc6f812793a17f8ed6b3a5bcabde4cc5ee5be83dc9bef9d3f3b10d79d0d3f00b4b55f"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4ec0d4e4-9774-4d69-b9a2-db99ccb24a1a/b108f97029f83c8a27d041e90583ba5c/dotnet-runtime-9.0.1-linux-x64.tar.gz",
+          "hash": "d4a31944a5ab063037dca5141dbc8466d0c894b8d2560256782bdbe5a8e86585e8c4c789c40fbe51d56b3853e15adba0985bdc6ae91c85a763565316e1c3cfcb"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/94c702e9-6334-4f72-814b-4a26d492771e/b583daf604626c9dfeee7ab5f5bb5c14/dotnet-runtime-9.0.1-osx-arm64.pkg",
+          "hash": "8fb808f613f37cddc61c43d11c0265aa71394266db0529d1c6f806f2c79c40ebb43f6dde0f4246a0feb06da276564a2c37c9bec265950dbe61c4d16a063a4639"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5c1d13ac-90d1-4f76-bcb1-d404b1ef6748/137435417c82ec2a5a519555b93b2344/dotnet-runtime-9.0.1-osx-arm64.tar.gz",
+          "hash": "f65f650ee3c289ca092fa151a3d9cf34fea2f5426f09882c194fe71655ecaf2a681b2d508b9c7849d6c908ca679625dc48171d00580cdff7f981f0518a843c65"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e71b09a9-de09-4641-84f5-d8f0a2220874/57d2fdfabe715eccb6a38fceb712b6a2/dotnet-runtime-9.0.1-osx-x64.pkg",
+          "hash": "f9d040bf19abfc79fce730f0fb50114b8002dbafd4dfa8e5315763cc342d85c02e34637e135f26168fe809bf3fffd54bfcf2d67ec79bf43365cc4da2dc5dc4e7"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/36d3662e-b23c-46cb-994c-3a46bf2b9759/2c090a2be99f96cb33a56183e747e27b/dotnet-runtime-9.0.1-osx-x64.tar.gz",
+          "hash": "b997c2c0f0350ef29ba6e865ac09ebecb1d3632e2a7561b5abe23bd0fb6abc8c0ca7388d6cf17c59ca87dd8168604ded6839a7b16cea1afbe36ca57234515e1b"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ee58a24d-2e62-468f-9349-de77065b4fcd/8c1a8bc6d3a693f73513790beb210659/dotnet-runtime-9.0.1-win-arm64.exe",
+          "hash": "3d866122fe7b560fce9d8313a37d2eb247e3e375079f456099854fdfcb5ab5c453b762ed347a48f23c56affb2d9cb9a4b92975290a6ef517fd69a6ff849a8cea"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d6ace5f4-cf28-4386-9f9a-9d756fb50763/82d2cebd4f7fc8692f5d5e16787bc1b7/dotnet-runtime-9.0.1-win-arm64.zip",
+          "hash": "2127e5064f6d446c4bf30610f48ca748eb67d6a8dcce55c22095f7e59720985339b07f64b887dd92ba5ed20bff10ce0f9fda69018da49e4cc2e30516b0769639"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/24046c49-1b56-4c1b-9c15-75c94d7a841a/d089fe00210b8113c33ea96e1e932fb7/dotnet-runtime-9.0.1-win-x64.exe",
+          "hash": "1031c5c76dbc8a5605354915a2f5e4c7b0d1a6b666ff6366589498f5b20f8a41366449dfbcb0e9181e8e79f42230a87eeb235bfd1d41b1128bf9b76bcdb4f200"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/057a1dae-2fb6-4adc-ac3f-d3f8c13926d8/6716df81f86b00a9e032134b1bab9d07/dotnet-runtime-9.0.1-win-x64.zip",
+          "hash": "30b880c3cd6c39355e92b5422e8c044a26fba1da15b4f1f8a89dc4622962c8a3537b075064c33c8493d8bbc909ae8c135a5533110080e95ef31e3407eade291f"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/21eed405-253a-4ac5-8eed-e54d36bffdaa/3692b7badff8c4311474b4511c3ab929/dotnet-runtime-9.0.1-win-x86.exe",
+          "hash": "191a9a61e8d6692b6d35a176cbcb7a9659128c646289977297744c64c98f4e18fa02751d1912e24a4450dae8ec459e7856a73271440a8abb7e9d479a23f3cdc1"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8ac967c1-7da4-4cd3-ad31-32ff01934f51/e3a1057ef293d962a3a59adc692c1c20/dotnet-runtime-9.0.1-win-x86.zip",
+          "hash": "b0914634b4b29230a000e0b00005992eb6e37094862e2d0a9e0975b366dad47455d6d26aeefe953563091f25538bf00ef9d74b8c01eca7f0ba6dd2888163b797"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "9.0.102",
+      "version-display": "9.0.102",
+      "runtime-version": "9.0.1",
+      "vs-version": "17.12.4",
+      "vs-mac-version": "",
+      "vs-support": "Visual Studio 2022 (v17.12)",
+      "vs-mac-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8f7ff743-f739-4b7c-835b-9405b3f7604f/b903530c774c08f30d3de3029f2e0bf9/dotnet-sdk-9.0.102-linux-arm.tar.gz",
+          "hash": "2c4c69d46c3e57ed990518a9d82963665d835c66a57da54b9d21e22c2a20e8018020dcb190eef54dfe68c001fcce385361eb2bd29896311a1683599ff9e6a777"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/555b12ca-d25f-4d4a-8c62-03b57998981e/b8f8f88c7809ea6c0e1d127deb18d8c6/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
+          "hash": "cb78931dcbb948a504891f112f11215f2792d169f0a0b53eaa81c03fc4ba78d31a91c60a41809ae6e2ddcae8640085a159e492035cedfda68d265bbeb4bf8b2e"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/db81a835-d9dc-4094-9c5c-cda20e684556/2d80354042afe6c8a2ef2f54c48a86cf/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
+          "hash": "e363e3d4edca93830d18bcebd41e01bf2856b095ae70e1a24b0533abb0a507e4c1f1542ff3046c285689318dac7e2b5c71a166bcb5933a8ab68d800bf3eedf03"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a35ae2c2-e906-4bb1-b12a-a9d435231626/d0da093a240d41c06da2f49dc3011a13/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
+          "hash": "5da98e46c280e21c3734a0c9081e7ddb78ad62775a51a129b42a6f021330d263a875da2f44a7aafe8156e7c9ae0f9bb21b502057692b360f2afe0882f0e61132"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5e11d2af-f335-44f6-90a0-a99cdf806855/97268da6caffc1e8182525c7a2f01b74/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
+          "hash": "60e091854d17da9a6011569f0a4819eac72ce6fe06d01757feeb83ad56c17645fa438257631ecbbf6ee94ac3a973eff9ad4d3e12deadda3eb41c1b69ca8d5308"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0e717d01-aad7-475a-8b67-50c59cf043b1/6eaa1c636e15ec8e1b97b3438360c770/dotnet-sdk-9.0.102-linux-x64.tar.gz",
+          "hash": "f093507ef635c3f8e572bf7b6ea7e144b85ccf6b7c6f914d3f182f782200a6088728663df5c9abe0638c9bd273fde3769ec824a6516f5fce734c4a4664ce3099"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/96489126-b9ba-414a-a2d0-d8c5b61a22be/fe047e117e9cc43738ba2222f4769da2/dotnet-sdk-9.0.102-osx-arm64.pkg",
+          "hash": "bf5759734f7aa010912e4806d1d7bcb86d635f7d1573e6bdc00eb5c443f64a43313ba0699ce249989b855b77d52b0209ad331cbec7a1493492d684f026d1d267"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/1b4a1593-695b-4496-aa2a-55fa572bd71a/3b44622f52d4695513dff04f0bbcc404/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
+          "hash": "13632c9e58d8fa46f191256d180ed19089e08b242881825dd3682f082d65bcc6d9756629fefdab609c11265b6043dc11635263fe8761339b72d36608acb43574"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2bda19b1-6389-4520-8e5e-363172398741/662eee446961503151bb78c29997933e/dotnet-sdk-9.0.102-osx-x64.pkg",
+          "hash": "25cf5bf146803d64a51b1fb6dc501edfa4cb8226531a70e5d651f2dbf13968a3a70c54434c7d65e2c5b12f58c358b35a97dff43931e54bf0214c6e5f59abc606"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/373e3b64-d88b-4d83-adf3-eb48a6d6e76c/0d24e9cdbb0e75999fc0c17dafb1ea17/dotnet-sdk-9.0.102-osx-x64.tar.gz",
+          "hash": "023e910b64819991831aa0e530443fa985fa673920ff291541ad7b7a4a532e20f5ac89f9a91b2e956cf69b3821ef1369828cf46c544e183a85425ae4b725e187"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/99315d83-565d-4f1f-9f89-2d07aae98af8/9348c4708d04cc933979d139413e3bc3/dotnet-sdk-9.0.102-win-arm64.exe",
+          "hash": "b9b78e41a3ecb4ea017471e8213ecfd1b0e0ec6504b74fa0fc4c8c601468fe9e966b76ce173b0d124478a5430d940408ee8f379725988bb3e0998054357d7239"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8ca0f979-057c-4bf2-9a7c-3d5feeff533f/2c1517241a46552f2525952acc083f39/dotnet-sdk-9.0.102-win-arm64.zip",
+          "hash": "4aa7343ab96b0403d9d543d1e2f11f8f10dbc5ebeb60f5be1dee455fd878c77f24e1710de3fc85ad0850d3913680f2d2605121db934a4ad6f969e73d9d6ee334"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe",
+          "hash": "91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/044ede4e-08d0-4c85-8c46-60e8b2e8e340/690f9b2c25bc27062edc71e0ccc2a639/dotnet-sdk-9.0.102-win-x64.zip",
+          "hash": "c3713f4db98fec9bcbb5be1378e7505a49cdb362e20e060045dc8e320ebc62e0f422e125efb9e966e957ee64e33219dea9b42c18ac5b8e51dd3648e5aa1319c5"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/7bbae865-0dcb-4a44-bc26-c94b1e776cc0/6041bed29060817cbc6088962a2c600d/dotnet-sdk-9.0.102-win-x86.exe",
+          "hash": "fb043c6deb487a743f86caacdd13d6dfd8a5239c40b54df99e6bdef8b9567289bfce715a8bbad452500c445b487b5d2a0aaaaf1e1065b08a0a23a6e2c98419ed"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/139daba9-b797-4dc9-a5a3-873604311459/90623d54cab92d97f66343147e318d6a/dotnet-sdk-9.0.102-win-x86.zip",
+          "hash": "898229b1c92ac1925d7155036755d451afcd52f39f4f204554918c7b0d16a78cf0ec1df06208d40c8d14ce43d8cf66107f9d93a5a3c4e62801d7fcc340a73fe5"
+        }
+      ]
+    },
+    "sdks": [
+      {
         "version": "9.0.102",
         "version-display": "9.0.102",
         "runtime-version": "9.0.1",
@@ -240,298 +347,186 @@
             "hash": "898229b1c92ac1925d7155036755d451afcd52f39f4f204554918c7b0d16a78cf0ec1df06208d40c8d14ce43d8cf66107f9d93a5a3c4e62801d7fcc340a73fe5"
           }
         ]
-      },
-      "sdks": [
-        {
-          "version": "9.0.102",
-          "version-display": "9.0.102",
-          "runtime-version": "9.0.1",
-          "vs-version": "17.12.4",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "vs-mac-support": "",
-          "csharp-version": "12.0",
-          "fsharp-version": "8.0",
-          "vb-version": "16.9",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8f7ff743-f739-4b7c-835b-9405b3f7604f/b903530c774c08f30d3de3029f2e0bf9/dotnet-sdk-9.0.102-linux-arm.tar.gz",
-              "hash": "2c4c69d46c3e57ed990518a9d82963665d835c66a57da54b9d21e22c2a20e8018020dcb190eef54dfe68c001fcce385361eb2bd29896311a1683599ff9e6a777"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/555b12ca-d25f-4d4a-8c62-03b57998981e/b8f8f88c7809ea6c0e1d127deb18d8c6/dotnet-sdk-9.0.102-linux-arm64.tar.gz",
-              "hash": "cb78931dcbb948a504891f112f11215f2792d169f0a0b53eaa81c03fc4ba78d31a91c60a41809ae6e2ddcae8640085a159e492035cedfda68d265bbeb4bf8b2e"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/db81a835-d9dc-4094-9c5c-cda20e684556/2d80354042afe6c8a2ef2f54c48a86cf/dotnet-sdk-9.0.102-linux-musl-arm.tar.gz",
-              "hash": "e363e3d4edca93830d18bcebd41e01bf2856b095ae70e1a24b0533abb0a507e4c1f1542ff3046c285689318dac7e2b5c71a166bcb5933a8ab68d800bf3eedf03"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a35ae2c2-e906-4bb1-b12a-a9d435231626/d0da093a240d41c06da2f49dc3011a13/dotnet-sdk-9.0.102-linux-musl-arm64.tar.gz",
-              "hash": "5da98e46c280e21c3734a0c9081e7ddb78ad62775a51a129b42a6f021330d263a875da2f44a7aafe8156e7c9ae0f9bb21b502057692b360f2afe0882f0e61132"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5e11d2af-f335-44f6-90a0-a99cdf806855/97268da6caffc1e8182525c7a2f01b74/dotnet-sdk-9.0.102-linux-musl-x64.tar.gz",
-              "hash": "60e091854d17da9a6011569f0a4819eac72ce6fe06d01757feeb83ad56c17645fa438257631ecbbf6ee94ac3a973eff9ad4d3e12deadda3eb41c1b69ca8d5308"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0e717d01-aad7-475a-8b67-50c59cf043b1/6eaa1c636e15ec8e1b97b3438360c770/dotnet-sdk-9.0.102-linux-x64.tar.gz",
-              "hash": "f093507ef635c3f8e572bf7b6ea7e144b85ccf6b7c6f914d3f182f782200a6088728663df5c9abe0638c9bd273fde3769ec824a6516f5fce734c4a4664ce3099"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/96489126-b9ba-414a-a2d0-d8c5b61a22be/fe047e117e9cc43738ba2222f4769da2/dotnet-sdk-9.0.102-osx-arm64.pkg",
-              "hash": "bf5759734f7aa010912e4806d1d7bcb86d635f7d1573e6bdc00eb5c443f64a43313ba0699ce249989b855b77d52b0209ad331cbec7a1493492d684f026d1d267"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1b4a1593-695b-4496-aa2a-55fa572bd71a/3b44622f52d4695513dff04f0bbcc404/dotnet-sdk-9.0.102-osx-arm64.tar.gz",
-              "hash": "13632c9e58d8fa46f191256d180ed19089e08b242881825dd3682f082d65bcc6d9756629fefdab609c11265b6043dc11635263fe8761339b72d36608acb43574"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2bda19b1-6389-4520-8e5e-363172398741/662eee446961503151bb78c29997933e/dotnet-sdk-9.0.102-osx-x64.pkg",
-              "hash": "25cf5bf146803d64a51b1fb6dc501edfa4cb8226531a70e5d651f2dbf13968a3a70c54434c7d65e2c5b12f58c358b35a97dff43931e54bf0214c6e5f59abc606"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/373e3b64-d88b-4d83-adf3-eb48a6d6e76c/0d24e9cdbb0e75999fc0c17dafb1ea17/dotnet-sdk-9.0.102-osx-x64.tar.gz",
-              "hash": "023e910b64819991831aa0e530443fa985fa673920ff291541ad7b7a4a532e20f5ac89f9a91b2e956cf69b3821ef1369828cf46c544e183a85425ae4b725e187"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/99315d83-565d-4f1f-9f89-2d07aae98af8/9348c4708d04cc933979d139413e3bc3/dotnet-sdk-9.0.102-win-arm64.exe",
-              "hash": "b9b78e41a3ecb4ea017471e8213ecfd1b0e0ec6504b74fa0fc4c8c601468fe9e966b76ce173b0d124478a5430d940408ee8f379725988bb3e0998054357d7239"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8ca0f979-057c-4bf2-9a7c-3d5feeff533f/2c1517241a46552f2525952acc083f39/dotnet-sdk-9.0.102-win-arm64.zip",
-              "hash": "4aa7343ab96b0403d9d543d1e2f11f8f10dbc5ebeb60f5be1dee455fd878c77f24e1710de3fc85ad0850d3913680f2d2605121db934a4ad6f969e73d9d6ee334"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe",
-              "hash": "91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/044ede4e-08d0-4c85-8c46-60e8b2e8e340/690f9b2c25bc27062edc71e0ccc2a639/dotnet-sdk-9.0.102-win-x64.zip",
-              "hash": "c3713f4db98fec9bcbb5be1378e7505a49cdb362e20e060045dc8e320ebc62e0f422e125efb9e966e957ee64e33219dea9b42c18ac5b8e51dd3648e5aa1319c5"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7bbae865-0dcb-4a44-bc26-c94b1e776cc0/6041bed29060817cbc6088962a2c600d/dotnet-sdk-9.0.102-win-x86.exe",
-              "hash": "fb043c6deb487a743f86caacdd13d6dfd8a5239c40b54df99e6bdef8b9567289bfce715a8bbad452500c445b487b5d2a0aaaaf1e1065b08a0a23a6e2c98419ed"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/139daba9-b797-4dc9-a5a3-873604311459/90623d54cab92d97f66343147e318d6a/dotnet-sdk-9.0.102-win-x86.zip",
-              "hash": "898229b1c92ac1925d7155036755d451afcd52f39f4f204554918c7b0d16a78cf0ec1df06208d40c8d14ce43d8cf66107f9d93a5a3c4e62801d7fcc340a73fe5"
-            }
-          ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "9.0.1",
-        "version-display": "9.0.1",
-        "version-aspnetcoremodule": [
-          "19.0.24346.1"
-        ],
-        "vs-version": "",
-        "files": [
-          {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/463fb01d-fcad-46bf-8e5f-0e568bb9ccf4/a3ac380fdc1e29ec25e5fa0a292a61df/aspnetcore-runtime-9.0.1-linux-arm.tar.gz",
-            "hash": "fa75d8d5ae99ade0d1ab90018839fe3f5ddc4e7b7461715caf2b0bf7a88c8e86e1d4f10ab69703d2318b289c0700846e2155746d7bb1ace3d2d12e175ab18be1"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2a193300-e0b1-4e9e-acc4-a4a695c7b94a/f197be75380aaa333c949bb8a1fe0510/aspnetcore-runtime-9.0.1-linux-arm64.tar.gz",
-            "hash": "e37dc1445e53c00bd950a531fab83354defbbe06c6f73af4bbef20bfcedc0483a98f478369a7bc7d7e52e35b2b33ad73781e255b46900d831e2770cd445d69c5"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2cfd68f3-5259-451d-83b1-6b5e80932813/bae5e023e887e42639426dd0824ac6bf/aspnetcore-runtime-9.0.1-linux-musl-arm.tar.gz",
-            "hash": "3ea55cc5098dc08909a385219fad1e38635f6eef6cd66ea526b92dd57f765dc348380422e5e0b9c8ade286e18e713caa4b7ff2d06a23c3fed31b8b5c91d2dc6b"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3b0e483-26b2-4115-8a8d-983c9b0ca58a/4d0058d82438c8de99347f40d3dee091/aspnetcore-runtime-9.0.1-linux-musl-arm64.tar.gz",
-            "hash": "e9a7e257f6b09e48c522b725be8ab498e57189d6687f840a37ab9fe4192e985bddd99a663418c5d5d96ee7c7c2b9f70e08f786aa4a1b207548586bd3fcc3710e"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d55550d5-16dc-4b17-90c7-e8bf65657e09/b3d4c31dd4c933aaa50e920f5465b111/aspnetcore-runtime-9.0.1-linux-musl-x64.tar.gz",
-            "hash": "d3f609184959849f7524fdfb55c5cf9a8391d0a773483aa6659d9baa152656835f26c2fe9ba322e718a8eb7781fb996eb4ebc6953beaf6fdfb5628ef31bfc853"
-          },
-          {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/78308995-ac02-4bed-b5c3-eefb06ff907c/795e0c20df95d8c432fda2a189235b67/aspnetcore-runtime-9.0.1-linux-x64.tar.gz",
-            "hash": "e5fc3093aed5756deae3e61f98b9f4bb0c847319db30cbd1668c2511e06529c2f6a5e1917ec776fe2b36a1f7bb7e009fc925fee57f87696a8d502a6c8f5dc613"
-          },
-          {
-            "name": "aspnetcore-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/26f85624-0eaf-4edc-a83f-428472ab31df/ba32371bac29f1738b9b0eb959dab0a3/aspnetcore-runtime-9.0.1-osx-arm64.tar.gz",
-            "hash": "b8ab3899b10b871159b01889694484cc3d9b3ae78a159638d68649a22c3f3328b92c435c5bcdf49a86bc488bbbd0fca7143f6f664f6594c552423c37ead99998"
-          },
-          {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6655b880-82dc-43d1-b5b2-f76d6a3c431c/4752d9d4811a2148de7eef5dcfd08441/aspnetcore-runtime-9.0.1-osx-x64.tar.gz",
-            "hash": "4aeb0943877dbf935f6554c637d2aa18f8ef22e9692e6cd3d716dde2dd5411e4881767cbe9c554bd8ec43c209a86a26194c2618c60d115ba0638e92e80423cc0"
-          },
-          {
-            "name": "aspnetcore-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2985fd4b-f7af-4654-a7a4-e2c14b42af0b/9849c95576f43d40a63016af552b9dd9/aspnetcore-runtime-9.0.1-win-arm64.exe",
-            "hash": "e6e9a564919a63ab268269610b65dd47a03770aa1f4f9fcd4b4f3c1363400e4037eaf4f614e337741abb44c8d97c092efcf63bd200dc05a5686accf97cc1e447"
-          },
-          {
-            "name": "aspnetcore-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8e308ca2-de0f-4202-9d52-81b0ed50ce01/169ea645ba895a387192fc9ff160a994/aspnetcore-runtime-9.0.1-win-arm64.zip",
-            "hash": "52c69b68f22a3fa1251716e96a64102fcc97c887ecb3c9a160c59c70e625b2ec8a7ef4f71626f522274a1e5f4c1286bb58b8fa31d4605ca4b3a239439e46472a"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3f41e6c7-c80d-4e44-afb4-9b9bc98547b7/d2f0ede399a87d7a4a78c2b5a0f90bf9/aspnetcore-runtime-9.0.1-win-x64.exe",
-            "hash": "82b4237d0589a70ffa5ca37c2ecce6c9548c839acc2215f218e27572a161da7caacd3857553d5a4c331e3f6a3aa3e468c6e9de802dbd63f2dd5c54befb9b047b"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0d79cb49-287b-4cf4-af5d-0fd6c1af4f64/12613555f622bf17c91a6d0d68fd7aa7/aspnetcore-runtime-9.0.1-win-x64.zip",
-            "hash": "613492bec0899bc451b11c572024feca2e068a471f2275b55b276c0eae85a695e2b7582b07101b9bc75e32cba6c198dc50ca65df0564e1c4c0241fe45db60c7d"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41921adc-acf1-4274-869a-ae605234f513/137993139816c6db85bdafc82facebab/aspnetcore-runtime-9.0.1-win-x86.exe",
-            "hash": "1a93e0d6df3eed98fc46ff5877fe7796f2aa4e01b3dcfb1b566cc68dcd3bcfe400e556f7f82fc99c1c53af7d496a319ee54dc67f01ed7ea43ea8a6a555813134"
-          },
-          {
-            "name": "aspnetcore-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dac9d379-bc70-4bcf-994b-14dde1467256/5999be7787bd5264aeaadae246cb0e22/aspnetcore-runtime-9.0.1-win-x86.zip",
-            "hash": "915335f60d3ef189c599372c2043b9a115cf538a22f3f6297070cab2913a89517ca69ecbc7aa2a600c8f0ff5ba86d77e992d3d2cb5d5d5eb21b8669e7694428b"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d66b5069-33c6-458b-a23c-55f2371fa9e9/aada72716d2b7c511e16fc5b3469da7e/aspnetcore-runtime-composite-9.0.1-linux-arm.tar.gz",
-            "hash": "ac2c004657e3f1c65d1b338272aecd16445b5130eab9dd1229440b0bbb29b9d2a94ed7cb4f2d5d7325dfce8b19ea64da3008403d4b18cc251781d6543bd94052"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/56dc5b89-ff34-467b-bdd0-16a93f2bd854/f6575b298c84d7b4f2f92377b0b3a736/aspnetcore-runtime-composite-9.0.1-linux-arm64.tar.gz",
-            "hash": "28cafe4ca6061397a1eafb21ee0ce5fee850c4368633ca16773208620ac47a6b94f35a0890740112118743b92e6652e46e27eff0b8d6a8a053ae4fd9af62f226"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8b8f6a71-419c-423e-92e8-d863f2868849/e012a04c7cbc0dc480df47152cf0f907/aspnetcore-runtime-composite-9.0.1-linux-musl-arm.tar.gz",
-            "hash": "46deba46b4458a3546da4db8118798d8baf5a230f1691c9a9745771a80f48a50c93a0ea56d0348fdbbdd9952eb397f8e1153274e0aeccb8e1d91f68f700f30cf"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d07d7f41-0df6-4eb5-96c9-474bd766a844/aaec7ce41fea5cf7da88aa816fac1e2d/aspnetcore-runtime-composite-9.0.1-linux-musl-arm64.tar.gz",
-            "hash": "5de05d1c2a12a4276d788295a78484360f2a65a99dab935469696bc8588d8a23a10ccdbc777df9dc9445dda7541e33f4f583ef7b00d06cfbcdfd43339cffa809"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e13dce8b-68b2-4841-b80b-ebefe704e5c4/f31b12d1c2e66bc6b660769664e2fdde/aspnetcore-runtime-composite-9.0.1-linux-musl-x64.tar.gz",
-            "hash": "fff2915b8bfe74fd4d882ed2d0a2e9d82c174e6ac186cfce7b28f87ef3043145e19d9be7f60b90e9af7b6532ee75b3e527a360f2fac4574e4b248b3ce3fe4367"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/abe4d958-5ae2-479d-86e6-c64393b0bd10/a70087aacb760aa42e3a1e52d1eefbe7/aspnetcore-runtime-composite-9.0.1-linux-x64.tar.gz",
-            "hash": "ce1034cc058d68869edacd5ed1feb8ff4a3e5a2931ee057789413da7fe17ce484ea563ab9f38a7d2c2d53d7a91d47e32680da7ed0953f81ff42b56489b8e47d0"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/450a6e4e-e4e3-4ed6-86a2-6a6f840e5a51/3629f0822ccc2ce265cf5e88b5b567cb/dotnet-hosting-9.0.1-win.exe",
-            "hash": "aa468f04071201827889d97bdf4c899bde5dd5ef9590b368761a40d5bf1db75ed7e647cc8580bd0f5676035e35d52c2e9b687f2dffc2995a372326f786145d6a",
-            "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
-          }
-        ]
-      },
-      "windowsdesktop": {
-        "version": "9.0.1",
-        "version-display": "9.0.1",
-        "files": [
-          {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4f816906-ea17-4076-b207-a66b4e06cb90/3bbcd6b97900356387435220ebf631e8/windowsdesktop-runtime-9.0.1-win-arm64.exe",
-            "hash": "df2c1a51ef9b1118b7a5f3cc20df25b7616b3340b62abcb2cebc383ec188ac2e955bf4804f2066a0848614b249f2e3149751a932912d4a6a12383add69817806"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/fa64dc36-e7ac-4742-8ff5-5c17eea57d24/528acce3232887137f7d24aecc67c131/windowsdesktop-runtime-9.0.1-win-arm64.zip",
-            "hash": "c62e4586129b9597cc8c323e6ed88e43ed6cf84836f33b2c86a30be25b8eb2d8ebeabcc50aaf16233a319d052d5e277c5bee59a541a811a94334f83d040b02d4"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ae0291d4-bcdc-4e56-a952-4f7d84bf2673/1bc4a93f466aab309776931e5a5c4eb4/windowsdesktop-runtime-9.0.1-win-x64.exe",
-            "hash": "4ad450ba0f0efed458a07f8d1ed8c5e75b78c349d6cd2b3374b190f878b3af80119e6797861a5ce2f9ad61216fb85ed046bfd905bd3006e940bd86bc0164ae46"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e274cb3b-49b9-451e-aa84-be569ed98eb7/61c81caf06d1d11a2fb6eb0f68555097/windowsdesktop-runtime-9.0.1-win-x64.zip",
-            "hash": "1256825e6d82cc05c19ae006f64171f63ae1b9114fca9d40666e665460c9a4e3d48a8afad1fca15c0b94b16a783fdf3c455298fe599bcd5a2c3509f9499389be"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/dcd86c7a-9e55-4cc0-8c71-b99ece1350c4/7cc9c0996933075f56ad69c1169e0c1c/windowsdesktop-runtime-9.0.1-win-x86.exe",
-            "hash": "b67c00b76ed6a601ee50cdc84126cec50d4f8f3d39f0280360555b600a38220ad683290b5fd5f3fe5b9bd6984fef8ce2f39f7ba82d417fb85b3801e41586911f"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/eb821758-fbac-46a2-aa38-e908c0e94b9f/fe3b0722e3c2a0fb9ee8976ac5443c2b/windowsdesktop-runtime-9.0.1-win-x86.zip",
-            "hash": "15fe87903087a705759ba6477cc9e4ad841c2ff44bab3583e56fa06d7daa3c25de1bb91da5bb2f91da996443704fcb459410ace7563ecb06dc107cf292820eb3"
-          }
-        ]
       }
-    }    
-  ]
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.1",
+      "version-display": "9.0.1",
+      "version-aspnetcoremodule": [
+        "19.0.24346.1"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/463fb01d-fcad-46bf-8e5f-0e568bb9ccf4/a3ac380fdc1e29ec25e5fa0a292a61df/aspnetcore-runtime-9.0.1-linux-arm.tar.gz",
+          "hash": "fa75d8d5ae99ade0d1ab90018839fe3f5ddc4e7b7461715caf2b0bf7a88c8e86e1d4f10ab69703d2318b289c0700846e2155746d7bb1ace3d2d12e175ab18be1"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a193300-e0b1-4e9e-acc4-a4a695c7b94a/f197be75380aaa333c949bb8a1fe0510/aspnetcore-runtime-9.0.1-linux-arm64.tar.gz",
+          "hash": "e37dc1445e53c00bd950a531fab83354defbbe06c6f73af4bbef20bfcedc0483a98f478369a7bc7d7e52e35b2b33ad73781e255b46900d831e2770cd445d69c5"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2cfd68f3-5259-451d-83b1-6b5e80932813/bae5e023e887e42639426dd0824ac6bf/aspnetcore-runtime-9.0.1-linux-musl-arm.tar.gz",
+          "hash": "3ea55cc5098dc08909a385219fad1e38635f6eef6cd66ea526b92dd57f765dc348380422e5e0b9c8ade286e18e713caa4b7ff2d06a23c3fed31b8b5c91d2dc6b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3b0e483-26b2-4115-8a8d-983c9b0ca58a/4d0058d82438c8de99347f40d3dee091/aspnetcore-runtime-9.0.1-linux-musl-arm64.tar.gz",
+          "hash": "e9a7e257f6b09e48c522b725be8ab498e57189d6687f840a37ab9fe4192e985bddd99a663418c5d5d96ee7c7c2b9f70e08f786aa4a1b207548586bd3fcc3710e"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d55550d5-16dc-4b17-90c7-e8bf65657e09/b3d4c31dd4c933aaa50e920f5465b111/aspnetcore-runtime-9.0.1-linux-musl-x64.tar.gz",
+          "hash": "d3f609184959849f7524fdfb55c5cf9a8391d0a773483aa6659d9baa152656835f26c2fe9ba322e718a8eb7781fb996eb4ebc6953beaf6fdfb5628ef31bfc853"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/78308995-ac02-4bed-b5c3-eefb06ff907c/795e0c20df95d8c432fda2a189235b67/aspnetcore-runtime-9.0.1-linux-x64.tar.gz",
+          "hash": "e5fc3093aed5756deae3e61f98b9f4bb0c847319db30cbd1668c2511e06529c2f6a5e1917ec776fe2b36a1f7bb7e009fc925fee57f87696a8d502a6c8f5dc613"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/26f85624-0eaf-4edc-a83f-428472ab31df/ba32371bac29f1738b9b0eb959dab0a3/aspnetcore-runtime-9.0.1-osx-arm64.tar.gz",
+          "hash": "b8ab3899b10b871159b01889694484cc3d9b3ae78a159638d68649a22c3f3328b92c435c5bcdf49a86bc488bbbd0fca7143f6f664f6594c552423c37ead99998"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6655b880-82dc-43d1-b5b2-f76d6a3c431c/4752d9d4811a2148de7eef5dcfd08441/aspnetcore-runtime-9.0.1-osx-x64.tar.gz",
+          "hash": "4aeb0943877dbf935f6554c637d2aa18f8ef22e9692e6cd3d716dde2dd5411e4881767cbe9c554bd8ec43c209a86a26194c2618c60d115ba0638e92e80423cc0"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2985fd4b-f7af-4654-a7a4-e2c14b42af0b/9849c95576f43d40a63016af552b9dd9/aspnetcore-runtime-9.0.1-win-arm64.exe",
+          "hash": "e6e9a564919a63ab268269610b65dd47a03770aa1f4f9fcd4b4f3c1363400e4037eaf4f614e337741abb44c8d97c092efcf63bd200dc05a5686accf97cc1e447"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8e308ca2-de0f-4202-9d52-81b0ed50ce01/169ea645ba895a387192fc9ff160a994/aspnetcore-runtime-9.0.1-win-arm64.zip",
+          "hash": "52c69b68f22a3fa1251716e96a64102fcc97c887ecb3c9a160c59c70e625b2ec8a7ef4f71626f522274a1e5f4c1286bb58b8fa31d4605ca4b3a239439e46472a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3f41e6c7-c80d-4e44-afb4-9b9bc98547b7/d2f0ede399a87d7a4a78c2b5a0f90bf9/aspnetcore-runtime-9.0.1-win-x64.exe",
+          "hash": "82b4237d0589a70ffa5ca37c2ecce6c9548c839acc2215f218e27572a161da7caacd3857553d5a4c331e3f6a3aa3e468c6e9de802dbd63f2dd5c54befb9b047b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0d79cb49-287b-4cf4-af5d-0fd6c1af4f64/12613555f622bf17c91a6d0d68fd7aa7/aspnetcore-runtime-9.0.1-win-x64.zip",
+          "hash": "613492bec0899bc451b11c572024feca2e068a471f2275b55b276c0eae85a695e2b7582b07101b9bc75e32cba6c198dc50ca65df0564e1c4c0241fe45db60c7d"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41921adc-acf1-4274-869a-ae605234f513/137993139816c6db85bdafc82facebab/aspnetcore-runtime-9.0.1-win-x86.exe",
+          "hash": "1a93e0d6df3eed98fc46ff5877fe7796f2aa4e01b3dcfb1b566cc68dcd3bcfe400e556f7f82fc99c1c53af7d496a319ee54dc67f01ed7ea43ea8a6a555813134"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dac9d379-bc70-4bcf-994b-14dde1467256/5999be7787bd5264aeaadae246cb0e22/aspnetcore-runtime-9.0.1-win-x86.zip",
+          "hash": "915335f60d3ef189c599372c2043b9a115cf538a22f3f6297070cab2913a89517ca69ecbc7aa2a600c8f0ff5ba86d77e992d3d2cb5d5d5eb21b8669e7694428b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d66b5069-33c6-458b-a23c-55f2371fa9e9/aada72716d2b7c511e16fc5b3469da7e/aspnetcore-runtime-composite-9.0.1-linux-arm.tar.gz",
+          "hash": "ac2c004657e3f1c65d1b338272aecd16445b5130eab9dd1229440b0bbb29b9d2a94ed7cb4f2d5d7325dfce8b19ea64da3008403d4b18cc251781d6543bd94052"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/56dc5b89-ff34-467b-bdd0-16a93f2bd854/f6575b298c84d7b4f2f92377b0b3a736/aspnetcore-runtime-composite-9.0.1-linux-arm64.tar.gz",
+          "hash": "28cafe4ca6061397a1eafb21ee0ce5fee850c4368633ca16773208620ac47a6b94f35a0890740112118743b92e6652e46e27eff0b8d6a8a053ae4fd9af62f226"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8b8f6a71-419c-423e-92e8-d863f2868849/e012a04c7cbc0dc480df47152cf0f907/aspnetcore-runtime-composite-9.0.1-linux-musl-arm.tar.gz",
+          "hash": "46deba46b4458a3546da4db8118798d8baf5a230f1691c9a9745771a80f48a50c93a0ea56d0348fdbbdd9952eb397f8e1153274e0aeccb8e1d91f68f700f30cf"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d07d7f41-0df6-4eb5-96c9-474bd766a844/aaec7ce41fea5cf7da88aa816fac1e2d/aspnetcore-runtime-composite-9.0.1-linux-musl-arm64.tar.gz",
+          "hash": "5de05d1c2a12a4276d788295a78484360f2a65a99dab935469696bc8588d8a23a10ccdbc777df9dc9445dda7541e33f4f583ef7b00d06cfbcdfd43339cffa809"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e13dce8b-68b2-4841-b80b-ebefe704e5c4/f31b12d1c2e66bc6b660769664e2fdde/aspnetcore-runtime-composite-9.0.1-linux-musl-x64.tar.gz",
+          "hash": "fff2915b8bfe74fd4d882ed2d0a2e9d82c174e6ac186cfce7b28f87ef3043145e19d9be7f60b90e9af7b6532ee75b3e527a360f2fac4574e4b248b3ce3fe4367"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/abe4d958-5ae2-479d-86e6-c64393b0bd10/a70087aacb760aa42e3a1e52d1eefbe7/aspnetcore-runtime-composite-9.0.1-linux-x64.tar.gz",
+          "hash": "ce1034cc058d68869edacd5ed1feb8ff4a3e5a2931ee057789413da7fe17ce484ea563ab9f38a7d2c2d53d7a91d47e32680da7ed0953f81ff42b56489b8e47d0"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/450a6e4e-e4e3-4ed6-86a2-6a6f840e5a51/3629f0822ccc2ce265cf5e88b5b567cb/dotnet-hosting-9.0.1-win.exe",
+          "hash": "aa468f04071201827889d97bdf4c899bde5dd5ef9590b368761a40d5bf1db75ed7e647cc8580bd0f5676035e35d52c2e9b687f2dffc2995a372326f786145d6a",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.1",
+      "version-display": "9.0.1",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4f816906-ea17-4076-b207-a66b4e06cb90/3bbcd6b97900356387435220ebf631e8/windowsdesktop-runtime-9.0.1-win-arm64.exe",
+          "hash": "df2c1a51ef9b1118b7a5f3cc20df25b7616b3340b62abcb2cebc383ec188ac2e955bf4804f2066a0848614b249f2e3149751a932912d4a6a12383add69817806"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fa64dc36-e7ac-4742-8ff5-5c17eea57d24/528acce3232887137f7d24aecc67c131/windowsdesktop-runtime-9.0.1-win-arm64.zip",
+          "hash": "c62e4586129b9597cc8c323e6ed88e43ed6cf84836f33b2c86a30be25b8eb2d8ebeabcc50aaf16233a319d052d5e277c5bee59a541a811a94334f83d040b02d4"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ae0291d4-bcdc-4e56-a952-4f7d84bf2673/1bc4a93f466aab309776931e5a5c4eb4/windowsdesktop-runtime-9.0.1-win-x64.exe",
+          "hash": "4ad450ba0f0efed458a07f8d1ed8c5e75b78c349d6cd2b3374b190f878b3af80119e6797861a5ce2f9ad61216fb85ed046bfd905bd3006e940bd86bc0164ae46"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e274cb3b-49b9-451e-aa84-be569ed98eb7/61c81caf06d1d11a2fb6eb0f68555097/windowsdesktop-runtime-9.0.1-win-x64.zip",
+          "hash": "1256825e6d82cc05c19ae006f64171f63ae1b9114fca9d40666e665460c9a4e3d48a8afad1fca15c0b94b16a783fdf3c455298fe599bcd5a2c3509f9499389be"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/dcd86c7a-9e55-4cc0-8c71-b99ece1350c4/7cc9c0996933075f56ad69c1169e0c1c/windowsdesktop-runtime-9.0.1-win-x86.exe",
+          "hash": "b67c00b76ed6a601ee50cdc84126cec50d4f8f3d39f0280360555b600a38220ad683290b5fd5f3fe5b9bd6984fef8ce2f39f7ba82d417fb85b3801e41586911f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/eb821758-fbac-46a2-aa38-e908c0e94b9f/fe3b0722e3c2a0fb9ee8976ac5443c2b/windowsdesktop-runtime-9.0.1-win-x86.zip",
+          "hash": "15fe87903087a705759ba6477cc9e4ad841c2ff44bab3583e56fa06d7daa3c25de1bb91da5bb2f91da996443704fcb459410ace7563ecb06dc107cf292820eb3"
+        }
+      ]
+    }
+  }
 }

--- a/release-notes/9.0/9.0.2/release.json
+++ b/release-notes/9.0/9.0.2/release.json
@@ -1,120 +1,227 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-02-11",
-  "release-version": "9.0.2",
-  "security": false,
-  "releases": [
-    {
-      "release-date": "2025-02-11",
-      "release-version": "9.0.2",
-      "security": false,
-      "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.2/9.0.2.md",
-      "runtime": {
-        "version": "9.0.2",
-        "version-display": "9.0.2",
-        "vs-version": "17.12.5, 17.13.0",
-        "vs-mac-version": "",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6ad62cc2-7db5-4961-9192-84d50536b636/19e78b86ce8b40becdca65a7b7e8d8df/dotnet-runtime-9.0.2-linux-arm.tar.gz",
-            "hash": "be31b790c8a5347c1a7fb75ecbbab16c675ff5e6352561631220b94d417f19eed07220d5c3972905123704dd6bd67d00138ff42484815e0def7d8ad916a30d94"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3658cac0-6e40-4467-af08-02cf5bc0309c/ad2d0efa6e2bf05fd1078182d232f052/dotnet-runtime-9.0.2-linux-arm64.tar.gz",
-            "hash": "460133ddc2582a209bd80673721e7b9add2b9b2967ef1503a7dc29be2777870870990ee7549351e8207c3e3e84dabeca6d5bdbbdea75e5e3e749eb16bd13e7ef"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/efa5ec39-7af0-4941-9886-6c37758df9cd/9b0910cf8f0be4645fd7bde1f2665e5c/dotnet-runtime-9.0.2-linux-musl-arm.tar.gz",
-            "hash": "38e03d8c12fa4520e311cf2d15fb2c2f0e019c7165b13fcbe58fc46914743ecea8e0ac4d914385b1430cfb5e0df3db6299424cfdccea6ffe469a681e2d9d93b7"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5a74dfdf-3b5d-4e92-bd17-878401c55dd5/a9fcf25e0571144a1cf08b23da3476fc/dotnet-runtime-9.0.2-linux-musl-arm64.tar.gz",
-            "hash": "0bb0dc7a4388c5b95d4fec9fe7ca1273f9afa502021c73eb946ed2928d6d6d0836414400f667eff30da97b83b04f66d3032c2344bb2587007b4001d75b696a16"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e848109e-b3a7-4496-ae31-345b92345a81/78db157b0850dd7d9ce22c908d53154f/dotnet-runtime-9.0.2-linux-musl-x64.tar.gz",
-            "hash": "df116ef9b7f6b717b7c7f057e826c9e1f1ed0d743fa6b26e9229fc36e500ab834d19ae1ab55ebc28b1c9b8cb4a7f41c62edd08c2dd2cdcb6e912defea2810ffb"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a15e92d8-e1db-402c-b06d-b6dcf7ad58eb/8c4233bceadcf8f57b40f64aceda69f7/dotnet-runtime-9.0.2-linux-x64.tar.gz",
-            "hash": "dc4af24d5d298392fd53491a56c6d4e3d1e85e3e294cb4a848c7ac8f0dce287f11dcb274f18f95f7db7195681386e5c6b0d99500808c1b3e68b9c6097a3484d7"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.pkg",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/016550c2-bc46-43e1-9a9b-31ddb92608ed/7f2a45a4560de9ce447a681162e2e753/dotnet-runtime-9.0.2-osx-arm64.pkg",
-            "hash": "18e680670708b1230786c1433f8126c926d261d6516917f2d65a9038f819eb1deeea473e5f14e74020c68e6d67e393ef1f69c70f6220d1d7d0482802cdd6460b"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e559996-ff59-4cdb-8a91-e6c7d7235f4e/e5766287ef607672cc47be8119afc28a/dotnet-runtime-9.0.2-osx-arm64.tar.gz",
-            "hash": "5ad890311607a5fb14f9a64103acd76385781e4b75085a8e755da474ffc1d50730bb8064e8bafb117afdb9d04ceacbd58452539f1e0e63be0b9731e19fd65156"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8639e61e-f1da-4e5b-a3d1-f1a92f726b3d/4a1f32a0db1e3858dee4f2f3823941e3/dotnet-runtime-9.0.2-osx-x64.pkg",
-            "hash": "a9bb2cda7b53410880cecd51ba9798f0b4872e4327f4f5a619876f6d85b24bdf83f134f523edfa547640993c1e87f1a61c4f42ad738887d10d665ca7b597ec48"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b5a5d3a4-2054-499f-99e2-cf64bbc7ad24/bf987a5f19a84196621b725b9e41b332/dotnet-runtime-9.0.2-osx-x64.tar.gz",
-            "hash": "abe0752f3437ce0e2415d1f70879b6b062dfda59128ef5b96db946639b506a54cac81845b6775d19014d52271abeb8dfaacfeb783452b98f66265c5efb1b3b55"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/13aefe6a-ec97-4166-9b8c-278d026a8db9/58b4801e50bdfd60eedef192248cb8fd/dotnet-runtime-9.0.2-win-arm64.exe",
-            "hash": "d66e00748adcf3d43124cfaff1bb6122dc984ee20a488966e1d6a36b3c83671b91100f985812d1553d52498e8b40d5eccbad87a4778c5aa4c6debe5ca59390d2"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f54f2ae-49f3-4c94-a49a-4a4a5331d106/8b71ca2d99b8a4c7360d4dbfcf9b4b1b/dotnet-runtime-9.0.2-win-arm64.zip",
-            "hash": "2fa9ff1951b62399e3b201e8c247f6646e9c2099ea302bf5b18e5a00e156017f438c6c68d3c7b634f744c250d8acdc8eef6e17bab6f25982ef5f0e36a5f8be90"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5b463-833d-4275-bcaf-5e10c24b31fd/f55af40f168e104e5d93aa1998879570/dotnet-runtime-9.0.2-win-x64.exe",
-            "hash": "da1d1ba1973d24bb42cf511d12931de88fd1e73efe26690fef60c61d20a6ca63018fd59d5a358f5a7a2bc8219ea294e0fb2786dbcea7d6c05b0a007ffef76e3c"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1b2400e-b3c9-487d-af4c-f46d78e24752/3769330a99d7556c0f625e657fe9b361/dotnet-runtime-9.0.2-win-x64.zip",
-            "hash": "a8c9402fab7f9f9afefea433e2f35f894f8411ea9b7139321b4dd4cc1a39cce59c678158dc0178e376d5bdd11bbdd48c1c748b7d0fdf7cbea7a8c5f8b7afb987"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e6149c1-93a5-4c39-93f7-acedb3b8f576/01b7d995fb8cf6d87d71bc625b61dc96/dotnet-runtime-9.0.2-win-x86.exe",
-            "hash": "d86fc1c6473d9a365a43b39da988b39a9a008f2c3fdde8b68cc6e0893af1e99a9fb5473a10128d55e3e02e808db088438431cce4610153fe3c4d0aadcaf6c7c5"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/25bb6f46-a94f-4ebf-952a-52c5d2310240/fc7a4440f6d8020483821e437d40cf5e/dotnet-runtime-9.0.2-win-x86.zip",
-            "hash": "ed9cb618e20abe5a03a2d132e6ededd7ef1e4338e61edbc301063ab2d82287cf9781e1e1738d175e73de751f3359671ed35d36e76bc6688485e6b2e0a2bf9864"
-          }
-        ]
-      },
-      "sdk": {
+  "release": {
+    "release-date": "2025-02-11",
+    "release-version": "9.0.2",
+    "security": false,
+    "cve-list": [],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.2/9.0.2.md",
+    "runtime": {
+      "version": "9.0.2",
+      "version-display": "9.0.2",
+      "vs-version": "17.12.5, 17.13.0",
+      "vs-mac-version": "",
+      "files": [
+        {
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6ad62cc2-7db5-4961-9192-84d50536b636/19e78b86ce8b40becdca65a7b7e8d8df/dotnet-runtime-9.0.2-linux-arm.tar.gz",
+          "hash": "be31b790c8a5347c1a7fb75ecbbab16c675ff5e6352561631220b94d417f19eed07220d5c3972905123704dd6bd67d00138ff42484815e0def7d8ad916a30d94"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3658cac0-6e40-4467-af08-02cf5bc0309c/ad2d0efa6e2bf05fd1078182d232f052/dotnet-runtime-9.0.2-linux-arm64.tar.gz",
+          "hash": "460133ddc2582a209bd80673721e7b9add2b9b2967ef1503a7dc29be2777870870990ee7549351e8207c3e3e84dabeca6d5bdbbdea75e5e3e749eb16bd13e7ef"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/efa5ec39-7af0-4941-9886-6c37758df9cd/9b0910cf8f0be4645fd7bde1f2665e5c/dotnet-runtime-9.0.2-linux-musl-arm.tar.gz",
+          "hash": "38e03d8c12fa4520e311cf2d15fb2c2f0e019c7165b13fcbe58fc46914743ecea8e0ac4d914385b1430cfb5e0df3db6299424cfdccea6ffe469a681e2d9d93b7"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5a74dfdf-3b5d-4e92-bd17-878401c55dd5/a9fcf25e0571144a1cf08b23da3476fc/dotnet-runtime-9.0.2-linux-musl-arm64.tar.gz",
+          "hash": "0bb0dc7a4388c5b95d4fec9fe7ca1273f9afa502021c73eb946ed2928d6d6d0836414400f667eff30da97b83b04f66d3032c2344bb2587007b4001d75b696a16"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e848109e-b3a7-4496-ae31-345b92345a81/78db157b0850dd7d9ce22c908d53154f/dotnet-runtime-9.0.2-linux-musl-x64.tar.gz",
+          "hash": "df116ef9b7f6b717b7c7f057e826c9e1f1ed0d743fa6b26e9229fc36e500ab834d19ae1ab55ebc28b1c9b8cb4a7f41c62edd08c2dd2cdcb6e912defea2810ffb"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a15e92d8-e1db-402c-b06d-b6dcf7ad58eb/8c4233bceadcf8f57b40f64aceda69f7/dotnet-runtime-9.0.2-linux-x64.tar.gz",
+          "hash": "dc4af24d5d298392fd53491a56c6d4e3d1e85e3e294cb4a848c7ac8f0dce287f11dcb274f18f95f7db7195681386e5c6b0d99500808c1b3e68b9c6097a3484d7"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/016550c2-bc46-43e1-9a9b-31ddb92608ed/7f2a45a4560de9ce447a681162e2e753/dotnet-runtime-9.0.2-osx-arm64.pkg",
+          "hash": "18e680670708b1230786c1433f8126c926d261d6516917f2d65a9038f819eb1deeea473e5f14e74020c68e6d67e393ef1f69c70f6220d1d7d0482802cdd6460b"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4e559996-ff59-4cdb-8a91-e6c7d7235f4e/e5766287ef607672cc47be8119afc28a/dotnet-runtime-9.0.2-osx-arm64.tar.gz",
+          "hash": "5ad890311607a5fb14f9a64103acd76385781e4b75085a8e755da474ffc1d50730bb8064e8bafb117afdb9d04ceacbd58452539f1e0e63be0b9731e19fd65156"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8639e61e-f1da-4e5b-a3d1-f1a92f726b3d/4a1f32a0db1e3858dee4f2f3823941e3/dotnet-runtime-9.0.2-osx-x64.pkg",
+          "hash": "a9bb2cda7b53410880cecd51ba9798f0b4872e4327f4f5a619876f6d85b24bdf83f134f523edfa547640993c1e87f1a61c4f42ad738887d10d665ca7b597ec48"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5a5d3a4-2054-499f-99e2-cf64bbc7ad24/bf987a5f19a84196621b725b9e41b332/dotnet-runtime-9.0.2-osx-x64.tar.gz",
+          "hash": "abe0752f3437ce0e2415d1f70879b6b062dfda59128ef5b96db946639b506a54cac81845b6775d19014d52271abeb8dfaacfeb783452b98f66265c5efb1b3b55"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/13aefe6a-ec97-4166-9b8c-278d026a8db9/58b4801e50bdfd60eedef192248cb8fd/dotnet-runtime-9.0.2-win-arm64.exe",
+          "hash": "d66e00748adcf3d43124cfaff1bb6122dc984ee20a488966e1d6a36b3c83671b91100f985812d1553d52498e8b40d5eccbad87a4778c5aa4c6debe5ca59390d2"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9f54f2ae-49f3-4c94-a49a-4a4a5331d106/8b71ca2d99b8a4c7360d4dbfcf9b4b1b/dotnet-runtime-9.0.2-win-arm64.zip",
+          "hash": "2fa9ff1951b62399e3b201e8c247f6646e9c2099ea302bf5b18e5a00e156017f438c6c68d3c7b634f744c250d8acdc8eef6e17bab6f25982ef5f0e36a5f8be90"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f3a5b463-833d-4275-bcaf-5e10c24b31fd/f55af40f168e104e5d93aa1998879570/dotnet-runtime-9.0.2-win-x64.exe",
+          "hash": "da1d1ba1973d24bb42cf511d12931de88fd1e73efe26690fef60c61d20a6ca63018fd59d5a358f5a7a2bc8219ea294e0fb2786dbcea7d6c05b0a007ffef76e3c"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a1b2400e-b3c9-487d-af4c-f46d78e24752/3769330a99d7556c0f625e657fe9b361/dotnet-runtime-9.0.2-win-x64.zip",
+          "hash": "a8c9402fab7f9f9afefea433e2f35f894f8411ea9b7139321b4dd4cc1a39cce59c678158dc0178e376d5bdd11bbdd48c1c748b7d0fdf7cbea7a8c5f8b7afb987"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4e6149c1-93a5-4c39-93f7-acedb3b8f576/01b7d995fb8cf6d87d71bc625b61dc96/dotnet-runtime-9.0.2-win-x86.exe",
+          "hash": "d86fc1c6473d9a365a43b39da988b39a9a008f2c3fdde8b68cc6e0893af1e99a9fb5473a10128d55e3e02e808db088438431cce4610153fe3c4d0aadcaf6c7c5"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/25bb6f46-a94f-4ebf-952a-52c5d2310240/fc7a4440f6d8020483821e437d40cf5e/dotnet-runtime-9.0.2-win-x86.zip",
+          "hash": "ed9cb618e20abe5a03a2d132e6ededd7ef1e4338e61edbc301063ab2d82287cf9781e1e1738d175e73de751f3359671ed35d36e76bc6688485e6b2e0a2bf9864"
+        }
+      ]
+    },
+    "sdk": {
+      "version": "9.0.200",
+      "version-display": "9.0.200",
+      "runtime-version": "9.0.2",
+      "vs-version": "17.13.0",
+      "vs-mac-version": "",
+      "vs-support": "Visual Studio 2022 (v17.13)",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "17.13",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3dde7d92-2a9d-44a5-8e83-6ef57d976c93/dddb3f71a8145f2729c38570694f95c3/dotnet-sdk-9.0.200-linux-arm.tar.gz",
+          "hash": "476a9a686af234482ea99ef53fd1a3b6bd65e4ef5f24eb1e2e94b60f146e7b7e7b99519a66a896836682e702007027a04e10ede857fc4540c3bae56b16cb3780"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b94570d9-8cb1-4672-be62-4acaa8675749/2697b4ae3923b16e72f6443f30333f5d/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
+          "hash": "c2d18644243d67d103471713f0e9ba659df0c0d5e098bd441310418dd03798d6a5a8539da7c8cc320d57085c193c753ff78bdff8a97a97c51f500433538fb722"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f65430d6-4ddf-4ed4-a91c-025933457f61/8e0766a17389dd840585ddc440431e19/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
+          "hash": "4297ed3b4f112e1d64a6617cb96191bfb4ebf6a5fbd01c75de6c0592897173f011aef3d9be7e61738e0c8ce8ba1815b06f28e0c251c840f2e0de2630d36616ca"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/071e3ccf-eb10-4658-814b-c86dc60525ee/2ef91c84593fb6f465082ee069502085/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
+          "hash": "f1a70807e0a2b5ee272bdd714535a2fa3d31bb8c2216b43c151a72cb364f64a6f893590baeebc7dfb2b78ff50e4ba11c3e4cadf11c75744404fefabdc7ff08db"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/625fe095-f8b3-4666-a4ab-b44931f482bf/bbc206404c3e402749523e37063931b3/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
+          "hash": "96b032d5209a838e97522528963e2e9589f8384dff4292e567030b0da0849104a57cd6d0f05e5fb7e7787730f47c6112a014df17c76010864f55c110a971f216"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3606de37-1325-4f5f-bbe9-1bc44b3c1c7f/91872629e9f0c205cace9c462d5e89a4/dotnet-sdk-9.0.200-linux-x64.tar.gz",
+          "hash": "1af5f3a444419b3f5cf99cb03ee740722722478226d0aff27ad41b1d11e69d73497e25c07ef06a6df9e73fb0fbdc4b9baca9accec95654d9ee7be4d5a5c3ac23"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b5dfd4eb-19f4-4ba5-9a0c-50af354aa434/3f307be41112d4a8de659535e8badff2/dotnet-sdk-9.0.200-osx-arm64.pkg",
+          "hash": "5f7528922738e520edf714cee636d8e1b44c62d1af984804ca00508f22bff54776a232cdd1e94d386c1d70fc02219f8e4d05db9b449bbe7853fdce284e5fc8db"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/be46fe4d-4225-4681-a301-8d2bd5c2e044/362014a73e57d02b9ffce618c5ab46e9/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
+          "hash": "a45d5a6fe5f046e9cd0a4482a41f0884822903134bcd2f25face71e1322749dacc53221cee21f814c6171326da0f64f42204ebd79f633a3bd1075c04fa73d1bc"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/24e6d730-e336-4ba9-a248-4519bdd38251/e35a7403d4b03ffa8ced47dff6b3111f/dotnet-sdk-9.0.200-osx-x64.pkg",
+          "hash": "a9dd1005ae1ab833c0c95a4ca1850e29a01b712b224eddf1edae3f152ea2a212402abb61956dbc8e8804762b10ca980371ddb0735cc950422c9ce3ba08c6f64f"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9983e36c-5e9f-4895-8f56-1d0a61cfa9cf/945b1788d8624457b631a383d55f109b/dotnet-sdk-9.0.200-osx-x64.tar.gz",
+          "hash": "f38a641d17dedf0be24c721cc4f78784050cd5184fb5cc6c04c4b2e6f7602c55fc5a3c80dcf2a1df5ec59aedad42947720510f07b2b3c59b6185b91aff2010ae"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/480881fc-fec9-468f-89de-17b1e50a6cce/bf53315c59df9c14f68398357503f047/dotnet-sdk-9.0.200-win-arm64.exe",
+          "hash": "06d7c4133bf7cb6f72b60b97f11c1f8773291e888f556c355d45dc66e3b36e597ac5562359fb3221b970b28f02649f0693d5109467698310752e0a8dc60f6703"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fde8f9b5-2f06-4a1a-a026-f5f49b686906/1709ada276f45c0e39af4af728e36a16/dotnet-sdk-9.0.200-win-arm64.zip",
+          "hash": "3a996171562f30ac2f4a73d196bcf5ae3077ed5425c4d9aec562116e886dc3a9c20a227753501ac3741a5a8c7473d95a5861100e9d38fc2b09de09193e1bb00f"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/83c595a0-def1-4aba-8284-2fd98007aa3d/5e5b47fb819ee59b2a10485f8cf5a89a/dotnet-sdk-9.0.200-win-x64.exe",
+          "hash": "801d4a40a7bdad5c7b50e75c55c5ab657da44b5d779fe50da5683450e23c595e8b18e6bc9ffb80636ffb347b72e575379cd83c7554dc27f5ba75246169f327a8"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6f8a9285-8627-419c-a2f9-3f9463b06bf3/6d0c9057e0f61f8a6e5708fb9261ff1e/dotnet-sdk-9.0.200-win-x64.zip",
+          "hash": "e274e0e8a0d926c58a2199e020fc5b2c2867689772f51673f655ee853a50a9ca0e435ae5682bb4ae146d1fbc9a40f6d4a7ecff14d5fea24db8a3f67d0dcbf2a9"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0804e70c-d375-4d40-8e62-fe355c58751b/340302fa7a9950697106fa0f87965923/dotnet-sdk-9.0.200-win-x86.exe",
+          "hash": "3ddeb620fc45c623ade58f179e80cea64b7af5b76b0b4b1f65b766df3c5614ce04809f40614ebeb98dd6b4662dc1c2bed38d1f78eadc489360d54e35b98b9904"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9c32ade8-845e-4171-8ab3-777890c8a4a0/f2f3cc161effa1fa31a43ff0aab570e7/dotnet-sdk-9.0.200-win-x86.zip",
+          "hash": "65daea90e55f93abe1484dd86bcf2b447d0caf20fb80734a361f2dba0e6ded2158b40d5a7834c192e51b108fb2205aefc856c2a1b34e363413bc371e3a7f2737"
+        }
+      ]
+    },
+    "sdks": [
+      {
         "version": "9.0.200",
         "version-display": "9.0.200",
         "runtime-version": "9.0.2",
@@ -224,407 +331,295 @@
           }
         ]
       },
-      "sdks": [
-        {
-          "version": "9.0.200",
-          "version-display": "9.0.200",
-          "runtime-version": "9.0.2",
-          "vs-version": "17.13.0",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.13)",
-          "vs-mac-support": "",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "17.13",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3dde7d92-2a9d-44a5-8e83-6ef57d976c93/dddb3f71a8145f2729c38570694f95c3/dotnet-sdk-9.0.200-linux-arm.tar.gz",
-              "hash": "476a9a686af234482ea99ef53fd1a3b6bd65e4ef5f24eb1e2e94b60f146e7b7e7b99519a66a896836682e702007027a04e10ede857fc4540c3bae56b16cb3780"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b94570d9-8cb1-4672-be62-4acaa8675749/2697b4ae3923b16e72f6443f30333f5d/dotnet-sdk-9.0.200-linux-arm64.tar.gz",
-              "hash": "c2d18644243d67d103471713f0e9ba659df0c0d5e098bd441310418dd03798d6a5a8539da7c8cc320d57085c193c753ff78bdff8a97a97c51f500433538fb722"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f65430d6-4ddf-4ed4-a91c-025933457f61/8e0766a17389dd840585ddc440431e19/dotnet-sdk-9.0.200-linux-musl-arm.tar.gz",
-              "hash": "4297ed3b4f112e1d64a6617cb96191bfb4ebf6a5fbd01c75de6c0592897173f011aef3d9be7e61738e0c8ce8ba1815b06f28e0c251c840f2e0de2630d36616ca"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/071e3ccf-eb10-4658-814b-c86dc60525ee/2ef91c84593fb6f465082ee069502085/dotnet-sdk-9.0.200-linux-musl-arm64.tar.gz",
-              "hash": "f1a70807e0a2b5ee272bdd714535a2fa3d31bb8c2216b43c151a72cb364f64a6f893590baeebc7dfb2b78ff50e4ba11c3e4cadf11c75744404fefabdc7ff08db"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/625fe095-f8b3-4666-a4ab-b44931f482bf/bbc206404c3e402749523e37063931b3/dotnet-sdk-9.0.200-linux-musl-x64.tar.gz",
-              "hash": "96b032d5209a838e97522528963e2e9589f8384dff4292e567030b0da0849104a57cd6d0f05e5fb7e7787730f47c6112a014df17c76010864f55c110a971f216"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3606de37-1325-4f5f-bbe9-1bc44b3c1c7f/91872629e9f0c205cace9c462d5e89a4/dotnet-sdk-9.0.200-linux-x64.tar.gz",
-              "hash": "1af5f3a444419b3f5cf99cb03ee740722722478226d0aff27ad41b1d11e69d73497e25c07ef06a6df9e73fb0fbdc4b9baca9accec95654d9ee7be4d5a5c3ac23"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b5dfd4eb-19f4-4ba5-9a0c-50af354aa434/3f307be41112d4a8de659535e8badff2/dotnet-sdk-9.0.200-osx-arm64.pkg",
-              "hash": "5f7528922738e520edf714cee636d8e1b44c62d1af984804ca00508f22bff54776a232cdd1e94d386c1d70fc02219f8e4d05db9b449bbe7853fdce284e5fc8db"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/be46fe4d-4225-4681-a301-8d2bd5c2e044/362014a73e57d02b9ffce618c5ab46e9/dotnet-sdk-9.0.200-osx-arm64.tar.gz",
-              "hash": "a45d5a6fe5f046e9cd0a4482a41f0884822903134bcd2f25face71e1322749dacc53221cee21f814c6171326da0f64f42204ebd79f633a3bd1075c04fa73d1bc"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/24e6d730-e336-4ba9-a248-4519bdd38251/e35a7403d4b03ffa8ced47dff6b3111f/dotnet-sdk-9.0.200-osx-x64.pkg",
-              "hash": "a9dd1005ae1ab833c0c95a4ca1850e29a01b712b224eddf1edae3f152ea2a212402abb61956dbc8e8804762b10ca980371ddb0735cc950422c9ce3ba08c6f64f"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9983e36c-5e9f-4895-8f56-1d0a61cfa9cf/945b1788d8624457b631a383d55f109b/dotnet-sdk-9.0.200-osx-x64.tar.gz",
-              "hash": "f38a641d17dedf0be24c721cc4f78784050cd5184fb5cc6c04c4b2e6f7602c55fc5a3c80dcf2a1df5ec59aedad42947720510f07b2b3c59b6185b91aff2010ae"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/480881fc-fec9-468f-89de-17b1e50a6cce/bf53315c59df9c14f68398357503f047/dotnet-sdk-9.0.200-win-arm64.exe",
-              "hash": "06d7c4133bf7cb6f72b60b97f11c1f8773291e888f556c355d45dc66e3b36e597ac5562359fb3221b970b28f02649f0693d5109467698310752e0a8dc60f6703"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fde8f9b5-2f06-4a1a-a026-f5f49b686906/1709ada276f45c0e39af4af728e36a16/dotnet-sdk-9.0.200-win-arm64.zip",
-              "hash": "3a996171562f30ac2f4a73d196bcf5ae3077ed5425c4d9aec562116e886dc3a9c20a227753501ac3741a5a8c7473d95a5861100e9d38fc2b09de09193e1bb00f"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/83c595a0-def1-4aba-8284-2fd98007aa3d/5e5b47fb819ee59b2a10485f8cf5a89a/dotnet-sdk-9.0.200-win-x64.exe",
-              "hash": "801d4a40a7bdad5c7b50e75c55c5ab657da44b5d779fe50da5683450e23c595e8b18e6bc9ffb80636ffb347b72e575379cd83c7554dc27f5ba75246169f327a8"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6f8a9285-8627-419c-a2f9-3f9463b06bf3/6d0c9057e0f61f8a6e5708fb9261ff1e/dotnet-sdk-9.0.200-win-x64.zip",
-              "hash": "e274e0e8a0d926c58a2199e020fc5b2c2867689772f51673f655ee853a50a9ca0e435ae5682bb4ae146d1fbc9a40f6d4a7ecff14d5fea24db8a3f67d0dcbf2a9"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0804e70c-d375-4d40-8e62-fe355c58751b/340302fa7a9950697106fa0f87965923/dotnet-sdk-9.0.200-win-x86.exe",
-              "hash": "3ddeb620fc45c623ade58f179e80cea64b7af5b76b0b4b1f65b766df3c5614ce04809f40614ebeb98dd6b4662dc1c2bed38d1f78eadc489360d54e35b98b9904"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/9c32ade8-845e-4171-8ab3-777890c8a4a0/f2f3cc161effa1fa31a43ff0aab570e7/dotnet-sdk-9.0.200-win-x86.zip",
-              "hash": "65daea90e55f93abe1484dd86bcf2b447d0caf20fb80734a361f2dba0e6ded2158b40d5a7834c192e51b108fb2205aefc856c2a1b34e363413bc371e3a7f2737"
-            }
-          ]
-        },
-        {
-          "version": "9.0.103",
-          "version-display": "9.0.103",
-          "runtime-version": "9.0.2",
-          "vs-version": "17.12.5",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "vs-mac-support": "",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "17.13",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c2cb3c08-be1a-4b0f-95f3-3c2b2c2371fb/04c3b5830bb78065424666956d65a503/dotnet-sdk-9.0.103-linux-arm.tar.gz",
-              "hash": "9b9ddbbd8a090ee78f40576ac9f3daca5a6845ee39448b10c3bb51b2b4f9e7e0a979b6a00c31da08f3e68601fa77a687a556d079c19d532aee4d7f25bc9f13c9"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/226328f5-ac73-4daa-99dc-04961042c422/18787af4ca8bd7d646534c559e4a3c75/dotnet-sdk-9.0.103-linux-arm64.tar.gz",
-              "hash": "32b5494e77689086e8d5b936434e4e87a8d88039f77c3381d96592757e7d716f58de1003fe41c7ef3a2089366a3205187f56d733d5f9d2f1505d83b1c16d3a0b"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/63a41de4-93be-4cbd-ac13-93d1feec6a30/a6bb2018d1a952daadf70852064686c9/dotnet-sdk-9.0.103-linux-musl-arm.tar.gz",
-              "hash": "663c3351edb0d38b25fa854be092a2cf7b6fefd568f4d7458ff40740b9637605390b48a4acdbb35640d40dc9efe666a6ee2947f10fe9c9a16b9743fd75bcf0d0"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bac1de02-acf7-442c-9caa-5267f24060c0/e94ab7e0015a34f7a76d33d3d0955fbf/dotnet-sdk-9.0.103-linux-musl-arm64.tar.gz",
-              "hash": "bcc5019831f9636d81a87369e1cf56e70dc52c2993eb64468f62029629a610333b23c2062e3f93647bebcbdf7de2aaefa7e9c96d6e96ec161e3a745766ae109f"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0211b6cf-e6b2-4034-b2a4-f47828046fe3/fcbc490417d2ea0114a74aafbb46b92b/dotnet-sdk-9.0.103-linux-musl-x64.tar.gz",
-              "hash": "ac4e2116f99999f249c290e9a87c628f6236f59c65eb7672bbb484cc1159bf739c9585dad80b50ff727335e4bf626e175913156b13a283f175dae7f6a965a542"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/053d1161-da60-4c43-bcf4-cfb91d3d3201/18cad0308294c91e3ca9913a33cb4371/dotnet-sdk-9.0.103-linux-x64.tar.gz",
-              "hash": "afda487365cf2d082f1dc462ff01607eae10657de8281c53c4e8775df72f5ed5b31b427ea8afd0917886e73b104a25db4c607e0510f8be3a761de9445d797b75"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/06a9e1cc-16a2-4054-810d-02538924b96f/c29ef6a7597763178cb3026973e23cf4/dotnet-sdk-9.0.103-osx-arm64.pkg",
-              "hash": "49e9eb2a3ca79b94f9062b130201962415befa18c5365458c1584f52379ab661a3d095e31a4269d068f56feb30285e665b190a925e2c9f1308f5fd93ef5986bf"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c54a9a42-e212-42ce-b00e-ac352d2fc848/3cbf76fac85c39e1eb8ba4a4bd9fcd55/dotnet-sdk-9.0.103-osx-arm64.tar.gz",
-              "hash": "52f29d18f7789bc53d15b0e1e96b83b8811eaecb3eb6035dfb94e2d2f2bb1a011d08b46912805a2860c574913ad338f5f0808ad66310dd87cf78163c3b025925"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/f04372d6-2f53-45fb-b7b1-b91f64ceab57/2d7ccbe05b267ec9c7e08a940638abb6/dotnet-sdk-9.0.103-osx-x64.pkg",
-              "hash": "4f0e90596b5b5d9878f58b28bdadf6fae0e07ffc7903609bf00087a1cda91b6c8d32efd65949f44d77905b456a9956ac1a2d78f71471b5d7569a4b389c34407e"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7306a1d9-153d-4417-9d94-950e2d2d0426/fa4dfb44bce429d39ebbc916e949c3cf/dotnet-sdk-9.0.103-osx-x64.tar.gz",
-              "hash": "7acefa171aacba663589d5c9ead080a808ee60696b789ce89aff88e0626f2085d32a198154a7ec94a8cd5cd272f70bd57e199819b3ec89997ea52e3c0f6b96f0"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a12cf12e-5a09-4ae3-aa2c-6023afa76b67/241a7d94a78c830a9a727e536d9d489c/dotnet-sdk-9.0.103-win-arm64.exe",
-              "hash": "b7a19c6c8c62c9db8605258b4fb21b1a9ea64646ab26f7b055bbe90154d462568d5ce202356f8f81b0cac1a1afe90d89252689f4ee6b65a4d4c27fa17a0e8f31"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/0580d1d7-4ff9-4e8b-9801-fc084507d7cc/f7afd81cc0d6e6f17def4258a617405c/dotnet-sdk-9.0.103-win-arm64.zip",
-              "hash": "e85fae99d88be4e2db63dedea809a97c29a9ff9cde04fb93247cad1feb19119bc7d2d9f4976075af534f8b9dc22af8df60b78a8bdba801a8eea67e521479b443"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/25df6db4-4cf7-4cb2-94aa-1138932e840f/bf87e06f6da564de405d3e9c4f38f025/dotnet-sdk-9.0.103-win-x64.exe",
-              "hash": "a4150ec3c57d2e1c77a889ef9eb6cf913e43c7aa6039a1b156fabfb70862187b60d43161dcde8b4edd606122f3b68e8583ee6438f1303607b7f9f29e9f926e56"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/ab33cf70-527c-4517-9ed1-97056db08896/997dd9b12cce454426babec7e0071bde/dotnet-sdk-9.0.103-win-x64.zip",
-              "hash": "9b691e4a4fc297ced20267975ee84641d4346052f6b5c192d27c05fb273b0a31966a2447277d9a7a948b944306bcaf7b8495ed1c15718d8bf2252e3adb43318e"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/80088bbe-136f-4cc6-9c16-212dd5a39ffc/cd51139a737774c90b1b90f051f42ca6/dotnet-sdk-9.0.103-win-x86.exe",
-              "hash": "282409ca8eb5e5f2e543a6450332436266e079703b8f0640f10f38241d42efb7def82f4509fe7d56a2545dd82cf7d657cb75b54f807eece55930c3dfce0ef726"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2fd8d789-df0d-4031-a8b9-87f7e7a22c4c/a2b6818b1e626904502f3ce5d79d0917/dotnet-sdk-9.0.103-win-x86.zip",
-              "hash": "9c2b5e1e764792abfc4eadb51c3177e6371af3985c15022042a34ef300724019ed38896fd021be27980e535fd128fe0a78ab0cb893ea54d6294301769a92f7a6"
-            }
-          ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "9.0.2",
-        "version-display": "9.0.2",
-        "version-aspnetcoremodule": [
-          "19.0.25017.2"
-        ],
+      {
+        "version": "9.0.103",
+        "version-display": "9.0.103",
+        "runtime-version": "9.0.2",
         "vs-version": "17.12.5",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2022 (v17.12)",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "17.13",
         "files": [
           {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0b7ddf3f-d43d-49c2-be1d-bf59075d85e7/b1da14023ea7fef1fada6c8898635fbb/aspnetcore-runtime-9.0.2-linux-arm.tar.gz",
-            "hash": "5576751ea9414449add100cb60c917f72305209dc831ecd3698b8ef6a69e2a802850148b33caf5a05d049be66b19c7404531ea6ecd643cc1fd6ae61179e1249b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c2cb3c08-be1a-4b0f-95f3-3c2b2c2371fb/04c3b5830bb78065424666956d65a503/dotnet-sdk-9.0.103-linux-arm.tar.gz",
+            "hash": "9b9ddbbd8a090ee78f40576ac9f3daca5a6845ee39448b10c3bb51b2b4f9e7e0a979b6a00c31da08f3e68601fa77a687a556d079c19d532aee4d7f25bc9f13c9"
           },
           {
-            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/744cd467-ac89-4656-9633-ed22e3afb35e/4277cdc84219d6515cb14220ddc0bde3/aspnetcore-runtime-9.0.2-linux-arm64.tar.gz",
-            "hash": "aa95ed396e5012cb7815db25f07b196261b91e4ca2e7ba07352896e1ab351a96232fdb692fbde1d1ddd1c916987353d2d3382e9e16bd7a97ce4b411c6426e0f6"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/226328f5-ac73-4daa-99dc-04961042c422/18787af4ca8bd7d646534c559e4a3c75/dotnet-sdk-9.0.103-linux-arm64.tar.gz",
+            "hash": "32b5494e77689086e8d5b936434e4e87a8d88039f77c3381d96592757e7d716f58de1003fe41c7ef3a2089366a3205187f56d733d5f9d2f1505d83b1c16d3a0b"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5eeaba7e-4140-4e62-b96c-7223293f3bd5/9d8d51b099c3141cdf63597816bd1eb4/aspnetcore-runtime-9.0.2-linux-musl-arm.tar.gz",
-            "hash": "f96a66442f7db558e40491f1deba42a58b697286a8c592f20b9b17006040544c3cde3851dbe9d5dd0be4ff68666575a10a8e1225dc97069081a66726a9f0fc8b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63a41de4-93be-4cbd-ac13-93d1feec6a30/a6bb2018d1a952daadf70852064686c9/dotnet-sdk-9.0.103-linux-musl-arm.tar.gz",
+            "hash": "663c3351edb0d38b25fa854be092a2cf7b6fefd568f4d7458ff40740b9637605390b48a4acdbb35640d40dc9efe666a6ee2947f10fe9c9a16b9743fd75bcf0d0"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/07c2a8a7-1b36-4ed3-b8c6-48674ad102e7/ed621013baa55acb77a88013d28ae14d/aspnetcore-runtime-9.0.2-linux-musl-arm64.tar.gz",
-            "hash": "5e74871d9133c52389559eb34ee82ed7b8ff2ee990857ef80ebf2b27c405e0dee1ae951c9a87355168901d98acfbe37bd6d516d6a0b4f5f495c58326243c0630"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bac1de02-acf7-442c-9caa-5267f24060c0/e94ab7e0015a34f7a76d33d3d0955fbf/dotnet-sdk-9.0.103-linux-musl-arm64.tar.gz",
+            "hash": "bcc5019831f9636d81a87369e1cf56e70dc52c2993eb64468f62029629a610333b23c2062e3f93647bebcbdf7de2aaefa7e9c96d6e96ec161e3a745766ae109f"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/435eb32e-b24f-4c82-b044-6f4b97e7338f/5e79b00ea13180f349e28f127cf1c26a/aspnetcore-runtime-9.0.2-linux-musl-x64.tar.gz",
-            "hash": "ff070ebfabb1fa776df69ce6fb1e6990069ff6e4b795dd0ea0ee028dcceaa278500f695c9ba6b6c839310ee0d9aaca398e079ebd9081ec36c1e2d5a63c5bc109"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0211b6cf-e6b2-4034-b2a4-f47828046fe3/fcbc490417d2ea0114a74aafbb46b92b/dotnet-sdk-9.0.103-linux-musl-x64.tar.gz",
+            "hash": "ac4e2116f99999f249c290e9a87c628f6236f59c65eb7672bbb484cc1159bf739c9585dad80b50ff727335e4bf626e175913156b13a283f175dae7f6a965a542"
           },
           {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36ab7b0d-966a-44ce-ad19-bc0d7e835724/a38c1f97ccc9f4ccce58427c830c32fb/aspnetcore-runtime-9.0.2-linux-x64.tar.gz",
-            "hash": "48a39dd4bee3e719273a4e4404b556e2e59e7f659def49f89745ae575fc976f7ebf121d9263c3d009db6081976f8261ca82de34aef69b0776a28fd0485bb6d3b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/053d1161-da60-4c43-bcf4-cfb91d3d3201/18cad0308294c91e3ca9913a33cb4371/dotnet-sdk-9.0.103-linux-x64.tar.gz",
+            "hash": "afda487365cf2d082f1dc462ff01607eae10657de8281c53c4e8775df72f5ed5b31b427ea8afd0917886e73b104a25db4c607e0510f8be3a761de9445d797b75"
           },
           {
-            "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e3c0776-3b1b-4e34-8dc5-1f764e435f68/3fc575fd1def4bba8258cdf39cf24e35/aspnetcore-runtime-9.0.2-osx-arm64.tar.gz",
-            "hash": "66fcd7a0589fb166d85caebd6f08c16049bdd0cacfd01ab3f199c442b98d54f8610c225a2a9a6f52bc4bce12bba8a3001e23689240996c697e2bc3a008957226"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/06a9e1cc-16a2-4054-810d-02538924b96f/c29ef6a7597763178cb3026973e23cf4/dotnet-sdk-9.0.103-osx-arm64.pkg",
+            "hash": "49e9eb2a3ca79b94f9062b130201962415befa18c5365458c1584f52379ab661a3d095e31a4269d068f56feb30285e665b190a925e2c9f1308f5fd93ef5986bf"
           },
           {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c54a9a42-e212-42ce-b00e-ac352d2fc848/3cbf76fac85c39e1eb8ba4a4bd9fcd55/dotnet-sdk-9.0.103-osx-arm64.tar.gz",
+            "hash": "52f29d18f7789bc53d15b0e1e96b83b8811eaecb3eb6035dfb94e2d2f2bb1a011d08b46912805a2860c574913ad338f5f0808ad66310dd87cf78163c3b025925"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/80ab707c-4568-4bb3-998d-04b1935648dd/cec09318721d7d5e3cdd64e987a1dd8e/aspnetcore-runtime-9.0.2-osx-x64.tar.gz",
-            "hash": "4e3b76bc423e9312b55449ff156bf65044f566445c4106fc47314517651d4d510c0418b1f8f17853b1cbc14769100b846f414f80d6a9cee5f95f5a6fb8547d9a"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f04372d6-2f53-45fb-b7b1-b91f64ceab57/2d7ccbe05b267ec9c7e08a940638abb6/dotnet-sdk-9.0.103-osx-x64.pkg",
+            "hash": "4f0e90596b5b5d9878f58b28bdadf6fae0e07ffc7903609bf00087a1cda91b6c8d32efd65949f44d77905b456a9956ac1a2d78f71471b5d7569a4b389c34407e"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.exe",
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7306a1d9-153d-4417-9d94-950e2d2d0426/fa4dfb44bce429d39ebbc916e949c3cf/dotnet-sdk-9.0.103-osx-x64.tar.gz",
+            "hash": "7acefa171aacba663589d5c9ead080a808ee60696b789ce89aff88e0626f2085d32a198154a7ec94a8cd5cd272f70bd57e199819b3ec89997ea52e3c0f6b96f0"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3575d404-da7d-4461-b032-4090fe1e8378/689e6cf07417805b2ce74c1b807d64f9/aspnetcore-runtime-9.0.2-win-arm64.exe",
-            "hash": "2fda149e90311f5f5bda6be635bbbe23fdcaf95359865a9880ae56e14eb5fbf36e1433ea772ae6427031bd8192bcaf50dbbfaa900044769ef462aeaa2636ad2e"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a12cf12e-5a09-4ae3-aa2c-6023afa76b67/241a7d94a78c830a9a727e536d9d489c/dotnet-sdk-9.0.103-win-arm64.exe",
+            "hash": "b7a19c6c8c62c9db8605258b4fb21b1a9ea64646ab26f7b055bbe90154d462568d5ce202356f8f81b0cac1a1afe90d89252689f4ee6b65a4d4c27fa17a0e8f31"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.zip",
+            "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/47a58b15-5ae9-40ba-836f-2e5f4fac689b/4e4444de85c10de9a950f6a883ba351a/aspnetcore-runtime-9.0.2-win-arm64.zip",
-            "hash": "a9612f88ae232e9dc517f02cb9a4faa605d2c0fda94a33897ba0ddb75979ee2eb09df5c49ad7ea93e90ba0dd5ff933af959a55c4ec9526eee06dbbdcd10a245b"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0580d1d7-4ff9-4e8b-9801-fc084507d7cc/f7afd81cc0d6e6f17def4258a617405c/dotnet-sdk-9.0.103-win-arm64.zip",
+            "hash": "e85fae99d88be4e2db63dedea809a97c29a9ff9cde04fb93247cad1feb19119bc7d2d9f4976075af534f8b9dc22af8df60b78a8bdba801a8eea67e521479b443"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.exe",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ef8f48ce-bf76-4ffc-bb8f-40991ec99b6e/f68b6492c75839333ad8c2fd3ff9c7b4/aspnetcore-runtime-9.0.2-win-x64.exe",
-            "hash": "8a6e225a03319f5995c943b32482f73ae08bdcb20a0f8ad24a049162c5e66d3071f271cad6829202794cc7066391777caa8ad5bd3514ced213ba8093d1e5784c"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/25df6db4-4cf7-4cb2-94aa-1138932e840f/bf87e06f6da564de405d3e9c4f38f025/dotnet-sdk-9.0.103-win-x64.exe",
+            "hash": "a4150ec3c57d2e1c77a889ef9eb6cf913e43c7aa6039a1b156fabfb70862187b60d43161dcde8b4edd606122f3b68e8583ee6438f1303607b7f9f29e9f926e56"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/01a196ac-edf8-4574-b9af-35db73e21094/d55bef75bde4f8a83c28b7913d56a76f/aspnetcore-runtime-9.0.2-win-x64.zip",
-            "hash": "0a5b0d4a0ac65dc0b11b104154143ef310e47b3aa92dbff32e7002d1ea6005b6444a6699eb03a5c728326c6ad97234a1fc9607972a133130727173247111472e"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ab33cf70-527c-4517-9ed1-97056db08896/997dd9b12cce454426babec7e0071bde/dotnet-sdk-9.0.103-win-x64.zip",
+            "hash": "9b691e4a4fc297ced20267975ee84641d4346052f6b5c192d27c05fb273b0a31966a2447277d9a7a948b944306bcaf7b8495ed1c15718d8bf2252e3adb43318e"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b985a5f3-8a2c-4854-a69d-e6a585a277fd/8e9965972940a2efd07b150432ee7f5f/aspnetcore-runtime-9.0.2-win-x86.exe",
-            "hash": "a633235f06943865b4176a919b1601d95618a4e43b3af6d374949700df68e02d0e71629c772a9b78c25bff609993d106621ed34a27856adce650bd47e9961e45"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/80088bbe-136f-4cc6-9c16-212dd5a39ffc/cd51139a737774c90b1b90f051f42ca6/dotnet-sdk-9.0.103-win-x86.exe",
+            "hash": "282409ca8eb5e5f2e543a6450332436266e079703b8f0640f10f38241d42efb7def82f4509fe7d56a2545dd82cf7d657cb75b54f807eece55930c3dfce0ef726"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.zip",
+            "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d2415741-da8d-49b2-b2a6-364799efdfcc/25ff042f508f91f14ed4f25f4a88bf66/aspnetcore-runtime-9.0.2-win-x86.zip",
-            "hash": "2b05a90bb7f59286ca2e6eb631ea49d999a66a8e2e7d3f13e12daeae412a71de073afeff9d1121b89133ed0e8b125f959b3678e5c4fdfa7639ad6eb0ff896762"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ff894111-ac98-4f95-962e-572af715ebda/e5f073c7a5d45544bb135a225bb2419f/aspnetcore-runtime-composite-9.0.2-linux-arm.tar.gz",
-            "hash": "9008fec9c3cc98b9608eb6635f73cb86d37cb721d6f4ba3dbb8eaee4d7adacf832cbef6c223320895656743a82b5a81209c78936973ba469e551dbf05bc40ce9"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4e9c59a5-551f-47c2-9eae-357cea44683c/e6c8fb5bf951847abf28697ca1a8e096/aspnetcore-runtime-composite-9.0.2-linux-arm64.tar.gz",
-            "hash": "8387f486d692f1299cc08f33c57e647000f986e6a69ccb4b426b6a207be28a0b5b6e636bd0d91fa2d9452d0c0bb00e48179e965612b7f66641884430675130e9"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9f40f94b-d02b-4c72-ace9-6987a4e95d58/8da22c3c69dd03f14e1b2a28d2d4f215/aspnetcore-runtime-composite-9.0.2-linux-musl-arm.tar.gz",
-            "hash": "9240868535b83a81f2dff1226be734d5f4d31095988c286455679e1b56a2ba7a56cb7d30d4c6f74d645024ed2526a2d5a2a06dae4194b2ffc2d86a8fbf2a42ef"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c47bb124-30c3-48ae-a1ae-75f3c2b1b974/95554947e0b06df6cb12f851a4d7b4f5/aspnetcore-runtime-composite-9.0.2-linux-musl-arm64.tar.gz",
-            "hash": "cde805a00d9db6de6e57fb573f392df8bcd2f21ef029a6ac22f059b85af635cd4553d9d749d6391b637a9958f3cea3f6430b3c575d217c428758330f864e2841"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4fcfd90f-1cab-4da7-bb8c-4468b6b90735/8153f9dc459a5dc83000b8b4aec6ed64/aspnetcore-runtime-composite-9.0.2-linux-musl-x64.tar.gz",
-            "hash": "7257c9093bb4fe4ce09e2169ccaa8500dd23008464aab7ae50f57e7ec187d8a0a3fad8c8d67fa0561801bce59300839f0d2044b0b4232b0e320d1305662fa465"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b1f88d20-3be3-45d5-942b-b800113c91d7/9f41b6252793ae58d98b5f138150021b/aspnetcore-runtime-composite-9.0.2-linux-x64.tar.gz",
-            "hash": "b819c4421c1110ecadfa4f1e790efb14d9788e7456be016d26023b993dda40c47f22e356483c5c6f00d0941e0daea8cf2c5fe6aa405c7422ec911a46b81b552c"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/785df3b0-8483-4eb0-8826-3cfb0d708ba7/28ad125421135a4fad3f03cea41cd673/dotnet-hosting-9.0.2-win.exe",
-            "hash": "b275c7f67f46d8d65da5fd07dadf52ab544d5f40aad02c12dc24c1460b8a92b6b5ba418101c4a5e29c29e547eb3c1c794e40fb8531a5e4d35233fdc8e12312eb",
-            "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
-          }
-        ]
-      },
-      "windowsdesktop": {
-        "version": "9.0.2",
-        "version-display": "9.0.2",
-        "files": [
-          {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d8b26b48-2f5c-4814-a253-c752a45b504e/2ff9ba5aa7ab19d3736a3c5d9d346b3d/windowsdesktop-runtime-9.0.2-win-arm64.exe",
-            "hash": "5c086ef4d49e510319bed586049d443c4861dc2b826f531e992855c0abe9818fd60d6ed5cb87a9ea3b21bfff76190337470428cf08dad49c4bb6a77afc4792fa"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/75abfa33-809b-41c4-b94c-69ee9b99c479/191c39940d49bc74e12389fc227dd6fe/windowsdesktop-runtime-9.0.2-win-arm64.zip",
-            "hash": "5ad933a83adbfa72ffe8d388b6e9902ea91c977f11dce9ae7a6b033fc7cb5371fefa1ad8f9d494e291ea68e97bcda1927bb560854e479b716b08cb63bd1fb61f"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0e1df956-98b6-48cc-86ac-8b6c02feb6d9/cb90f6c099d4cdefe8d35af6115a3ec5/windowsdesktop-runtime-9.0.2-win-x64.exe",
-            "hash": "60958279f9ff96cc953ed6cf404d8deb68e554374d08dc31e8b62a226ea67ae13d6c9eaf1fb44f783fa6241862e83d1cb8c21bbbadfc9386200fbb0345714be9"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e735ff26-3688-4614-abf9-fd0ed0a25957/bd48e68990f8d9054e550712da812c91/windowsdesktop-runtime-9.0.2-win-x64.zip",
-            "hash": "7929c2a718eef9db6964b08657dda04e6ac2bd86a60d756b0c4497cd68209e2f7a41ca7f7ea163748870c6e86e4a2f4234675afa893f2d20db5a9d8724a9e683"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/f9db1de7-9170-443f-955c-565c56ede288/b0a583d9f169ee3357639479786d1eb8/windowsdesktop-runtime-9.0.2-win-x86.exe",
-            "hash": "798b3e13f0276ccdaa4c593c28e83d8c90652d454ffd0e8fe878bfb44b6485a5b21cc5a93eb0c72586d170b3632283cebeaab25c70c793eff30a73e6369c819f"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e4d30006-ea09-450d-a4e2-95c523c80ccc/bdd10fd7bca8f5941e830bff1589c756/windowsdesktop-runtime-9.0.2-win-x86.zip",
-            "hash": "d868b73dbc79a36eff3500419fa0a46154fee80692c1dbfa8873ca5cd97aca49e18352d18e93902754f997ebdaa0999d52d4b3b50e587b6ba9378c0a4f90cd5f"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2fd8d789-df0d-4031-a8b9-87f7e7a22c4c/a2b6818b1e626904502f3ce5d79d0917/dotnet-sdk-9.0.103-win-x86.zip",
+            "hash": "9c2b5e1e764792abfc4eadb51c3177e6371af3985c15022042a34ef300724019ed38896fd021be27980e535fd128fe0a78ab0cb893ea54d6294301769a92f7a6"
           }
         ]
       }
-    }  
-  ]
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.2",
+      "version-display": "9.0.2",
+      "version-aspnetcoremodule": [
+        "19.0.25017.2"
+      ],
+      "vs-version": "17.12.5",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0b7ddf3f-d43d-49c2-be1d-bf59075d85e7/b1da14023ea7fef1fada6c8898635fbb/aspnetcore-runtime-9.0.2-linux-arm.tar.gz",
+          "hash": "5576751ea9414449add100cb60c917f72305209dc831ecd3698b8ef6a69e2a802850148b33caf5a05d049be66b19c7404531ea6ecd643cc1fd6ae61179e1249b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/744cd467-ac89-4656-9633-ed22e3afb35e/4277cdc84219d6515cb14220ddc0bde3/aspnetcore-runtime-9.0.2-linux-arm64.tar.gz",
+          "hash": "aa95ed396e5012cb7815db25f07b196261b91e4ca2e7ba07352896e1ab351a96232fdb692fbde1d1ddd1c916987353d2d3382e9e16bd7a97ce4b411c6426e0f6"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5eeaba7e-4140-4e62-b96c-7223293f3bd5/9d8d51b099c3141cdf63597816bd1eb4/aspnetcore-runtime-9.0.2-linux-musl-arm.tar.gz",
+          "hash": "f96a66442f7db558e40491f1deba42a58b697286a8c592f20b9b17006040544c3cde3851dbe9d5dd0be4ff68666575a10a8e1225dc97069081a66726a9f0fc8b"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/07c2a8a7-1b36-4ed3-b8c6-48674ad102e7/ed621013baa55acb77a88013d28ae14d/aspnetcore-runtime-9.0.2-linux-musl-arm64.tar.gz",
+          "hash": "5e74871d9133c52389559eb34ee82ed7b8ff2ee990857ef80ebf2b27c405e0dee1ae951c9a87355168901d98acfbe37bd6d516d6a0b4f5f495c58326243c0630"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/435eb32e-b24f-4c82-b044-6f4b97e7338f/5e79b00ea13180f349e28f127cf1c26a/aspnetcore-runtime-9.0.2-linux-musl-x64.tar.gz",
+          "hash": "ff070ebfabb1fa776df69ce6fb1e6990069ff6e4b795dd0ea0ee028dcceaa278500f695c9ba6b6c839310ee0d9aaca398e079ebd9081ec36c1e2d5a63c5bc109"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/36ab7b0d-966a-44ce-ad19-bc0d7e835724/a38c1f97ccc9f4ccce58427c830c32fb/aspnetcore-runtime-9.0.2-linux-x64.tar.gz",
+          "hash": "48a39dd4bee3e719273a4e4404b556e2e59e7f659def49f89745ae575fc976f7ebf121d9263c3d009db6081976f8261ca82de34aef69b0776a28fd0485bb6d3b"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0e3c0776-3b1b-4e34-8dc5-1f764e435f68/3fc575fd1def4bba8258cdf39cf24e35/aspnetcore-runtime-9.0.2-osx-arm64.tar.gz",
+          "hash": "66fcd7a0589fb166d85caebd6f08c16049bdd0cacfd01ab3f199c442b98d54f8610c225a2a9a6f52bc4bce12bba8a3001e23689240996c697e2bc3a008957226"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/80ab707c-4568-4bb3-998d-04b1935648dd/cec09318721d7d5e3cdd64e987a1dd8e/aspnetcore-runtime-9.0.2-osx-x64.tar.gz",
+          "hash": "4e3b76bc423e9312b55449ff156bf65044f566445c4106fc47314517651d4d510c0418b1f8f17853b1cbc14769100b846f414f80d6a9cee5f95f5a6fb8547d9a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3575d404-da7d-4461-b032-4090fe1e8378/689e6cf07417805b2ce74c1b807d64f9/aspnetcore-runtime-9.0.2-win-arm64.exe",
+          "hash": "2fda149e90311f5f5bda6be635bbbe23fdcaf95359865a9880ae56e14eb5fbf36e1433ea772ae6427031bd8192bcaf50dbbfaa900044769ef462aeaa2636ad2e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/47a58b15-5ae9-40ba-836f-2e5f4fac689b/4e4444de85c10de9a950f6a883ba351a/aspnetcore-runtime-9.0.2-win-arm64.zip",
+          "hash": "a9612f88ae232e9dc517f02cb9a4faa605d2c0fda94a33897ba0ddb75979ee2eb09df5c49ad7ea93e90ba0dd5ff933af959a55c4ec9526eee06dbbdcd10a245b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ef8f48ce-bf76-4ffc-bb8f-40991ec99b6e/f68b6492c75839333ad8c2fd3ff9c7b4/aspnetcore-runtime-9.0.2-win-x64.exe",
+          "hash": "8a6e225a03319f5995c943b32482f73ae08bdcb20a0f8ad24a049162c5e66d3071f271cad6829202794cc7066391777caa8ad5bd3514ced213ba8093d1e5784c"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/01a196ac-edf8-4574-b9af-35db73e21094/d55bef75bde4f8a83c28b7913d56a76f/aspnetcore-runtime-9.0.2-win-x64.zip",
+          "hash": "0a5b0d4a0ac65dc0b11b104154143ef310e47b3aa92dbff32e7002d1ea6005b6444a6699eb03a5c728326c6ad97234a1fc9607972a133130727173247111472e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b985a5f3-8a2c-4854-a69d-e6a585a277fd/8e9965972940a2efd07b150432ee7f5f/aspnetcore-runtime-9.0.2-win-x86.exe",
+          "hash": "a633235f06943865b4176a919b1601d95618a4e43b3af6d374949700df68e02d0e71629c772a9b78c25bff609993d106621ed34a27856adce650bd47e9961e45"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d2415741-da8d-49b2-b2a6-364799efdfcc/25ff042f508f91f14ed4f25f4a88bf66/aspnetcore-runtime-9.0.2-win-x86.zip",
+          "hash": "2b05a90bb7f59286ca2e6eb631ea49d999a66a8e2e7d3f13e12daeae412a71de073afeff9d1121b89133ed0e8b125f959b3678e5c4fdfa7639ad6eb0ff896762"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ff894111-ac98-4f95-962e-572af715ebda/e5f073c7a5d45544bb135a225bb2419f/aspnetcore-runtime-composite-9.0.2-linux-arm.tar.gz",
+          "hash": "9008fec9c3cc98b9608eb6635f73cb86d37cb721d6f4ba3dbb8eaee4d7adacf832cbef6c223320895656743a82b5a81209c78936973ba469e551dbf05bc40ce9"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4e9c59a5-551f-47c2-9eae-357cea44683c/e6c8fb5bf951847abf28697ca1a8e096/aspnetcore-runtime-composite-9.0.2-linux-arm64.tar.gz",
+          "hash": "8387f486d692f1299cc08f33c57e647000f986e6a69ccb4b426b6a207be28a0b5b6e636bd0d91fa2d9452d0c0bb00e48179e965612b7f66641884430675130e9"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9f40f94b-d02b-4c72-ace9-6987a4e95d58/8da22c3c69dd03f14e1b2a28d2d4f215/aspnetcore-runtime-composite-9.0.2-linux-musl-arm.tar.gz",
+          "hash": "9240868535b83a81f2dff1226be734d5f4d31095988c286455679e1b56a2ba7a56cb7d30d4c6f74d645024ed2526a2d5a2a06dae4194b2ffc2d86a8fbf2a42ef"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c47bb124-30c3-48ae-a1ae-75f3c2b1b974/95554947e0b06df6cb12f851a4d7b4f5/aspnetcore-runtime-composite-9.0.2-linux-musl-arm64.tar.gz",
+          "hash": "cde805a00d9db6de6e57fb573f392df8bcd2f21ef029a6ac22f059b85af635cd4553d9d749d6391b637a9958f3cea3f6430b3c575d217c428758330f864e2841"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4fcfd90f-1cab-4da7-bb8c-4468b6b90735/8153f9dc459a5dc83000b8b4aec6ed64/aspnetcore-runtime-composite-9.0.2-linux-musl-x64.tar.gz",
+          "hash": "7257c9093bb4fe4ce09e2169ccaa8500dd23008464aab7ae50f57e7ec187d8a0a3fad8c8d67fa0561801bce59300839f0d2044b0b4232b0e320d1305662fa465"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b1f88d20-3be3-45d5-942b-b800113c91d7/9f41b6252793ae58d98b5f138150021b/aspnetcore-runtime-composite-9.0.2-linux-x64.tar.gz",
+          "hash": "b819c4421c1110ecadfa4f1e790efb14d9788e7456be016d26023b993dda40c47f22e356483c5c6f00d0941e0daea8cf2c5fe6aa405c7422ec911a46b81b552c"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/785df3b0-8483-4eb0-8826-3cfb0d708ba7/28ad125421135a4fad3f03cea41cd673/dotnet-hosting-9.0.2-win.exe",
+          "hash": "b275c7f67f46d8d65da5fd07dadf52ab544d5f40aad02c12dc24c1460b8a92b6b5ba418101c4a5e29c29e547eb3c1c794e40fb8531a5e4d35233fdc8e12312eb",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.2",
+      "version-display": "9.0.2",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d8b26b48-2f5c-4814-a253-c752a45b504e/2ff9ba5aa7ab19d3736a3c5d9d346b3d/windowsdesktop-runtime-9.0.2-win-arm64.exe",
+          "hash": "5c086ef4d49e510319bed586049d443c4861dc2b826f531e992855c0abe9818fd60d6ed5cb87a9ea3b21bfff76190337470428cf08dad49c4bb6a77afc4792fa"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/75abfa33-809b-41c4-b94c-69ee9b99c479/191c39940d49bc74e12389fc227dd6fe/windowsdesktop-runtime-9.0.2-win-arm64.zip",
+          "hash": "5ad933a83adbfa72ffe8d388b6e9902ea91c977f11dce9ae7a6b033fc7cb5371fefa1ad8f9d494e291ea68e97bcda1927bb560854e479b716b08cb63bd1fb61f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0e1df956-98b6-48cc-86ac-8b6c02feb6d9/cb90f6c099d4cdefe8d35af6115a3ec5/windowsdesktop-runtime-9.0.2-win-x64.exe",
+          "hash": "60958279f9ff96cc953ed6cf404d8deb68e554374d08dc31e8b62a226ea67ae13d6c9eaf1fb44f783fa6241862e83d1cb8c21bbbadfc9386200fbb0345714be9"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e735ff26-3688-4614-abf9-fd0ed0a25957/bd48e68990f8d9054e550712da812c91/windowsdesktop-runtime-9.0.2-win-x64.zip",
+          "hash": "7929c2a718eef9db6964b08657dda04e6ac2bd86a60d756b0c4497cd68209e2f7a41ca7f7ea163748870c6e86e4a2f4234675afa893f2d20db5a9d8724a9e683"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/f9db1de7-9170-443f-955c-565c56ede288/b0a583d9f169ee3357639479786d1eb8/windowsdesktop-runtime-9.0.2-win-x86.exe",
+          "hash": "798b3e13f0276ccdaa4c593c28e83d8c90652d454ffd0e8fe878bfb44b6485a5b21cc5a93eb0c72586d170b3632283cebeaab25c70c793eff30a73e6369c819f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e4d30006-ea09-450d-a4e2-95c523c80ccc/bdd10fd7bca8f5941e830bff1589c756/windowsdesktop-runtime-9.0.2-win-x86.zip",
+          "hash": "d868b73dbc79a36eff3500419fa0a46154fee80692c1dbfa8873ca5cd97aca49e18352d18e93902754f997ebdaa0999d52d4b3b50e587b6ba9378c0a4f90cd5f"
+        }
+      ]
+    }
+  }
 }

--- a/release-notes/9.0/9.0.3/release.json
+++ b/release-notes/9.0/9.0.3/release.json
@@ -1,125 +1,232 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-03-11",
-  "release-version": "9.0.3",
-  "security": true,
-  "releases": [
-    {
-      "release-date": "2025-03-11",
-      "release-version": "9.0.3",
-      "security": true,
-      "cve-list": [
+  "release": {
+    "release-date": "2025-03-11",
+    "release-version": "9.0.3",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2025-24070",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-24070"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.3/9.0.3.md",
+    "runtime": {
+      "version": "9.0.3",
+      "version-display": "9.0.3",
+      "vs-version": "17.12.6, 17.13.3",
+      "vs-mac-version": "",
+      "files": [
         {
-          "cve-id": "CVE-2025-24070",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-24070"
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/6a2bc9fa-ffb0-4113-993e-902e2049ffc9/fb2589c89729fabade52bc737605ed93/dotnet-runtime-9.0.3-linux-arm.tar.gz",
+          "hash": "22b35dca40dba8a6bc6663c63c04a3e6edf59f04b1db3bf792a1e64b573c3896f65e322cdbe8c1522009c2e81d94fe0ef85ab436e2961e81f4d7cc2123ba33e3"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/79e65a77-46e2-47b5-9bf4-efa8a6426308/211a9c0c2952d0bbdb0aa5eb1348e2b6/dotnet-runtime-9.0.3-linux-arm64.tar.gz",
+          "hash": "0b18859800c75d293b05b58938b7c3ebd9a7aa5d5b163c8d5a08aa84f95017d2d0114dd6f3a688bce9974c43dbd073a930977b7ccfe06577207a67f00319d20c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e7fd172a-a601-45c2-a715-14cd18c2cddb/93a3a7689181ae8847bf940d20e56148/dotnet-runtime-9.0.3-linux-musl-arm.tar.gz",
+          "hash": "bd807c994b02aa0c97e001492c16146894f6aa1fdef12d0979ffb0c84d809cdf955fd351016bb59d5098ec945fc3cce7958a6fedcd0e301ef28159700e380278"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/4b7b3320-dc33-4da2-93cf-de158ad5a41f/9ea1944f72dca2106dcf1477e0b7e2da/dotnet-runtime-9.0.3-linux-musl-arm64.tar.gz",
+          "hash": "2385114169e32b29b3a13b275a441af1edbb4c14ebed52ff8f45f11ac8a571efa2984be2ef91e38e670038c8e29db8c585ff12d1e05502f4120e4dd05e98b72c"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cbcb4e59-932b-4edd-9a0d-228e1c0753d8/5b2d904fdfe7381c3f6e857c409fd78d/dotnet-runtime-9.0.3-linux-musl-x64.tar.gz",
+          "hash": "8533a061f4fad61135269ae7987d9bdc8000cbc4999e00392f0e9d234d40e20a4f4e753dd5724373772349a896f2a84e3ba86e876d81a9bf068888e421afb13f"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a58fcc04-99ee-4dea-aa5d-d6d22c4040dc/4433f4e97ad4658bd76f52acc1cb9c21/dotnet-runtime-9.0.3-linux-x64.tar.gz",
+          "hash": "4b16a57e94592fb9712421ed90c025fc3b4f9039faea37b432b6d8a3e8caf192dead732fb84bbdca9dfa4ed40ddb46078dd3c2710801c92aee8e21c084bfd664"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c17c9c8a-11dc-41b4-975f-89b5b101a0e3/dbefaaf56c7388afb76cc96c76a13316/dotnet-runtime-9.0.3-osx-arm64.pkg",
+          "hash": "e465ac53f042de610dd2897489b3c199043bf56c72c57607e09ff484dcaf8c8b2414fbe0a8fbc47b7593fbc254535e1153ae0c99e02675dbd0b6ca77706c6bbc"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/041326f6-a1c8-4af5-8178-df0248ede629/a4a0f730a9ea09b73c30e44b3efd54eb/dotnet-runtime-9.0.3-osx-arm64.tar.gz",
+          "hash": "b6808f69704b22d56b8af4afd4695997e20fa13c9e0116d28b5d8f3022d9c039c3af75910d2532873b8331526997d50ffd1b5642d36f1e3edd6485edc15d8009"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e59ade14-21cb-4303-8875-69373a17234c/fdd434f76c113afae01211b02470c302/dotnet-runtime-9.0.3-osx-x64.pkg",
+          "hash": "abf16ef042bc18d550524f0c2588f2037a4ef56cfeeb822c5f9e31f0b8e7765bb8c2c8009987168a7b3c9f9cbf3b7a131283e345049a4bcd6854d4e6837dfa22"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b4b321f3-ee2b-46e5-96eb-8c809a901ecb/252a64bf8c5b5b196764c5b301357249/dotnet-runtime-9.0.3-osx-x64.tar.gz",
+          "hash": "f60688f3c747d0e75c3f2c24b9021b147d7aa4ab4b5aa939b861d5584a590bf9b1d6e88577bd08e9ec23437fcaa295da633ef0406591cb5d14ac6659f8726164"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/740a2ea6-fb51-43b3-ab02-ef2cd66e5cda/6e1ccbef9b9f4caee395caba8cd7e72f/dotnet-runtime-9.0.3-win-arm64.exe",
+          "hash": "dc4f1af15338302f44e9a1ed219f6786c7f81e3d0ff3a2043a07a04d357450984391f13185a9dae8afdf0bff251aea9857b5895d27bd4122e73f1faeb290decb"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2dbedba0-b638-4695-b480-b1fd5b7fd2eb/7b42b6d4a11ff7d0e641b2b42319c5e5/dotnet-runtime-9.0.3-win-arm64.zip",
+          "hash": "d3a2e5574f95d076baaaaf4c54278ff4169e604229aeb3c5d45d420c1a8fd5be4704befc8d86d13495242f5a47e25b0883f060384ea585779c8645223c8100c9"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/0234f264-bfe0-4f2f-b37f-a1564c746642/47fe774e87dfb99537cd475cdf32f62f/dotnet-runtime-9.0.3-win-x64.exe",
+          "hash": "f4730f354c10898908ac43c455364554273bc10d367e5221b09d3ac41b8780ead888496f4a1b79270b53239d666a2fdb571b683105bea4c453ddf233f937f834"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/00ea272c-9902-4b5c-b638-18793f44622f/c33b500211f70908ed8370e65a7b3472/dotnet-runtime-9.0.3-win-x64.zip",
+          "hash": "61e33b0569b5727348d3e74e3dba5d814a8c017292abaa5deaa79c41e78e6b73eb6ee8f09568ee805f8537b81d978f3e54c1c583e85df29d85fa6c87fde442eb"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3500ef5d-0841-4b4e-87f3-a64ddf39fba1/1bad0a48cdcd6e69677321e1c354c194/dotnet-runtime-9.0.3-win-x86.exe",
+          "hash": "ea82dbf00bb91d2b66e3c06dfb6ad2a6f3443d75b575176113576e128878baa5760755e164901ad4ef69e3610fceecfc316be294a6ad8661fccb8388a2abafbf"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/36e88a17-1f22-4cdc-976f-631fde74a582/fd912c0d1be14c0b153b1b4ad81fb3c4/dotnet-runtime-9.0.3-win-x86.zip",
+          "hash": "6848d49fcbc499d679112d07db68662b7b253c627fe8baba8bf8296388ec1161a356f59306b2234dc6c622a534c6b3aadc5cee2cce8d56d7b97255ed7581d56a"
         }
-      ],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.3/9.0.3.md",
-      "runtime": {
-        "version": "9.0.3",
-        "version-display": "9.0.3",
-        "vs-version": "17.12.6, 17.13.3",
-        "vs-mac-version": "",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/6a2bc9fa-ffb0-4113-993e-902e2049ffc9/fb2589c89729fabade52bc737605ed93/dotnet-runtime-9.0.3-linux-arm.tar.gz",
-            "hash": "22b35dca40dba8a6bc6663c63c04a3e6edf59f04b1db3bf792a1e64b573c3896f65e322cdbe8c1522009c2e81d94fe0ef85ab436e2961e81f4d7cc2123ba33e3"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/79e65a77-46e2-47b5-9bf4-efa8a6426308/211a9c0c2952d0bbdb0aa5eb1348e2b6/dotnet-runtime-9.0.3-linux-arm64.tar.gz",
-            "hash": "0b18859800c75d293b05b58938b7c3ebd9a7aa5d5b163c8d5a08aa84f95017d2d0114dd6f3a688bce9974c43dbd073a930977b7ccfe06577207a67f00319d20c"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e7fd172a-a601-45c2-a715-14cd18c2cddb/93a3a7689181ae8847bf940d20e56148/dotnet-runtime-9.0.3-linux-musl-arm.tar.gz",
-            "hash": "bd807c994b02aa0c97e001492c16146894f6aa1fdef12d0979ffb0c84d809cdf955fd351016bb59d5098ec945fc3cce7958a6fedcd0e301ef28159700e380278"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/4b7b3320-dc33-4da2-93cf-de158ad5a41f/9ea1944f72dca2106dcf1477e0b7e2da/dotnet-runtime-9.0.3-linux-musl-arm64.tar.gz",
-            "hash": "2385114169e32b29b3a13b275a441af1edbb4c14ebed52ff8f45f11ac8a571efa2984be2ef91e38e670038c8e29db8c585ff12d1e05502f4120e4dd05e98b72c"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/cbcb4e59-932b-4edd-9a0d-228e1c0753d8/5b2d904fdfe7381c3f6e857c409fd78d/dotnet-runtime-9.0.3-linux-musl-x64.tar.gz",
-            "hash": "8533a061f4fad61135269ae7987d9bdc8000cbc4999e00392f0e9d234d40e20a4f4e753dd5724373772349a896f2a84e3ba86e876d81a9bf068888e421afb13f"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a58fcc04-99ee-4dea-aa5d-d6d22c4040dc/4433f4e97ad4658bd76f52acc1cb9c21/dotnet-runtime-9.0.3-linux-x64.tar.gz",
-            "hash": "4b16a57e94592fb9712421ed90c025fc3b4f9039faea37b432b6d8a3e8caf192dead732fb84bbdca9dfa4ed40ddb46078dd3c2710801c92aee8e21c084bfd664"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.pkg",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c17c9c8a-11dc-41b4-975f-89b5b101a0e3/dbefaaf56c7388afb76cc96c76a13316/dotnet-runtime-9.0.3-osx-arm64.pkg",
-            "hash": "e465ac53f042de610dd2897489b3c199043bf56c72c57607e09ff484dcaf8c8b2414fbe0a8fbc47b7593fbc254535e1153ae0c99e02675dbd0b6ca77706c6bbc"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/041326f6-a1c8-4af5-8178-df0248ede629/a4a0f730a9ea09b73c30e44b3efd54eb/dotnet-runtime-9.0.3-osx-arm64.tar.gz",
-            "hash": "b6808f69704b22d56b8af4afd4695997e20fa13c9e0116d28b5d8f3022d9c039c3af75910d2532873b8331526997d50ffd1b5642d36f1e3edd6485edc15d8009"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e59ade14-21cb-4303-8875-69373a17234c/fdd434f76c113afae01211b02470c302/dotnet-runtime-9.0.3-osx-x64.pkg",
-            "hash": "abf16ef042bc18d550524f0c2588f2037a4ef56cfeeb822c5f9e31f0b8e7765bb8c2c8009987168a7b3c9f9cbf3b7a131283e345049a4bcd6854d4e6837dfa22"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b4b321f3-ee2b-46e5-96eb-8c809a901ecb/252a64bf8c5b5b196764c5b301357249/dotnet-runtime-9.0.3-osx-x64.tar.gz",
-            "hash": "f60688f3c747d0e75c3f2c24b9021b147d7aa4ab4b5aa939b861d5584a590bf9b1d6e88577bd08e9ec23437fcaa295da633ef0406591cb5d14ac6659f8726164"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/740a2ea6-fb51-43b3-ab02-ef2cd66e5cda/6e1ccbef9b9f4caee395caba8cd7e72f/dotnet-runtime-9.0.3-win-arm64.exe",
-            "hash": "dc4f1af15338302f44e9a1ed219f6786c7f81e3d0ff3a2043a07a04d357450984391f13185a9dae8afdf0bff251aea9857b5895d27bd4122e73f1faeb290decb"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2dbedba0-b638-4695-b480-b1fd5b7fd2eb/7b42b6d4a11ff7d0e641b2b42319c5e5/dotnet-runtime-9.0.3-win-arm64.zip",
-            "hash": "d3a2e5574f95d076baaaaf4c54278ff4169e604229aeb3c5d45d420c1a8fd5be4704befc8d86d13495242f5a47e25b0883f060384ea585779c8645223c8100c9"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/0234f264-bfe0-4f2f-b37f-a1564c746642/47fe774e87dfb99537cd475cdf32f62f/dotnet-runtime-9.0.3-win-x64.exe",
-            "hash": "f4730f354c10898908ac43c455364554273bc10d367e5221b09d3ac41b8780ead888496f4a1b79270b53239d666a2fdb571b683105bea4c453ddf233f937f834"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/00ea272c-9902-4b5c-b638-18793f44622f/c33b500211f70908ed8370e65a7b3472/dotnet-runtime-9.0.3-win-x64.zip",
-            "hash": "61e33b0569b5727348d3e74e3dba5d814a8c017292abaa5deaa79c41e78e6b73eb6ee8f09568ee805f8537b81d978f3e54c1c583e85df29d85fa6c87fde442eb"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3500ef5d-0841-4b4e-87f3-a64ddf39fba1/1bad0a48cdcd6e69677321e1c354c194/dotnet-runtime-9.0.3-win-x86.exe",
-            "hash": "ea82dbf00bb91d2b66e3c06dfb6ad2a6f3443d75b575176113576e128878baa5760755e164901ad4ef69e3610fceecfc316be294a6ad8661fccb8388a2abafbf"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/36e88a17-1f22-4cdc-976f-631fde74a582/fd912c0d1be14c0b153b1b4ad81fb3c4/dotnet-runtime-9.0.3-win-x86.zip",
-            "hash": "6848d49fcbc499d679112d07db68662b7b253c627fe8baba8bf8296388ec1161a356f59306b2234dc6c622a534c6b3aadc5cee2cce8d56d7b97255ed7581d56a"
-          }
-        ]
-      },
-      "sdk": {
+      ]
+    },
+    "sdk": {
+      "version": "9.0.202",
+      "version-display": "9.0.202",
+      "runtime-version": "9.0.3",
+      "vs-version": "",
+      "vs-mac-version": "",
+      "vs-support": "",
+      "vs-mac-support": "",
+      "csharp-version": "13.0",
+      "fsharp-version": "9.0",
+      "vb-version": "17.13",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e41720b8-c635-4b25-bcb1-dcf307a917d6/fea66a31e0dec0411b3e123661f443fc/dotnet-sdk-9.0.202-linux-arm.tar.gz",
+          "hash": "2e88683ee3894b72581ce3829efd2cc5214968f0782e17f504a79bc80ecc31efe9d5360303545e45537f992f5ac8c47aaec8eca5ea8a4efacde9742de6c8ffe0"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/52daf653-e6d8-4915-aea1-9c2e2be169a5/9f3e289918eb9054770b69c0b100bb8f/dotnet-sdk-9.0.202-linux-arm64.tar.gz",
+          "hash": "6916fd37907c6563baebb5c9f82a6761d13d53a0442451bae73ad62a36a72744771017a2d3f665eecaa5c76f6a0036ddd503c2e195a8ea307973a292748b87d5"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2399a26-a81c-4039-bc90-62a6ac27416e/25e7626b936ba69c2f0fcf1c5403f172/dotnet-sdk-9.0.202-linux-musl-arm.tar.gz",
+          "hash": "38194d67497dc72ebf7d5a7ea6764624d1c524ac26261ce888a10af940ab661973306cb00bf8909a3694215c0c134ae90195e6ee11818046f920e0ff65a83662"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/fc1b0d83-d63a-4469-b0a4-d36b3c2d7c65/c8522a9bf1a9e3c1c8ee3d1e65153641/dotnet-sdk-9.0.202-linux-musl-arm64.tar.gz",
+          "hash": "21071ff46853b4155569c5a70fd8186b8250759db1d7945198e523023be3cd0e97058499491f1f2d2d77156a61919b6287c70df5520b4ec012aa9ec172889f6d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c99de83d-6caa-4ec0-ae22-b542cef5833a/90ef16f45a552623155d86732478f958/dotnet-sdk-9.0.202-linux-musl-x64.tar.gz",
+          "hash": "8b6538d3056dd9f231d964daa2d07ad71409b4e6eb991d406ac1f07626001085573726ba35294b54f2e8596d3a77e018d72ea5df4ec61fbb79faa04510a49fa3"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2220b38-c512-4447-b564-a18048d14327/965cdfe500a937c2d28bc9d2db45cd1f/dotnet-sdk-9.0.202-linux-x64.tar.gz",
+          "hash": "0eb52300023d9df6494aadfbd8380dddf84e2f217d444ad9fe880292afbf378be3700d7fbeca3136ec95962ba355e44abfc9f8a679cd0d08e68f85cb0320ce73"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2a1ee63f-194f-4d90-b452-6c1f3b70f432/7c8112ad777e298257dd0a76b0f07cbc/dotnet-sdk-9.0.202-osx-arm64.pkg",
+          "hash": "cc49774082e5a7f5ca9a18dc59a5a91032e35795c66f452325cf89df52d5c22293983a80d98f0a8409f7941eb75536403d48f9eb9e24ff749ddbb7507731e6fc"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/98cc1e45-e17c-4e63-afb1-86583dce24fe/948df23085579a4ce3f38620540eb088/dotnet-sdk-9.0.202-osx-arm64.tar.gz",
+          "hash": "63badde1614aea8a7551f8e56c4b7ba379b15f37e6c008133e22c08df0607eab8c3c2f0306e441e9fe60c2166dec953272a0cbd150eb5b0b77dac5b287880115"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/cd8e24b6-57b7-47b2-bf27-047adc13b442/ac51bb4c40ac79deb9d06e0cad92026c/dotnet-sdk-9.0.202-osx-x64.pkg",
+          "hash": "0fa362a500aa054d45620bde593c407cd8217d2423e795f6e982587fe7da12c8f7b8010d8ba1a3c5c135c515806c3cdb979b46092d1e7545efa3a8c945a77051"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/bc0334a2-641c-4e60-b07b-b1f65c05da0f/f1e9820b1ad0ddf0104103cd5d4fe69b/dotnet-sdk-9.0.202-osx-x64.tar.gz",
+          "hash": "fa47b5712462a704aeed37a2399074111e6f5f6fb0377ca93bfaa9177b31f9508cdd7f492d5ea24e0cd3c3a0fb977bbb5e582a0ebfd84baa0ec4d0a7abd0518d"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e9683032-95f6-489a-a49f-c6221cfc377f/29cf342ed94af9559e8a6f9017719390/dotnet-sdk-9.0.202-win-arm64.exe",
+          "hash": "24aebb2c523ad1306ea5c05b829a9c5fe4c84da44b5923d68d4ca82a527efd716d69c93dce41f250403dae5e82b6ce6fa0f2a54d12e5f5d062f89dcf2a7b690d"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/31f2d59e-c4a9-4439-a248-cbf04a645713/0c5e22648cd7673cfc4c8bf308903d02/dotnet-sdk-9.0.202-win-arm64.zip",
+          "hash": "92d25b151bac28920508937f944bcc01d2b00e478a2b3139421d5f58636a5711994ebc0f724cda5b2d012e15d6979dc184f09c72574136dde63ba85d110efd2b"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b0032fde-aac9-4c3e-b78c-4bd605910241/8d2aa21baac4aef9b996671cd8a48fb2/dotnet-sdk-9.0.202-win-x64.exe",
+          "hash": "1ebb3db377b96dfc73b271c65a7831b5ab91559fa4defd509c9978c947dc408ebf43b14b2fdb47a05b298fdb5747c7ada0f7005dfe5820226e118b65e5a276dc"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a16e9966-3076-4d6d-914e-6b8228444876/123e08ddbdf6da335a3b636e66375c87/dotnet-sdk-9.0.202-win-x64.zip",
+          "hash": "caf88c10ff1e3f59d420b7556ed14f21c156d54e69b8288a38e6b0c470a41374c10d2ed84cd6434a89e2a23c6a1a2ee6cb762941706b85c40f6f047df0b8127b"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a918b1d9-24b7-4894-9bdb-1fef8b22db0f/b222a74f6a487dc0e935f12784cd9b1a/dotnet-sdk-9.0.202-win-x86.exe",
+          "hash": "8ee88e28132514734cde8bf1d1b0687716423347f39219a6b478b58c35f3d7732140f7f765348b9860df195f7df8caab1a7eacd111f5e54a5b9fc769053960e4"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/39a7dd23-5db8-4421-a404-25ceed8289b0/413a8a323454453b4af73cadfc77a0ff/dotnet-sdk-9.0.202-win-x86.zip",
+          "hash": "c0c586fa7f02901b3126c143f7896292d4d91ce3a1da2e26e2c7c757d809bf38db804f7da8424756326b1f51604ec948f9d004b967b83937c394a2e0366a7401"
+        }
+      ]
+    },
+    "sdks": [
+      {
         "version": "9.0.202",
         "version-display": "9.0.202",
         "runtime-version": "9.0.3",
@@ -229,517 +336,405 @@
           }
         ]
       },
-      "sdks": [
-        {
-          "version": "9.0.202",
-          "version-display": "9.0.202",
-          "runtime-version": "9.0.3",
-          "vs-version": "",
-          "vs-mac-version": "",
-          "vs-support": "",
-          "vs-mac-support": "",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "17.13",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e41720b8-c635-4b25-bcb1-dcf307a917d6/fea66a31e0dec0411b3e123661f443fc/dotnet-sdk-9.0.202-linux-arm.tar.gz",
-              "hash": "2e88683ee3894b72581ce3829efd2cc5214968f0782e17f504a79bc80ecc31efe9d5360303545e45537f992f5ac8c47aaec8eca5ea8a4efacde9742de6c8ffe0"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/52daf653-e6d8-4915-aea1-9c2e2be169a5/9f3e289918eb9054770b69c0b100bb8f/dotnet-sdk-9.0.202-linux-arm64.tar.gz",
-              "hash": "6916fd37907c6563baebb5c9f82a6761d13d53a0442451bae73ad62a36a72744771017a2d3f665eecaa5c76f6a0036ddd503c2e195a8ea307973a292748b87d5"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c2399a26-a81c-4039-bc90-62a6ac27416e/25e7626b936ba69c2f0fcf1c5403f172/dotnet-sdk-9.0.202-linux-musl-arm.tar.gz",
-              "hash": "38194d67497dc72ebf7d5a7ea6764624d1c524ac26261ce888a10af940ab661973306cb00bf8909a3694215c0c134ae90195e6ee11818046f920e0ff65a83662"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fc1b0d83-d63a-4469-b0a4-d36b3c2d7c65/c8522a9bf1a9e3c1c8ee3d1e65153641/dotnet-sdk-9.0.202-linux-musl-arm64.tar.gz",
-              "hash": "21071ff46853b4155569c5a70fd8186b8250759db1d7945198e523023be3cd0e97058499491f1f2d2d77156a61919b6287c70df5520b4ec012aa9ec172889f6d"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c99de83d-6caa-4ec0-ae22-b542cef5833a/90ef16f45a552623155d86732478f958/dotnet-sdk-9.0.202-linux-musl-x64.tar.gz",
-              "hash": "8b6538d3056dd9f231d964daa2d07ad71409b4e6eb991d406ac1f07626001085573726ba35294b54f2e8596d3a77e018d72ea5df4ec61fbb79faa04510a49fa3"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c2220b38-c512-4447-b564-a18048d14327/965cdfe500a937c2d28bc9d2db45cd1f/dotnet-sdk-9.0.202-linux-x64.tar.gz",
-              "hash": "0eb52300023d9df6494aadfbd8380dddf84e2f217d444ad9fe880292afbf378be3700d7fbeca3136ec95962ba355e44abfc9f8a679cd0d08e68f85cb0320ce73"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2a1ee63f-194f-4d90-b452-6c1f3b70f432/7c8112ad777e298257dd0a76b0f07cbc/dotnet-sdk-9.0.202-osx-arm64.pkg",
-              "hash": "cc49774082e5a7f5ca9a18dc59a5a91032e35795c66f452325cf89df52d5c22293983a80d98f0a8409f7941eb75536403d48f9eb9e24ff749ddbb7507731e6fc"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/98cc1e45-e17c-4e63-afb1-86583dce24fe/948df23085579a4ce3f38620540eb088/dotnet-sdk-9.0.202-osx-arm64.tar.gz",
-              "hash": "63badde1614aea8a7551f8e56c4b7ba379b15f37e6c008133e22c08df0607eab8c3c2f0306e441e9fe60c2166dec953272a0cbd150eb5b0b77dac5b287880115"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/cd8e24b6-57b7-47b2-bf27-047adc13b442/ac51bb4c40ac79deb9d06e0cad92026c/dotnet-sdk-9.0.202-osx-x64.pkg",
-              "hash": "0fa362a500aa054d45620bde593c407cd8217d2423e795f6e982587fe7da12c8f7b8010d8ba1a3c5c135c515806c3cdb979b46092d1e7545efa3a8c945a77051"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/bc0334a2-641c-4e60-b07b-b1f65c05da0f/f1e9820b1ad0ddf0104103cd5d4fe69b/dotnet-sdk-9.0.202-osx-x64.tar.gz",
-              "hash": "fa47b5712462a704aeed37a2399074111e6f5f6fb0377ca93bfaa9177b31f9508cdd7f492d5ea24e0cd3c3a0fb977bbb5e582a0ebfd84baa0ec4d0a7abd0518d"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e9683032-95f6-489a-a49f-c6221cfc377f/29cf342ed94af9559e8a6f9017719390/dotnet-sdk-9.0.202-win-arm64.exe",
-              "hash": "24aebb2c523ad1306ea5c05b829a9c5fe4c84da44b5923d68d4ca82a527efd716d69c93dce41f250403dae5e82b6ce6fa0f2a54d12e5f5d062f89dcf2a7b690d"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/31f2d59e-c4a9-4439-a248-cbf04a645713/0c5e22648cd7673cfc4c8bf308903d02/dotnet-sdk-9.0.202-win-arm64.zip",
-              "hash": "92d25b151bac28920508937f944bcc01d2b00e478a2b3139421d5f58636a5711994ebc0f724cda5b2d012e15d6979dc184f09c72574136dde63ba85d110efd2b"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/b0032fde-aac9-4c3e-b78c-4bd605910241/8d2aa21baac4aef9b996671cd8a48fb2/dotnet-sdk-9.0.202-win-x64.exe",
-              "hash": "1ebb3db377b96dfc73b271c65a7831b5ab91559fa4defd509c9978c947dc408ebf43b14b2fdb47a05b298fdb5747c7ada0f7005dfe5820226e118b65e5a276dc"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a16e9966-3076-4d6d-914e-6b8228444876/123e08ddbdf6da335a3b636e66375c87/dotnet-sdk-9.0.202-win-x64.zip",
-              "hash": "caf88c10ff1e3f59d420b7556ed14f21c156d54e69b8288a38e6b0c470a41374c10d2ed84cd6434a89e2a23c6a1a2ee6cb762941706b85c40f6f047df0b8127b"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a918b1d9-24b7-4894-9bdb-1fef8b22db0f/b222a74f6a487dc0e935f12784cd9b1a/dotnet-sdk-9.0.202-win-x86.exe",
-              "hash": "8ee88e28132514734cde8bf1d1b0687716423347f39219a6b478b58c35f3d7732140f7f765348b9860df195f7df8caab1a7eacd111f5e54a5b9fc769053960e4"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/39a7dd23-5db8-4421-a404-25ceed8289b0/413a8a323454453b4af73cadfc77a0ff/dotnet-sdk-9.0.202-win-x86.zip",
-              "hash": "c0c586fa7f02901b3126c143f7896292d4d91ce3a1da2e26e2c7c757d809bf38db804f7da8424756326b1f51604ec948f9d004b967b83937c394a2e0366a7401"
-            }
-          ]
-        },
-        {
-          "version": "9.0.201",
-          "version-display": "9.0.201",
-          "runtime-version": "9.0.3",
-          "vs-version": "17.13.3",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.13)",
-          "vs-mac-support": "",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "17.13",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a2cf96fc-f298-41e2-9dc6-8c0861916597/d505f4b28a7765d7bea6d2883a7fe170/dotnet-sdk-9.0.201-linux-arm.tar.gz",
-              "hash": "681218635821ad49586b20a0eeb03d029d15f2cf2c795074bd3e27a773f90a17a8b6bac9df44e083233cecf362bbfee7d0c6b83a24917e696bde8ad7e52f1155"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/6d91bd91-9bb6-4b3f-9256-83f8c982e817/9248655502cac509f9c738509913770c/dotnet-sdk-9.0.201-linux-arm64.tar.gz",
-              "hash": "4eb78c7608355ca2780990934592c49579ed59f0983377c4c2c99a4091970264642b8fee92c65e91baeb6c6bc22066d6958085eacd1a850055b52f6d04436d5b"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/905c96fd-1e89-4024-834f-dd2690ec6eab/6b3cec8a13b42bf55f65f65badf0b89f/dotnet-sdk-9.0.201-linux-musl-arm.tar.gz",
-              "hash": "38dbe814f4ecd5281f7821059661ee0265fb219cde085facfccd59e9fb340c03818449064dfea4622de0c0c6e390ca1979515bde77bf30cbe7aae614c1cd4f2b"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/26b8a5c2-b79c-425f-8356-d8f0d231bf45/0da5d6f19a28a5d07ebda7fe5a1ec536/dotnet-sdk-9.0.201-linux-musl-arm64.tar.gz",
-              "hash": "0ca9d313acca194716ffadbf724e3257700428e92b5bd092055d9df631cd3a267f3c57ba755d75e41fb7b027848321bb0ab6dfee0374e0e45e54990b34bc67a8"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1de65d68-6aaf-46dc-b103-5461e03b8d81/160ce3ce92da0cc3eaf465279b6b61f1/dotnet-sdk-9.0.201-linux-musl-x64.tar.gz",
-              "hash": "756fe885d5916040c77995ceed02e852a93eee94489fb2521d9613da80b1a066c0553526c5b3d6c24bcd031c10e9848ad80d27b75945e4699909e6adfd39bacb"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/82a7fc96-b53b-4af4-ac3a-ef0a6c9325d5/84e522c31482538cddf696d03c5b20af/dotnet-sdk-9.0.201-linux-x64.tar.gz",
-              "hash": "93a8084ef38da810c3c96504c20ea2020a6b755b73a19f7acc6cd73a8b62ace0adda14452d11e6458f73dc7d58ffad22fcd151f111d2320cb23a10fd54dcb772"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/df799588-f7c7-4b9e-98f3-e93bf6b3a917/9779d41bff69c93a5ad52162d6547455/dotnet-sdk-9.0.201-osx-arm64.pkg",
-              "hash": "a40cb08334a6a11ecc3bb1ba9a4b98a1b5ef0ec6b7128bc3f88533a60fb61ec49bed4f1b91e9b2d7b3d9dfcbbcc753bc7012351571a8d147c9d99efba895e677"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/2dfd9746-db33-464f-93f7-6101f0f85968/6d20c7591ed80ad5c8b8039860b4626d/dotnet-sdk-9.0.201-osx-arm64.tar.gz",
-              "hash": "225dc2dc67f1fc41c05209e49a315651b20196ff0287f95ee083e4c932c90eed7b78f68287a889a41fb3ed11f48d0b75f6285fd0e81612f984b59cfa73d0a7c3"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c4538324-a899-4a99-8961-627b9448c38d/ee34a89933c2471a243feccfb225fd6f/dotnet-sdk-9.0.201-osx-x64.pkg",
-              "hash": "e86dbcdd0a1b6cd9a3f1768eeda5885073db5697a2a3ad496205adc035a3747ccc352b066108e63f1f78775b01c566ff1da08fa158c27b3f19e2de7617b1cc31"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/abc40bfa-5976-482c-9143-e8ac8ed267dd/8ec0035953d18fcb07aa3bb033ca35a2/dotnet-sdk-9.0.201-osx-x64.tar.gz",
-              "hash": "6b3183339a7b4fcd6975731f0c4079a7fa1a618bcf7a33583aa35ed8dbed5d841e5f17ce118416c21fea72babfabd0fc2cc04266f36af9d6c7bc8c5520cb5a81"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/acf7355d-cfd6-4c12-a11f-3f4b0a11e567/3c65c6657de59c5893fd30737da9caea/dotnet-sdk-9.0.201-win-arm64.exe",
-              "hash": "8dfc09eaadbe3bbc9c574b39c852fd027cea1ed9478b677c0bdca1f8ccb46acd2afe541ca47f6287fd13ea043379c1795d91288be21537319a8b7af18358e4b9"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a7ce7c57-89b0-4e48-9520-0e636e8a1c1e/a70b788941ac62651bdc3de8fbc01d20/dotnet-sdk-9.0.201-win-arm64.zip",
-              "hash": "0b3f8edc703110145cdecd37d1a5c3677b9cc1666f57a896da8bbe978751a673a6a86f3c04f16aa82c28bebbcfb00143b60253c10fcbc3340f442a6d012fa5cb"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/e91a9a25-ec83-4a12-8c15-0b65081b59f5/4e21a057218b753a437bf7bebb7dcbab/dotnet-sdk-9.0.201-win-x64.exe",
-              "hash": "8e3d95a6d22c27dd27412ebd886ff63e4c37484b2c1f3bde451b8e1329ef86eae75f0bfa9bb2acc54cab1ed942c343ab86d3c4ffe2ccff323e5661897006adf9"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5f4264b2-7499-46c4-88a6-cfe5d988cdeb/0e0243c0bfd628b99b38b8e30cadbfca/dotnet-sdk-9.0.201-win-x64.zip",
-              "hash": "5a6d8eadb389e0ab4984bf36cd2950583ee5e3f3a20e8fc1c5a526a197029988052616e1be1662c4b9e13020b572685423d664d0b68a009b4b98661f65bf1a73"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/c04fed06-8d66-4b84-877d-bf2a5b8efe34/ac8499841c5f107bff892f9920cdbc93/dotnet-sdk-9.0.201-win-x86.exe",
-              "hash": "cdb0d9d8a4e628f892edb25c959ee131b6d7439b6286b432be05e4e2e2e1c175d57683b49fa7b9d4e004bea0e408bab9e89260f00850ae5b3b5bafd4c033b5a5"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7d5c3ef7-5d95-47f3-84fb-264f2cd4f4b8/7744c37ea139fc9e9735b03e170d56f2/dotnet-sdk-9.0.201-win-x86.zip",
-              "hash": "b1b7b3db0fc4d2b3f8060938042e191cd1abe230d35c901cb67a5cf8f0472c1ed767226819c954cc6ae9e4fbacea1f634f507b6a88dcf9a543ce00128e66f64a"
-            }
-          ]
-        },
-        {
-          "version": "9.0.104",
-          "version-display": "9.0.104",
-          "runtime-version": "9.0.3",
-          "vs-version": "17.12.6",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "vs-mac-support": "",
-          "csharp-version": "13.0",
-          "fsharp-version": "9.0",
-          "vb-version": "17.13",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/aa05fba2-27d4-464d-b95c-49839de3bd90/6dc2b2e5628a115458c6d0c2cff4299a/dotnet-sdk-9.0.104-linux-arm.tar.gz",
-              "hash": "9d4d4a69a946fb61e9d3a0b3a575cf9eb87f419477a90acb002ded5c6a34c6eb746d14103493e330f0a43fbd82fa479591b64ab13bc1f92c619d735d0862e32a"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/a8072dab-fea1-424f-a90b-12c64f6dd881/1e800a277f917b5ccef8d3476ece7bf3/dotnet-sdk-9.0.104-linux-arm64.tar.gz",
-              "hash": "bca55566ea5fd74a9e0f757cae2f572823c450469f456756042987b27e9d15fbe59e1993742532a82fdfc7fb21f26a63e74b4c80ed17e52b12f0738b461d70e3"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/3f9a99e2-ef1e-4b82-9f31-4bdb4d9066e5/fd05e0620afcc053b79c51e770ed01e9/dotnet-sdk-9.0.104-linux-musl-arm.tar.gz",
-              "hash": "50222ede71ae50fac4970b2457de2dd90ec3e6297c29c5576ef1e17d523e6dcb04d60a1383f86bed288d0206728273df6dc0fddde595cfcf832651cca3619cc7"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/7b3014ae-980c-4756-a2db-4e1cf8a5aad0/43e168ffdf16a261bbd44926958996ff/dotnet-sdk-9.0.104-linux-musl-arm64.tar.gz",
-              "hash": "68a5e20a906dedd58e128c90116ce6f41fcbb3d6737397a3049eb81ff6a8ccc132326dd147480284535ee17a545be5e47b41dfdb482f50c15e76f5b84f31b9fd"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4c76ef5d-d592-407d-8551-925a7479bdfe/44d4204797f4a435a00dcc63e4920f1f/dotnet-sdk-9.0.104-linux-musl-x64.tar.gz",
-              "hash": "e88d054c0b91209f41d009129d186c3188066ee0bfc5ff0569c6489602d375e63b52142beb756f7f09edef9c60fa70d5de6d05cf7b3280388fd83d93e82cca76"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/33664896-3281-443d-a030-394719c926c9/f0f8964a84b092b7f7277ce9a6d99d9d/dotnet-sdk-9.0.104-linux-x64.tar.gz",
-              "hash": "99b6b1bcd46d3cd59896139054bfd6c15909b7aead7bb2f19d3e97bbf87a425db5bce4506d5f77bf6f7f1249b0cacafa679c9bc9c3b1e4f2ab2e79cb5d0b2c79"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/81a5a433-5f2f-4291-9135-b7409ebebf85/39acd5ef77a8486e8b7c5bc12a7d4eeb/dotnet-sdk-9.0.104-osx-arm64.pkg",
-              "hash": "b1b7f692e7602740e3880841be2e5e061e577f10ba4e58c3f07ebc9df0c5d4c13330fd99dd4f54ddceab55781b73b60b35ff39becf21230e5d23d26329ca0ae2"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4db0c5f9-9a8e-4878-8711-4687108f9157/ab18273765fec69310b3c0efb6b72eeb/dotnet-sdk-9.0.104-osx-arm64.tar.gz",
-              "hash": "2145b705149186444948a69d10a95451c579ff7314c78477555e06f7659a792172630db4a16fd27401f720f5e994e082bed23f437efef3c7198f1c83e5c61d77"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/64252241-074c-4dc0-9e4b-f451e8a53985/0b636d4f1ea92f45ae25bd855edf41ef/dotnet-sdk-9.0.104-osx-x64.pkg",
-              "hash": "9d1451e0de57e449b402937677110ab506e7e25773db9cfa67bb8467fc3eb0a876c7df9eff4369bc26f6456334c9dde276ed1e4d6714b377a0729494761f0c8a"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/fe6987a1-394f-4f04-b9bf-52a9ff020ca2/de9b3377974b7e24a910d1a4184a609a/dotnet-sdk-9.0.104-osx-x64.tar.gz",
-              "hash": "25b64652440b8c600a387f126dcbba5bc6646ddb906a3c27638b09264aa3ff668749cfc6e3a1e53070c97288ca71a58c7e91f1d10a4f0f4169a2d04e5f86a4b1"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/406109db-01bd-4c4a-9ef5-0797de2c2a6e/f47b5ab59a55804bf719686793663453/dotnet-sdk-9.0.104-win-arm64.exe",
-              "hash": "34bdab3f6a32baeb3e852262e132a3fddfe051d46ac5bdd82b28577ad3a9d2302821e990230a9684d89152077ff62887351b837d4a4d083871f3625ef368e980"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1aa4b6c4-6aa7-4021-a5a6-95ed9edd4fff/9a3b2f3fc82488044a66a40eae661e21/dotnet-sdk-9.0.104-win-arm64.zip",
-              "hash": "7ddb0c81f8f247655630883727d59d86800f8aa00d0f302cdce47d95566374e7687372fa51a12dde0c1e356efa24d11e65be5f8dc39005b2ca63ab4ab2ba3277"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/8f953ae6-70e5-422c-9923-dc608b37656f/a1a0fab794f1b22deccf2a56595586b2/dotnet-sdk-9.0.104-win-x64.exe",
-              "hash": "d6a9abfb2752cf51a583cee18c24ae340d7d8622b18eb846204cbf1a597ea80dc42d5189928cf27963f0fc649cf2a64a9d9565af8de82951f7b6dcdb0317a5a2"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/4b71bfb4-a43b-46f0-8a7c-2da1f45c88f8/995924ed9d8159cc7695ced2411bf234/dotnet-sdk-9.0.104-win-x64.zip",
-              "hash": "a6609ab702a48c6c5df4caa4b5fb63c237238926e8952322e141b7de7d8a403fe97728727598b2c449be1de1a7e9cbe902cca365add8c4e59056f90b58dfd27c"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/1daf7819-e0c2-43dc-9117-f8889ae394f9/bab9a531916bf1f11f02ebf81b2343a1/dotnet-sdk-9.0.104-win-x86.exe",
-              "hash": "f3f4ce834d45e8d26ae1cb729bc2d83a3bc5763f667910a918e878da95e2dba331488afcef92ba2d7f6ae05e591fb8956fd116aba88d188195bc24d4219281ca"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://download.visualstudio.microsoft.com/download/pr/5b69e47e-6207-4337-9151-54184ecf32d4/37a020f07ab7fabdeaded53237cfee70/dotnet-sdk-9.0.104-win-x86.zip",
-              "hash": "dac2558d0922f62585ff556488d6bdedef61f72cfb8244c7ba1fcc7bae92c049fc2303ead3d1ad81b59098eff2d16fa26c37e02d21b2f808ecb04666cfd5ea07"
-            }
-          ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "9.0.3",
-        "version-display": "9.0.3",
-        "version-aspnetcoremodule": [
-          "19.0.25044.3"
-        ],
-        "vs-version": "",
+      {
+        "version": "9.0.201",
+        "version-display": "9.0.201",
+        "runtime-version": "9.0.3",
+        "vs-version": "17.13.3",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2022 (v17.13)",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "17.13",
         "files": [
           {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/ce50fb55-0885-4427-8636-74a4be7a62b0/88b3a34f6713ba012258bc43c8f6fb2b/aspnetcore-runtime-9.0.3-linux-arm.tar.gz",
-            "hash": "2a7508de9795d8238a1d4ff7e74df819538ca47d6ff8663ddb27b5f7514dcf487e7eed22d8c84258cad3fb30066621a6c79e08f3b060f15d64e85145b376aef0"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a2cf96fc-f298-41e2-9dc6-8c0861916597/d505f4b28a7765d7bea6d2883a7fe170/dotnet-sdk-9.0.201-linux-arm.tar.gz",
+            "hash": "681218635821ad49586b20a0eeb03d029d15f2cf2c795074bd3e27a773f90a17a8b6bac9df44e083233cecf362bbfee7d0c6b83a24917e696bde8ad7e52f1155"
           },
           {
-            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/3ad17a72-66ec-41fc-b771-8094284b066d/ebf2d0da156c97776e9d27ad699d96ff/aspnetcore-runtime-9.0.3-linux-arm64.tar.gz",
-            "hash": "8a027078b46b6ebb3f4beda2b3f3cf7960701b71b9f2b6704c17f2752279c764755cadfd30f3e2f3e3ab26869e50a35c567c2fbd41fd98d77ae2f6fecde18b50"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d91bd91-9bb6-4b3f-9256-83f8c982e817/9248655502cac509f9c738509913770c/dotnet-sdk-9.0.201-linux-arm64.tar.gz",
+            "hash": "4eb78c7608355ca2780990934592c49579ed59f0983377c4c2c99a4091970264642b8fee92c65e91baeb6c6bc22066d6958085eacd1a850055b52f6d04436d5b"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2ed3b832-349f-4c3a-93c4-b78c10419da1/ed7d2f3d5deb8bf9501c9d62bd0481f2/aspnetcore-runtime-9.0.3-linux-musl-arm.tar.gz",
-            "hash": "416bf072c817abca07a3ec5e3527d8baf01f798c208a9091599a4d1826f3e9adb6f0b40bbbec597548e0715283cc166f5e9ff61836426c2de5c726b45f5fc8be"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/905c96fd-1e89-4024-834f-dd2690ec6eab/6b3cec8a13b42bf55f65f65badf0b89f/dotnet-sdk-9.0.201-linux-musl-arm.tar.gz",
+            "hash": "38dbe814f4ecd5281f7821059661ee0265fb219cde085facfccd59e9fb340c03818449064dfea4622de0c0c6e390ca1979515bde77bf30cbe7aae614c1cd4f2b"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/41ba2cc4-4df1-4386-a17c-4741e1f28b8c/7a52866c6cc1a00cfb4d2f09f7d80346/aspnetcore-runtime-9.0.3-linux-musl-arm64.tar.gz",
-            "hash": "6322fc1a733a541f94e13db91cd27d976f55734689d40c3fdfbb10a057a575f7e02b32b1d4ab7c879cd599380fddd7e0a17d7f0ad0eb370db142f4f3c7eb5bdc"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/26b8a5c2-b79c-425f-8356-d8f0d231bf45/0da5d6f19a28a5d07ebda7fe5a1ec536/dotnet-sdk-9.0.201-linux-musl-arm64.tar.gz",
+            "hash": "0ca9d313acca194716ffadbf724e3257700428e92b5bd092055d9df631cd3a267f3c57ba755d75e41fb7b027848321bb0ab6dfee0374e0e45e54990b34bc67a8"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/53087890-9ecf-4a5b-ab19-30f6d4e68472/d992febf2434ee68f9e63e0c599130ee/aspnetcore-runtime-9.0.3-linux-musl-x64.tar.gz",
-            "hash": "13585a919350ba2257f00a90ac2de0306b1e952ebba0c7f9039d7ec8da13554b2e3c86add01db83de4e647009b8a3ac66c3a68629e7701b463703b79db86e4ac"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1de65d68-6aaf-46dc-b103-5461e03b8d81/160ce3ce92da0cc3eaf465279b6b61f1/dotnet-sdk-9.0.201-linux-musl-x64.tar.gz",
+            "hash": "756fe885d5916040c77995ceed02e852a93eee94489fb2521d9613da80b1a066c0553526c5b3d6c24bcd031c10e9848ad80d27b75945e4699909e6adfd39bacb"
           },
           {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/30d54f5c-f3c6-4ee3-bdef-75e7cb0a40c2/cdb0ba537467777ff193f8f3cae6fc76/aspnetcore-runtime-9.0.3-linux-x64.tar.gz",
-            "hash": "38a3b73a6c41ee6f67e9108ebf684ec082fc6dfaa941ea225f6eb200a1e34909c05fa47a087c35c18eab607350796ecd16c09f2e3774dba590083c93742e39a3"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/82a7fc96-b53b-4af4-ac3a-ef0a6c9325d5/84e522c31482538cddf696d03c5b20af/dotnet-sdk-9.0.201-linux-x64.tar.gz",
+            "hash": "93a8084ef38da810c3c96504c20ea2020a6b755b73a19f7acc6cd73a8b62ace0adda14452d11e6458f73dc7d58ffad22fcd151f111d2320cb23a10fd54dcb772"
           },
           {
-            "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9209345f-0826-47ed-8761-de661e135630/f600961b518bbd8f70d6210332fca2ea/aspnetcore-runtime-9.0.3-osx-arm64.tar.gz",
-            "hash": "0f91a731182071ed511755e8521d82dc0e0c9bd1baaee705e16ddb2f235e8b632ea707465b817a240799e5fd7c524b50e3a1f6abd7d9a5edcee9025e473f4184"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/df799588-f7c7-4b9e-98f3-e93bf6b3a917/9779d41bff69c93a5ad52162d6547455/dotnet-sdk-9.0.201-osx-arm64.pkg",
+            "hash": "a40cb08334a6a11ecc3bb1ba9a4b98a1b5ef0ec6b7128bc3f88533a60fb61ec49bed4f1b91e9b2d7b3d9dfcbbcc753bc7012351571a8d147c9d99efba895e677"
           },
           {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2dfd9746-db33-464f-93f7-6101f0f85968/6d20c7591ed80ad5c8b8039860b4626d/dotnet-sdk-9.0.201-osx-arm64.tar.gz",
+            "hash": "225dc2dc67f1fc41c05209e49a315651b20196ff0287f95ee083e4c932c90eed7b78f68287a889a41fb3ed11f48d0b75f6285fd0e81612f984b59cfa73d0a7c3"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/c2e9f12c-01e1-450d-b1b4-e5d09de3d94e/01baa500c4071fb47d864d7f772047b1/aspnetcore-runtime-9.0.3-osx-x64.tar.gz",
-            "hash": "32aacaf3ebd41990362ff5a1236bf83c7a9e431c88169a6bcb2a7e9322278b7ee613f565a883077c5343d217ea6ac715bec1f696e1c9e8119dc4da664919fdf8"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c4538324-a899-4a99-8961-627b9448c38d/ee34a89933c2471a243feccfb225fd6f/dotnet-sdk-9.0.201-osx-x64.pkg",
+            "hash": "e86dbcdd0a1b6cd9a3f1768eeda5885073db5697a2a3ad496205adc035a3747ccc352b066108e63f1f78775b01c566ff1da08fa158c27b3f19e2de7617b1cc31"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.exe",
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/abc40bfa-5976-482c-9143-e8ac8ed267dd/8ec0035953d18fcb07aa3bb033ca35a2/dotnet-sdk-9.0.201-osx-x64.tar.gz",
+            "hash": "6b3183339a7b4fcd6975731f0c4079a7fa1a618bcf7a33583aa35ed8dbed5d841e5f17ce118416c21fea72babfabd0fc2cc04266f36af9d6c7bc8c5520cb5a81"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5943a039-13fe-45a7-91f1-769bcc642a46/7d4b5d8289c853bb3c0e091620f45ade/aspnetcore-runtime-9.0.3-win-arm64.exe",
-            "hash": "b468b96f39b7aa6035412d475c78eb820ed7f8dbf7257e9f99861ef1bac77f0fc56a4d8f53636116358470ee63d4ffcf27623db235b674b9340e3785b2652d9e"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/acf7355d-cfd6-4c12-a11f-3f4b0a11e567/3c65c6657de59c5893fd30737da9caea/dotnet-sdk-9.0.201-win-arm64.exe",
+            "hash": "8dfc09eaadbe3bbc9c574b39c852fd027cea1ed9478b677c0bdca1f8ccb46acd2afe541ca47f6287fd13ea043379c1795d91288be21537319a8b7af18358e4b9"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.zip",
+            "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/62b06c60-4604-45e4-a36d-340e8b8413d0/ed1d113824d9e09f047f9f63e4f84a64/aspnetcore-runtime-9.0.3-win-arm64.zip",
-            "hash": "a5ed15e458f28a057040a1f8de3b0b83878847a8eaef40657b05b60db4edda4691b7a97b30f75b1130349d35c0a2291c15c4181d2a940170fc248b27a042586a"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7ce7c57-89b0-4e48-9520-0e636e8a1c1e/a70b788941ac62651bdc3de8fbc01d20/dotnet-sdk-9.0.201-win-arm64.zip",
+            "hash": "0b3f8edc703110145cdecd37d1a5c3677b9cc1666f57a896da8bbe978751a673a6a86f3c04f16aa82c28bebbcfb00143b60253c10fcbc3340f442a6d012fa5cb"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.exe",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/9af55977-0e45-4500-8d1d-dc7f9195558a/c69aa6b827d50faecc2b4b0da5214aa6/aspnetcore-runtime-9.0.3-win-x64.exe",
-            "hash": "20d2929c4cb85f7bac7b6875a79b877ca2ae5f59471c7b4c6ec089de33cb980584ef77042a20209afdd0e6128f1fc50c647813956675300aa19b6257ece90034"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e91a9a25-ec83-4a12-8c15-0b65081b59f5/4e21a057218b753a437bf7bebb7dcbab/dotnet-sdk-9.0.201-win-x64.exe",
+            "hash": "8e3d95a6d22c27dd27412ebd886ff63e4c37484b2c1f3bde451b8e1329ef86eae75f0bfa9bb2acc54cab1ed942c343ab86d3c4ffe2ccff323e5661897006adf9"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/2412bec6-4a91-4846-9596-b9633d050ab1/c2840a791c06eda4bc23f72173445bad/aspnetcore-runtime-9.0.3-win-x64.zip",
-            "hash": "252866541dbf82eace90582620eac7550061de913a888623992ce947c31c364cc1965a6b25b9d3c5cc1cf4b24903f8c5b7a90f6f90b3eb4fd1ddf60d4f0159d3"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5f4264b2-7499-46c4-88a6-cfe5d988cdeb/0e0243c0bfd628b99b38b8e30cadbfca/dotnet-sdk-9.0.201-win-x64.zip",
+            "hash": "5a6d8eadb389e0ab4984bf36cd2950583ee5e3f3a20e8fc1c5a526a197029988052616e1be1662c4b9e13020b572685423d664d0b68a009b4b98661f65bf1a73"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/38c1b207-6261-4fa0-a133-27f25586d97a/8c3ab4eccb3e7c777520e362979db086/aspnetcore-runtime-9.0.3-win-x86.exe",
-            "hash": "27bf39dc5e116fe7f7f99c5a0d1bbcd23a5133ae903718c565e9b5470b2f598fc84cf6088fa3eced8456f34685dfd1e1dac980780ae76b57d744f2c6b4e57a53"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c04fed06-8d66-4b84-877d-bf2a5b8efe34/ac8499841c5f107bff892f9920cdbc93/dotnet-sdk-9.0.201-win-x86.exe",
+            "hash": "cdb0d9d8a4e628f892edb25c959ee131b6d7439b6286b432be05e4e2e2e1c175d57683b49fa7b9d4e004bea0e408bab9e89260f00850ae5b3b5bafd4c033b5a5"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.zip",
+            "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/8bd6c1a5-77bc-4007-a397-a77035cfcfba/6755008e43af854ef1b54bcb49d16e1d/aspnetcore-runtime-9.0.3-win-x86.zip",
-            "hash": "a84d3a77d268a1a7752b2660aa723e3aba86504ae4d522aa5b2af963487ad99ecc09dc55c142fc58039151c46b55430494807079ab3bb4af50c48f96e9e7844d"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5c5fa571-e78f-4bdc-b922-3518b9aa0aa9/a98c9b9ddaba0cd65e2c92d7057afada/aspnetcore-runtime-composite-9.0.3-linux-arm.tar.gz",
-            "hash": "52a7478e2ae6e0835ca96f54cfab5e93e31ccbd50fa034bf478a0c1c0f83d2ec163e085218694de49fc252cbbe4f0601249a6cb344fad5d5c2c56b33beb5c9d7"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/75f4a442-aca0-4d45-a4f1-e273b56b91fb/dfee286bec85d2d725675a9234b5df1b/aspnetcore-runtime-composite-9.0.3-linux-arm64.tar.gz",
-            "hash": "1b950c7b49d47618288bc570d4821c1ec56deb2364453c1380e778fc311fd00c1884a740743ad083978b94246b2bf33a3c64b5ed1ee807dd9ffac25ee03f0352"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5d7e2317-d70e-4a12-b9f0-279a9146426b/cba723df011d4f37c57c86c72bead8bb/aspnetcore-runtime-composite-9.0.3-linux-musl-arm.tar.gz",
-            "hash": "11b2a8bf1d615722a5ccda4a6fb09ceda98bd1c1e4b22471b6c1b9f38f7fa58c109aa290d5e2f5106b6c0d240cd80a616b4aa953658e6bbba0ef394160aedd2b"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/5053976d-f1a7-44c1-b697-fc5c2664b711/492b292ed92b78f29ad26a4e70a9245d/aspnetcore-runtime-composite-9.0.3-linux-musl-arm64.tar.gz",
-            "hash": "dedfb7919e127eda84454a0c6460a02840a4e96eefb2b7475e16dad61a737630515428e15d043e9beaa83f5e5f09cf7b1a12e4845b705ef38b81a249229ed8eb"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/985e3f3f-dfdf-4c59-8463-f5bc1064fd51/be66054c8f372db2fac482608aa58b71/aspnetcore-runtime-composite-9.0.3-linux-musl-x64.tar.gz",
-            "hash": "61e271dc0f8ac14e5dc026b8021e4a9b56c4115a05f2ff04f042248105600225053dd7b1cb26aa4df4c070bec3897a05ae103ba3a257b4864a7ce964412b3ee7"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/a1273378-d468-498d-a54e-0ca24b7a7120/7eb067cc97bcedf061011de57ca98069/aspnetcore-runtime-composite-9.0.3-linux-x64.tar.gz",
-            "hash": "020563a599541f944ef1fc42a710e025dbc86f40e28299316c2de9dd23e307d26ba7bb4a016d7423fdb7fff018955f333f267753233788a5c636a86e20aafda4"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/712e0fb1-575c-44f8-9253-3b32ef25e122/763e1cbd0aac7cefe69d2b720316770c/dotnet-hosting-9.0.3-win.exe",
-            "hash": "47ac3ebd0b58125d022215516b471e425af17a5cf65d63ae5b38b2ec55bf89c981bb56acbb6977dcab4f77278f12b5fdf9034ec20246e12343a65f76eeb0b798",
-            "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7d5c3ef7-5d95-47f3-84fb-264f2cd4f4b8/7744c37ea139fc9e9735b03e170d56f2/dotnet-sdk-9.0.201-win-x86.zip",
+            "hash": "b1b7b3db0fc4d2b3f8060938042e191cd1abe230d35c901cb67a5cf8f0472c1ed767226819c954cc6ae9e4fbacea1f634f507b6a88dcf9a543ce00128e66f64a"
           }
         ]
       },
-      "windowsdesktop": {
-        "version": "9.0.3",
-        "version-display": "9.0.3",
+      {
+        "version": "9.0.104",
+        "version-display": "9.0.104",
+        "runtime-version": "9.0.3",
+        "vs-version": "17.12.6",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2022 (v17.12)",
+        "vs-mac-support": "",
+        "csharp-version": "13.0",
+        "fsharp-version": "9.0",
+        "vb-version": "17.13",
         "files": [
           {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa05fba2-27d4-464d-b95c-49839de3bd90/6dc2b2e5628a115458c6d0c2cff4299a/dotnet-sdk-9.0.104-linux-arm.tar.gz",
+            "hash": "9d4d4a69a946fb61e9d3a0b3a575cf9eb87f419477a90acb002ded5c6a34c6eb746d14103493e330f0a43fbd82fa479591b64ab13bc1f92c619d735d0862e32a"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a8072dab-fea1-424f-a90b-12c64f6dd881/1e800a277f917b5ccef8d3476ece7bf3/dotnet-sdk-9.0.104-linux-arm64.tar.gz",
+            "hash": "bca55566ea5fd74a9e0f757cae2f572823c450469f456756042987b27e9d15fbe59e1993742532a82fdfc7fb21f26a63e74b4c80ed17e52b12f0738b461d70e3"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+            "rid": "linux-musl-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f9a99e2-ef1e-4b82-9f31-4bdb4d9066e5/fd05e0620afcc053b79c51e770ed01e9/dotnet-sdk-9.0.104-linux-musl-arm.tar.gz",
+            "hash": "50222ede71ae50fac4970b2457de2dd90ec3e6297c29c5576ef1e17d523e6dcb04d60a1383f86bed288d0206728273df6dc0fddde595cfcf832651cca3619cc7"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7b3014ae-980c-4756-a2db-4e1cf8a5aad0/43e168ffdf16a261bbd44926958996ff/dotnet-sdk-9.0.104-linux-musl-arm64.tar.gz",
+            "hash": "68a5e20a906dedd58e128c90116ce6f41fcbb3d6737397a3049eb81ff6a8ccc132326dd147480284535ee17a545be5e47b41dfdb482f50c15e76f5b84f31b9fd"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c76ef5d-d592-407d-8551-925a7479bdfe/44d4204797f4a435a00dcc63e4920f1f/dotnet-sdk-9.0.104-linux-musl-x64.tar.gz",
+            "hash": "e88d054c0b91209f41d009129d186c3188066ee0bfc5ff0569c6489602d375e63b52142beb756f7f09edef9c60fa70d5de6d05cf7b3280388fd83d93e82cca76"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/33664896-3281-443d-a030-394719c926c9/f0f8964a84b092b7f7277ce9a6d99d9d/dotnet-sdk-9.0.104-linux-x64.tar.gz",
+            "hash": "99b6b1bcd46d3cd59896139054bfd6c15909b7aead7bb2f19d3e97bbf87a425db5bce4506d5f77bf6f7f1249b0cacafa679c9bc9c3b1e4f2ab2e79cb5d0b2c79"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.pkg",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/81a5a433-5f2f-4291-9135-b7409ebebf85/39acd5ef77a8486e8b7c5bc12a7d4eeb/dotnet-sdk-9.0.104-osx-arm64.pkg",
+            "hash": "b1b7f692e7602740e3880841be2e5e061e577f10ba4e58c3f07ebc9df0c5d4c13330fd99dd4f54ddceab55781b73b60b35ff39becf21230e5d23d26329ca0ae2"
+          },
+          {
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4db0c5f9-9a8e-4878-8711-4687108f9157/ab18273765fec69310b3c0efb6b72eeb/dotnet-sdk-9.0.104-osx-arm64.tar.gz",
+            "hash": "2145b705149186444948a69d10a95451c579ff7314c78477555e06f7659a792172630db4a16fd27401f720f5e994e082bed23f437efef3c7198f1c83e5c61d77"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64252241-074c-4dc0-9e4b-f451e8a53985/0b636d4f1ea92f45ae25bd855edf41ef/dotnet-sdk-9.0.104-osx-x64.pkg",
+            "hash": "9d1451e0de57e449b402937677110ab506e7e25773db9cfa67bb8467fc3eb0a876c7df9eff4369bc26f6456334c9dde276ed1e4d6714b377a0729494761f0c8a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fe6987a1-394f-4f04-b9bf-52a9ff020ca2/de9b3377974b7e24a910d1a4184a609a/dotnet-sdk-9.0.104-osx-x64.tar.gz",
+            "hash": "25b64652440b8c600a387f126dcbba5bc6646ddb906a3c27638b09264aa3ff668749cfc6e3a1e53070c97288ca71a58c7e91f1d10a4f0f4169a2d04e5f86a4b1"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/b2f2a05c-c22b-4409-b41e-5f32aaa119a8/71171816b6261ddf0050b3b9172a75ce/windowsdesktop-runtime-9.0.3-win-arm64.exe",
-            "hash": "1c6b40cd3e00ad441306c1a2e534c1970dd00d19856ef57e7c8b09a85e187da357e5825763e6cd6446ae317de212cb2ab7c92bbdf9faf7c07a079a7394909479"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/406109db-01bd-4c4a-9ef5-0797de2c2a6e/f47b5ab59a55804bf719686793663453/dotnet-sdk-9.0.104-win-arm64.exe",
+            "hash": "34bdab3f6a32baeb3e852262e132a3fddfe051d46ac5bdd82b28577ad3a9d2302821e990230a9684d89152077ff62887351b837d4a4d083871f3625ef368e980"
           },
           {
-            "name": "windowsdesktop-runtime-win-arm64.zip",
+            "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/d945a7f6-2c45-4a0d-9ea6-d81a7fd0ac68/e59f9714eef7d4ac969ff4c814db76d1/windowsdesktop-runtime-9.0.3-win-arm64.zip",
-            "hash": "abd07d1ee5d714b8583b5acbd07dc477c457b00f1d2ca6f80f1d0c80c9edb12274f8e3be342c5790993e22c3ed2eb7ff4c744d5596153735d39bf6e17541c7fa"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1aa4b6c4-6aa7-4021-a5a6-95ed9edd4fff/9a3b2f3fc82488044a66a40eae661e21/dotnet-sdk-9.0.104-win-arm64.zip",
+            "hash": "7ddb0c81f8f247655630883727d59d86800f8aa00d0f302cdce47d95566374e7687372fa51a12dde0c1e356efa24d11e65be5f8dc39005b2ca63ab4ab2ba3277"
           },
           {
-            "name": "windowsdesktop-runtime-win-x64.exe",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/63f0335a-6012-4017-845f-5d655d56a44f/f8d5150469889387a1de578d45415201/windowsdesktop-runtime-9.0.3-win-x64.exe",
-            "hash": "344603c607ad8a73dbfccba08f3d5400b28d831fe146541924ef02a5f838c84405837a08eba5f9b4a855ddfb94962e625b24cf51f8d3860135e305baf9114e49"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8f953ae6-70e5-422c-9923-dc608b37656f/a1a0fab794f1b22deccf2a56595586b2/dotnet-sdk-9.0.104-win-x64.exe",
+            "hash": "d6a9abfb2752cf51a583cee18c24ae340d7d8622b18eb846204cbf1a597ea80dc42d5189928cf27963f0fc649cf2a64a9d9565af8de82951f7b6dcdb0317a5a2"
           },
           {
-            "name": "windowsdesktop-runtime-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/770a3479-d8bf-46c5-93c9-3fb6bf39d71e/1f12afea31e2c70be61e638c42ae0d4e/windowsdesktop-runtime-9.0.3-win-x64.zip",
-            "hash": "0dcdb04d054ef5e8871c7a70c1b1fd82e84797f213a5ba4fde6bdd1d1903462de0cf296a7165449492f8af8f19a1ef5b6bb3ea91385264d9bea8c1d782a4a0db"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b71bfb4-a43b-46f0-8a7c-2da1f45c88f8/995924ed9d8159cc7695ced2411bf234/dotnet-sdk-9.0.104-win-x64.zip",
+            "hash": "a6609ab702a48c6c5df4caa4b5fb63c237238926e8952322e141b7de7d8a403fe97728727598b2c449be1de1a7e9cbe902cca365add8c4e59056f90b58dfd27c"
           },
           {
-            "name": "windowsdesktop-runtime-win-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/48649e20-00b9-43d4-95df-112b80ff7d4e/5652d3ca690f5dc13bbb93ec816c763c/windowsdesktop-runtime-9.0.3-win-x86.exe",
-            "hash": "b482793c9daac8888fdb53123748fe6438a8952a7d64e0820feeb580fcadbdb7c2f6efd90fe0d5fda73deb6e3e9830939538fb262362705c3e495b5b404f1750"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1daf7819-e0c2-43dc-9117-f8889ae394f9/bab9a531916bf1f11f02ebf81b2343a1/dotnet-sdk-9.0.104-win-x86.exe",
+            "hash": "f3f4ce834d45e8d26ae1cb729bc2d83a3bc5763f667910a918e878da95e2dba331488afcef92ba2d7f6ae05e591fb8956fd116aba88d188195bc24d4219281ca"
           },
           {
-            "name": "windowsdesktop-runtime-win-x86.zip",
+            "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/e82fad71-96ae-4a0a-b0c5-432414776159/20304ae3865c6495cc4df478c515a053/windowsdesktop-runtime-9.0.3-win-x86.zip",
-            "hash": "a05f65a29ec10ebc95536b3ab1a57809c998a8c05b32084884c0e5d26f681dacaf8081c53d89c5c552242a13f7e70ef33d8255aa8a4894d163e5fc87ef3a48c1"
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5b69e47e-6207-4337-9151-54184ecf32d4/37a020f07ab7fabdeaded53237cfee70/dotnet-sdk-9.0.104-win-x86.zip",
+            "hash": "dac2558d0922f62585ff556488d6bdedef61f72cfb8244c7ba1fcc7bae92c049fc2303ead3d1ad81b59098eff2d16fa26c37e02d21b2f808ecb04666cfd5ea07"
           }
         ]
       }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.3",
+      "version-display": "9.0.3",
+      "version-aspnetcoremodule": [
+        "19.0.25044.3"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/ce50fb55-0885-4427-8636-74a4be7a62b0/88b3a34f6713ba012258bc43c8f6fb2b/aspnetcore-runtime-9.0.3-linux-arm.tar.gz",
+          "hash": "2a7508de9795d8238a1d4ff7e74df819538ca47d6ff8663ddb27b5f7514dcf487e7eed22d8c84258cad3fb30066621a6c79e08f3b060f15d64e85145b376aef0"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/3ad17a72-66ec-41fc-b771-8094284b066d/ebf2d0da156c97776e9d27ad699d96ff/aspnetcore-runtime-9.0.3-linux-arm64.tar.gz",
+          "hash": "8a027078b46b6ebb3f4beda2b3f3cf7960701b71b9f2b6704c17f2752279c764755cadfd30f3e2f3e3ab26869e50a35c567c2fbd41fd98d77ae2f6fecde18b50"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2ed3b832-349f-4c3a-93c4-b78c10419da1/ed7d2f3d5deb8bf9501c9d62bd0481f2/aspnetcore-runtime-9.0.3-linux-musl-arm.tar.gz",
+          "hash": "416bf072c817abca07a3ec5e3527d8baf01f798c208a9091599a4d1826f3e9adb6f0b40bbbec597548e0715283cc166f5e9ff61836426c2de5c726b45f5fc8be"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/41ba2cc4-4df1-4386-a17c-4741e1f28b8c/7a52866c6cc1a00cfb4d2f09f7d80346/aspnetcore-runtime-9.0.3-linux-musl-arm64.tar.gz",
+          "hash": "6322fc1a733a541f94e13db91cd27d976f55734689d40c3fdfbb10a057a575f7e02b32b1d4ab7c879cd599380fddd7e0a17d7f0ad0eb370db142f4f3c7eb5bdc"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/53087890-9ecf-4a5b-ab19-30f6d4e68472/d992febf2434ee68f9e63e0c599130ee/aspnetcore-runtime-9.0.3-linux-musl-x64.tar.gz",
+          "hash": "13585a919350ba2257f00a90ac2de0306b1e952ebba0c7f9039d7ec8da13554b2e3c86add01db83de4e647009b8a3ac66c3a68629e7701b463703b79db86e4ac"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/30d54f5c-f3c6-4ee3-bdef-75e7cb0a40c2/cdb0ba537467777ff193f8f3cae6fc76/aspnetcore-runtime-9.0.3-linux-x64.tar.gz",
+          "hash": "38a3b73a6c41ee6f67e9108ebf684ec082fc6dfaa941ea225f6eb200a1e34909c05fa47a087c35c18eab607350796ecd16c09f2e3774dba590083c93742e39a3"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9209345f-0826-47ed-8761-de661e135630/f600961b518bbd8f70d6210332fca2ea/aspnetcore-runtime-9.0.3-osx-arm64.tar.gz",
+          "hash": "0f91a731182071ed511755e8521d82dc0e0c9bd1baaee705e16ddb2f235e8b632ea707465b817a240799e5fd7c524b50e3a1f6abd7d9a5edcee9025e473f4184"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/c2e9f12c-01e1-450d-b1b4-e5d09de3d94e/01baa500c4071fb47d864d7f772047b1/aspnetcore-runtime-9.0.3-osx-x64.tar.gz",
+          "hash": "32aacaf3ebd41990362ff5a1236bf83c7a9e431c88169a6bcb2a7e9322278b7ee613f565a883077c5343d217ea6ac715bec1f696e1c9e8119dc4da664919fdf8"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5943a039-13fe-45a7-91f1-769bcc642a46/7d4b5d8289c853bb3c0e091620f45ade/aspnetcore-runtime-9.0.3-win-arm64.exe",
+          "hash": "b468b96f39b7aa6035412d475c78eb820ed7f8dbf7257e9f99861ef1bac77f0fc56a4d8f53636116358470ee63d4ffcf27623db235b674b9340e3785b2652d9e"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/62b06c60-4604-45e4-a36d-340e8b8413d0/ed1d113824d9e09f047f9f63e4f84a64/aspnetcore-runtime-9.0.3-win-arm64.zip",
+          "hash": "a5ed15e458f28a057040a1f8de3b0b83878847a8eaef40657b05b60db4edda4691b7a97b30f75b1130349d35c0a2291c15c4181d2a940170fc248b27a042586a"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/9af55977-0e45-4500-8d1d-dc7f9195558a/c69aa6b827d50faecc2b4b0da5214aa6/aspnetcore-runtime-9.0.3-win-x64.exe",
+          "hash": "20d2929c4cb85f7bac7b6875a79b877ca2ae5f59471c7b4c6ec089de33cb980584ef77042a20209afdd0e6128f1fc50c647813956675300aa19b6257ece90034"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/2412bec6-4a91-4846-9596-b9633d050ab1/c2840a791c06eda4bc23f72173445bad/aspnetcore-runtime-9.0.3-win-x64.zip",
+          "hash": "252866541dbf82eace90582620eac7550061de913a888623992ce947c31c364cc1965a6b25b9d3c5cc1cf4b24903f8c5b7a90f6f90b3eb4fd1ddf60d4f0159d3"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/38c1b207-6261-4fa0-a133-27f25586d97a/8c3ab4eccb3e7c777520e362979db086/aspnetcore-runtime-9.0.3-win-x86.exe",
+          "hash": "27bf39dc5e116fe7f7f99c5a0d1bbcd23a5133ae903718c565e9b5470b2f598fc84cf6088fa3eced8456f34685dfd1e1dac980780ae76b57d744f2c6b4e57a53"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/8bd6c1a5-77bc-4007-a397-a77035cfcfba/6755008e43af854ef1b54bcb49d16e1d/aspnetcore-runtime-9.0.3-win-x86.zip",
+          "hash": "a84d3a77d268a1a7752b2660aa723e3aba86504ae4d522aa5b2af963487ad99ecc09dc55c142fc58039151c46b55430494807079ab3bb4af50c48f96e9e7844d"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5c5fa571-e78f-4bdc-b922-3518b9aa0aa9/a98c9b9ddaba0cd65e2c92d7057afada/aspnetcore-runtime-composite-9.0.3-linux-arm.tar.gz",
+          "hash": "52a7478e2ae6e0835ca96f54cfab5e93e31ccbd50fa034bf478a0c1c0f83d2ec163e085218694de49fc252cbbe4f0601249a6cb344fad5d5c2c56b33beb5c9d7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/75f4a442-aca0-4d45-a4f1-e273b56b91fb/dfee286bec85d2d725675a9234b5df1b/aspnetcore-runtime-composite-9.0.3-linux-arm64.tar.gz",
+          "hash": "1b950c7b49d47618288bc570d4821c1ec56deb2364453c1380e778fc311fd00c1884a740743ad083978b94246b2bf33a3c64b5ed1ee807dd9ffac25ee03f0352"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5d7e2317-d70e-4a12-b9f0-279a9146426b/cba723df011d4f37c57c86c72bead8bb/aspnetcore-runtime-composite-9.0.3-linux-musl-arm.tar.gz",
+          "hash": "11b2a8bf1d615722a5ccda4a6fb09ceda98bd1c1e4b22471b6c1b9f38f7fa58c109aa290d5e2f5106b6c0d240cd80a616b4aa953658e6bbba0ef394160aedd2b"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/5053976d-f1a7-44c1-b697-fc5c2664b711/492b292ed92b78f29ad26a4e70a9245d/aspnetcore-runtime-composite-9.0.3-linux-musl-arm64.tar.gz",
+          "hash": "dedfb7919e127eda84454a0c6460a02840a4e96eefb2b7475e16dad61a737630515428e15d043e9beaa83f5e5f09cf7b1a12e4845b705ef38b81a249229ed8eb"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/985e3f3f-dfdf-4c59-8463-f5bc1064fd51/be66054c8f372db2fac482608aa58b71/aspnetcore-runtime-composite-9.0.3-linux-musl-x64.tar.gz",
+          "hash": "61e271dc0f8ac14e5dc026b8021e4a9b56c4115a05f2ff04f042248105600225053dd7b1cb26aa4df4c070bec3897a05ae103ba3a257b4864a7ce964412b3ee7"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/a1273378-d468-498d-a54e-0ca24b7a7120/7eb067cc97bcedf061011de57ca98069/aspnetcore-runtime-composite-9.0.3-linux-x64.tar.gz",
+          "hash": "020563a599541f944ef1fc42a710e025dbc86f40e28299316c2de9dd23e307d26ba7bb4a016d7423fdb7fff018955f333f267753233788a5c636a86e20aafda4"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/712e0fb1-575c-44f8-9253-3b32ef25e122/763e1cbd0aac7cefe69d2b720316770c/dotnet-hosting-9.0.3-win.exe",
+          "hash": "47ac3ebd0b58125d022215516b471e425af17a5cf65d63ae5b38b2ec55bf89c981bb56acbb6977dcab4f77278f12b5fdf9034ec20246e12343a65f76eeb0b798",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.3",
+      "version-display": "9.0.3",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/b2f2a05c-c22b-4409-b41e-5f32aaa119a8/71171816b6261ddf0050b3b9172a75ce/windowsdesktop-runtime-9.0.3-win-arm64.exe",
+          "hash": "1c6b40cd3e00ad441306c1a2e534c1970dd00d19856ef57e7c8b09a85e187da357e5825763e6cd6446ae317de212cb2ab7c92bbdf9faf7c07a079a7394909479"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/d945a7f6-2c45-4a0d-9ea6-d81a7fd0ac68/e59f9714eef7d4ac969ff4c814db76d1/windowsdesktop-runtime-9.0.3-win-arm64.zip",
+          "hash": "abd07d1ee5d714b8583b5acbd07dc477c457b00f1d2ca6f80f1d0c80c9edb12274f8e3be342c5790993e22c3ed2eb7ff4c744d5596153735d39bf6e17541c7fa"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/63f0335a-6012-4017-845f-5d655d56a44f/f8d5150469889387a1de578d45415201/windowsdesktop-runtime-9.0.3-win-x64.exe",
+          "hash": "344603c607ad8a73dbfccba08f3d5400b28d831fe146541924ef02a5f838c84405837a08eba5f9b4a855ddfb94962e625b24cf51f8d3860135e305baf9114e49"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/770a3479-d8bf-46c5-93c9-3fb6bf39d71e/1f12afea31e2c70be61e638c42ae0d4e/windowsdesktop-runtime-9.0.3-win-x64.zip",
+          "hash": "0dcdb04d054ef5e8871c7a70c1b1fd82e84797f213a5ba4fde6bdd1d1903462de0cf296a7165449492f8af8f19a1ef5b6bb3ea91385264d9bea8c1d782a4a0db"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/48649e20-00b9-43d4-95df-112b80ff7d4e/5652d3ca690f5dc13bbb93ec816c763c/windowsdesktop-runtime-9.0.3-win-x86.exe",
+          "hash": "b482793c9daac8888fdb53123748fe6438a8952a7d64e0820feeb580fcadbdb7c2f6efd90fe0d5fda73deb6e3e9830939538fb262362705c3e495b5b404f1750"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://download.visualstudio.microsoft.com/download/pr/e82fad71-96ae-4a0a-b0c5-432414776159/20304ae3865c6495cc4df478c515a053/windowsdesktop-runtime-9.0.3-win-x86.zip",
+          "hash": "a05f65a29ec10ebc95536b3ab1a57809c998a8c05b32084884c0e5d26f681dacaf8081c53d89c5c552242a13f7e70ef33d8255aa8a4894d163e5fc87ef3a48c1"
+        }
+      ]
     }
-  ]
+  }
 }

--- a/release-notes/9.0/9.0.4/release.json
+++ b/release-notes/9.0/9.0.4/release.json
@@ -1,125 +1,232 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-04-08",
-  "release-version": "9.0.4",
-  "security": true,
-  "releases": [
-    {
-      "release-date": "2025-04-08",
-      "release-version": "9.0.4",
-      "security": true,
-      "cve-list": [
+  "release": {
+    "release-date": "2025-04-08",
+    "release-version": "9.0.4",
+    "security": true,
+    "cve-list": [
+      {
+        "cve-id": "CVE-2025-26682",
+        "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-26682"
+      }
+    ],
+    "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.4/9.0.4.md",
+    "runtime": {
+      "version": "9.0.4",
+      "version-display": "9.0.4",
+      "vs-version": "17.12.7, 17.13.6",
+      "vs-mac-version": "",
+      "files": [
         {
-          "cve-id": "CVE-2025-26682",
-          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-26682"
+          "name": "dotnet-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-arm.tar.gz",
+          "hash": "aacde9722446e37c8bede60cc3d6dc14d8104ca9772cb2d7b05f3f78f2216af2ed642f97dcd4f2f11c0b7567f3402d6ae08c3260c0fb105f664b4a92a024ef18"
+        },
+        {
+          "name": "dotnet-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-arm64.tar.gz",
+          "hash": "90865902fd1babc49d288efb61cd78ca63f43cfb9bbd9343f2871ff0da023f80129b3a9c26edc9583fbbf8a91932efbad3c823ad8622fe389b20b53f87254f1b"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-arm.tar.gz",
+          "hash": "152315bad4db61f6de20e47103e0804f64e9dbc3adbb8cf874c3e979a0d19b4b26f5fac07f1cd224a8881f4afdedb3c244f970a7d647eae1aa44ac2604c43526"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-arm64.tar.gz",
+          "hash": "f91cb422005c64c92c804b02670526492446cbe368633579dbf670a4a6d679c74ef012b8ee73fea672ccd85f0aa44c7164ed20876772af15052fa7447c10e255"
+        },
+        {
+          "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-x64.tar.gz",
+          "hash": "a5e597643deae25a998759bd9b0eb19b933f13a36b1d7f2e4696068a9a9e0324bfd43490e8dec222168b8c063b6827fbee80181e4700bb4712550acc1801048c"
+        },
+        {
+          "name": "dotnet-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-x64.tar.gz",
+          "hash": "fb421fdd87ac2b4143b5746a049f802d11430b770422bf60310ee4e8e2e6a2c943ff8870d4ddf689c6e0f05bf5947fd4b9dfeb56783e796bb4f4f0191a5abb2c"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-arm64.pkg",
+          "hash": "0645e17b8dcaa3cf99d0c9b5b819adad7e6948ae57bee33256c09f7f9d668cf09a2639179dc09d40927f436d1c0bb46f82b88e39c7155e8c197f9467a014a9bd"
+        },
+        {
+          "name": "dotnet-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-arm64.tar.gz",
+          "hash": "ce4a7c9491a631ebc19bac75923e8d94ba5d699f07318580408bb1bdbd67cb8a42bf6e87397f26803580326c47c3d04839bc762ec9d843320199a1587ea078bd"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-x64.pkg",
+          "hash": "12bd18f22c326dc71ad3e52655e42d0804069b162407cc9c2a707d6d70cf208a30da3498ec536fde0475e52bb3d7a08acc0aab754dffa1b2d90adb023894072c"
+        },
+        {
+          "name": "dotnet-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-x64.tar.gz",
+          "hash": "a227905ea8693d4e6af30cd44424c2849804965ce2d8e5807cde900d4e84b23ff263795ca2cf68376382863b0bb5e6aa27ecfd55030d2ac5012b5fc118ce0fcc"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-arm64.exe",
+          "hash": "6a701b6bdc42318c342990ae2f6f968e1063334f26eeebf8f2bdc6b5cbe3f360e97411eb43e6be250438125808a26f1bfa9d2a5295b48b71440e1d6c1c17c5b5"
+        },
+        {
+          "name": "dotnet-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-arm64.zip",
+          "hash": "4ecf516da62b4f1e523d062170389087a5c33adb5806ae2119fcc4d1b53a2446753c8b30030e77fdb616b6e728ab8b7efec53c95b6cd8650c5731e1f5991da3b"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x64.exe",
+          "hash": "cc385d981405bf8c62dac62550c4dbf1e4420d7375848326055dae18e89f252e0e866087763ad5c8c42ebebf8e51a64ad5a66834b24465eab9769753203c383d"
+        },
+        {
+          "name": "dotnet-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x64.zip",
+          "hash": "741dfaac5ff4df3bad55eb1b891c96d051d7225928e83a8891528023a0aa1252ad33015d5888ca142fcf3b1ce9cc1a915db92408c107766c6143171e3fc86e3f"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x86.exe",
+          "hash": "432a88e38c3e033ee6b1b3ea6394b4d661030cf1c25b07ef8e6f68ef4e43446e3f805b4054b5ca0a340bbda4d3d3bf8a9e85cbd69aae896d723d1ee046356e77"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x86.zip",
+          "hash": "a01453aa8435bf06811983861d95a60ca206c8dcff5dca9eaef4e5e911a5ddd7eb94fb82d3e529406dbc2f1c73a9fb7bc34b7a2d30af37c9fc8f943b105eee2a"
         }
-      ],
-      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.4/9.0.4.md",
-      "runtime": {
-        "version": "9.0.4",
-        "version-display": "9.0.4",
-        "vs-version": "17.12.7, 17.13.6",
-        "vs-mac-version": "",
-        "files": [
-          {
-            "name": "dotnet-runtime-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-arm.tar.gz",
-            "hash": "aacde9722446e37c8bede60cc3d6dc14d8104ca9772cb2d7b05f3f78f2216af2ed642f97dcd4f2f11c0b7567f3402d6ae08c3260c0fb105f664b4a92a024ef18"
-          },
-          {
-            "name": "dotnet-runtime-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-arm64.tar.gz",
-            "hash": "90865902fd1babc49d288efb61cd78ca63f43cfb9bbd9343f2871ff0da023f80129b3a9c26edc9583fbbf8a91932efbad3c823ad8622fe389b20b53f87254f1b"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-arm.tar.gz",
-            "hash": "152315bad4db61f6de20e47103e0804f64e9dbc3adbb8cf874c3e979a0d19b4b26f5fac07f1cd224a8881f4afdedb3c244f970a7d647eae1aa44ac2604c43526"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-arm64.tar.gz",
-            "hash": "f91cb422005c64c92c804b02670526492446cbe368633579dbf670a4a6d679c74ef012b8ee73fea672ccd85f0aa44c7164ed20876772af15052fa7447c10e255"
-          },
-          {
-            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-musl-x64.tar.gz",
-            "hash": "a5e597643deae25a998759bd9b0eb19b933f13a36b1d7f2e4696068a9a9e0324bfd43490e8dec222168b8c063b6827fbee80181e4700bb4712550acc1801048c"
-          },
-          {
-            "name": "dotnet-runtime-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-linux-x64.tar.gz",
-            "hash": "fb421fdd87ac2b4143b5746a049f802d11430b770422bf60310ee4e8e2e6a2c943ff8870d4ddf689c6e0f05bf5947fd4b9dfeb56783e796bb4f4f0191a5abb2c"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.pkg",
-            "rid": "osx-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-arm64.pkg",
-            "hash": "0645e17b8dcaa3cf99d0c9b5b819adad7e6948ae57bee33256c09f7f9d668cf09a2639179dc09d40927f436d1c0bb46f82b88e39c7155e8c197f9467a014a9bd"
-          },
-          {
-            "name": "dotnet-runtime-osx-arm64.tar.gz",
-            "rid": "osx-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-arm64.tar.gz",
-            "hash": "ce4a7c9491a631ebc19bac75923e8d94ba5d699f07318580408bb1bdbd67cb8a42bf6e87397f26803580326c47c3d04839bc762ec9d843320199a1587ea078bd"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.pkg",
-            "rid": "osx-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-x64.pkg",
-            "hash": "12bd18f22c326dc71ad3e52655e42d0804069b162407cc9c2a707d6d70cf208a30da3498ec536fde0475e52bb3d7a08acc0aab754dffa1b2d90adb023894072c"
-          },
-          {
-            "name": "dotnet-runtime-osx-x64.tar.gz",
-            "rid": "osx-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-osx-x64.tar.gz",
-            "hash": "a227905ea8693d4e6af30cd44424c2849804965ce2d8e5807cde900d4e84b23ff263795ca2cf68376382863b0bb5e6aa27ecfd55030d2ac5012b5fc118ce0fcc"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-arm64.exe",
-            "hash": "6a701b6bdc42318c342990ae2f6f968e1063334f26eeebf8f2bdc6b5cbe3f360e97411eb43e6be250438125808a26f1bfa9d2a5295b48b71440e1d6c1c17c5b5"
-          },
-          {
-            "name": "dotnet-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-arm64.zip",
-            "hash": "4ecf516da62b4f1e523d062170389087a5c33adb5806ae2119fcc4d1b53a2446753c8b30030e77fdb616b6e728ab8b7efec53c95b6cd8650c5731e1f5991da3b"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x64.exe",
-            "hash": "cc385d981405bf8c62dac62550c4dbf1e4420d7375848326055dae18e89f252e0e866087763ad5c8c42ebebf8e51a64ad5a66834b24465eab9769753203c383d"
-          },
-          {
-            "name": "dotnet-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x64.zip",
-            "hash": "741dfaac5ff4df3bad55eb1b891c96d051d7225928e83a8891528023a0aa1252ad33015d5888ca142fcf3b1ce9cc1a915db92408c107766c6143171e3fc86e3f"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x86.exe",
-            "hash": "432a88e38c3e033ee6b1b3ea6394b4d661030cf1c25b07ef8e6f68ef4e43446e3f805b4054b5ca0a340bbda4d3d3bf8a9e85cbd69aae896d723d1ee046356e77"
-          },
-          {
-            "name": "dotnet-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.4/dotnet-runtime-9.0.4-win-x86.zip",
-            "hash": "a01453aa8435bf06811983861d95a60ca206c8dcff5dca9eaef4e5e911a5ddd7eb94fb82d3e529406dbc2f1c73a9fb7bc34b7a2d30af37c9fc8f943b105eee2a"
-          }
-        ]
-      },
-      "sdk": {
+      ]
+    },
+    "sdk": {
+      "version": "9.0.203",
+      "version-display": "9.0.203",
+      "runtime-version": "9.0.4",
+      "vs-version": "17.13.6",
+      "vs-mac-version": "",
+      "vs-support": "Visual Studio 2022 (v17.13)",
+      "vs-mac-support": "",
+      "csharp-version": "12.0",
+      "fsharp-version": "8.0",
+      "vb-version": "16.9",
+      "files": [
+        {
+          "name": "dotnet-sdk-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-arm.tar.gz",
+          "hash": "7b0969a09148ac8dddf1fdcd41948f163f17acccaa68787195d2935e0e69554fef423291d60579bfb94d676aca8fd498eec49f8555fe750f0e88eadf6317eb37"
+        },
+        {
+          "name": "dotnet-sdk-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-arm64.tar.gz",
+          "hash": "3070ecef0d6c550a80c3ca497598d09e9a97a264bfd72e86f7c568d2f39368bd7db837681d64d9ed187a8923915d964d02b02f5bc6a493910a18184f5321d233"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-arm.tar.gz",
+          "hash": "4d43cb65e398dbeed77613eea92ae0c2ccb4720b7b3db47afc144e310b3e76cc6da42e2a5415d9f1b98617240bc7331961b5a83fe8550dc7df5e06010a21267e"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-arm64.tar.gz",
+          "hash": "e21b7c01fadc6d26337d64c89adb96d2914080f02fe57130b927b0f67945c6b5adea63e4c38e681247961d85ec36e6bb89cc7475c791219fced6f18b5bcb7c9d"
+        },
+        {
+          "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-x64.tar.gz",
+          "hash": "83b0c47dca699b57c5c7b51d33fad61eb74bdf4285a992befe8d5ff8ea35c0f241225ff2fda709816b66462945ebaead6ea4ef2fbfb28f6194468916ce608d1e"
+        },
+        {
+          "name": "dotnet-sdk-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-x64.tar.gz",
+          "hash": "67d62c3274aae593b61780db57f07ac85a50da82d04707fdaca66f25889a1cc01eaa95bce173247d1a9f566a92eb7ede71a7306b5af6a17ed84ee9525823ddd3"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.pkg",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-arm64.pkg",
+          "hash": "77cbf7a4b6e8d80426b07395dff67b33a3c1ffd80fd87b10348a06628f142b47acd9605f61852e7cbcb4e36d473bd9ad91a411dc7bff5ac25486a60bcbf84b4a"
+        },
+        {
+          "name": "dotnet-sdk-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-arm64.tar.gz",
+          "hash": "50a7e19b0d55de868a9cc52f6ebc1ba39b9b787b3343df5581ec50cce27b86793bb1c63168b5e8843479605e35515b49d1aaeee3a469611c2e2fc966be8c3ae5"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.pkg",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-x64.pkg",
+          "hash": "ef5f0a16eccb7b7231c8d3cc788bd0f84df8a59bda669fcb70d9dab1fa903bc10140b5ae61c9e80981feaf789fea0cea144bb827693f70ac2e90b0887bfc1888"
+        },
+        {
+          "name": "dotnet-sdk-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-x64.tar.gz",
+          "hash": "837f6fb8ca30f443d7678c73619f7a004440f809e7c339932616f377954c6e1b4a6c9fef1434d75df991641641d62f9cf1a16d5aee6640170cbb27a1b961632b"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-arm64.exe",
+          "hash": "d1420d062e4f3d130a2ebfd0bee7ed870552a1c5ef901fe18f6eaf4c2534ee85121e3b7a40eadc2f6af164a41d322dc65a9ef896c2e909f4d89f179e6607dd65"
+        },
+        {
+          "name": "dotnet-sdk-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-arm64.zip",
+          "hash": "379cdd811623966b25418af2b87611fd8c359f3db2a9618428554d77d05f73e6410f67c425c45240613e556de9ecbbc89695d036ac2f73c7d71ba9de704f3fb0"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.exe",
+          "hash": "77b87bd1785d5272912d6d8b732871ce3dd2f52a481aca24504c19e247772244310f89d686c9cdf50d518c1839238aa4775417e3a37ca33e6310b4ea01f05f1e"
+        },
+        {
+          "name": "dotnet-sdk-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.zip",
+          "hash": "5fc935b55c8a72ad274b1f5747efddf64712d80992424347fc2ad8b303f73a5b9616d41273be48505acde2691aacc97c9bfa07ca3a9b1036835cf5927dfd7526"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x86.exe",
+          "hash": "dd47554df1f1d217429924bad81ccf22a7533b511473fdb1e019c5fecc63c6ea67ea2abd870130864d6a6c63be0bb4f005f91f67e61bfeb314fa8fa639d81821"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x86.zip",
+          "hash": "7f72a6d9923bd4b7e0a8bfc5f395ebebed452a92b3ec1097bbccb3adb7ab00356bdf9869c770248a44033f4672b3d4157eb430261fed7e219893e10d91d454bf"
+        }
+      ]
+    },
+    "sdks": [
+      {
         "version": "9.0.203",
         "version-display": "9.0.203",
         "runtime-version": "9.0.4",
@@ -229,407 +336,295 @@
           }
         ]
       },
-      "sdks": [
-        {
-          "version": "9.0.203",
-          "version-display": "9.0.203",
-          "runtime-version": "9.0.4",
-          "vs-version": "17.13.6",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.13)",
-          "vs-mac-support": "",
-          "csharp-version": "12.0",
-          "fsharp-version": "8.0",
-          "vb-version": "16.9",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-arm.tar.gz",
-              "hash": "7b0969a09148ac8dddf1fdcd41948f163f17acccaa68787195d2935e0e69554fef423291d60579bfb94d676aca8fd498eec49f8555fe750f0e88eadf6317eb37"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-arm64.tar.gz",
-              "hash": "3070ecef0d6c550a80c3ca497598d09e9a97a264bfd72e86f7c568d2f39368bd7db837681d64d9ed187a8923915d964d02b02f5bc6a493910a18184f5321d233"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-arm.tar.gz",
-              "hash": "4d43cb65e398dbeed77613eea92ae0c2ccb4720b7b3db47afc144e310b3e76cc6da42e2a5415d9f1b98617240bc7331961b5a83fe8550dc7df5e06010a21267e"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-arm64.tar.gz",
-              "hash": "e21b7c01fadc6d26337d64c89adb96d2914080f02fe57130b927b0f67945c6b5adea63e4c38e681247961d85ec36e6bb89cc7475c791219fced6f18b5bcb7c9d"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-musl-x64.tar.gz",
-              "hash": "83b0c47dca699b57c5c7b51d33fad61eb74bdf4285a992befe8d5ff8ea35c0f241225ff2fda709816b66462945ebaead6ea4ef2fbfb28f6194468916ce608d1e"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-linux-x64.tar.gz",
-              "hash": "67d62c3274aae593b61780db57f07ac85a50da82d04707fdaca66f25889a1cc01eaa95bce173247d1a9f566a92eb7ede71a7306b5af6a17ed84ee9525823ddd3"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-arm64.pkg",
-              "hash": "77cbf7a4b6e8d80426b07395dff67b33a3c1ffd80fd87b10348a06628f142b47acd9605f61852e7cbcb4e36d473bd9ad91a411dc7bff5ac25486a60bcbf84b4a"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-arm64.tar.gz",
-              "hash": "50a7e19b0d55de868a9cc52f6ebc1ba39b9b787b3343df5581ec50cce27b86793bb1c63168b5e8843479605e35515b49d1aaeee3a469611c2e2fc966be8c3ae5"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-x64.pkg",
-              "hash": "ef5f0a16eccb7b7231c8d3cc788bd0f84df8a59bda669fcb70d9dab1fa903bc10140b5ae61c9e80981feaf789fea0cea144bb827693f70ac2e90b0887bfc1888"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-x64.tar.gz",
-              "hash": "837f6fb8ca30f443d7678c73619f7a004440f809e7c339932616f377954c6e1b4a6c9fef1434d75df991641641d62f9cf1a16d5aee6640170cbb27a1b961632b"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-arm64.exe",
-              "hash": "d1420d062e4f3d130a2ebfd0bee7ed870552a1c5ef901fe18f6eaf4c2534ee85121e3b7a40eadc2f6af164a41d322dc65a9ef896c2e909f4d89f179e6607dd65"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-arm64.zip",
-              "hash": "379cdd811623966b25418af2b87611fd8c359f3db2a9618428554d77d05f73e6410f67c425c45240613e556de9ecbbc89695d036ac2f73c7d71ba9de704f3fb0"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.exe",
-              "hash": "77b87bd1785d5272912d6d8b732871ce3dd2f52a481aca24504c19e247772244310f89d686c9cdf50d518c1839238aa4775417e3a37ca33e6310b4ea01f05f1e"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.zip",
-              "hash": "5fc935b55c8a72ad274b1f5747efddf64712d80992424347fc2ad8b303f73a5b9616d41273be48505acde2691aacc97c9bfa07ca3a9b1036835cf5927dfd7526"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x86.exe",
-              "hash": "dd47554df1f1d217429924bad81ccf22a7533b511473fdb1e019c5fecc63c6ea67ea2abd870130864d6a6c63be0bb4f005f91f67e61bfeb314fa8fa639d81821"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x86.zip",
-              "hash": "7f72a6d9923bd4b7e0a8bfc5f395ebebed452a92b3ec1097bbccb3adb7ab00356bdf9869c770248a44033f4672b3d4157eb430261fed7e219893e10d91d454bf"
-            }
-          ]
-        },
-        {
-          "version": "9.0.105",
-          "version-display": "9.0.105",
-          "runtime-version": "9.0.4",
-          "vs-version": "17.12.7",
-          "vs-mac-version": "",
-          "vs-support": "Visual Studio 2022 (v17.12)",
-          "vs-mac-support": "",
-          "csharp-version": "12.0",
-          "fsharp-version": "8.0",
-          "vb-version": "16.9",
-          "files": [
-            {
-              "name": "dotnet-sdk-linux-arm.tar.gz",
-              "rid": "linux-arm",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-arm.tar.gz",
-              "hash": "904aedeeb9a4ec89d5a6a9e5c5c060f20b9ad9a2e67b01c6f10bafcf75b333e797827ae55c3e0f2f3df3f1a7265eb31bd678a8674bb467d71e87cfb1e060c331"
-            },
-            {
-              "name": "dotnet-sdk-linux-arm64.tar.gz",
-              "rid": "linux-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-arm64.tar.gz",
-              "hash": "6e184a6bf7f6b6800996f34976fe83ce0891710a95407221cdf53df7185f21dce9893efafc8cf1e7104f05a02ac55fe21aec3b1b6d161d7b7e086d729458056f"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm.tar.gz",
-              "rid": "linux-musl-arm",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-arm.tar.gz",
-              "hash": "6e6cb0b8fdc71ef3945c1734bc85d31a961c0492856a762802f1a5af43590a898f92f717e8df29f0b585debe7e13afa11ed482b611821116c0513a246f239bd4"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
-              "rid": "linux-musl-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-arm64.tar.gz",
-              "hash": "e22b57ffca4b5b17a97902e8cfa81be3bc9575e9762765b2f93c9e7f156f9a888c76f7961e0f8942080076ccac25cfecf17138e016a45758a4ffd8c5d7f21651"
-            },
-            {
-              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
-              "rid": "linux-musl-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-x64.tar.gz",
-              "hash": "71291709bc0defc461f291d96f57f0626540c7723d82d300d1401d7a3fcd150b6ce78ed4b4b2996b1c4688deb2f75ddb0fd2b0ef221ab3d56bc2cf8e852c7de7"
-            },
-            {
-              "name": "dotnet-sdk-linux-x64.tar.gz",
-              "rid": "linux-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-x64.tar.gz",
-              "hash": "f795bb35f432b71f940eb62bfa4ca3df5d708f497467ae16a67d2d19817a8f7e8cf5e6faa791412eb0da017be59ff93a2ad723675b3f3152f39bff64d545f4c0"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.pkg",
-              "rid": "osx-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-arm64.pkg",
-              "hash": "1ea09c2c1b84e6c76ec4f51f848c35321fdea8a92dabde20e4ab5fa031854dfd500e958f39c31fec4e16bd8e180ebe50d924b4e332b7b33b66db18e378589335"
-            },
-            {
-              "name": "dotnet-sdk-osx-arm64.tar.gz",
-              "rid": "osx-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-arm64.tar.gz",
-              "hash": "75fbdcc62d13596d1781e90a44aa83147f70d15f70b173e588a012393ee4db299d5342f13176d95314cf24c41bdadb32d17b27103283c3f412afb8778980f1aa"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.pkg",
-              "rid": "osx-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-x64.pkg",
-              "hash": "e44c0e09f3fb05a352b1946a39abfdc362c13495a4b0618841756fd15cb379438a8823283a60970fc0def3b98ca362f598c44e925076a0b623569217f6ff5ed4"
-            },
-            {
-              "name": "dotnet-sdk-osx-x64.tar.gz",
-              "rid": "osx-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-x64.tar.gz",
-              "hash": "0f0ccd8c359d37d026ce88c0e121cb69e9f8e9be61d7e28032d522bf046e5517ec0f31ea2830d0405636ee586db2dab54ae69b36d5311f99bcb2dc929dce48bb"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.exe",
-              "rid": "win-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-arm64.exe",
-              "hash": "ce028ce05a84f96e6528a56013f07a333627d677d39605484f8c9a63d53d9b388978b2b8a92ad194ed149de2568f6acb8aeb3ee18fbb1fbf7061f73d68703505"
-            },
-            {
-              "name": "dotnet-sdk-win-arm64.zip",
-              "rid": "win-arm64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-arm64.zip",
-              "hash": "7e6e5a8dd7375c5adc0e2368a3bd8f10e1cebf788765c254f032b755104ae3525801b82d786a1f1f780bcbb2938ec7b6c1094cb6579661362fa96db2221ef620"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.exe",
-              "rid": "win-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x64.exe",
-              "hash": "9f72bfb85db1cc21344071703b6c20cd085534c2fb6d0e2be77863768e1525b8951241b10adcd6b88a4db253ec6772a1df965cea85f9ae2979e204cb527a67b1"
-            },
-            {
-              "name": "dotnet-sdk-win-x64.zip",
-              "rid": "win-x64",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x64.zip",
-              "hash": "328ae0d73475f09ba46747cea055a2c40eb82a7ec2f7a730296b7fd506e1660177c9f3c365003c51d9dd23e9e0e5a9688b09b22d3a74c972251e95054846045f"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.exe",
-              "rid": "win-x86",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x86.exe",
-              "hash": "99dcff0ba8e252bac04df5bae9149a07107811ad5b3fc829e4d6e64a5ba807d59cd516a246a8ac46ef027f0fdf046b360308d464c05935451f323500504d92c0"
-            },
-            {
-              "name": "dotnet-sdk-win-x86.zip",
-              "rid": "win-x86",
-              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x86.zip",
-              "hash": "19d639426eab4011960a210f6d66b4c809e5a633f4560fff3c42df5f030d987823dcb1bb525606beac72b91021631a9d8eef93de88d8676fb92064565cf6381f"
-            }
-          ]
-        }
-      ],
-      "aspnetcore-runtime": {
-        "version": "9.0.4",
-        "version-display": "9.0.4",
-        "version-aspnetcoremodule": [
-          "19.0.25073.4"
-        ],
-        "vs-version": "",
+      {
+        "version": "9.0.105",
+        "version-display": "9.0.105",
+        "runtime-version": "9.0.4",
+        "vs-version": "17.12.7",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2022 (v17.12)",
+        "vs-mac-support": "",
+        "csharp-version": "12.0",
+        "fsharp-version": "8.0",
+        "vb-version": "16.9",
         "files": [
           {
-            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "name": "dotnet-sdk-linux-arm.tar.gz",
             "rid": "linux-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-arm.tar.gz",
-            "hash": "6b3c1c5af12fb09910967d6485603d04c8a3c47a9e6bb11c7375a5ae1b76175b013afb4923cadd99a7a22b782ca4b8b824070bf5252c5481324ac023fe72cea4"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-arm.tar.gz",
+            "hash": "904aedeeb9a4ec89d5a6a9e5c5c060f20b9ad9a2e67b01c6f10bafcf75b333e797827ae55c3e0f2f3df3f1a7265eb31bd678a8674bb467d71e87cfb1e060c331"
           },
           {
-            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
             "rid": "linux-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-arm64.tar.gz",
-            "hash": "7cca4084341c2e978e6d75e09cae308a35de7cd84c5b27d5246b9d1b3e6aaff200bae8de5a25b816e30c3ba354bef17b84bae0ce15144895518661e53af18331"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-arm64.tar.gz",
+            "hash": "6e184a6bf7f6b6800996f34976fe83ce0891710a95407221cdf53df7185f21dce9893efafc8cf1e7104f05a02ac55fe21aec3b1b6d161d7b7e086d729458056f"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm.tar.gz",
             "rid": "linux-musl-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-arm.tar.gz",
-            "hash": "11cea0b91ae542bc4d2fc451247595071eeb01f801d3305f9c9ccda7c04b4b1c327ee75a21452ac1b584a50a639e6d622272fc7ab9cbb744a8bb691b45baf2c2"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-arm.tar.gz",
+            "hash": "6e6cb0b8fdc71ef3945c1734bc85d31a961c0492856a762802f1a5af43590a898f92f717e8df29f0b585debe7e13afa11ed482b611821116c0513a246f239bd4"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-arm64.tar.gz",
             "rid": "linux-musl-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-arm64.tar.gz",
-            "hash": "67fe12c34c4859dd8c50b57145e2fefbb929dbe2a729a5a8bfb1a53441689f68295cff4d93194ff3b9611212f13674c70e142b2cfe3bf6a57710fd4206722898"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-arm64.tar.gz",
+            "hash": "e22b57ffca4b5b17a97902e8cfa81be3bc9575e9762765b2f93c9e7f156f9a888c76f7961e0f8942080076ccac25cfecf17138e016a45758a4ffd8c5d7f21651"
           },
           {
-            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
             "rid": "linux-musl-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-x64.tar.gz",
-            "hash": "89d8a05c65f886e1708dbfa4ea97baaf64029eca2aee9b883c9e516129058c5636c313554f05bdeb52801339ab4e326ebeb708e14dcea75e3cd70ddbc5f81caf"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-musl-x64.tar.gz",
+            "hash": "71291709bc0defc461f291d96f57f0626540c7723d82d300d1401d7a3fcd150b6ce78ed4b4b2996b1c4688deb2f75ddb0fd2b0ef221ab3d56bc2cf8e852c7de7"
           },
           {
-            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "name": "dotnet-sdk-linux-x64.tar.gz",
             "rid": "linux-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-x64.tar.gz",
-            "hash": "f3eae8863634a050b90b672b14d466a44c623ca06c6501a3a70efea93e540995e2fa348ae5ef7a3f278110a9ba24043a651150a378e4e5a84c25690b73364132"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-linux-x64.tar.gz",
+            "hash": "f795bb35f432b71f940eb62bfa4ca3df5d708f497467ae16a67d2d19817a8f7e8cf5e6faa791412eb0da017be59ff93a2ad723675b3f3152f39bff64d545f4c0"
           },
           {
-            "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.pkg",
             "rid": "osx-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-osx-arm64.tar.gz",
-            "hash": "34461f12204c61c7f23ffd0f89bc769846de8ae902c15e348a672b9bf279183b26f2ca35d36f1c12a60529bc291f42253e127ec3464621d0cfedaa0e9a5d9adf"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-arm64.pkg",
+            "hash": "1ea09c2c1b84e6c76ec4f51f848c35321fdea8a92dabde20e4ab5fa031854dfd500e958f39c31fec4e16bd8e180ebe50d924b4e332b7b33b66db18e378589335"
           },
           {
-            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "name": "dotnet-sdk-osx-arm64.tar.gz",
+            "rid": "osx-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-arm64.tar.gz",
+            "hash": "75fbdcc62d13596d1781e90a44aa83147f70d15f70b173e588a012393ee4db299d5342f13176d95314cf24c41bdadb32d17b27103283c3f412afb8778980f1aa"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
             "rid": "osx-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-osx-x64.tar.gz",
-            "hash": "b07d2bef605bdb36f9c7ddfb5c183ba4965e6fcb3b4f00c148fbdcd62fede1f1eb405553d2ef84f57e057558c643b87102816ccefa28b2eb08500fd6b50b490c"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-x64.pkg",
+            "hash": "e44c0e09f3fb05a352b1946a39abfdc362c13495a4b0618841756fd15cb379438a8823283a60970fc0def3b98ca362f598c44e925076a0b623569217f6ff5ed4"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.exe",
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-osx-x64.tar.gz",
+            "hash": "0f0ccd8c359d37d026ce88c0e121cb69e9f8e9be61d7e28032d522bf046e5517ec0f31ea2830d0405636ee586db2dab54ae69b36d5311f99bcb2dc929dce48bb"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
             "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-arm64.exe",
-            "hash": "1d4d856c3f23b309856e3f9d2e08b3cb5c99b11dbab460ab7d3e9ffea7bb36ddb2a916ebf3bdc51ea936176074f0742b7573be52904b9efa6bbea059c3dad924"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-arm64.exe",
+            "hash": "ce028ce05a84f96e6528a56013f07a333627d677d39605484f8c9a63d53d9b388978b2b8a92ad194ed149de2568f6acb8aeb3ee18fbb1fbf7061f73d68703505"
           },
           {
-            "name": "aspnetcore-runtime-win-arm64.zip",
+            "name": "dotnet-sdk-win-arm64.zip",
             "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-arm64.zip",
-            "hash": "080a49595409802e76e2d356a344f8293ebe1900c99cae17936c4697e05de4084b822b250713d5e1aeb54c3122bc6f9dce06dd49c92e21239e02f207963290d1"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-arm64.zip",
+            "hash": "7e6e5a8dd7375c5adc0e2368a3bd8f10e1cebf788765c254f032b755104ae3525801b82d786a1f1f780bcbb2938ec7b6c1094cb6579661362fa96db2221ef620"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.exe",
+            "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x64.exe",
-            "hash": "76b740deb1ce9332c094459f916245d9823e28d680ca9a1fc4f21826ad6155a58c5aec60fcd9dd0e5d698a4d746beea3c7b6d69906ef6ec3491c61e32b5a2b1b"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x64.exe",
+            "hash": "9f72bfb85db1cc21344071703b6c20cd085534c2fb6d0e2be77863768e1525b8951241b10adcd6b88a4db253ec6772a1df965cea85f9ae2979e204cb527a67b1"
           },
           {
-            "name": "aspnetcore-runtime-win-x64.zip",
+            "name": "dotnet-sdk-win-x64.zip",
             "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x64.zip",
-            "hash": "161a5b226b9035bb54f566f57a1f6503ceeef66e79fce463c55717a60129a0f4ed525e4179c7d8072e9cd921fb584d74bc600a85f9e976f80ce2f1d429f2c10d"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x64.zip",
+            "hash": "328ae0d73475f09ba46747cea055a2c40eb82a7ec2f7a730296b7fd506e1660177c9f3c365003c51d9dd23e9e0e5a9688b09b22d3a74c972251e95054846045f"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.exe",
+            "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x86.exe",
-            "hash": "82c7158cbf6488adc29b6568ebf9d05a2ddfe99319e019c077084a25d5d366a020bc98eb55882088f6c22a5a4b1ee2de7dfe289c1ea1ec95976633e5d42e5bbd"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x86.exe",
+            "hash": "99dcff0ba8e252bac04df5bae9149a07107811ad5b3fc829e4d6e64a5ba807d59cd516a246a8ac46ef027f0fdf046b360308d464c05935451f323500504d92c0"
           },
           {
-            "name": "aspnetcore-runtime-win-x86.zip",
+            "name": "dotnet-sdk-win-x86.zip",
             "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x86.zip",
-            "hash": "cf33e5d462e957e67b04dc5bc64b5c216a13a3a996bd2486b75a6fe760f6289fe8186e4b9d05ff9684473577973378350a64f46fb0697b060fcedcac867b5685"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
-            "rid": "linux-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-arm.tar.gz",
-            "hash": "5fd6b16fff9687ca350fbc81737ceb1861291a548ca75cd80c3a57bc896529da82e02cbe90d2ab8b9419cfecce2023f0af92d8180e90bbd591e8e2db01334a4f"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
-            "rid": "linux-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-arm64.tar.gz",
-            "hash": "f049a6674a6a38968c42920826f6f25fe0c6c0869ec6a9a010b67d0a25e2a6af4634a3f767f4de39785f7a4eb89037aa3de3e0ff3ab7f7ffcb062f59f2d26c72"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
-            "rid": "linux-musl-arm",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-arm.tar.gz",
-            "hash": "a2e29106e1717595c447948424baa1b5e113105f328868cf458ab6403bb51879ed8a66fae706b51a18ca2d8130455d294f3e09be2619bb5c4a00345b51dafa37"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
-            "rid": "linux-musl-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-arm64.tar.gz",
-            "hash": "623b0c2bf6e1279694b7a0551d8b0527404ece523a99e196a00f9f236b01140e8776b788744dba53960287fb40ec614e7b5b1a0e1fbd617f11521bc8af5b10cb"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
-            "rid": "linux-musl-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-x64.tar.gz",
-            "hash": "e061672712e4646108f8b36c1da61a9f993970db8ed598515a62d6e467305d4cffe53b654e7af6000bc93d0769f67c452f1b9523e91b63ed5c5e248163644c40"
-          },
-          {
-            "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
-            "rid": "linux-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-x64.tar.gz",
-            "hash": "f8a1ec81def3954221aea5e2e24d6302aee8055d4c5811ff289c139cf7e08925279a75fdd557c33afb88d4948da1e2a38af7cf801ac5248039783c983a4d782b"
-          },
-          {
-            "name": "dotnet-hosting-win.exe",
-            "rid": "",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/dotnet-hosting-9.0.4-win.exe",
-            "hash": "e02d6e48361bc09f84aefef0653bd1eaa1324795d120758115818d77f1ba0bca751dcc7e7c143293c7831fd72ff566d7c2248d1cb795f8d251c04631bc4459ea",
-            "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
-          }
-        ]
-      },
-      "windowsdesktop": {
-        "version": "9.0.4",
-        "version-display": "9.0.4",
-        "files": [
-          {
-            "name": "windowsdesktop-runtime-win-arm64.exe",
-            "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-arm64.exe",
-            "hash": "6209799b87d2f7d3b17656e3229420dc2870217f8efc0f9000dba85f1811e95a4098ffd1601e78041b17fb181a3f58a89b5ca9da8bbb02f736e1d8c023e6cb9f"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-arm64.zip",
-            "rid": "win-arm64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-arm64.zip",
-            "hash": "a2bebab263c635e9cd56adbb09c79ca2d905226429e016f20151e216c292a9c91583e72d623f4c7e1396ef7eb3dca852b03828df236e0ff3b347a87bb924d9e5"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.exe",
-            "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x64.exe",
-            "hash": "c277fe5434b66c05f7782d40b90ab04dd2a9ac3d1570b2ab96a2311a58aeefff27761ca4488aadebe3b897e961b24b2f9c5a597ee27c2c4387d3cf0833f6cc48"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x64.zip",
-            "rid": "win-x64",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x64.zip",
-            "hash": "ec38fab3d387ced97d55d28aef34d3979cadfed48f86bd01f44d2b3a864edf4339ee82df5ba4af535d2cf91832bd56b902f7195a4352641e6210efc1c4a70681"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.exe",
-            "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x86.exe",
-            "hash": "214a98c6d468566cb0d84898e7129897890384b1f3a49f1c59187f3711cea6340df588850d65c1b0c239fd0151806cfa7bc056551da05d9a0d94130b2e4fba7d"
-          },
-          {
-            "name": "windowsdesktop-runtime-win-x86.zip",
-            "rid": "win-x86",
-            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x86.zip",
-            "hash": "9516c6cb24e51a5b457de0d26992cf52ace1a96ea406f4f4ff37d4293d08717d05a39eeb19a844b815b4bc061ebeffaaedb17d964289ee5c66217e5054a26f64"
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.105/dotnet-sdk-9.0.105-win-x86.zip",
+            "hash": "19d639426eab4011960a210f6d66b4c809e5a633f4560fff3c42df5f030d987823dcb1bb525606beac72b91021631a9d8eef93de88d8676fb92064565cf6381f"
           }
         ]
       }
+    ],
+    "aspnetcore-runtime": {
+      "version": "9.0.4",
+      "version-display": "9.0.4",
+      "version-aspnetcoremodule": [
+        "19.0.25073.4"
+      ],
+      "vs-version": "",
+      "files": [
+        {
+          "name": "aspnetcore-runtime-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-arm.tar.gz",
+          "hash": "6b3c1c5af12fb09910967d6485603d04c8a3c47a9e6bb11c7375a5ae1b76175b013afb4923cadd99a7a22b782ca4b8b824070bf5252c5481324ac023fe72cea4"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-arm64.tar.gz",
+          "hash": "7cca4084341c2e978e6d75e09cae308a35de7cd84c5b27d5246b9d1b3e6aaff200bae8de5a25b816e30c3ba354bef17b84bae0ce15144895518661e53af18331"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-arm.tar.gz",
+          "hash": "11cea0b91ae542bc4d2fc451247595071eeb01f801d3305f9c9ccda7c04b4b1c327ee75a21452ac1b584a50a639e6d622272fc7ab9cbb744a8bb691b45baf2c2"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-arm64.tar.gz",
+          "hash": "67fe12c34c4859dd8c50b57145e2fefbb929dbe2a729a5a8bfb1a53441689f68295cff4d93194ff3b9611212f13674c70e142b2cfe3bf6a57710fd4206722898"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-musl-x64.tar.gz",
+          "hash": "89d8a05c65f886e1708dbfa4ea97baaf64029eca2aee9b883c9e516129058c5636c313554f05bdeb52801339ab4e326ebeb708e14dcea75e3cd70ddbc5f81caf"
+        },
+        {
+          "name": "aspnetcore-runtime-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-linux-x64.tar.gz",
+          "hash": "f3eae8863634a050b90b672b14d466a44c623ca06c6501a3a70efea93e540995e2fa348ae5ef7a3f278110a9ba24043a651150a378e4e5a84c25690b73364132"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-arm64.tar.gz",
+          "rid": "osx-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-osx-arm64.tar.gz",
+          "hash": "34461f12204c61c7f23ffd0f89bc769846de8ae902c15e348a672b9bf279183b26f2ca35d36f1c12a60529bc291f42253e127ec3464621d0cfedaa0e9a5d9adf"
+        },
+        {
+          "name": "aspnetcore-runtime-osx-x64.tar.gz",
+          "rid": "osx-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-osx-x64.tar.gz",
+          "hash": "b07d2bef605bdb36f9c7ddfb5c183ba4965e6fcb3b4f00c148fbdcd62fede1f1eb405553d2ef84f57e057558c643b87102816ccefa28b2eb08500fd6b50b490c"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-arm64.exe",
+          "hash": "1d4d856c3f23b309856e3f9d2e08b3cb5c99b11dbab460ab7d3e9ffea7bb36ddb2a916ebf3bdc51ea936176074f0742b7573be52904b9efa6bbea059c3dad924"
+        },
+        {
+          "name": "aspnetcore-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-arm64.zip",
+          "hash": "080a49595409802e76e2d356a344f8293ebe1900c99cae17936c4697e05de4084b822b250713d5e1aeb54c3122bc6f9dce06dd49c92e21239e02f207963290d1"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x64.exe",
+          "hash": "76b740deb1ce9332c094459f916245d9823e28d680ca9a1fc4f21826ad6155a58c5aec60fcd9dd0e5d698a4d746beea3c7b6d69906ef6ec3491c61e32b5a2b1b"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x64.zip",
+          "hash": "161a5b226b9035bb54f566f57a1f6503ceeef66e79fce463c55717a60129a0f4ed525e4179c7d8072e9cd921fb584d74bc600a85f9e976f80ce2f1d429f2c10d"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x86.exe",
+          "hash": "82c7158cbf6488adc29b6568ebf9d05a2ddfe99319e019c077084a25d5d366a020bc98eb55882088f6c22a5a4b1ee2de7dfe289c1ea1ec95976633e5d42e5bbd"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-9.0.4-win-x86.zip",
+          "hash": "cf33e5d462e957e67b04dc5bc64b5c216a13a3a996bd2486b75a6fe760f6289fe8186e4b9d05ff9684473577973378350a64f46fb0697b060fcedcac867b5685"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
+          "rid": "linux-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-arm.tar.gz",
+          "hash": "5fd6b16fff9687ca350fbc81737ceb1861291a548ca75cd80c3a57bc896529da82e02cbe90d2ab8b9419cfecce2023f0af92d8180e90bbd591e8e2db01334a4f"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-arm64.tar.gz",
+          "rid": "linux-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-arm64.tar.gz",
+          "hash": "f049a6674a6a38968c42920826f6f25fe0c6c0869ec6a9a010b67d0a25e2a6af4634a3f767f4de39785f7a4eb89037aa3de3e0ff3ab7f7ffcb062f59f2d26c72"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm.tar.gz",
+          "rid": "linux-musl-arm",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-arm.tar.gz",
+          "hash": "a2e29106e1717595c447948424baa1b5e113105f328868cf458ab6403bb51879ed8a66fae706b51a18ca2d8130455d294f3e09be2619bb5c4a00345b51dafa37"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-arm64.tar.gz",
+          "rid": "linux-musl-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-arm64.tar.gz",
+          "hash": "623b0c2bf6e1279694b7a0551d8b0527404ece523a99e196a00f9f236b01140e8776b788744dba53960287fb40ec614e7b5b1a0e1fbd617f11521bc8af5b10cb"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-musl-x64.tar.gz",
+          "rid": "linux-musl-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-musl-x64.tar.gz",
+          "hash": "e061672712e4646108f8b36c1da61a9f993970db8ed598515a62d6e467305d4cffe53b654e7af6000bc93d0769f67c452f1b9523e91b63ed5c5e248163644c40"
+        },
+        {
+          "name": "aspnetcore-runtime-composite-linux-x64.tar.gz",
+          "rid": "linux-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/aspnetcore-runtime-composite-9.0.4-linux-x64.tar.gz",
+          "hash": "f8a1ec81def3954221aea5e2e24d6302aee8055d4c5811ff289c139cf7e08925279a75fdd557c33afb88d4948da1e2a38af7cf801ac5248039783c983a4d782b"
+        },
+        {
+          "name": "dotnet-hosting-win.exe",
+          "rid": "",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.4/dotnet-hosting-9.0.4-win.exe",
+          "hash": "e02d6e48361bc09f84aefef0653bd1eaa1324795d120758115818d77f1ba0bca751dcc7e7c143293c7831fd72ff566d7c2248d1cb795f8d251c04631bc4459ea",
+          "akams": "https://aka.ms/dotnetcore-9-0-windowshosting"
+        }
+      ]
+    },
+    "windowsdesktop": {
+      "version": "9.0.4",
+      "version-display": "9.0.4",
+      "files": [
+        {
+          "name": "windowsdesktop-runtime-win-arm64.exe",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-arm64.exe",
+          "hash": "6209799b87d2f7d3b17656e3229420dc2870217f8efc0f9000dba85f1811e95a4098ffd1601e78041b17fb181a3f58a89b5ca9da8bbb02f736e1d8c023e6cb9f"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-arm64.zip",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-arm64.zip",
+          "hash": "a2bebab263c635e9cd56adbb09c79ca2d905226429e016f20151e216c292a9c91583e72d623f4c7e1396ef7eb3dca852b03828df236e0ff3b347a87bb924d9e5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.exe",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x64.exe",
+          "hash": "c277fe5434b66c05f7782d40b90ab04dd2a9ac3d1570b2ab96a2311a58aeefff27761ca4488aadebe3b897e961b24b2f9c5a597ee27c2c4387d3cf0833f6cc48"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x64.zip",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x64.zip",
+          "hash": "ec38fab3d387ced97d55d28aef34d3979cadfed48f86bd01f44d2b3a864edf4339ee82df5ba4af535d2cf91832bd56b902f7195a4352641e6210efc1c4a70681"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.exe",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x86.exe",
+          "hash": "214a98c6d468566cb0d84898e7129897890384b1f3a49f1c59187f3711cea6340df588850d65c1b0c239fd0151806cfa7bc056551da05d9a0d94130b2e4fba7d"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.zip",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.4/windowsdesktop-runtime-9.0.4-win-x86.zip",
+          "hash": "9516c6cb24e51a5b457de0d26992cf52ace1a96ea406f4f4ff37d4293d08717d05a39eeb19a844b815b4bc061ebeffaaedb17d964289ee5c66217e5054a26f64"
+        }
+      ]
     }
-  ]
+  }
 }

--- a/release-notes/9.0/9.0.5/release.json
+++ b/release-notes/9.0/9.0.5/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-05-13",
-  "release-version": "9.0.5",
-  "security": true,
   "release": 
   {
     "release-date": "2025-05-13",

--- a/release-notes/9.0/9.0.6/release.json
+++ b/release-notes/9.0/9.0.6/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-06-10",
-  "release-version": "9.0.6",
-  "security": true,
   "release": 
   {
     "release-date": "2025-06-10",

--- a/release-notes/9.0/9.0.7/release.json
+++ b/release-notes/9.0/9.0.7/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-07-08",
-  "release-version": "9.0.7",
-  "security": false,
   "release": {
     "release-date": "2025-07-17",
     "release-version": "9.0.7",

--- a/release-notes/9.0/9.0.8/release.json
+++ b/release-notes/9.0/9.0.8/release.json
@@ -1,8 +1,5 @@
 {
   "channel-version": "9.0",
-  "release-date": "2025-08-05",
-  "release-version": "9.0.8",
-  "security": false,
   "release": {
     "release-date": "2025-08-05",
     "release-version": "9.0.8",


### PR DESCRIPTION
This PR is an attempt to update the release json files (single release json) for .NET 8.0, 9.0 and 10.0. This change is to update the prior json schema by removing redundant key value pairs: ``release-date": "", "release-version": " ", "security":`` since they are declared within the "release" object and become outdated when with a new release.

This helps towards making the release.jsons more immutable.