### PR TITLE
Use full display names instead of acronyms in distro JSON files

### DIFF
--- a/.github/skills/update-distro-packages/SKILL.md
+++ b/.github/skills/update-distro-packages/SKILL.md
@@ -456,3 +456,21 @@ If the query returns a feed name not listed above, ask the user for the registra
 - Debian/Ubuntu/Fedora use: `dotnet-sdk-{major}.{minor}`, `dotnet-runtime-{major}.{minor}`
 - Microsoft is phasing out packages.microsoft.com for Ubuntu 24.04+ and newer Fedora
 - `install_command` uses `{packages}` as a placeholder for the package list
+
+## Display name rules
+
+The `name` fields (both top-level distro name and per-release names) must use full display names, **never acronyms**. These names appear in generated markdown and user-facing documentation.
+
+| ❌ Acronym | ✅ Full display name |
+|-----------|----------------------|
+| RHEL | Red Hat Enterprise Linux |
+| SLES | SUSE Linux Enterprise Server |
+
+**Examples:**
+
+- Top-level: `"name": "Red Hat Enterprise Linux"` (not `"RHEL"`)
+- Release: `"name": "Red Hat Enterprise Linux 9"` (not `"RHEL 9"`)
+- Top-level: `"name": "SUSE Linux Enterprise Server"` (not `"SLES"`)
+- Release: `"name": "SUSE Linux Enterprise Server 15.7"` (not `"SLES 15.7"`)
+
+File names (`rhel.json`, `sles.json`) remain short — only the `name` fields inside must use full names. When creating new distro files or adding releases, always verify the display name is the full product name, not an abbreviation.

--- a/release-notes/10.0/distros/index.json
+++ b/release-notes/10.0/distros/index.json
@@ -11,8 +11,8 @@
     "homebrew.json": "Homebrew",
     "nixos.json": "NixOS",
     "opensuse_leap.json": "openSUSE Leap",
-    "rhel.json": "RHEL",
-    "sles.json": "SLES",
+    "rhel.json": "Red Hat Enterprise Linux",
+    "sles.json": "SUSE Linux Enterprise Server",
     "ubuntu.json": "Ubuntu"
   }
 }

--- a/release-notes/10.0/distros/rhel.json
+++ b/release-notes/10.0/distros/rhel.json
@@ -1,9 +1,9 @@
 {
-  "name": "RHEL",
+  "name": "Red Hat Enterprise Linux",
   "install_command": "dnf install -y {packages}",
   "releases": [
     {
-      "name": "RHEL 10",
+      "name": "Red Hat Enterprise Linux 10",
       "release": "10",
       "dependencies": [
         {
@@ -55,7 +55,7 @@
       ]
     },
     {
-      "name": "RHEL 9",
+      "name": "Red Hat Enterprise Linux 9",
       "release": "9",
       "dependencies": [
         {
@@ -107,7 +107,7 @@
       ]
     },
     {
-      "name": "RHEL 8",
+      "name": "Red Hat Enterprise Linux 8",
       "release": "8",
       "dependencies": [
         {

--- a/release-notes/10.0/distros/sles.json
+++ b/release-notes/10.0/distros/sles.json
@@ -1,9 +1,9 @@
 {
-  "name": "SLES",
+  "name": "SUSE Linux Enterprise Server",
   "install_command": "zypper install -y {packages}",
   "releases": [
     {
-      "name": "SLES 16.0",
+      "name": "SUSE Linux Enterprise Server 16.0",
       "release": "16.0",
       "dependencies": [
         {
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "name": "SLES 15.7",
+      "name": "SUSE Linux Enterprise Server 15.7",
       "release": "15.7",
       "dependencies": [
         {
@@ -79,7 +79,7 @@
       ]
     },
     {
-      "name": "SLES 15.6",
+      "name": "SUSE Linux Enterprise Server 15.6",
       "release": "15.6",
       "dependencies": [
         {

--- a/release-notes/11.0/distros/index.json
+++ b/release-notes/11.0/distros/index.json
@@ -8,8 +8,8 @@
     "fedora.json": "Fedora",
     "freebsd.json": "FreeBSD",
     "opensuse_leap.json": "openSUSE Leap",
-    "rhel.json": "RHEL",
-    "sles.json": "SLES",
+    "rhel.json": "Red Hat Enterprise Linux",
+    "sles.json": "SUSE Linux Enterprise Server",
     "ubuntu.json": "Ubuntu"
   }
 }

--- a/release-notes/11.0/distros/rhel.json
+++ b/release-notes/11.0/distros/rhel.json
@@ -1,9 +1,9 @@
 {
-  "name": "RHEL",
+  "name": "Red Hat Enterprise Linux",
   "install_command": "dnf install -y {packages}",
   "releases": [
     {
-      "name": "RHEL 10",
+      "name": "Red Hat Enterprise Linux 10",
       "release": "10",
       "dependencies": [
         {
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "name": "RHEL 9",
+      "name": "Red Hat Enterprise Linux 9",
       "release": "9",
       "dependencies": [
         {
@@ -79,7 +79,7 @@
       ]
     },
     {
-      "name": "RHEL 8",
+      "name": "Red Hat Enterprise Linux 8",
       "release": "8",
       "dependencies": [
         {

--- a/release-notes/11.0/distros/sles.json
+++ b/release-notes/11.0/distros/sles.json
@@ -1,9 +1,9 @@
 {
-  "name": "SLES",
+  "name": "SUSE Linux Enterprise Server",
   "install_command": "zypper install -y {packages}",
   "releases": [
     {
-      "name": "SLES 16.0",
+      "name": "SUSE Linux Enterprise Server 16.0",
       "release": "16.0",
       "dependencies": [
         {
@@ -41,7 +41,7 @@
       ]
     },
     {
-      "name": "SLES 15.7",
+      "name": "SUSE Linux Enterprise Server 15.7",
       "release": "15.7",
       "dependencies": [
         {
@@ -79,7 +79,7 @@
       ]
     },
     {
-      "name": "SLES 15.6",
+      "name": "SUSE Linux Enterprise Server 15.6",
       "release": "15.6",
       "dependencies": [
         {


### PR DESCRIPTION
## Summary

Replace acronyms with full display names in all distro JSON files under `release-notes/10.0/distros/` and `release-notes/11.0/distros/`.

### Changes

**JSON data fixes (6 files):**
- `rhel.json`: `RHEL` → `Red Hat Enterprise Linux` (top-level and all release names)
- `sles.json`: `SLES` → `SUSE Linux Enterprise Server` (top-level and all release names)
- `index.json`: Updated display name values for both entries

Applied to both 10.0 and 11.0 distros directories.

**Skill update:**
- Added a "Display name rules" section to the `update-distro-packages` skill with a table mapping acronyms to full names, preventing this from recurring.