### PR TITLE
[docs][release-notes] Fix broken link for dotnet 11

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -9,7 +9,7 @@
 | [.NET 9.0](./9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | Active | [9.0.15][9.0.15] | November 10, 2026 |
 | [.NET 8.0](./8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | Active | [8.0.26][8.0.26] | November 10, 2026 |
 
-[11.0.0-preview.3]: release-notes/11.0/preview/preview3/11.0.0-preview.3.md
+[11.0.0-preview.3]: ./11.0/preview/preview3/11.0.0-preview.3.md
 [10.0.6]: ./10.0/10.0.6/10.0.6.md
 [9.0.15]: ./9.0/9.0.15/9.0.15.md
 [8.0.26]: ./8.0/8.0.26/8.0.26.md

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -4,7 +4,7 @@
 
 |  Version  | Release Date | Release type | Support phase | Latest Patch Version | End of Support |
 | :-- | :-- | :-- | :-- | :-- | :-- |
-| [.NET 11.0](release-notes/11.0/README.md) | November 10, 2026 | [STS][policies] | Preview | [11.0.0-preview.3][11.0.0-preview.3] | TBD |
+| [.NET 11.0](./11.0/README.md) | November 10, 2026 | [STS][policies] | Preview | [11.0.0-preview.3][11.0.0-preview.3] | TBD |
 | [.NET 10.0](./10.0/README.md) | [November 11, 2025](https://devblogs.microsoft.com/dotnet/announcing-dotnet-10/) | [LTS][policies] | Active | [10.0.6][10.0.6] | November 14, 2028 |
 | [.NET 9.0](./9.0/README.md) | [November 12, 2024](https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/) | [STS][policies] | Active | [9.0.15][9.0.15] | November 10, 2026 |
 | [.NET 8.0](./8.0/README.md) | [November 14, 2023](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8/) | [LTS][policies] | Active | [8.0.26][8.0.26] | November 10, 2026 |


### PR DESCRIPTION
It was repeating top-directory path within link which was causing 404.