### PR TITLE
Fix macOS RID in SDK release notes for 10.0-preview.7

### DIFF
--- a/release-notes/10.0/preview/preview7/sdk.md
+++ b/release-notes/10.0/preview/preview7/sdk.md
@@ -22,7 +22,7 @@ platform-specific .NET Tools work this way, you only need to add one thing to yo
   <RuntimeIdentifiers>
         linux-x64;
         linux-arm64;
-        macos-arm64;
+        osx-arm64;
         win-x64;
 -       win-arm64
 +       win-arm64;


### PR DESCRIPTION
Fix incorrect [RID for macOS](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids) in example.

Otherwise you get this error if you copy-paste it into a project:

```text
error NETSDK1083: The specified RuntimeIdentifier 'macos-arm64' is not recognized. See https://aka.ms/netsdk1083 for more information.
```
