### PR TITLE
Add aspnetcore.md for .NET 11 Preview 2

### DIFF
--- a/release-notes/11.0/preview/preview2/aspnetcore.md
+++ b/release-notes/11.0/preview/preview2/aspnetcore.md
@@ -69,7 +69,7 @@ TempData is automatically registered when calling `AddRazorComponents()` and is 
 
 The `ITempData` interface provides `Get`, `Peek`, `Keep`, and `Keep(string)` methods for controlling value lifecycle. A `SessionStorageTempDataProvider` is available as an alternative to the default `CookieTempDataProvider` ([dotnet/aspnetcore#49683](https://github.com/dotnet/aspnetcore/issues/49683)).
 
-## OpenAPI 3.2.0 support
+## OpenAPI 3.2.0 support (Breaking Change)
 
 `Microsoft.AspNetCore.OpenApi` now supports OpenAPI 3.2.0 through an updated dependency on `Microsoft.OpenApi` 3.3.1 ([dotnet/aspnetcore#65415](https://github.com/dotnet/aspnetcore/pull/65415)). This update includes breaking changes from the underlying library — see the [Microsoft.OpenApi upgrade guide](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-3.md) for details.
 


### PR DESCRIPTION
## ASP.NET Core Release Notes for .NET 11 Preview 2

### Generation methodology
These release notes were generated using the repository release notes skill process:
1. Collected all 50 merged PRs from [dotnet/aspnetcore milestone 11.0-preview2](https://github.com/dotnet/aspnetcore/milestone/378)
2. Filtered to user-facing feature PRs (excluded infra, deps, backports, test-only, bug fixes)
3. Enriched with full PR descriptions, linked issues, and reaction counts
4. Categorized by impact tier and authored following format-template.md and editorial-rules.md
5. **Validated against installed Preview 2 build** (SDK 11.0.100-preview.2.26122.107) by creating working code samples
6. Reviewed against release notes guidance: removed bug fixes and internal implementation details, added code samples

### Features documented

| Feature | Category | Verified |
|---------|----------|----------|
| Native OpenTelemetry tracing | Observability | Yes |
| TempData for Blazor | Blazor | Yes |
| OpenAPI 3.2.0 support | API | Yes (via branch) |
| Web Worker template | Templates | Yes |
| Passkey display name inference | Identity | No (requires Identity scaffolding) |

### Excluded per release notes guidance

**Bug fixes** (fixing bugs in existing functionality is assumed):
- Passkey sign-in confirmation/lockout checks (#65024)
- Label id attribute in interactive mode (#65263)
- Dev cert compatibility with older SDKs (#65151)
- SignalR HTTP/2 SkipNegotiation (#62940)
- SignalR WebSocketFactory for browser environments (#65359)
- Request smuggling mitigation (#65445)

**Internal implementation details** (no user-facing action):
- Kestrel bad request handling optimization (#65256)
- HTTP logging middleware allocation reduction (#65147)

**Not in release branch**:
- Validation source gen indexer fix (#65432) - merged to main only

### Code samples
Working samples committed to [danroth27/AspNetCore11Samples@dotnet11p2](https://github.com/danroth27/AspNetCore11Samples/tree/dotnet11p2)

### Community contributors
@baywet, @BekAllaev, @WeihanLi