### PR TITLE
Add .NET 11 installation instructions for Linux

### DIFF
--- a/release-notes/11.0/dotnet-dependencies.md
+++ b/release-notes/11.0/dotnet-dependencies.md
@@ -1,0 +1,374 @@
+# .NET 11.0 Linux package dependencies
+
+.NET 11.0 has several dependencies that must be installed to run .NET apps. The install commands for each supported Linux distribution are listed below.
+
+Tips:
+
+- [runtime-deps container images](https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps) install these same packages.
+- [pkgs.org](https://pkgs.org/) is useful for searching packages across distributions.
+
+## Packages
+
+- [C Library][0]
+- [GCC low-level runtime library][1]
+- [CA Certificates][2]
+- [OpenSSL][3]
+- [C++ Library][4]
+- [ICU][5]
+- [tz database][6]
+- [Kerberos][7]
+
+You do not need to install ICU if you [enable globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode).
+
+If your app relies on `https` endpoints, you'll also need to install `ca-certificates`.
+
+[0]: https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.md#linux-compatibility
+[1]: https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html
+[2]: https://www.redhat.com/sysadmin/ca-certificates-cli
+[3]: https://www.openssl.org/
+[4]: https://gcc.gnu.org/onlinedocs/libstdc++/
+[5]: https://icu.unicode.org
+[6]: https://data.iana.org/time-zones/tz-link.html
+[7]: https://web.mit.edu/kerberos
+
+## Alpine
+
+### Alpine 3.22
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.21
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+## Azure Linux
+
+### Azure Linux 3.0
+
+```bash
+sudo tdnf install -y \
+    ca-certificates \
+    glibc \
+    icu \
+    krb5 \
+    libgcc \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## CentOS Stream
+
+### CentOS Stream 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## Debian
+
+### Debian 13 (Trixie)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Debian 12 (Bookworm)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu72 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```
+
+## Fedora
+
+### Fedora 43
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 42
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## FreeBSD
+
+### FreeBSD 14.1
+
+```bash
+sudo pkg install -A \
+    icu \
+    krb5
+```
+
+## openSUSE Leap
+
+### openSUSE Leap 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### openSUSE Leap 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## RHEL
+
+### RHEL 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### RHEL 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### RHEL 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## SLES
+
+### SLES 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SLES 15.7
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SLES 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## Ubuntu
+
+### Ubuntu 26.04 LTS (Resolute Raccoon)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 25.10 (Questing Quokka)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 24.04 (Noble Numbat)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu74 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu70 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```

--- a/release-notes/11.0/install-linux.md
+++ b/release-notes/11.0/install-linux.md
@@ -1,0 +1,44 @@
+# .NET 11 installation instructions for Linux
+
+The following instructions demonstrate installing .NET 11 on Linux. These instructions augment the more general [.NET install instructions](install.md), including installing with `.tar.gz` files, that work on multiple operating systems.
+
+[.NET 11 Required Packages](os-packages.md) describes the set of packages required to run .NET on Linux.
+
+## Distributions
+
+The following distributions are available for Linux:
+
+- .NET SDK: includes tools for building and testing applications, and includes the runtime distributions that follow.
+- .NET Runtime: includes the .NET runtime and libraries, enabling running console applications.
+- ASP.NET Core Runtime: includes the .NET and ASP.NET Core runtimes, enabling running console, and web applications.
+
+We recommend you install the .NET SDK to develop and build applications, and to install one of the runtime packages (like ASP.NET Core) to exclusively run applications.
+
+## Downloads
+
+Each of the distributions can be downloaded from:
+
+- [Microsoft .NET website](https://dotnet.microsoft.com/download/dotnet/11.0)
+- [.NET 11 release notes](README.md)
+
+
+## Installing from a binary archive
+
+You can install .NET with a binary archive. This option is required if you want to install .NET for a single user. It is also recommended if you want to install .NET temporarily.
+
+The following workflow demonstrates downloading, unpacking, configuring, and running the .NET SDK from the command line. You may choose to do some of these tasks via the browser and functionality provided by your operating system.
+
+```bash
+~# curl -Lo dotnet.tar.gz https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.2.26159.112/dotnet-sdk-11.0.100-preview.2.26159.112-linux-x64.tar.gz
+~# mkdir dotnet
+~# tar -C dotnet -xf dotnet.tar.gz
+~# rm dotnet.tar.gz
+~# export DOTNET_ROOT=~/dotnet
+~# export PATH=$PATH:~/dotnet
+~# dotnet --version
+11.0.100-preview.2.26159.112
+```
+
+The `DOTNET_ROOT` environment variable is required to launch an application with their executables (like `myapp.exe`). The executables look for this environment variable to find the runtime if it isn't installed in its regular location. The `PATH` environment variable must be updated if you want to use `dotnet` without absolute paths to its location. Setting both of these environment variables is optional.
+
+You can add your .NET install location permanently to your path if you'd like.

--- a/release-notes/11.0/install-linux.md
+++ b/release-notes/11.0/install-linux.md
@@ -1,8 +1,12 @@
 # .NET 11 installation instructions for Linux
 
-The following instructions demonstrate installing .NET 11 on Linux. These instructions augment the more general [.NET install instructions](install.md), including installing with `.tar.gz` files, that work on multiple operating systems.
+The following instructions demonstrate installing .NET 11 on Linux. These instructions augment the more general [Install .NET on Linux](https://learn.microsoft.com/dotnet/core/install/linux) guidance, including installing with `.tar.gz` files.
 
-[.NET 11 Required Packages](os-packages.md) describes the set of packages required to run .NET on Linux.
+For distro-specific guidance, see:
+
+- [Supported Linux distributions](supported-os.md)
+- [.NET 11 Linux package dependencies](dotnet-dependencies.md)
+- [Linux package feeds and availability](../../linux.md#packages)
 
 ## Distributions
 
@@ -18,7 +22,7 @@ We recommend you install the .NET SDK to develop and build applications, and to 
 
 Each of the distributions can be downloaded from:
 
-- [Microsoft .NET website](https://dotnet.microsoft.com/download/dotnet/11.0)
+- [`aka.ms/dotnet`](https://dotnet.microsoft.com/download)
 - [.NET 11 release notes](README.md)
 
 ## Installing from a binary archive
@@ -28,7 +32,7 @@ You can install .NET with a binary archive. This option is required if you want 
 The following workflow demonstrates downloading, unpacking, configuring, and running the .NET SDK from the command line. You may choose to do some of these tasks via the browser and functionality provided by your operating system.
 
 ```bash
-~# curl -Lo dotnet.tar.gz https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.2.26159.112/dotnet-sdk-11.0.100-preview.2.26159.112-linux-x64.tar.gz
+~# curl -Lo dotnet.tar.gz https://aka.ms/dotnet/11.0/preview/dotnet-sdk-linux-x64.tar.gz
 ~# mkdir dotnet
 ~# tar -C dotnet -xf dotnet.tar.gz
 ~# rm dotnet.tar.gz

--- a/release-notes/11.0/install-linux.md
+++ b/release-notes/11.0/install-linux.md
@@ -21,7 +21,6 @@ Each of the distributions can be downloaded from:
 - [Microsoft .NET website](https://dotnet.microsoft.com/download/dotnet/11.0)
 - [.NET 11 release notes](README.md)
 
-
 ## Installing from a binary archive
 
 You can install .NET with a binary archive. This option is required if you want to install .NET for a single user. It is also recommended if you want to install .NET temporarily.


### PR DESCRIPTION
Added detailed installation instructions for .NET 11 on Linux, including distribution options and binary archive installation steps.