### PR TITLE
Update feedback link

### DIFF
--- a/release-notes/8.0/8.0.22/8.0.22.md
+++ b/release-notes/8.0/8.0.22/8.0.22.md
@@ -60,7 +60,7 @@ You need [Visual Studio 17.10](https://visualstudio.microsoft.com) or later to u
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #xxxxx](https://github.com/dotnet/core/issues/xxxxx) for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core #xxxxx](https://github.com/dotnet/core/issues/10155) for your questions and comments.
 
 [8.0.416]: 8.0.22.md
 [8.0.319]: 8.0.319.md

--- a/release-notes/9.0/9.0.11/9.0.11.md
+++ b/release-notes/9.0/9.0.11/9.0.11.md
@@ -59,7 +59,7 @@ You need [Visual Studio 17.12](https://visualstudio.microsoft.com) or later to u
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #10120](https://github.com/dotnet/core/issues/10120) for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core #10120](https://github.com/dotnet/core/issues/10155) for your questions and comments.
 
 [9.0.307]: 9.0.11.md
 [9.0.112]: 9.0.112.md


### PR DESCRIPTION
This pull request updates the feedback links in the release notes for versions 8.0.22 and 9.0.11 to point to the correct GitHub issue for user questions and comments.

Documentation updates:

* Updated the feedback link in `release-notes/8.0/8.0.22/8.0.22.md` to reference `dotnet/core/issues/10155` instead of a placeholder issue.
* Updated the feedback link in `release-notes/9.0/9.0.11/9.0.11.md` to reference `dotnet/core/issues/10155` for consistency across release notes.