### PR TITLE
Change EOL date for .NET 9

### DIFF
--- a/release-notes/9.0/releases.json
+++ b/release-notes/9.0/releases.json
@@ -6,7 +6,7 @@
   "latest-sdk": "9.0.305",
   "support-phase": "active",
   "release-type": "sts",
-  "eol-date": "2026-05-12",
+  "eol-date": "2026-11-10",
   "lifecycle-policy": "https://aka.ms/dotnetcoresupport",
   "releases": [
     {

--- a/release-notes/releases-index.json
+++ b/release-notes/releases-index.json
@@ -23,7 +23,7 @@
       "latest-sdk": "9.0.305",
       "product": ".NET",
       "support-phase": "active",
-      "eol-date": "2026-05-12",
+      "eol-date": "2026-11-10",
       "release-type": "sts",
       "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/releases.json",
       "supported-os.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/supported-os.json"


### PR DESCRIPTION
Related to https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/