### PR TITLE
Fix typo in .NET security advisory

### DIFF
--- a/release-notes/10.0/10.0.4/10.0.4.md
+++ b/release-notes/10.0/10.0.4/10.0.4.md
@@ -64,7 +64,7 @@ A denial of service vulnerability exists in ASP.NET  Core due to uncontrolled re
 
 Microsoft is releasing this security advisory to provide information about a vulnerability in .NET 10.0. This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.
 
-An elevation of privilege vulnerability exists in .NET due to improper authorization. Incorrect packaging permissions could allow an attacker to gain elevatied privileges.
+An elevation of privilege vulnerability exists in .NET due to improper authorization. Incorrect packaging permissions could allow an attacker to gain elevated privileges.
 
 ### Visual Studio Compatibility
 


### PR DESCRIPTION
Corrected a typo in the security advisory regarding .NET elevation of privilege vulnerability.