### PR TITLE
Fix typo in security advisory for .NET vulnerability

### DIFF
--- a/release-notes/9.0/9.0.14/9.0.14.md
+++ b/release-notes/9.0/9.0.14/9.0.14.md
@@ -52,7 +52,7 @@ A denial of service vulnerability exists in .NET and Microsoft.Bcl.Memory due to
 
 Microsoft is releasing this security advisory to provide information about a vulnerability in .NET 8.0, .NET 9.0, and .NET 10.0. This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.
 
-An elevation of privilege vulnerability exists in .NET due to improper authorization. Incorrect packaging permissions could allow an attacker to gain elevatied privileges.
+An elevation of privilege vulnerability exists in .NET due to improper authorization. Incorrect packaging permissions could allow an attacker to gain elevated privileges.
 
 ## Visual Studio Compatibility
 


### PR DESCRIPTION
Corrected a typo in the description of a .NET elevation of privilege vulnerability.