### PR TITLE
Fix feedback link in release notes for 10.0.6

### DIFF
--- a/release-notes/10.0/10.0.6/10.0.6.md
+++ b/release-notes/10.0/10.0.6/10.0.6.md
@@ -80,7 +80,7 @@ You can also use Visual Studio Code and the [C# Dev Kit](https://marketplace.vis
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #]() for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core 10356](https://github.com/dotnet/core/issues/10356) for your questions and comments.
 
 [10.0.202]: 10.0.6.md
 [10.0.106]: 10.0.106.md


### PR DESCRIPTION
Updated the feedback section with a link to issue #10356.