### PR TITLE
Document known issue for covariant Task overrides

### DIFF
--- a/release-notes/11.0/known-issues.md
+++ b/release-notes/11.0/known-issues.md
@@ -1,3 +1,7 @@
 # .NET 11 Known Issues
 
 You may encounter some known issues, which may include workarounds, mitigations, or expected resolution timeframes. Watch this space for any known issues in .NET 11.0.
+
+## Covariant overrides of `Task`/`Task<T>` causes TypeLoadException
+
+Refactoring for the [Runtime-Async](https://github.com/dotnet/runtime/issues/109632) feature caused a bug in Task-returning methods with covariant returns. The bug has been fixed for Preview 2, but the fix did not make Preview 1. 


### PR DESCRIPTION
Added a known issue regarding covariant overrides of Task causing TypeLoadException in .NET 11.