### PR TITLE
Refactor PR creation workflow for .NET 10 release for preview and RC

### DIFF
--- a/.github/prompts/createprs-for-preview.prompt.md
+++ b/.github/prompts/createprs-for-preview.prompt.md
@@ -1,6 +1,6 @@
-# Create PRs for .NET 10 release milestones (Preview or RC)
+# Create PRs for .NET 10 release milestones (Preview, RC, or GA)
 
-Use this workflow to create one PR per release-notes file for .NET 10 pre-release milestones. It supports both Previews (typically 6 or 7; .NET 10 had 7) and Release Candidates (RC). After the last Preview, the next milestone is RC1.
+Use this workflow to create one PR per release-notes file for .NET 10 milestones. It supports Previews (typically 6 or 7; .NET 10 had 7), Release Candidates (RC), and the GA release. After the last Preview, the next milestone is RC1, followed by GA.
 
 Fixed settings:
 
@@ -9,20 +9,32 @@ Fixed settings:
 
 Inputs:
 
-- Milestone Kind: `{milestoneKind}` — either `preview` or `rc`
-- Milestone Number: `{milestoneNumber}` — integer like `1`, `2`, ... (`7` for the last preview of .NET 10; next is `1` for RC1)
+- Milestone Kind: `{milestoneKind}` — one of `preview`, `rc`, or `ga`
+- Milestone Number: `{milestoneNumber}` — required for `preview`/`rc` (e.g., `7`, `1`), omit for `ga`
 
 Derived values:
 
-- Release notes folder: `release-notes/10.0/{milestoneKind}/{milestoneKind}{milestoneNumber}` (e.g., `release-notes/10.0/preview/preview7` or `release-notes/10.0/rc/rc1`)
-- Branch prefix (short): `{short}` where `{short} = 'p'` when `{milestoneKind} = 'preview'`, otherwise `{short} = 'rc'`
-- Base branch for iteration: `dotnet10-{short}{milestoneNumber}` (e.g., `dotnet10-p7` or `dotnet10-rc1`)
-- Per-file working branch: `dotnet10-{short}{milestoneNumber}-{name}`
-- Milestone label for titles/bodies: `{MilestoneLabel}` — use `Preview {milestoneNumber}` for previews and `RC {milestoneNumber}` for RCs
+- Release notes folder (always under the `preview` subfolder):
+	- For Preview N: `release-notes/10.0/preview/preview{milestoneNumber}` (e.g., `release-notes/10.0/preview/preview7`)
+	- For RC N: `release-notes/10.0/preview/rc{milestoneNumber}` (e.g., `release-notes/10.0/preview/rc1`)
+	- For GA: `release-notes/10.0/preview/ga`
+- Branch prefix (short): `{short}` mapping — `preview` → `p`, `rc` → `rc`, `ga` → `ga`
+- Base branch for iteration:
+	- Preview N → `dotnet10-p{milestoneNumber}` (e.g., `dotnet10-p7`)
+	- RC N → `dotnet10-rc{milestoneNumber}` (e.g., `dotnet10-rc1`)
+	- GA → `dotnet10-ga`
+- Per-file working branch:
+	- Preview N → `dotnet10-p{milestoneNumber}-{name}`
+	- RC N → `dotnet10-rc{milestoneNumber}-{name}`
+	- GA → `dotnet10-ga-{name}`
+- Milestone label for titles/bodies: `Preview {N}`, `RC {N}`, or `GA`
 
 Process (repeat per file in the milestone folder):
 
-1. From the base branch `dotnet10-{short}{milestoneNumber}`, create a new branch named `dotnet10-{short}{milestoneNumber}-{name}` where `{name}` is the filename without extension.
+1. Create a new branch from the appropriate base branch (see mapping above):
+	- Preview N: base `dotnet10-p{N}`, new branch `dotnet10-p{N}-{name}`
+	- RC N: base `dotnet10-rc{N}`, new branch `dotnet10-rc{N}-{name}`
+	- GA: base `dotnet10-ga`, new branch `dotnet10-ga-{name}`
 2. Modify the corresponding file by adding a simple new line at the end with the text: `Something about the feature`.
 3. Commit with message: `Update {name} for {MilestoneLabel}`.
 4. Push the branch to the remote repository.
@@ -30,11 +42,12 @@ Process (repeat per file in the milestone folder):
 	- Title: `Update {name} for {MilestoneLabel}`
 	- Body: `Please update the release notes here as needed for {MilestoneLabel}.\n\n/cc @{assignees}`
 	- Assignees: Assign the PR to the person(s) listed for the file in the table below.
-6. Switch back to the base branch `dotnet10-{short}{milestoneNumber}` and repeat for the next file.
+6. Switch back to the corresponding base branch (e.g., `dotnet10-p{N}`, `dotnet10-rc{N}`, or `dotnet10-ga`) and repeat for the next file.
 
 Notes:
 
-- Previews usually run 6–7 iterations; after the final Preview, the next milestone is `RC1`.
+- Previews usually run 6–7 iterations; after the final Preview, the next milestone is `RC1`, followed by `GA`.
+- All Preview, RC, and GA release notes live under the `release-notes/10.0/preview/` directory (for example, `.NET 9 RC 1` notes are in `release-notes/9.0/preview/rc1`).
 - Keep the same file-to-assignee mapping unless explicitly changed.
 
 ## Assignment Table (based on Preview 7 PRs)

--- a/.github/prompts/createprs-for-preview.prompt.md
+++ b/.github/prompts/createprs-for-preview.prompt.md
@@ -1,32 +1,60 @@
-# Create PRs for Preview
+# Create PRs for .NET 10 release milestones (Preview or RC)
 
-Go through each folder in release-notes/10.0/preview7 and one at a time i want you do to the following:
+Use this workflow to create one PR per release-notes file for .NET 10 pre-release milestones. It supports both Previews (typically 6 or 7; .NET 10 had 7) and Release Candidates (RC). After the last Preview, the next milestone is RC1.
 
-1. create a new branch names **dotnet10-p7-{name}** where {name} is the name of the file without the extension.
-2. modify the file in some simple way by adding a new line at the end of the file with the text "Something about the feature" in it.
-3. commit the change with the message "Update {name} for preview 7" where {name} is the name of the file without the extension.
-4. push the branch to the remote repository.
-5. create a pull request with the title "Update {name} for preview 7" and the body "Please update the release notes here as needed for Preview 7.\n\n/cc @{reviewer}" where {name} is the name of the file without the extension and {reviewer} is assigned based on the assignment table below.
-6. go back to the dotnet10-p7 branch and repeat the process for the next file.
+Fixed settings:
 
-## Assignment Table (based on Preview 6 patterns)
+- Version Major: 10
+- Version Path: 10.0
 
-| File | Assignee(s) | Based on Preview 6 PR |
-|------|-------------|----------------------|
-| aspnetcore.md | @danroth27 | #9953 |
-| containers.md | @lbussell | #9942 |
-| csharp.md | @BillWagner | #9943 |
-| dotnetmaui.md | @davidortinau | #10013 |
-| efcore.md | @roji | #9945 |
-| fsharp.md | @T-Gro | #9946 |
-| libraries.md | @richlander @tarekgh | #9952 |
-| runtime.md | @ericstj @kunalspathak | #9951 |
-| sdk.md | @baronfel @mariam-abdulla @nohwnd | #9949 |
-| visualbasic.md | @BillWagner | #9950 |
-| winforms.md | @merriemcgaw | #9947 |
-| wpf.md | @harshit7962 | #9948 |
+Inputs:
 
-Here are the files you need to do this one at a time for:
+- Milestone Kind: `{milestoneKind}` — either `preview` or `rc`
+- Milestone Number: `{milestoneNumber}` — integer like `1`, `2`, ... (`7` for the last preview of .NET 10; next is `1` for RC1)
+
+Derived values:
+
+- Release notes folder: `release-notes/10.0/{milestoneKind}/{milestoneKind}{milestoneNumber}` (e.g., `release-notes/10.0/preview/preview7` or `release-notes/10.0/rc/rc1`)
+- Branch prefix (short): `{short}` where `{short} = 'p'` when `{milestoneKind} = 'preview'`, otherwise `{short} = 'rc'`
+- Base branch for iteration: `dotnet10-{short}{milestoneNumber}` (e.g., `dotnet10-p7` or `dotnet10-rc1`)
+- Per-file working branch: `dotnet10-{short}{milestoneNumber}-{name}`
+- Milestone label for titles/bodies: `{MilestoneLabel}` — use `Preview {milestoneNumber}` for previews and `RC {milestoneNumber}` for RCs
+
+Process (repeat per file in the milestone folder):
+
+1. From the base branch `dotnet10-{short}{milestoneNumber}`, create a new branch named `dotnet10-{short}{milestoneNumber}-{name}` where `{name}` is the filename without extension.
+2. Modify the corresponding file by adding a simple new line at the end with the text: `Something about the feature`.
+3. Commit with message: `Update {name} for {MilestoneLabel}`.
+4. Push the branch to the remote repository.
+5. Create a pull request with:
+	- Title: `Update {name} for {MilestoneLabel}`
+	- Body: `Please update the release notes here as needed for {MilestoneLabel}.\n\n/cc @{assignees}`
+	- Assignees: Assign the PR to the person(s) listed for the file in the table below.
+6. Switch back to the base branch `dotnet10-{short}{milestoneNumber}` and repeat for the next file.
+
+Notes:
+
+- Previews usually run 6–7 iterations; after the final Preview, the next milestone is `RC1`.
+- Keep the same file-to-assignee mapping unless explicitly changed.
+
+## Assignment Table (based on Preview 7 PRs)
+
+| File | Assignee(s) | Based on Preview 7 PR |
+|------|-------------|-----------------------|
+| aspnetcore.md | @danroth27 | #10023 |
+| containers.md | @lbussell | #9995 |
+| csharp.md | @BillWagner @MadsTorgersen @jcouv | #9996 |
+| dotnetmaui.md | @davidortinau | #9997 |
+| efcore.md | @roji | #9998 |
+| fsharp.md | @T-Gro | #9999 |
+| libraries.md | @richlander @tarekgh | #10000 |
+| runtime.md | @ericstj @kunalspathak @AndyAyersMS | #10001 |
+| sdk.md | @baronfel @mariam-abdulla @nohwnd @DamianEdwards | #10002 |
+| visualbasic.md | @BillWagner | #10003 |
+| winforms.md | @merriemcgaw @KlausLoeffelmann | #10004 |
+| wpf.md | @harshit7962 @adegeo | #10005 |
+
+Here are the files to process one at a time:
 
 - aspnetcore.md
 - containers.md

--- a/.github/prompts/createprs-for-preview.prompt.md
+++ b/.github/prompts/createprs-for-preview.prompt.md
@@ -15,34 +15,38 @@ Inputs:
 Derived values:
 
 - Release notes folder (always under the `preview` subfolder):
-	- For Preview N: `release-notes/10.0/preview/preview{milestoneNumber}` (e.g., `release-notes/10.0/preview/preview7`)
-	- For RC N: `release-notes/10.0/preview/rc{milestoneNumber}` (e.g., `release-notes/10.0/preview/rc1`)
-	- For GA: `release-notes/10.0/preview/ga`
+  - For Preview N: `release-notes/10.0/preview/preview{milestoneNumber}` (e.g., `release-notes/10.0/preview/preview7`)
+  - For RC N: `release-notes/10.0/preview/rc{milestoneNumber}` (e.g., `release-notes/10.0/preview/rc1`)
+  - For GA: `release-notes/10.0/preview/ga`
 - Branch prefix (short): `{short}` mapping — `preview` → `p`, `rc` → `rc`, `ga` → `ga`
 - Base branch for iteration:
-	- Preview N → `dotnet10-p{milestoneNumber}` (e.g., `dotnet10-p7`)
-	- RC N → `dotnet10-rc{milestoneNumber}` (e.g., `dotnet10-rc1`)
-	- GA → `dotnet10-ga`
+  - Preview N → `dotnet10-p{milestoneNumber}` (e.g., `dotnet10-p7`)
+  - RC N → `dotnet10-rc{milestoneNumber}` (e.g., `dotnet10-rc1`)
+  - GA → `dotnet10-ga`
 - Per-file working branch:
-	- Preview N → `dotnet10-p{milestoneNumber}-{name}`
-	- RC N → `dotnet10-rc{milestoneNumber}-{name}`
-	- GA → `dotnet10-ga-{name}`
+  - Preview N → `dotnet10-p{milestoneNumber}-{name}`
+  - RC N → `dotnet10-rc{milestoneNumber}-{name}`
+  - GA → `dotnet10-ga-{name}`
 - Milestone label for titles/bodies: `Preview {N}`, `RC {N}`, or `GA`
 
 Process (repeat per file in the milestone folder):
 
 1. Create a new branch from the appropriate base branch (see mapping above):
-	- Preview N: base `dotnet10-p{N}`, new branch `dotnet10-p{N}-{name}`
-	- RC N: base `dotnet10-rc{N}`, new branch `dotnet10-rc{N}-{name}`
-	- GA: base `dotnet10-ga`, new branch `dotnet10-ga-{name}`
-2. Modify the corresponding file by adding a simple new line at the end with the text: `Something about the feature`.
-3. Commit with message: `Update {name} for {MilestoneLabel}`.
-4. Push the branch to the remote repository.
-5. Create a pull request with:
-	- Title: `Update {name} for {MilestoneLabel}`
-	- Body: `Please update the release notes here as needed for {MilestoneLabel}.\n\n/cc @{assignees}`
-	- Assignees: Assign the PR to the person(s) listed for the file in the table below.
-6. Switch back to the corresponding base branch (e.g., `dotnet10-p{N}`, `dotnet10-rc{N}`, or `dotnet10-ga`) and repeat for the next file.
+
+- Preview N: base `dotnet10-p{N}`, new branch `dotnet10-p{N}-{name}`
+- RC N: base `dotnet10-rc{N}`, new branch `dotnet10-rc{N}-{name}`
+- GA: base `dotnet10-ga`, new branch `dotnet10-ga-{name}`
+
+1. Modify the corresponding file by adding a simple new line at the end with the text: `Something about the feature`.
+1. Commit with message: `Update {name} for {MilestoneLabel}`.
+1. Push the branch to the remote repository.
+1. Create a pull request with:
+
+- Title: `Update {name} for {MilestoneLabel}`
+- Body: `Please update the release notes here as needed for {MilestoneLabel}.\n\n/cc @{assignees}`
+- Assignees: Assign the PR to the person(s) listed for the file in the table below.
+
+1. Switch back to the corresponding base branch (e.g., `dotnet10-p{N}`, `dotnet10-rc{N}`, or `dotnet10-ga`) and repeat for the next file.
 
 Notes:
 


### PR DESCRIPTION
This pull request updates the workflow documentation for creating pull requests for .NET 10 release milestones, making it more flexible and maintainable for both Preview and Release Candidate (RC) cycles. The instructions are now parameterized for milestone type and number, and the file-to-assignee mapping has been refreshed to match the latest release cycle.

**Workflow improvements:**

* The workflow now supports both Preview and RC milestones, with parameterized inputs for milestone kind and number, making it reusable for future releases.
* Branch naming, folder paths, and PR messaging are now dynamically derived from milestone inputs, reducing manual errors and simplifying future updates.

**Assignment updates:**

* The assignment table has been updated to reflect the most recent assignees and PR references from Preview 7, including new contributors for several files.

**Documentation clarity:**

* The instructions have been rewritten for clarity, with step-by-step guidance and notes on milestone progression.
* Outdated references and hard-coded values have been removed or replaced with dynamic placeholders.