### PR TITLE
Update known issues for startup regression

### DIFF
--- a/release-notes/10.0/known-issues.md
+++ b/release-notes/10.0/known-issues.md
@@ -64,7 +64,3 @@ A `global.json` that sets SDK version along with the test runner will look like:
 ## Startup Performance Regression in Fractional CPU Containers
 
 Up to 10% startup performance regression was identified in .NET 10 runtime, particularly affecting scenarios running in containers with fractional CPU allocations. This issue has been observed only on x64 architecture. We are actively investigating and working to resolve the issue in future updates.
-
-
-
-


### PR DESCRIPTION
Added a known issue regarding startup regression n .NET 10 runtime in fractional CPU container scenarios.