### PR TITLE
Add security group information

### DIFF
--- a/Documentation/security-group/dotnet-security-group-agreement.md
+++ b/Documentation/security-group/dotnet-security-group-agreement.md
@@ -1,0 +1,46 @@
+# MICROSOFT PRE-DISCLOSURE COMMON VULNERABILITIES AND EXPOSURES COLLABORATION AGREEMENT
+
+Microsoft Corporation (“Microsoft”) is pleased to work with Company Ltd. (“Collaborator”) on an information sharing engagement. This letter (“Agreement”) outlines the terms and conditions of this limited engagement. Microsoft and Collaborator agree to work  together in good faith as described herein for the benefit of the .NET ecosystem. Confidential information disclosed or exchanged  pursuant to this Agreement is subject to the Microsoft Corporation Non-Disclosure Agreement between Microsoft and Collaborator, dated [NDA date] (“NDA”).
+
+1. **Disclosure of Information**. Microsoft is collaborating with Collaborator and certain other third parties who are users of .NET to  share in confidence early information concerning possible security vulnerabilities in advance of their publication by Microsoft (“Pre Disclosure CVEs”). Collaborator will share with Microsoft information it discovers or learns of on possible .NET security vulnerabilities, which  Microsoft may in its discretion publish as CVEs. Each party will bear its own expenses in relation to the Project and no fees or payments are contemplated by either party to the other.
+
+2. **Coordination**. Microsoft will share confidential Pre-Disclosure CVEs (description and fixes) with Collaborator from time to time, generally on a schedule pre-determined by Microsoft. Collaborator will make commercially reasonable efforts to apply sufficient resources to release updates (to  Collaborator assets) in a reasonably timely manner after a release embargo is lifted by Microsoft. Release embargoes are lifted after published disclosure by Microsoft, at dotnet/announcements (GitHub), the .NET Blog (devblogs.microsoft.com), or as communicated by Microsoft in writing. The  parties may agree during the Term to a specific release schedule for updates. The parties acknowledge that potential vulnerabilities,  which may be similar to or the same as a Pre-Disclosure CVE, may be discovered or learned of by third parties independent of this  Agreement, but the parties will nonetheless coordinate and observe release embargoes with respect to Pre-Disclosure CVEs.
+
+3. **Collaboration with Other Parties**. Microsoft intends to engage with a group of interested and known industry parties (who have  also entered into an agreement substantially the same as this Agreement) in a similar way as Microsoft and Collaborator are  collaborating under this Agreement. Each party agrees to use commercially reasonable efforts to collaborate in good faith with all other such parties to the program. Within the group, parties may share information relating to their respective products, builds, schedules, processes, dependencies, etc.  Collaborator agrees to keep confidential all information received from other parties while participating in the group.
+
+4. **Proprietary Rights**. With the exception of information shared under Section 1, neither party grants the other (by implication, estoppel or otherwise) any right, title, interest, or license, in any patents, patent applications, trade secrets, copyrights, mask work rights, trademarks or other intellectual property. Collaborator grants Microsoft a license to use, publish, and commercialize information shared under Section 1. 
+
+5. **Data**. Collaborator and Microsoft will not provide each other with any customer data, personal data, or personally identifiable  information in connection with this Agreement.
+
+6. **Confidentiality and Publicity**. Without limiting the parties’ obligations under the NDA with respect to Pre-Disclosure CVEs and any  other confidential information or materials exchanged between the parties in connection with this Agreement, Microsoft is free to  publish CVEs when and in such form it determines in its discretion, after which time such published information shall no longer be  considered confidential information. Collaborator agrees to be named as a member of Microsoft’s .NET pre-disclosure group along  with other participants and to collaborate in good faith in group communications and agreed publications.
+
+7. **Termination**. This Agreement is effective as of the date on which it has been signed by Collaborator as shown in the signature block  below (“Effective Date”) and will remain in effect for a term of one year following the Effective Date (“Term”), after which the  Agreement will automatically renew for additional one year renewal terms. Either party may terminate this Agreement effective immediately at any time  by providing written notice to the other, provided that Collaborator will continue to make commercially reasonable efforts to apply sufficient resources to release updates (to  Collaborator assets) in a reasonably timely manner for Pre-Disclosure CVEs shared during the Term. Upon request, each party will return to the other party or destroy any Confidential Information received from the other party in connection with this Agreement. Provisions pertaining to confidentiality,  limitation of liability, and choice of law provisions will survive any such termination of this Agreement.
+
+8. **Warranties**. Neither party makes any warranties. To the maximum extent permitted by law, each party, and its respective  affiliates, agents, and representatives expressly disclaim all express, statutory, and implied warranties. Microsoft’s Pre-Disclosure  CVEs and related information may be incomplete, may contain bugs or errors and may not become published as CVEs. Collaborator agrees that it is solely responsible for determining the appropriateness of utilizing the Pre-Disclosure CVEs.
+
+9. **Limitation of liability**. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE PARTIES LIMIT THEIR LIABILITY FOR ANY  CLAIMS UNDER THIS AGREEMENT TO $500 USD AND IN NO EVENT WILL EITHER PARTY (INCLUDING THEIR DIRECTORS, OFFICERS  AND AFFILIATES) BE LIABLE FOR ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, SPECIAL, OR EXEMPLARY DAMAGES  ARISING OUT OF THIS AGREEMENT. THESE EXCLUSIONS APPLY REGARDLESS OF WHETHER APPLICATION OF THESE EXCLUSIONS  CAUSES ANY REMEDY TO FAIL OF ITS ESSENTIAL PURPOSE. THIS SECTION 9 WILL NOT APPLY TO LIABILITY ARISING OUT OF EITHER  PARTY’S LIABILITY FOR (i) VIOLATION OF ITS CONFIDENTIALITY OBLIGATIONS OR (ii) WILLFUL MISCONDUCT.
+
+10. **Governing Law**. The terms of this Agreement will be governed and construed in accordance with the laws of the state of  New York of the United States of America, U.S.A. 
+
+11. **Entire agreement; assignment**. This Agreement is the entire agreement between the parties regarding its limited subject matter  and merges and replaces all prior and contemporaneous agreements, communications, and representations between the parties  regarding its subject matter. Collaborator may not assign or transfer this Agreement to a third party without Microsoft’s prior  written consent.
+
+Sincerely,
+
+Microsoft Corporation
+One Microsoft Way, Redmond, WA 98052 USA
+
+Signed: __________________________________
+Name: __________________________________
+Title: __________________________________
+Date: __________________________________
+
+Acknowledged and agreed:
+
+Company Limited
+Registered Address:  Address
+Correspondence Address:  Address
+
+Signed: __________________________________
+Name: __________________________________
+Title: __________________________________
+Date: __________________________________

--- a/Documentation/security-group/dotnet-security-group.md
+++ b/Documentation/security-group/dotnet-security-group.md
@@ -1,0 +1,51 @@
+# .NET Security Group
+
+The .NET upstream project is run by Microsoft and follows Microsoft security reporting and disclosure practices. Microsoft shares vulnerability information with the .NET Security Group (subsequently referred to as the “Group”) prior to public disclosure to enable members to build, validate, and publish packages at the same time as Microsoft.
+
+The overall charter of the Group is to ensure that vulnerability descriptions and patches are consistently and transparently published, enabling users everywhere to deploy patches quickly.
+
+The Group was established in 2016 by Microsoft and Red Hat, in advance of .NET Core 1.0.
+
+See [Announcing the .NET Security Group](https://devblogs.microsoft.com/dotnet/announcing-dotnet-security-group/) for process information.
+
+## Membership
+
+Membership in the Group is limited to companies that distribute or support .NET and that have a track record of careful handling of embargo information. Members must have a non-disclosure agreement with Microsoft and sign a [pre-disclosure collaboration agreement](./dotnet-security-group-agreement.md). Members are added at the discretion of the Group. Member removal is subject to the agreement.
+
+Members:
+
+-	Canonical
+-	IBM
+-	Microsoft
+-	Red Hat
+
+## Responsibilities
+
+The group is modelled on common open source practices. It is oriented on source as the shared artifact and securing supply chains that rely on supported .NET versions. There is no affordance for sharing source patches for unsupported .NET versions or binaries. Binary sharing establishes a high level of business continuity, which is outside the scope of a program oriented around an open source project.
+
+Members must publish builds for supported .NET versions. They can additionally patch end-of-life .NET versions, however, that activity is outside the scope of the Group. Members who exclusively use early-access source patches to update end-of-life versions may be removed from the program.
+
+Members are expected to be active in `main` or other active branches as an investment in the .NET ecosystem. Doing that demonstrates a strong commitment to the ecosystem and earned community credibility. 
+
+## Vulnerability publishing process
+
+Vulnerability information is strictly confidential until the public disclosure. The Group coordinates primarily via regular Teams calls, open to all members.
+
+Process:
+
+- Vulnerabilities are discovered and [privately reported](https://github.com/dotnet/runtime/blob/main/README.md#reporting-security-issues-and-security-bugs) by project engineers, security researchers, or other parties.
+- Vulnerabilities are validated and resolved.
+- Vulnerability descriptions and patches are shared with Group members via shared git repositories, typically a minimum of 10 business days before publishing. Embargo starts at that time.
+- Group members follow their own established vulnerability process. They privately build and validate patches in preparation for publishing patched binaries for their users at the same time as or soon after Microsoft.
+- Microsoft publicly publishes [vulnerability disclosures](https://github.com/dotnet/announcements/issues?q=is%3Aissue+is%3Aopen+label%3ASecurity). Embargo ends at that time.
+- Group members publicly publish vulnerability disclosures and patched builds to their users via their established means.
+
+The publishing day is almost always [Patch Tuesday](https://en.wikipedia.org/wiki/Patch_Tuesday). The same overall process will be followed in case accelerated action is needed, possibly with shorter timelines.
+
+This process applies to [supported .NET releases](https://github.com/dotnet/core/blob/main/releases.md). Some months may have no security patches.
+
+## Reporting and inquiries
+
+Vulnerability reports should be sent through the [security reporting process](https://github.com/dotnet/runtime/blob/main/README.md#reporting-security-issues-and-security-bugs).
+
+Inquiries about the Group can be sent to [dotnet@microsoft.com](mailto:dotnet@microsoft.com). 


### PR DESCRIPTION
We are establishing a public security group for ensuring the broad distribution of .NET security patches in a controlled and responsible manner.

Context: https://devblogs.microsoft.com/dotnet/announcing-dotnet-security-group/

The group has existed for some time. The change to make the group public was in part inspired by the good work of other projects:

- https://openjdk.org/groups/vulnerability/
- https://github.com/rust-lang/rfcs/pull/3259