### PR TITLE
Update supported OSes

### DIFF
--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -11,7 +11,7 @@
           "link": "https://www.android.com/",
           "lifecycle": "https://support.google.com/android",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["15", "14", "13", "12.1", "12"],
+          "supported-versions": ["16", "15", "14", "13"],
           "notes": ["API 21 is used as the minimum SDK target."]
         }
       ]
@@ -24,7 +24,7 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["18"],
+          "supported-versions": ["26", "18"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {
@@ -32,14 +32,14 @@
           "name": "iPadOS",
           "link": "https://developer.apple.com/ipados/",
           "architectures": ["Arm64"],
-          "supported-versions": ["18"]
+          "supported-versions": ["26", "18"]
         },
         {
           "id": "macos",
           "name": "macOS",
           "link": "https://developer.apple.com/macos/",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["15", "14"],
+          "supported-versions": ["26", "15", "14"],
           "notes": [
             "The iOS and tvOS simulators are supported on macOS Arm64 and x64.",
             "The x64 emulator (Rosetta 2) is supported on macOS Arm64.",
@@ -51,7 +51,7 @@
           "name": "tvOS",
           "link": "https://developer.apple.com/tvos/",
           "architectures": ["Arm64"],
-          "supported-versions": ["18"]
+          "supported-versions": ["26"]
         }
       ]
     },
@@ -103,7 +103,7 @@
           "link": "https://www.opensuse.org/",
           "lifecycle": "https://en.opensuse.org/Lifetime",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["15.6"]
+          "supported-versions": ["16.0", "15.6"]
         },
         {
           "id": "rhel",
@@ -122,7 +122,7 @@
           "link": "https://www.suse.com/",
           "lifecycle": "https://www.suse.com/lifecycle/",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["15.6"]
+          "supported-versions": ["15.7", "15.6"]
         },
         {
           "id": "ubuntu",
@@ -130,7 +130,7 @@
           "link": "https://ubuntu.com/",
           "lifecycle": "https://wiki.ubuntu.com/Releases",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["25.04", "24.04", "22.04"]
+          "supported-versions": ["25.10", "25.04", "24.04", "22.04"]
         }
       ]
     },
@@ -152,14 +152,14 @@
           "lifecycle": "https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet",
           "architectures": ["Arm64", "x64", "x86"],
           "supported-versions": [
+            "11-25h2-e",
+            "11-25h2-w",
             "11-24h2-iot-lts",
             "11-24h2-e-lts",
             "11-24h2-e",
             "11-24h2-w",
             "11-23h2-e",
             "11-23h2-w",
-            "11-22h2-e",
-            "10-22h2",
             "10-21h2-e-lts",
             "10-21h2-iot-lts",
             "10-1809-e-lts",

--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -1,14 +1,14 @@
 # .NET 10.0 - Supported OS versions
 
-Last Updated: 2025/06/02; Support phase: Preview
+Last Updated: 2025/06/02; Support phase: GoLive
 
 [.NET 10.0](README.md) is an [LTS](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
 ## Android
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Android][0]                  | 15, 14, 13, 12.1, 12        | Arm32, Arm64, x64     | [Lifecycle][1]       |
+| OS           | Versions       | Architectures     | Lifecycle      |
+| ------------ | -------------- | ----------------- | -------------- |
+| [Android][0] | 16, 15, 14, 13 | Arm32, Arm64, x64 | [Lifecycle][1] |
 
 Notes:
 
@@ -19,12 +19,12 @@ Notes:
 
 ## Apple
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [iOS][2]                      | 18                          | Arm64                 | None                 |
-| [iPadOS][3]                   | 18                          | Arm64                 | None                 |
-| [macOS][4]                    | 15, 14                      | Arm64, x64            | None                 |
-| [tvOS][5]                     | 18                          | Arm64                 | None                 |
+| OS          | Versions   | Architectures | Lifecycle |
+| ----------- | ---------- | ------------- | --------- |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
+| [iPadOS][3] | 26, 18     | Arm64         | None      |
+| [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
+| [tvOS][5]   | 26         | Arm64         | None      |
 
 Notes:
 
@@ -40,17 +40,17 @@ Notes:
 
 ## Linux
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Alpine][6]                   | 3.22                        | Arm32, Arm64, x64     | [Lifecycle][7]       |
-| [Azure Linux][8]              | 3.0                         | Arm64, x64            | None                 |
-| [CentOS Stream][9]            | 10, 9                       | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                  | 13, 12                      | Arm32, Arm64, x64     | [Lifecycle][12]      |
-| [Fedora][13]                  | 42                          | Arm32, Arm64, x64     | [Lifecycle][14]      |
-| [openSUSE Leap][15]           | 15.6                        | Arm64, x64            | [Lifecycle][16]      |
-| [Red Hat Enterprise Linux][17] | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Enterprise Linux][19]   | 15.6                        | Arm64, x64            | [Lifecycle][20]      |
-| [Ubuntu][21]                  | 25.04, 24.04, 22.04         | Arm32, Arm64, x64     | [Lifecycle][22]      |
+| OS                             | Versions   | Architectures              | Lifecycle       |
+| ------------------------------ | ---------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.22       | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 42         | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6 | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9      | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Enterprise Linux][19]    | 15.7, 15.6 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 25.04, 24.04, 22.04 | Arm32, Arm64, x64 | [Lifecycle][22] |
 
 Notes:
 
@@ -76,12 +76,12 @@ Notes:
 
 ## Windows
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Nano Server][23]             | 2025, 2022, 2019            | x64                   | [Lifecycle][24]      |
-| [Windows][25]                 | 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 11 22H2 (E), 10 22H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
-| [Windows Server][27]          | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86 | [Lifecycle][24]   |
-| [Windows Server Core][23]     | 2025, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][24]      |
+| OS                        | Versions                                                                                                    | Architectures   | Lifecycle       |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------- | --------------- |
+| [Nano Server][23]         | 2025, 2022, 2019                                                                                            | x64             | [Lifecycle][24] |
+| [Windows][25]             | 11 25H2, 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
+| [Windows Server][27]      | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012                                                                 | x64, x86        | [Lifecycle][24] |
+| [Windows Server Core][23] | 2025, 2022, 2019, 2016, 2012-R2, 2012                                                                       | x64, x86        | [Lifecycle][24] |
 
 Notes:
 
@@ -99,11 +99,11 @@ Notes:
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-| Libc          | Version | Architectures         | Source       |
-| ------------- | ------- | --------------------- | ------------ |
-| glibc         | 2.27    | Arm64, x64            | Ubuntu 18.04 |
-| glibc         | 2.35    | Arm32                 | Ubuntu 22.04 |
-| musl          | 1.2.3   | Arm32, Arm64, x64     | Alpine 3.17  |
+| Libc  | Version | Architectures     | Source       |
+| ----- | ------- | ----------------- | ------------ |
+| glibc | 2.27    | Arm64, x64        | Ubuntu 18.04 |
+| glibc | 2.35    | Arm32             | Ubuntu 22.04 |
+| musl  | 1.2.3   | Arm32, Arm64, x64 | Alpine 3.17  |
 
 ## Notes
 

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -16,13 +16,14 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "16",
                         "15",
                         "14",
-                        "13",
-                        "12.1",
-                        "12"
+                        "13"
                     ],
                     "unsupported-versions": [
+                        "12.1",
+                        "12",
                         "11"
                     ],
                     "notes": [
@@ -42,10 +43,11 @@
                         "Arm64"
                     ],
                     "supported-versions": [
-                        "18",
-                        "17"
+                        "26",
+                        "18"
                     ],
                     "unsupported-versions": [
+                        "17",
                         "16",
                         "15"
                     ],
@@ -61,6 +63,7 @@
                         "Arm64"
                     ],
                     "supported-versions": [
+                        "26",
                         "18",
                         "17"
                     ],
@@ -78,11 +81,12 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "26",
                         "15",
-                        "14",
-                        "13"
+                        "14"
                     ],
                     "unsupported-versions": [
+                        "13",
                         "12"
                     ],
                     "notes": [
@@ -99,10 +103,11 @@
                         "Arm64"
                     ],
                     "supported-versions": [
-                        "18",
-                        "17"
+                        "26"
                     ],
                     "unsupported-versions": [
+                        "18",
+                        "17",
                         "16",
                         "15",
                         "14",
@@ -176,6 +181,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "13",
                         "12"
                     ],
                     "unsupported-versions": [
@@ -213,6 +219,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "16.0",
                         "15.6"
                     ],
                     "unsupported-versions": [
@@ -250,6 +257,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "15.7",
                         "15.6"
                     ],
                     "unsupported-versions": [
@@ -269,6 +277,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "25.10",
                         "25.04",
                         "24.04",
                         "22.04"
@@ -310,22 +319,24 @@
                         "x86"
                     ],
                     "supported-versions": [
+                        "11-25h2-e",
+                        "11-25h2-w",
                         "11-24h2-iot-lts",
                         "11-24h2-e-lts",
                         "11-24h2-e",
                         "11-24h2-w",
                         "11-23h2-e",
                         "11-23h2-w",
-                        "11-22h2-e",
-                        "10-22h2",
                         "10-21h2-e-lts",
                         "10-21h2-iot-lts",
                         "10-1809-e-lts",
                         "10-1607-e-lts"
                     ],
                     "unsupported-versions": [
+                        "11-22h2-e",
                         "11-22h2-w",
                         "11-21h2-e",
+                        "10-22h2",
                         "10-21h2-e"
                     ],
                     "notes": [

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -6,9 +6,9 @@ Last Updated: 2025/06/02; Support phase: Active
 
 ## Android
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Android][0]                  | 15, 14, 13, 12.1, 12        | Arm32, Arm64, x64     | [Lifecycle][1]       |
+| OS           | Versions       | Architectures     | Lifecycle      |
+| ------------ | -------------- | ----------------- | -------------- |
+| [Android][0] | 16, 15, 14, 13 | Arm32, Arm64, x64 | [Lifecycle][1] |
 
 Notes:
 
@@ -19,12 +19,12 @@ Notes:
 
 ## Apple
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [iOS][2]                      | 18, 17                      | Arm64                 | None                 |
-| [iPadOS][3]                   | 18, 17                      | Arm64                 | None                 |
-| [macOS][4]                    | 15, 14, 13                  | Arm64, x64            | None                 |
-| [tvOS][5]                     | 18, 17                      | Arm64                 | None                 |
+| OS          | Versions   | Architectures | Lifecycle |
+| ----------- | ---------- | ------------- | --------- |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
+| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
+| [tvOS][5]   | 26         | Arm64         | None      |
 
 Notes:
 
@@ -40,17 +40,17 @@ Notes:
 
 ## Linux
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Alpine][6]                   | 3.22, 3.21, 3.20, 3.19      | Arm32, Arm64, x64     | [Lifecycle][7]       |
-| [Azure Linux][8]              | 3.0                         | Arm64, x64            | None                 |
-| [CentOS Stream][9]            | 10, 9                       | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                  | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]      |
-| [Fedora][13]                  | 42, 41                      | Arm32, Arm64, x64     | [Lifecycle][14]      |
-| [openSUSE Leap][15]           | 15.6                        | Arm64, x64            | [Lifecycle][16]      |
+| OS                             | Versions                   | Architectures              | Lifecycle       |
+| ------------------------------ | -------------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.22, 3.21, 3.20, 3.19     | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12                     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 42, 41                     | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6                 | Arm64, x64                 | [Lifecycle][16] |
 | [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Enterprise Linux][19]   | 15.6                        | Arm64, x64            | [Lifecycle][20]      |
-| [Ubuntu][21]                  | 25.04, 24.04, 22.04         | Arm32, Arm64, x64     | [Lifecycle][22]      |
+| [SUSE Enterprise Linux][19]    | 15.7, 15.6                 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 25.04, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -76,12 +76,12 @@ Notes:
 
 ## Windows
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Nano Server][23]             | 2025, 2022, 2019            | x64                   | [Lifecycle][24]      |
-| [Windows][25]                 | 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 11 22H2 (E), 10 22H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
-| [Windows Server][27]          | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86 | [Lifecycle][24]   |
-| [Windows Server Core][23]     | 2025, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][24]      |
+| OS                        | Versions                                                                                                    | Architectures   | Lifecycle       |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------- | --------------- |
+| [Nano Server][23]         | 2025, 2022, 2019                                                                                            | x64             | [Lifecycle][24] |
+| [Windows][25]             | 11 25H2, 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
+| [Windows Server][27]      | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012                                                                 | x64, x86        | [Lifecycle][24] |
+| [Windows Server Core][23] | 2025, 2022, 2019, 2016, 2012-R2, 2012                                                                       | x64, x86        | [Lifecycle][24] |
 
 Notes:
 
@@ -99,10 +99,10 @@ Notes:
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-| Libc          | Version | Architectures         | Source       |
-| ------------- | ------- | --------------------- | ------------ |
-| glibc         | 2.23    | Arm32, Arm64, x64     | Ubuntu 16.04 |
-| musl          | 1.2.2   | Arm32, Arm64, x64     | Alpine 3.13  |
+| Libc  | Version | Architectures     | Source       |
+| ----- | ------- | ----------------- | ------------ |
+| glibc | 2.23    | Arm32, Arm64, x64 | Ubuntu 16.04 |
+| musl  | 1.2.2   | Arm32, Arm64, x64 | Alpine 3.13  |
 
 ## Notes
 
@@ -113,39 +113,47 @@ Microsoft-provided [portable Linux builds](../../linux.md) define minimum compat
 
 The following operating system versions are no longer supported.
 
-| OS                    | Version       | Date                 |
-| --------------------- | ------------- | -------------------- |
-| Alpine                | 3.18          | [2025-05-09](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html) |
-| Alpine                | 3.17          | [2024-11-22](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html) |
-| Alpine                | 3.16          | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html) |
-| Android               | 11            | 2024-02-05           |
-| Debian                | 11            | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html) |
-| Fedora                | 40            | 2025-05-13           |
-| Fedora                | 39            | 2024-11-26           |
-| Fedora                | 38            | 2024-05-21           |
-| Fedora                | 37            | 2023-12-05           |
-| iOS                   | 16            | [2025-03-31](https://support.apple.com/HT213407) |
-| iOS                   | 15            | [2025-03-31](https://support.apple.com/HT212788) |
-| iPadOS                | 16            | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
-| iPadOS                | 15            | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15-release-notes) |
-| macOS                 | 12            | [2024-09-16](https://support.apple.com/HT212585) |
-| openSUSE Leap         | 15.5          | 2024-12-31           |
-| openSUSE Leap         | 15.4          | 2023-12-07           |
-| SUSE Enterprise Linux | 15.5          | 2024-12-31           |
-| SUSE Enterprise Linux | 12.5          | 2024-10-31           |
-| SUSE Enterprise Linux | 15.4          | 2023-12-31           |
-| tvOS                  | 16            | 2023-09-18           |
-| tvOS                  | 15            | 2022-09-12           |
-| tvOS                  | 14            | 2021-09-20           |
-| tvOS                  | 13            | 2020-09-16           |
-| tvOS                  | 12.2          | -                    |
-| Ubuntu                | 24.10         | 2025-07-10           |
-| Ubuntu                | 20.04         | 2025-05-31           |
-| Ubuntu                | 23.10         | 2024-07-12           |
-| Ubuntu                | 23.04         | 2024-01-20           |
-| Windows               | 11 22H2 (W)   | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-| Windows               | 11 21H2 (E)   | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-| Windows               | 10 21H2 (E)   | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
+| OS      | Version | Date                                                                                                     |
+| ------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| Alpine  | 3.18    | [2025-05-09](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)            |
+| Alpine  | 3.17    | [2024-11-22](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)            |
+| Alpine  | 3.16    | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)                    |
+| Android | 12.1    | [2025-03-03](https://developer.android.com/about/versions/12/12L)                                        |
+| Android | 12      | 2025-03-03                                                                                               |
+| Android | 11      | 2024-02-05                                                                                               |
+| Debian  | 11      | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)                              |
+| Fedora  | 40      | 2025-05-13                                                                                               |
+| Fedora  | 39      | 2024-11-26                                                                                               |
+| Fedora  | 38      | 2024-05-21                                                                                               |
+| Fedora  | 37      | 2023-12-05                                                                                               |
+| iOS     | 16      | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)    |
+| iOS     | 15      | 2025-03-31                                                                                               |
+| iOS     | 17      | 2024-11-19                                                                                               |
+| iPadOS  | 16      | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
+| iPadOS  | 15      | 2025-03-31                                                                                               |
+| macOS   | 13      | 2025-09-15                                                                                               |
+| macOS   | 12      | [2024-09-16](https://developer.apple.com/documentation/macos-release-notes/macos-12_0_1-release-notes)   |
+| openSUSE Leap | 15.5 | 2024-12-31                                                                                            |
+| openSUSE Leap | 15.4 | 2023-12-07                                                                                            |
+| SUSE Enterprise Linux | 15.5 | 2024-12-31                                                                                    |
+| SUSE Enterprise Linux | 12.5 | 2024-10-31                                                                                    |
+| SUSE Enterprise Linux | 15.4 | 2023-12-31                                                                                    |
+| tvOS    | 18      | 2025-09-15                                                                                               |
+| tvOS    | 17      | 2024-09-16                                                                                               |
+| tvOS    | 16      | 2023-09-18                                                                                               |
+| tvOS    | 15      | 2022-09-12                                                                                               |
+| tvOS    | 14      | 2021-09-20                                                                                               |
+| tvOS    | 13      | 2020-09-16                                                                                               |
+| tvOS    | 12.2    | -                                                                                                        |
+| Ubuntu  | 24.10   | 2025-07-10                                                                                               |
+| Ubuntu  | 20.04   | 2025-05-31                                                                                               |
+| Ubuntu  | 23.10   | 2024-07-12                                                                                               |
+| Ubuntu  | 23.04   | 2024-01-20                                                                                               |
+| Windows | 11 22H2 (E) | [2025-10-14](https://learn.microsoft.com/windows/release-health/windows11-release-information)       |
+| Windows | 10 22H2 | [2025-10-14](https://learn.microsoft.com/windows/release-health/release-information)                     |
+| Windows | 11 22H2 (W) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)       |
+| Windows | 11 21H2 (E) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)       |
+| Windows | 10 21H2 (E) | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education)     |
 
 ## About
 

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -16,9 +16,12 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "16",
                         "15",
                         "14",
-                        "13",
+                        "13"
+                    ],
+                    "unsupported-versions": [
                         "12.1",
                         "12"
                     ],
@@ -39,10 +42,11 @@
                         "Arm64"
                     ],
                     "supported-versions": [
-                        "18",
-                        "17"
+                        "26",
+                        "18"
                     ],
                     "unsupported-versions": [
+                        "17",
                         "16"
                     ],
                     "notes": [
@@ -57,6 +61,7 @@
                         "Arm64"
                     ],
                     "supported-versions": [
+                        "26",
                         "18",
                         "17"
                     ],
@@ -73,8 +78,11 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "26",
                         "15",
-                        "14",
+                        "14"
+                    ],
+                    "unsupported-versions": [
                         "13"
                     ],
                     "notes": [
@@ -91,10 +99,11 @@
                         "Arm64"
                     ],
                     "supported-versions": [
-                        "18",
-                        "17"
+                        "26"
                     ],
                     "unsupported-versions": [
+                        "18",
+                        "17",
                         "16",
                         "15",
                         "14",
@@ -163,6 +172,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "13",
                         "12"
                     ]
                 },
@@ -194,6 +204,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "16.0",
                         "15.6"
                     ],
                     "unsupported-versions": [
@@ -230,6 +241,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "15.7",
                         "15.6"
                     ]
                 },
@@ -244,6 +256,7 @@
                         "x64"
                     ],
                     "supported-versions": [
+                        "25.10",
                         "25.04",
                         "24.04",
                         "22.04"
@@ -282,18 +295,22 @@
                         "x86"
                     ],
                     "supported-versions": [
+                        "11-25h2-e",
+                        "11-25h2-w",
                         "11-24h2-iot-lts",
                         "11-24h2-e-lts",
                         "11-24h2-e",
                         "11-24h2-w",
                         "11-23h2-e",
                         "11-23h2-w",
-                        "11-22h2-e",
-                        "10-22h2",
                         "10-21h2-e-lts",
                         "10-21h2-iot-lts",
                         "10-1809-e-lts",
                         "10-1607-e-lts"
+                    ],
+                    "unsupported-versions": [
+                        "11-22h2-e",
+                        "10-22h2"
                     ],
                     "notes": [
                         "The x64 emulator is supported on Windows 11 Arm64."

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -6,9 +6,9 @@ Last Updated: 2025/06/02; Support phase: Active
 
 ## Android
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Android][0]                  | 15, 14, 13, 12.1, 12        | Arm32, Arm64, x64     | [Lifecycle][1]       |
+| OS           | Versions       | Architectures     | Lifecycle      |
+| ------------ | -------------- | ----------------- | -------------- |
+| [Android][0] | 16, 15, 14, 13 | Arm32, Arm64, x64 | [Lifecycle][1] |
 
 Notes:
 
@@ -19,12 +19,12 @@ Notes:
 
 ## Apple
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [iOS][2]                      | 18, 17                      | Arm64                 | None                 |
-| [iPadOS][3]                   | 18, 17                      | Arm64                 | None                 |
-| [macOS][4]                    | 15, 14, 13                  | Arm64, x64            | None                 |
-| [tvOS][5]                     | 18, 17                      | Arm64                 | None                 |
+| OS          | Versions   | Architectures | Lifecycle |
+| ----------- | ---------- | ------------- | --------- |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
+| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
+| [tvOS][5]   | 26         | Arm64         | None      |
 
 Notes:
 
@@ -40,17 +40,17 @@ Notes:
 
 ## Linux
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Alpine][6]                   | 3.22, 3.21, 3.20, 3.19      | Arm32, Arm64, x64     | [Lifecycle][7]       |
-| [Azure Linux][8]              | 3.0                         | Arm64, x64            | None                 |
-| [CentOS Stream][9]            | 10, 9                       | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                  | 12                          | Arm32, Arm64, x64     | [Lifecycle][12]      |
-| [Fedora][13]                  | 42, 41                      | Arm32, Arm64, x64     | [Lifecycle][14]      |
-| [openSUSE Leap][15]           | 15.6                        | Arm64, x64            | [Lifecycle][16]      |
+| OS                             | Versions                   | Architectures              | Lifecycle       |
+| ------------------------------ | -------------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.22, 3.21, 3.20, 3.19     | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12                     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 42, 41                     | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6                 | Arm64, x64                 | [Lifecycle][16] |
 | [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Enterprise Linux][19]   | 15.6                        | Arm64, x64            | [Lifecycle][20]      |
-| [Ubuntu][21]                  | 25.04, 24.04, 22.04         | Arm32, Arm64, x64     | [Lifecycle][22]      |
+| [SUSE Enterprise Linux][19]    | 15.7, 15.6                 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 25.04, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -76,12 +76,12 @@ Notes:
 
 ## Windows
 
-| OS                            | Versions                    | Architectures         | Lifecycle            |
-| ----------------------------- | --------------------------- | --------------------- | -------------------- |
-| [Nano Server][23]             | 2025, 2022, 2019            | x64                   | [Lifecycle][24]      |
-| [Windows][25]                 | 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 11 22H2 (E), 10 22H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
-| [Windows Server][27]          | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86 | [Lifecycle][24]   |
-| [Windows Server Core][23]     | 2025, 2022, 2019, 2016, 2012-R2, 2012 | x64, x86    | [Lifecycle][24]      |
+| OS                        | Versions                                                                                                    | Architectures   | Lifecycle       |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------- | --------------- |
+| [Nano Server][23]         | 2025, 2022, 2019                                                                                            | x64             | [Lifecycle][24] |
+| [Windows][25]             | 11 25H2, 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2, 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E) | Arm64, x64, x86 | [Lifecycle][26] |
+| [Windows Server][27]      | 2025, 23H2, 2022, 2019, 2016, 2012-R2, 2012                                                                 | x64, x86        | [Lifecycle][24] |
+| [Windows Server Core][23] | 2025, 2022, 2019, 2016, 2012-R2, 2012                                                                       | x64, x86        | [Lifecycle][24] |
 
 Notes:
 
@@ -99,11 +99,11 @@ Notes:
 
 Microsoft-provided [portable Linux builds](../../linux.md) define minimum compatibility primarily via libc version.
 
-| Libc          | Version | Architectures         | Source       |
-| ------------- | ------- | --------------------- | ------------ |
-| glibc         | 2.23    | Arm64, x64            | Ubuntu 16.04 |
-| glibc         | 2.35    | Arm32                 | Ubuntu 22.04 |
-| musl          | 1.2.2   | Arm32, Arm64, x64     | Alpine 3.13  |
+| Libc  | Version | Architectures     | Source       |
+| ----- | ------- | ----------------- | ------------ |
+| glibc | 2.23    | Arm64, x64        | Ubuntu 16.04 |
+| glibc | 2.35    | Arm32             | Ubuntu 22.04 |
+| musl  | 1.2.2   | Arm32, Arm64, x64 | Alpine 3.13  |
 
 ## Notes
 
@@ -114,18 +114,26 @@ Microsoft-provided [portable Linux builds](../../linux.md) define minimum compat
 
 The following operating system versions are no longer supported.
 
-| OS                    | Version       | Date                 |
-| --------------------- | ------------- | -------------------- |
-| Fedora                | 40            | 2025-05-13           |
-| iOS                   | 16            | [2025-03-31](https://support.apple.com/HT213407) |
-| iPadOS                | 16            | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
-| openSUSE Leap         | 15.5          | 2024-12-31           |
-| tvOS                  | 16            | 2023-09-18           |
-| tvOS                  | 15            | 2022-09-12           |
-| tvOS                  | 14            | 2021-09-20           |
-| tvOS                  | 13            | 2020-09-16           |
-| tvOS                  | 12.2          | -                    |
-| Ubuntu                | 24.10         | 2025-07-10           |
+| OS      | Version | Date                                                                                           |
+| ------- | ------- | ---------------------------------------------------------------------------------------------- |
+| Android | 12.1    | [2025-03-03](https://developer.android.com/about/versions/12/12L)                              |
+| Android | 12      | 2025-03-03                                                                                     |
+| Fedora  | 40      | 2025-05-13                                                                                     |
+| iOS     | 16      | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes) |
+| iOS     | 17      | 2024-11-19                                                                                     |
+| iPadOS  | 16      | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
+| macOS   | 13      | 2025-09-15                                                                                     |
+| openSUSE Leap | 15.5 | 2024-12-31                                                                                  |
+| tvOS    | 18      | 2025-09-15                                                                                     |
+| tvOS    | 17      | 2024-09-16                                                                                     |
+| tvOS    | 16      | 2023-09-18                                                                                     |
+| tvOS    | 15      | 2022-09-12                                                                                     |
+| tvOS    | 14      | 2021-09-20                                                                                     |
+| tvOS    | 13      | 2020-09-16                                                                                     |
+| tvOS    | 12.2    | -                                                                                              |
+| Ubuntu  | 24.10   | 2025-07-10                                                                                     |
+| Windows | 11 22H2 (E) | [2025-10-14](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
+| Windows | 10 22H2 | [2025-10-14](https://learn.microsoft.com/windows/release-health/release-information)           |
 
 ## About
 


### PR DESCRIPTION
The supported-os files seem to be a bit outdated. Therefore many changes. I hope I listed all of them.

Additions:
* Android 16
* iOS 26
* iPadOS 26
* macOS 26
* tvOS 26
* Debian 13
* openSUSE Leap 16.0
* SUSE Enterprise Linux 15.7
* Ubuntu 25.10
* Windows 11 25H2

Removals:
* Android 12 / 12.1
* iOS 17
* macOS 13
* tvOS 17
* tvOS 18
* Windows 11 22H2 (E)
* Windows 10 22H2

NOTE: I updated the MDs using the latest distroessed, but it seems the formatting is off. Do I have to adjust something or use a config?

/CC @richlander 