### PR TITLE
Update release notes for .NET 10.0.6 security advisory

### DIFF
--- a/release-notes/10.0/10.0.6/10.0.6.md
+++ b/release-notes/10.0/10.0.6/10.0.6.md
@@ -71,6 +71,42 @@ Microsoft is releasing this security advisory to provide information about a vul
 
 A vulnerability exists in System.Net.Mail where specially crafted data allows an unauthorized attacker to perform a spoofing attack over the network.
 
+### Note on System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml 
+
+Applications using System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml might encounter two new CryptographicException occurrences when processing deeply nested payloads or entities with unsafe transforms.
+
+ 
+
+1. “The XML element has exceeded the maximum nesting depth allowed for decryption.”
+
+This is a new exception message that can only be thrown from the new behavior. This exception indicates the XML being processed has a deeply nested XML structure beyond a new default depth limit of 64. This limit can be overridden with a different numeric value, and a value of 0 indicates “no limit,” which restores the previous behavior.
+
+* .NET Framework: Set a registry value named CryptoXmlDangerousMaxRecursionDepth within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+ 
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.DangerousMaxRecursionDepth
+ 
+2. “The specified cryptographic transform is not supported.”
+
+Exceptions with this message were reachable before this update, but there are new circumstances where this exception can now be thrown. This exception indicates the XML payload is attempting to apply a transform not included in the known safe transforms list.
+ 
+The safe transforms are:
+ 
+SignedXml.XmlDsigC14NTransformUrl
+SignedXml.XmlDsigC14NWithCommentsTransformUrl
+SignedXml.XmlDsigExcC14NTransformUrl
+SignedXml.XmlDsigExcC14NWithCommentsTransformUrl
+SignedXml.XmlDsigBase64TransformUrl
+SignedXml.XmlLicenseTransformUrl
+SignedXml.XmlDecryptionTransformUrl
+ 
+
+The previous behavior can be restored by applying an override.
+
+ 
+
+* .NET Framework: Set a registry value named EncryptedXmlAllowDangerousTransforms to a non-zero numeric value within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.AllowDangerousEncryptedXmlTransforms to ‘true’.
+
 
 ### Visual Studio Compatibility
 

--- a/release-notes/8.0/8.0.26/8.0.26.md
+++ b/release-notes/8.0/8.0.26/8.0.26.md
@@ -66,6 +66,43 @@ Microsoft is releasing this security advisory to provide information about a vul
 
 A vulnerability exists in System.Net.Mail where specially crafted data allows an unauthorized attacker to perform a spoofing attack over the network.
 
+### Note on System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml 
+
+Applications using System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml might encounter two new CryptographicException occurrences when processing deeply nested payloads or entities with unsafe transforms.
+
+ 
+
+1. “The XML element has exceeded the maximum nesting depth allowed for decryption.”
+
+This is a new exception message that can only be thrown from the new behavior. This exception indicates the XML being processed has a deeply nested XML structure beyond a new default depth limit of 64. This limit can be overridden with a different numeric value, and a value of 0 indicates “no limit,” which restores the previous behavior.
+
+* .NET Framework: Set a registry value named CryptoXmlDangerousMaxRecursionDepth within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+ 
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.DangerousMaxRecursionDepth
+ 
+2. “The specified cryptographic transform is not supported.”
+
+Exceptions with this message were reachable before this update, but there are new circumstances where this exception can now be thrown. This exception indicates the XML payload is attempting to apply a transform not included in the known safe transforms list.
+ 
+The safe transforms are:
+ 
+SignedXml.XmlDsigC14NTransformUrl
+SignedXml.XmlDsigC14NWithCommentsTransformUrl
+SignedXml.XmlDsigExcC14NTransformUrl
+SignedXml.XmlDsigExcC14NWithCommentsTransformUrl
+SignedXml.XmlDsigBase64TransformUrl
+SignedXml.XmlLicenseTransformUrl
+SignedXml.XmlDecryptionTransformUrl
+ 
+
+The previous behavior can be restored by applying an override.
+
+ 
+
+* .NET Framework: Set a registry value named EncryptedXmlAllowDangerousTransforms to a non-zero numeric value within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.AllowDangerousEncryptedXmlTransforms to ‘true’.
+
+
 ## Visual Studio Compatibility
 
 You need [Visual Studio 17.10](https://visualstudio.microsoft.com) or later to use .NET 8.0 on Windows. While not officially supported, we’ve also enabled rudimentary support for .NET 8.0 in Visual Studio for Mac. Users have to enable a preview feature in Preferences to enable the IDE to discover and use the .NET 8.0 SDK for creating, loading, building, and debugging projects. The [C# extension](https://code.visualstudio.com/docs/languages/dotnet) for [Visual Studio Code](https://code.visualstudio.com/) supports .NET 8.0 and C# 12.

--- a/release-notes/9.0/9.0.15/9.0.15.md
+++ b/release-notes/9.0/9.0.15/9.0.15.md
@@ -67,6 +67,41 @@ Microsoft is releasing this security advisory to provide information about a vul
 
 A vulnerability exists in System.Net.Mail where specially crafted data allows an unauthorized attacker to perform a spoofing attack over the network.
 
+### Note on System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml 
+
+Applications using System.Security.Cryptography.Xml.EncryptedXml or System.Security.Cryptography.Xml.SignedXml might encounter two new CryptographicException occurrences when processing deeply nested payloads or entities with unsafe transforms.
+
+ 
+
+1. “The XML element has exceeded the maximum nesting depth allowed for decryption.”
+
+This is a new exception message that can only be thrown from the new behavior. This exception indicates the XML being processed has a deeply nested XML structure beyond a new default depth limit of 64. This limit can be overridden with a different numeric value, and a value of 0 indicates “no limit,” which restores the previous behavior.
+
+* .NET Framework: Set a registry value named CryptoXmlDangerousMaxRecursionDepth within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+ 
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.DangerousMaxRecursionDepth
+ 
+2. “The specified cryptographic transform is not supported.”
+
+Exceptions with this message were reachable before this update, but there are new circumstances where this exception can now be thrown. This exception indicates the XML payload is attempting to apply a transform not included in the known safe transforms list.
+ 
+The safe transforms are:
+ 
+SignedXml.XmlDsigC14NTransformUrl
+SignedXml.XmlDsigC14NWithCommentsTransformUrl
+SignedXml.XmlDsigExcC14NTransformUrl
+SignedXml.XmlDsigExcC14NWithCommentsTransformUrl
+SignedXml.XmlDsigBase64TransformUrl
+SignedXml.XmlLicenseTransformUrl
+SignedXml.XmlDecryptionTransformUrl
+ 
+
+The previous behavior can be restored by applying an override.
+
+ 
+
+* .NET Framework: Set a registry value named EncryptedXmlAllowDangerousTransforms to a non-zero numeric value within HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security
+* .NET: Set an AppContext property named System.Security.Cryptography.Xml.AllowDangerousEncryptedXmlTransforms to ‘true’.
 
 ## Visual Studio Compatibility
 


### PR DESCRIPTION
Added notes on new CryptographicException occurrences related to System.Security.Cryptography.Xml.EncryptedXml and System.Security.Cryptography.Xml.SignedXml, including details on maximum nesting depth and unsupported cryptographic transforms.