### PR TITLE
Update NET 9.0 EOL Date

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -5,7 +5,7 @@
 |  Version  | Release Date | Release type | Support phase | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- | :-- |
 | [.NET 10.0](./10.0/README.md) | [November 11, 2025](https://devblogs.microsoft.com/dotnet/announcing-dotnet-10/) | [LTS][policies] | Preview | [10.0.0][10.0.0] | November 14, 2028 |
-| [.NET 9.0](./9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | Active | [9.0.11][9.0.11] | May 12, 2026 |
+| [.NET 9.0](./9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | Active | [9.0.11][9.0.11] | November 10, 2026 |
 | [.NET 8.0](./8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | Active | [8.0.22][8.0.22] | November 10, 2026 |
 
 [10.0.0]: ./10.0/10.0.0/10.0.0.md


### PR DESCRIPTION
Correct NET 9.0 EOL date that was forgotten in the original PR:
https://github.com/dotnet/core/pull/10123