### PR TITLE
Add Windows tarballs that were included in 11.0-preview3 to the releases.json

### DIFF
--- a/release-notes/11.0/preview/preview3/release.json
+++ b/release-notes/11.0/preview/preview3/release.json
@@ -79,16 +79,34 @@
           "hash": "6e1460ea6224f5a0bd9a1fd12f83ed6995d1268cb59d1c64caeaf44b7a009a63b270619fa7d4f3dfa7ff0ac456e89379a5791962c85201254aaf89ab6aafd9b1"
         },
         {
+          "name": "dotnet-apphost-pack-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "a1950226e25eab1882bb1a52b8df7e1a15d298cafd56aaae47b8a1f1cf602033feb4e561655058daf59fce56f4007bae8b62235e1e80ddf37bf70eff78fca63f"
+        },
+        {
           "name": "dotnet-apphost-pack-win-x64.zip",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x64.zip",
           "hash": "97f07fd72d03e0ea0e25a2bdd8a62d0481d6dee8cd74159c8f4b2bdea4712ec6ae29c7e50ac6d53378ce2ad785a20233858bffb5822aeeaeec760ed32b920ff7"
         },
         {
+          "name": "dotnet-apphost-pack-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "5c30fa7a5e7b52b0dcec76454ccf16f3d4f8bc5a46fe55ff7d5ce5fc06f4d9c7d773d9f67ca84e0a966363fac67c6bf9142589e6bf6717f6f46851e393bb341e"
+        },
+        {
           "name": "dotnet-apphost-pack-win-x86.zip",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x86.zip",
           "hash": "b3e2bb366ccc1b25943498dce365038aa55921a5118981927678646c9c4c712f2590ae0f75d4ec3b007eabe17d484bf8b12deb4d39fc300f0d110b7d284437a8"
+        },
+        {
+          "name": "dotnet-apphost-pack-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "3af23ecbf70f65fce423ae9af373fcb02018efe5b7926bf3c9c531c81c1a6fb63b3c49c1a17e1fba546bb6c7abd1ec376e7c97d157f64d0001d3e5f8d0d0e6ab"
         },
         {
           "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -175,6 +193,12 @@
           "hash": "34ffef369f35464b488418303979fef59adb0915e64d96797fc877b6db43c72eb3949ef2c5335c505ad5d255001294bf0f811103aa9eebb26a7aa43fd7edc171"
         },
         {
+          "name": "dotnet-runtime-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "1ae70956b6cc982f9d42164e2cdc4632019b1144af45dd1caeac936bf3e0fe58c81df04ccae3370983dd1964bdd453fe6ce152f8ff4da267027c64f5256face2"
+        },
+        {
           "name": "dotnet-runtime-win-x64.exe",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -187,6 +211,12 @@
           "hash": "647a5063970728e35138fbff442e08184de75f0689e2cef56a1045b25eca074bd3ba09945ecbe971f3cc7e74e227f3b3b03f9dc9709f87a3613f480a3e785753"
         },
         {
+          "name": "dotnet-runtime-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "b904302d8aa8a2432e0889bddc12bfd66d3c3a3ba32e171cd1cf20ee98e24f760bf0be1eba9c12d2c94be7e35ee4fecf96e932507f463a1889a87e54ec7d0c2b"
+        },
+        {
           "name": "dotnet-runtime-win-x86.exe",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -197,6 +227,12 @@
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
           "hash": "6f59e8d1049ca4da1e8626d1718baca20a9ce90aa8727e63af5c13fd144a6cce165a81b90c9d5c3bf248cf817173933a63d6a84b7e93207b37fa292c2997c63c"
+        },
+        {
+          "name": "dotnet-runtime-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "3138caf47c28ce84038720cb72dc6827c78e369c8b2d0621cb105ba707dab84259cf52629c2b274a7d098f561f78a4812b19e795077d93b61a599192baa2e3f0"
         }
       ]
     },
@@ -285,6 +321,12 @@
           "hash": "c201f2ddd778b95f41a8d8d02873643638e3c1a58fdcd71c3234b6f97bcbf122fdd914451d962e6a4b760d94efcd786a3930b506b2dacab8b07f40f542eba580"
         },
         {
+          "name": "dotnet-sdk-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "dd6df587e6ffa908189b34dd979ac06e3a853580ee174c50b571f49d147762db3498358fc9765dc060d9315a01495e947ab7017e727c4f6ac06ed3af5c843b3c"
+        },
+        {
           "name": "dotnet-sdk-win-x64.exe",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.exe",
@@ -297,6 +339,12 @@
           "hash": "6c8e71848cdcc91f25d2dce2f5f953225e1ac913af3aab0e926373215b75c662fbb23b09469b5f70e39ae9c03851c0998330bafbe75007f45985f9368346a500"
         },
         {
+          "name": "dotnet-sdk-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "e7ef53c07773977f9f057f8087276dcc5ea7b9ca7dcb615b66b9719dd1c5d4b125e17d5ab452e7fd897c8a3cc5893833e6285edc070d80636cfd8783f0461698"
+        },
+        {
           "name": "dotnet-sdk-win-x86.exe",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.exe",
@@ -307,6 +355,12 @@
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.zip",
           "hash": "5e06cae867c4ba45ad03315bfe6d1bfaf643f3b57b4b752847660c64e07767834051b59897994f58e6d7c216dcc38ab1b6a6af42eb10ddfb95395395263d6b91"
+        },
+        {
+          "name": "dotnet-sdk-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "93be6ee11a7b047d355e9ba2277ec3aa741f030aa8140a4574b137e0eb42d53661246c30b6cc8026801228c6af7f1a73c11257c6790a93e743d10b4d2858d657"
         }
       ]
     },
@@ -396,6 +450,12 @@
             "hash": "c201f2ddd778b95f41a8d8d02873643638e3c1a58fdcd71c3234b6f97bcbf122fdd914451d962e6a4b760d94efcd786a3930b506b2dacab8b07f40f542eba580"
           },
           {
+            "name": "dotnet-sdk-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "dd6df587e6ffa908189b34dd979ac06e3a853580ee174c50b571f49d147762db3498358fc9765dc060d9315a01495e947ab7017e727c4f6ac06ed3af5c843b3c"
+          },
+          {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.exe",
@@ -408,6 +468,12 @@
             "hash": "6c8e71848cdcc91f25d2dce2f5f953225e1ac913af3aab0e926373215b75c662fbb23b09469b5f70e39ae9c03851c0998330bafbe75007f45985f9368346a500"
           },
           {
+            "name": "dotnet-sdk-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "e7ef53c07773977f9f057f8087276dcc5ea7b9ca7dcb615b66b9719dd1c5d4b125e17d5ab452e7fd897c8a3cc5893833e6285edc070d80636cfd8783f0461698"
+          },
+          {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.exe",
@@ -418,6 +484,12 @@
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.zip",
             "hash": "5e06cae867c4ba45ad03315bfe6d1bfaf643f3b57b4b752847660c64e07767834051b59897994f58e6d7c216dcc38ab1b6a6af42eb10ddfb95395395263d6b91"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "93be6ee11a7b047d355e9ba2277ec3aa741f030aa8140a4574b137e0eb42d53661246c30b6cc8026801228c6af7f1a73c11257c6790a93e743d10b4d2858d657"
           }
         ]
       }
@@ -491,6 +563,12 @@
           "hash": "81cb7dd894e6172890723432328e42c88337f02dc41d5ef22c7ab47144c26b66f114dc79c4212c36e0bf826769ab250f296d9cf2710fce3d037d3b692b961403"
         },
         {
+          "name": "aspnetcore-runtime-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "cbe62d98744dd37218de209734e7801a1f12475be987ee3524d526d38c41d2b6a3d18e5db10708ae6edfdb761f18c1cbc80118c4d8dd6c2ac031d8d3766fd3b5"
+        },
+        {
           "name": "aspnetcore-runtime-win-x64.exe",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -503,6 +581,12 @@
           "hash": "a87befa6a25b4f18c0ad0ae5d2352962a4d0121d1f7610b38710feab28fb9a081c649db6886c1e291a341f3ad9be5fd084647075de5650d8d3d4863d3d2dd44d"
         },
         {
+          "name": "aspnetcore-runtime-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "60fb03fca2b29078c34c96b24266e1546a15a67555708e2b2d30cef1409c7f6cfc971ce1bf9d463bf6031534fe6ae6d265a17f6a35d7cbec7ba18701b5636dc0"
+        },
+        {
           "name": "aspnetcore-runtime-win-x86.exe",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -513,6 +597,12 @@
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
           "hash": "5ffc8d210e1e35499ed160ac8ddc9c4cac9d72d1f33862d3f2f93df1e028d5962a02339a3d046ced19029e0f607715fb102ba8cf5295ff50413a32e0b7c741ba"
+        },
+        {
+          "name": "aspnetcore-runtime-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "2ace3c4c439fe4afa637e240399c7cc7e2d2201e2695d38ae6fcdafa032e0a88cee1b18b0037b12f0a057d633a747177d67ce0f63ef54a3fe511b592f834c348"
         },
         {
           "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
@@ -617,16 +707,34 @@
           "hash": "674c4d4e919b9d0633a824fa4778a9219f3ddda0faf22c929bfeb514129b9990c7be3ad44cf3bae1483c1081694caef2d55e21397fe703b4f9ee08a4115f1389"
         },
         {
+          "name": "aspnetcore-targeting-pack-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "23996e18a396e0d980d5e52b745ff6aa6ee4234dd6475d69a99ed75cae83175aee1f3ad4eb33665c29279f1d1a2c940058179938a356068c23ea4595eaca9dc0"
+        },
+        {
           "name": "aspnetcore-targeting-pack-win-x64.zip",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x64.zip",
           "hash": "c96c275db86e3da6d5b31d931f83eb710468e231c60c66ac79c632da847487742d1f5d62b5638637cb8a4bbe7d6a2757720eb3f9b04277219e8da5d3349ec0ec"
         },
         {
+          "name": "aspnetcore-targeting-pack-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "32b58ff9b4c1d7f424711dbdd79a22a748413ac2e61df652faca9bdd75821fbc7fc6cec3d87654796fcba0f6199004e7610f687640f3593292b610fb278d5dbd"
+        },
+        {
           "name": "aspnetcore-targeting-pack-win-x86.zip",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x86.zip",
           "hash": "40c79af1e23a122f8e491f4ce85febddc03192457edbf7d0a6ffb9ab4a3bf0ede5f0a16361ad700024ae4f86aada695c7bffdb6bd9aab53b0b4a4435e0eb43c8"
+        },
+        {
+          "name": "aspnetcore-targeting-pack-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "9fee02ba6cf92e8fc3bfa721b9690ae2aeb5669f1350752bd6c494189b43b7fc65c4bf6c24864abb518cdb37b01f890b4fa9395cc9c69ac62ab008c84ecd7e3a"
         },
         {
           "name": "dotnet-hosting-win.exe",
@@ -654,6 +762,12 @@
           "hash": "c44e7c2ca8495d48099682fb41c3360fc36e7548b753cb973621e251f9ff7dac3e83f32149270d6afab8541cf576478996ad48d60d1d01191d37172141d29500"
         },
         {
+          "name": "windowsdesktop-runtime-win-arm64.tar.gz",
+          "rid": "win-arm64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+          "hash": "32b6a115c2ac193821b391b6de6693610ae244f7f8f76401deff4a29d515218e6c7432355c1239346710e9f8564281ad3cbd473711e3cac6df202779c44a9048"
+        },
+        {
           "name": "windowsdesktop-runtime-win-x64.exe",
           "rid": "win-x64",
           "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -666,6 +780,12 @@
           "hash": "57ae2bc585054f54f4a199163b9490f850363f8ea16de28cd31d8bf3a0ff943f2d6de53eb76899b7a9fcee8ec38e622c5a29dc9fb694809997ab95bc2a97be4e"
         },
         {
+          "name": "windowsdesktop-runtime-win-x64.tar.gz",
+          "rid": "win-x64",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+          "hash": "bf11471e1f9d0fff1b49ff7d5142aff5d460585157fa1db1e7f64d80d27529cf6fb4c86b3fde2348d7b5851e12e26acddfa4544b5da92f226b4afa5f26ecbfcd"
+        },
+        {
           "name": "windowsdesktop-runtime-win-x86.exe",
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -676,6 +796,12 @@
           "rid": "win-x86",
           "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
           "hash": "502cdde92f49290067067f6f6edfabb0b5f5566ec58582f5fc5a0bd281abd2a6def29710030eaa05d243bc988e8822b988dd1309c745207888be663fa203eea5"
+        },
+        {
+          "name": "windowsdesktop-runtime-win-x86.tar.gz",
+          "rid": "win-x86",
+          "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+          "hash": "aa25db6c5b4f8521dab7b46449b1e55d4213bf15fb8b1737d7d0b0ec561447e8f2da3e4017155076571392e95ee66dc2c9f79807f5cf2e9e4a45dfe6cf256e35"
         }
       ]
     }

--- a/release-notes/11.0/releases.json
+++ b/release-notes/11.0/releases.json
@@ -87,16 +87,34 @@
             "hash": "6e1460ea6224f5a0bd9a1fd12f83ed6995d1268cb59d1c64caeaf44b7a009a63b270619fa7d4f3dfa7ff0ac456e89379a5791962c85201254aaf89ab6aafd9b1"
           },
           {
+            "name": "dotnet-apphost-pack-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "a1950226e25eab1882bb1a52b8df7e1a15d298cafd56aaae47b8a1f1cf602033feb4e561655058daf59fce56f4007bae8b62235e1e80ddf37bf70eff78fca63f"
+          },
+          {
             "name": "dotnet-apphost-pack-win-x64.zip",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x64.zip",
             "hash": "97f07fd72d03e0ea0e25a2bdd8a62d0481d6dee8cd74159c8f4b2bdea4712ec6ae29c7e50ac6d53378ce2ad785a20233858bffb5822aeeaeec760ed32b920ff7"
           },
           {
+            "name": "dotnet-apphost-pack-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "5c30fa7a5e7b52b0dcec76454ccf16f3d4f8bc5a46fe55ff7d5ce5fc06f4d9c7d773d9f67ca84e0a966363fac67c6bf9142589e6bf6717f6f46851e393bb341e"
+          },
+          {
             "name": "dotnet-apphost-pack-win-x86.zip",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x86.zip",
             "hash": "b3e2bb366ccc1b25943498dce365038aa55921a5118981927678646c9c4c712f2590ae0f75d4ec3b007eabe17d484bf8b12deb4d39fc300f0d110b7d284437a8"
+          },
+          {
+            "name": "dotnet-apphost-pack-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-apphost-pack-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "3af23ecbf70f65fce423ae9af373fcb02018efe5b7926bf3c9c531c81c1a6fb63b3c49c1a17e1fba546bb6c7abd1ec376e7c97d157f64d0001d3e5f8d0d0e6ab"
           },
           {
             "name": "dotnet-runtime-linux-arm.tar.gz",
@@ -183,6 +201,12 @@
             "hash": "34ffef369f35464b488418303979fef59adb0915e64d96797fc877b6db43c72eb3949ef2c5335c505ad5d255001294bf0f811103aa9eebb26a7aa43fd7edc171"
           },
           {
+            "name": "dotnet-runtime-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "1ae70956b6cc982f9d42164e2cdc4632019b1144af45dd1caeac936bf3e0fe58c81df04ccae3370983dd1964bdd453fe6ce152f8ff4da267027c64f5256face2"
+          },
+          {
             "name": "dotnet-runtime-win-x64.exe",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -195,6 +219,12 @@
             "hash": "647a5063970728e35138fbff442e08184de75f0689e2cef56a1045b25eca074bd3ba09945ecbe971f3cc7e74e227f3b3b03f9dc9709f87a3613f480a3e785753"
           },
           {
+            "name": "dotnet-runtime-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "b904302d8aa8a2432e0889bddc12bfd66d3c3a3ba32e171cd1cf20ee98e24f760bf0be1eba9c12d2c94be7e35ee4fecf96e932507f463a1889a87e54ec7d0c2b"
+          },
+          {
             "name": "dotnet-runtime-win-x86.exe",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -205,6 +235,12 @@
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
             "hash": "6f59e8d1049ca4da1e8626d1718baca20a9ce90aa8727e63af5c13fd144a6cce165a81b90c9d5c3bf248cf817173933a63d6a84b7e93207b37fa292c2997c63c"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "3138caf47c28ce84038720cb72dc6827c78e369c8b2d0621cb105ba707dab84259cf52629c2b274a7d098f561f78a4812b19e795077d93b61a599192baa2e3f0"
           }
         ]
       },
@@ -293,6 +329,12 @@
             "hash": "c201f2ddd778b95f41a8d8d02873643638e3c1a58fdcd71c3234b6f97bcbf122fdd914451d962e6a4b760d94efcd786a3930b506b2dacab8b07f40f542eba580"
           },
           {
+            "name": "dotnet-sdk-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "dd6df587e6ffa908189b34dd979ac06e3a853580ee174c50b571f49d147762db3498358fc9765dc060d9315a01495e947ab7017e727c4f6ac06ed3af5c843b3c"
+          },
+          {
             "name": "dotnet-sdk-win-x64.exe",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.exe",
@@ -305,6 +347,12 @@
             "hash": "6c8e71848cdcc91f25d2dce2f5f953225e1ac913af3aab0e926373215b75c662fbb23b09469b5f70e39ae9c03851c0998330bafbe75007f45985f9368346a500"
           },
           {
+            "name": "dotnet-sdk-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "e7ef53c07773977f9f057f8087276dcc5ea7b9ca7dcb615b66b9719dd1c5d4b125e17d5ab452e7fd897c8a3cc5893833e6285edc070d80636cfd8783f0461698"
+          },
+          {
             "name": "dotnet-sdk-win-x86.exe",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.exe",
@@ -315,6 +363,12 @@
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.zip",
             "hash": "5e06cae867c4ba45ad03315bfe6d1bfaf643f3b57b4b752847660c64e07767834051b59897994f58e6d7c216dcc38ab1b6a6af42eb10ddfb95395395263d6b91"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "93be6ee11a7b047d355e9ba2277ec3aa741f030aa8140a4574b137e0eb42d53661246c30b6cc8026801228c6af7f1a73c11257c6790a93e743d10b4d2858d657"
           }
         ]
       },
@@ -404,6 +458,12 @@
               "hash": "c201f2ddd778b95f41a8d8d02873643638e3c1a58fdcd71c3234b6f97bcbf122fdd914451d962e6a4b760d94efcd786a3930b506b2dacab8b07f40f542eba580"
             },
             {
+              "name": "dotnet-sdk-win-arm64.tar.gz",
+              "rid": "win-arm64",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-arm64.tar.gz",
+              "hash": "dd6df587e6ffa908189b34dd979ac06e3a853580ee174c50b571f49d147762db3498358fc9765dc060d9315a01495e947ab7017e727c4f6ac06ed3af5c843b3c"
+            },
+            {
               "name": "dotnet-sdk-win-x64.exe",
               "rid": "win-x64",
               "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.exe",
@@ -416,6 +476,12 @@
               "hash": "6c8e71848cdcc91f25d2dce2f5f953225e1ac913af3aab0e926373215b75c662fbb23b09469b5f70e39ae9c03851c0998330bafbe75007f45985f9368346a500"
             },
             {
+              "name": "dotnet-sdk-win-x64.tar.gz",
+              "rid": "win-x64",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.tar.gz",
+              "hash": "e7ef53c07773977f9f057f8087276dcc5ea7b9ca7dcb615b66b9719dd1c5d4b125e17d5ab452e7fd897c8a3cc5893833e6285edc070d80636cfd8783f0461698"
+            },
+            {
               "name": "dotnet-sdk-win-x86.exe",
               "rid": "win-x86",
               "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.exe",
@@ -426,6 +492,12 @@
               "rid": "win-x86",
               "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.zip",
               "hash": "5e06cae867c4ba45ad03315bfe6d1bfaf643f3b57b4b752847660c64e07767834051b59897994f58e6d7c216dcc38ab1b6a6af42eb10ddfb95395395263d6b91"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.tar.gz",
+              "rid": "win-x86",
+              "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.tar.gz",
+              "hash": "93be6ee11a7b047d355e9ba2277ec3aa741f030aa8140a4574b137e0eb42d53661246c30b6cc8026801228c6af7f1a73c11257c6790a93e743d10b4d2858d657"
             }
           ]
         }
@@ -499,6 +571,12 @@
             "hash": "81cb7dd894e6172890723432328e42c88337f02dc41d5ef22c7ab47144c26b66f114dc79c4212c36e0bf826769ab250f296d9cf2710fce3d037d3b692b961403"
           },
           {
+            "name": "aspnetcore-runtime-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "cbe62d98744dd37218de209734e7801a1f12475be987ee3524d526d38c41d2b6a3d18e5db10708ae6edfdb761f18c1cbc80118c4d8dd6c2ac031d8d3766fd3b5"
+          },
+          {
             "name": "aspnetcore-runtime-win-x64.exe",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -511,6 +589,12 @@
             "hash": "a87befa6a25b4f18c0ad0ae5d2352962a4d0121d1f7610b38710feab28fb9a081c649db6886c1e291a341f3ad9be5fd084647075de5650d8d3d4863d3d2dd44d"
           },
           {
+            "name": "aspnetcore-runtime-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "60fb03fca2b29078c34c96b24266e1546a15a67555708e2b2d30cef1409c7f6cfc971ce1bf9d463bf6031534fe6ae6d265a17f6a35d7cbec7ba18701b5636dc0"
+          },
+          {
             "name": "aspnetcore-runtime-win-x86.exe",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -521,6 +605,12 @@
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
             "hash": "5ffc8d210e1e35499ed160ac8ddc9c4cac9d72d1f33862d3f2f93df1e028d5962a02339a3d046ced19029e0f607715fb102ba8cf5295ff50413a32e0b7c741ba"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "2ace3c4c439fe4afa637e240399c7cc7e2d2201e2695d38ae6fcdafa032e0a88cee1b18b0037b12f0a057d633a747177d67ce0f63ef54a3fe511b592f834c348"
           },
           {
             "name": "aspnetcore-runtime-composite-linux-arm.tar.gz",
@@ -625,16 +715,34 @@
             "hash": "674c4d4e919b9d0633a824fa4778a9219f3ddda0faf22c929bfeb514129b9990c7be3ad44cf3bae1483c1081694caef2d55e21397fe703b4f9ee08a4115f1389"
           },
           {
+            "name": "aspnetcore-targeting-pack-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "23996e18a396e0d980d5e52b745ff6aa6ee4234dd6475d69a99ed75cae83175aee1f3ad4eb33665c29279f1d1a2c940058179938a356068c23ea4595eaca9dc0"
+          },
+          {
             "name": "aspnetcore-targeting-pack-win-x64.zip",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x64.zip",
             "hash": "c96c275db86e3da6d5b31d931f83eb710468e231c60c66ac79c632da847487742d1f5d62b5638637cb8a4bbe7d6a2757720eb3f9b04277219e8da5d3349ec0ec"
           },
           {
+            "name": "aspnetcore-targeting-pack-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "32b58ff9b4c1d7f424711dbdd79a22a748413ac2e61df652faca9bdd75821fbc7fc6cec3d87654796fcba0f6199004e7610f687640f3593292b610fb278d5dbd"
+          },
+          {
             "name": "aspnetcore-targeting-pack-win-x86.zip",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x86.zip",
             "hash": "40c79af1e23a122f8e491f4ce85febddc03192457edbf7d0a6ffb9ab4a3bf0ede5f0a16361ad700024ae4f86aada695c7bffdb6bd9aab53b0b4a4435e0eb43c8"
+          },
+          {
+            "name": "aspnetcore-targeting-pack-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-targeting-pack-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "9fee02ba6cf92e8fc3bfa721b9690ae2aeb5669f1350752bd6c494189b43b7fc65c4bf6c24864abb518cdb37b01f890b4fa9395cc9c69ac62ab008c84ecd7e3a"
           },
           {
             "name": "dotnet-hosting-win.exe",
@@ -662,6 +770,12 @@
             "hash": "c44e7c2ca8495d48099682fb41c3360fc36e7548b753cb973621e251f9ff7dac3e83f32149270d6afab8541cf576478996ad48d60d1d01191d37172141d29500"
           },
           {
+            "name": "windowsdesktop-runtime-win-arm64.tar.gz",
+            "rid": "win-arm64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz",
+            "hash": "32b6a115c2ac193821b391b6de6693610ae244f7f8f76401deff4a29d515218e6c7432355c1239346710e9f8564281ad3cbd473711e3cac6df202779c44a9048"
+          },
+          {
             "name": "windowsdesktop-runtime-win-x64.exe",
             "rid": "win-x64",
             "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x64.exe",
@@ -674,6 +788,12 @@
             "hash": "57ae2bc585054f54f4a199163b9490f850363f8ea16de28cd31d8bf3a0ff943f2d6de53eb76899b7a9fcee8ec38e622c5a29dc9fb694809997ab95bc2a97be4e"
           },
           {
+            "name": "windowsdesktop-runtime-win-x64.tar.gz",
+            "rid": "win-x64",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz",
+            "hash": "bf11471e1f9d0fff1b49ff7d5142aff5d460585157fa1db1e7f64d80d27529cf6fb4c86b3fde2348d7b5851e12e26acddfa4544b5da92f226b4afa5f26ecbfcd"
+          },
+          {
             "name": "windowsdesktop-runtime-win-x86.exe",
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.exe",
@@ -684,6 +804,12 @@
             "rid": "win-x86",
             "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.zip",
             "hash": "502cdde92f49290067067f6f6edfabb0b5f5566ec58582f5fc5a0bd281abd2a6def29710030eaa05d243bc988e8822b988dd1309c745207888be663fa203eea5"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.tar.gz",
+            "rid": "win-x86",
+            "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/11.0.0-preview.3.26207.106/windowsdesktop-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz",
+            "hash": "aa25db6c5b4f8521dab7b46449b1e55d4213bf15fb8b1737d7d0b0ec561447e8f2da3e4017155076571392e95ee66dc2c9f79807f5cf2e9e4a45dfe6cf256e35"
           }
         ]
       }


### PR DESCRIPTION
The Windows tarballs were added in Preview3 but the template used to generate the releases.json files was not updated.  That has been corrected.  Manually updating the Preview3 releases.json.