### PR TITLE
Add query-os-support-packages skill; add 8.0/9.0 distro metadata; fix Ubuntu ICU

### DIFF
--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -65,7 +65,7 @@ For maintenance work, use:
 
 For Linux distro questions about supported .NET versions, start with versions that have both `supported-os.json` and `distros/<distro>.json`. That is the default, richest query set. Only fall back to older versions that use `os-packages.json` when the user explicitly asks about older or out-of-support versions, or when the question is dependency-only.
 
-Because the current supported versions share the same file layout and keys, prefer direct file reads over broad repo-wide text search. Use discovery only to enumerate candidate version directories if you do not already know them; once you have that list, read the matching JSON files directly.
+Because the current supported versions share the same file layout and keys, prefer direct JSON extraction over broad repo-wide text search. Use discovery only to enumerate candidate version directories if you do not already know them; once you have that list, read or script against the matching JSON files directly.
 
 If discovery or text search looks wrong, open representative JSON files directly before concluding the data is absent.
 
@@ -116,7 +116,7 @@ Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `t
 
 ## Automation hints
 
-Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, Python, or shell snippet locally and discard it after use.
+Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, `python3`, or shell snippet locally and discard it after use. Prefer JSON-oriented extraction over `rg`/`grep` when you already know which files and fields you need.
 
 ### Canonical join keys
 
@@ -152,7 +152,8 @@ Do not add a checked-in helper script just to answer a read-only question. If ad
    - `.dotnet_packages` as built-in/base-feed availability
    - `.dotnet_packages_other` as additional feed-registration options
    - `.dependencies` for manual-install or self-contained native requirements
-7. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
+7. Prefer a single ad hoc `jq` or `python3` extraction pass over those JSON files instead of repeating `rg`/`grep` queries against known paths.
+8. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
 
 ### Good ad hoc output shape
 

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -55,9 +55,10 @@ For maintenance work, use:
 
 1. Never infer **official support** from package data.
 2. Never infer **package availability** from `supported-os.json` or `os-packages.json`.
-3. If the repo does not document package-feed availability for a version or release, say that plainly instead of claiming the packages are unavailable.
-4. Quote package names exactly as documented.
-5. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
+3. Do not reason from preview/GA status when answering support or package questions; use the documented JSON fields only.
+4. If the repo does not document package-feed availability for a version or release, say that plainly instead of claiming the packages are unavailable.
+5. Quote package names exactly as documented.
+6. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
 
 ## Process
 

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -48,6 +48,7 @@ For maintenance work, use:
 ## Version-specific schema notes
 
 - **Supported .NET versions** use a uniform pattern: `supported-os.json` for official support and `distros/<distro>.json` for Linux package-feed availability and native dependencies.
+- Because that supported-version layout is uniform, **support-only** queries should usually be answered with a direct pass over the relevant `supported-os.json` files instead of broad text discovery. Enumerate the current version directories once, then read the same distro entry from each file.
 - **Older .NET versions** may have `supported-os.json` plus legacy `os-packages.json`. That legacy file documents native dependencies only; it does **not** document `.NET` package-feed availability.
 
 ## Critical rules
@@ -64,9 +65,13 @@ For maintenance work, use:
 
 For Linux distro questions about supported .NET versions, start with versions that have both `supported-os.json` and `distros/<distro>.json`. That is the default, richest query set. Only fall back to older versions that use `os-packages.json` when the user explicitly asks about older or out-of-support versions, or when the question is dependency-only.
 
+Because the current supported versions share the same file layout and keys, prefer direct file reads over broad repo-wide text search. Use discovery only to enumerate candidate version directories if you do not already know them; once you have that list, read the matching JSON files directly.
+
 If discovery or text search looks wrong, open representative JSON files directly before concluding the data is absent.
 
 ### 2. Determine official support
+
+For support-only questions, this is the fast path: read the distro entry from each `release-notes/<version>/supported-os.json` and stop there unless the user also asked about package feeds or dependencies.
 
 For each version:
 
@@ -138,15 +143,16 @@ Do not add a checked-in helper script just to answer a read-only question. If ad
 
 ### Minimal extraction recipe
 
-1. Enumerate candidate versions from `release-notes/*/supported-os.json`.
+1. Enumerate candidate versions from `release-notes/*/supported-os.json` once.
 2. For current supported Linux versions, prefer the subset that also has `release-notes/<version>/distros/<distro>.json`.
-3. In each `supported-os.json`, find the distro entry and test whether the requested distro release is in `supported-versions` or `unsupported-versions`.
-4. In each `distros/<distro>.json`, find `releases[] | select(.release == "<distro-release>")`.
-5. Read:
+3. For support-only questions, stop after step 3 unless the user also asked about packages or dependencies.
+4. In each `supported-os.json`, find the distro entry and test whether the requested distro release is in `supported-versions` or `unsupported-versions`.
+5. In each `distros/<distro>.json`, find `releases[] | select(.release == "<distro-release>")`.
+6. Read:
    - `.dotnet_packages` as built-in/base-feed availability
    - `.dotnet_packages_other` as additional feed-registration options
    - `.dependencies` for manual-install or self-contained native requirements
-6. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
+7. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
 
 ### Good ad hoc output shape
 

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: query-os-support-packages
+description: >
+  Answer read-only questions about .NET OS support, distro package
+  availability, and native dependencies using the release metadata in this
+  repository. USE FOR: questions like which .NET versions support Ubuntu
+  26.04, which packages are installable via apt or dnf, and which native
+  packages are required for manual or self-contained deployments. DO NOT USE
+  FOR: updating repository data; use update-supported-os, update-os-packages,
+  or update-distro-packages for maintenance.
+---
+
+# Query OS Support and Packages
+
+Use this skill to answer read-only questions from the repository's OS support
+and Linux package metadata without changing any files.
+
+## When to use
+
+- "Which .NET versions support Ubuntu 26.04?"
+- "Which .NET versions can I install via `apt` on Ubuntu 26.04?"
+- "What dependencies are required if I install .NET manually?"
+- "What native packages are still required for a self-contained deployment?"
+- "Is this distro supported, installable, both, or neither?"
+
+## Do not use
+
+- Updating `supported-os.json` / `supported-os.md`
+- Updating `os-packages.json` / `os-packages.md`
+- Updating `release-notes/{version}/distros/`
+
+For maintenance work, use:
+
+- [`update-supported-os`](../update-supported-os/SKILL.md)
+- [`update-os-packages`](../update-os-packages/SKILL.md)
+- [`update-distro-packages`](../update-distro-packages/SKILL.md)
+
+## Source precedence
+
+| Question | Primary source | Notes |
+| --- | --- | --- |
+| Official OS support | `release-notes/<version>/supported-os.json` | The only authoritative source for whether a .NET version officially supports an OS or distro release. |
+| Native dependencies, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `releases[].dependencies`. `dotnet-dependencies.md` is a generated view of this data. |
+| Package feed availability, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `dotnet_packages` and `dotnet_packages_other`. `dotnet-packages.md` is a generated view of this data. |
+| Native dependencies, legacy schema | `release-notes/<version>/os-packages.json` | Use when the version does not have `distros/` data for that question. `os-packages.md` is a generated view. |
+| Rendered docs | `supported-os.md`, `dotnet-dependencies.md`, `dotnet-packages.md`, `os-packages.md` | Useful for quoting commands, but prefer JSON as the canonical source. |
+
+## Critical rules
+
+1. Never infer **official support** from package data.
+2. Never infer **package availability** from `supported-os.json`.
+3. Never infer **package availability** from `os-packages.json`. That file documents native dependencies, not which `.NET` packages a distro feed carries.
+4. If the repo does not document package-feed availability for a version, say that plainly instead of claiming the packages are unavailable.
+5. If a question spans versions that use different schemas, answer each version separately and state which source was used.
+6. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
+
+## Process
+
+### 1. Identify versions in scope
+
+If the user asks "which versions", check the active release directories that could reasonably apply. For package questions, only versions with relevant package metadata can be answered authoritatively from this repo.
+
+### 2. Determine official support
+
+For each version:
+
+1. Open `release-notes/<version>/supported-os.json`.
+2. Find the distro or OS entry.
+3. Check whether the requested release appears in `supported-versions` or `unsupported-versions`.
+
+Treat that result as authoritative for support status.
+
+### 3. Determine package-feed availability
+
+For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
+
+1. Prefer `release-notes/<version>/distros/<distro>.json` when it exists.
+2. Find the matching release in `releases[]`.
+3. Use:
+   - `dotnet_packages` for built-in distro feeds
+   - `dotnet_packages_other` for alternative feeds that require a registration step
+4. If those fields are absent, the repo may not document package-feed availability for that version or release. Do not infer "not available" from absence alone.
+
+### 4. Determine native dependencies
+
+For manual installs or self-contained deployments:
+
+1. Prefer `release-notes/<version>/distros/<distro>.json` and use `dependencies`.
+2. If that schema is not present for the version, fall back to `release-notes/<version>/os-packages.json` and use the distro release's `packages` list.
+3. Use the distro's `install_command` only as a formatting template for the package list; do not confuse it with a .NET package feed command.
+
+## Important distinctions
+
+### Support vs packages
+
+A distro release can appear in package metadata without being officially supported. Answer these separately.
+
+### Built-in vs alternative feeds
+
+`dotnet_packages` means the packages are available from the distro's normal package feeds. `dotnet_packages_other` means an extra feed-registration step is required before installation.
+
+### Dependencies vs .NET packages
+
+Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `tzdata`. They are separate from `.NET` packages like `dotnet-sdk-10.0` or `aspnetcore-runtime-10.0`.
+
+### Linux vs non-Linux
+
+Package and dependency questions are mainly Linux-specific in this repo. For Windows and macOS, `supported-os.json` is usually the only relevant source.
+
+## Output guidance
+
+- Lead with the support answer.
+- Then list package-feed availability, if documented.
+- Then list native dependencies for manual or self-contained scenarios.
+- Call out uncertainty explicitly when the repo has incomplete data for a version.
+
+## Example framing
+
+For a question like "I'm using Ubuntu 26.04. Which .NET versions are supported, which can I install via `apt`, and what dependencies are required for manual install?":
+
+1. Use each version's `supported-os.json` for support.
+2. Use `distros/ubuntu.json` for package-feed availability when that file exists.
+3. Use `distros/ubuntu.json` or `os-packages.json` for native dependencies.
+4. Present support, packages, and dependencies as separate answers so the user can see where the results differ.

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -12,164 +12,106 @@ description: >
 
 # Query OS Support and Packages
 
-Use this skill to answer read-only questions from the repository's OS support
-and Linux package metadata without changing any files.
-
-## When to use
-
-- "Which .NET versions support Ubuntu RHEL 10?"
-- "Which .NET versions can I install via `apt` on Ubuntu 26.04?"
-- "What dependencies are required if I install .NET manually?"
-- "What native packages are still required for a self-contained deployment?"
-- "Is this distro supported, installable, both, or neither?"
+Read-only answers about .NET OS support, distro package availability, and
+native dependencies from this repo's release metadata. For updating data
+files, use [`update-supported-os`](../update-supported-os/SKILL.md),
+[`update-os-packages`](../update-os-packages/SKILL.md), or
+[`update-distro-packages`](../update-distro-packages/SKILL.md).
 
 ## Source precedence
 
-| Question | Primary source | Notes |
+| Question | File | Field |
 | --- | --- | --- |
-| Official OS support | `release-notes/<version>/supported-os.json` | The only authoritative source for whether a .NET version officially supports an OS or distro release. |
-| Native dependencies, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `releases[].dependencies`. `dotnet-dependencies.md` is a generated view of this data. |
-| Package feed availability, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `dotnet_packages` for the base/built-in distro feed and `dotnet_packages_other` for additional feed-registration options. `dotnet-packages.md` is a generated view of this data. |
-| Native dependencies, legacy schema | `release-notes/<version>/os-packages.json` | Use when the version does not have `distros/` data for that question. `os-packages.md` is a generated view. |
-| Rendered docs | `supported-os.md`, `dotnet-dependencies.md`, `dotnet-packages.md`, `os-packages.md` | Useful for quoting commands, but prefer JSON as the canonical source. |
+| Official support | `release-notes/<v>/supported-os.json` | `families[].distributions[].{supported,unsupported}-versions` |
+| Package feeds (current schema) | `release-notes/<v>/distros/<distro>.json` | `releases[].dotnet_packages` (built-in), `releases[].dotnet_packages_other` (extra-feed) |
+| Native dependencies (current schema) | `release-notes/<v>/distros/<distro>.json` | `releases[].dependencies` |
+| Native dependencies (legacy) | `release-notes/<v>/os-packages.json` | release entry's `packages[]` (older versions only; does **not** document package-feed availability) |
 
-## Schema notes
-
-Currently supported .NET versions share a uniform layout (`supported-os.json` + `distros/<distro>.json`), so most queries reduce to reading the same fields across versions. Older versions may only have `supported-os.json` + legacy `os-packages.json`, which documents native dependencies but **not** package-feed availability.
+The `.md` siblings (`supported-os.md`, `dotnet-packages.md`,
+`dotnet-dependencies.md`, `os-packages.md`) are generated views — useful for
+quoting commands, but JSON is canonical.
 
 ## Critical rules
 
-1. Never infer **official support** from package data.
-2. Never infer **package availability** from `supported-os.json` or `os-packages.json`.
-3. Do not substitute preview/GA status for the documented JSON fields when those fields have a value. Preview/GA status is only a tiebreaker for interpreting null fields (see rule #4).
-4. When `dotnet_packages` and `dotnet_packages_other` are both null, distinguish three cases by cross-checking `releases-index.json` for the channel's `support-phase`:
-   - **Preview** channel: report as **not yet available** — packages may land before GA.
-   - **Active** (or other GA) channel with current `distros/<distro>.json` data: report as **not available** from the distro package manager.
-   - **No `distros/<distro>.json` for that version, or the file predates the distro release**: report as **not documented**.
-5. Quote package names exactly as documented.
-6. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
+1. Never infer **official support** from package data, or **package
+   availability** from support data. A distro release can appear in package
+   metadata without being officially supported.
+2. Treat the `supported-os.json` lists as authoritative: a release in
+   `supported-versions` is supported, a release in `unsupported-versions`
+   (or absent from both) is unsupported.
+3. Do not substitute preview/GA status for documented JSON fields.
+   Preview/GA is only a tiebreaker for null fields (rule 4).
+4. When `dotnet_packages` and `dotnet_packages_other` are both null,
+   cross-check `releases-index.json` `support-phase`:
+   - **Preview** channel → **not yet available** (packages may land before
+     GA).
+   - **Active** (or other GA) channel with current `distros/<distro>.json`
+     data → **not available** from the distro package manager.
+   - **No `distros/<distro>.json` for that version, or the file predates the
+     distro release** → **not documented**.
+5. `dotnet_packages` = built-in/base distro feed.
+   `dotnet_packages_other` = extra feed requiring a registration step.
+6. Native dependencies (`libicu`, `libssl`, `libstdc++`, `tzdata`, etc.) are
+   OS packages, distinct from .NET packages (`dotnet-sdk-10.0`,
+   `aspnetcore-runtime-10.0`).
+7. The distro's `install_command` is only a formatting template for the
+   package list — not a .NET package feed command.
+8. Quote package names exactly as documented.
+9. For combined questions, split the answer into **Support**, **Packages**,
+   and **Dependencies**.
 
 ## Process
 
-### 1. Classify the query
+1. **Classify** — support only, packages only, dependencies only, or
+   combined; and the version scope (single, named set, or
+   current-supported).
+2. **Scope versions** — for current Linux-distro questions, default to
+   versions with both `supported-os.json` and `distros/<distro>.json`. Fall
+   back to legacy `os-packages.json` only when the user asks about older or
+   out-of-support versions, or for dependency-only questions on those
+   versions.
+3. **Extract** — read the fields named in [Canonical JSON
+   paths](#canonical-json-paths). Stop as soon as the question's facets are
+   answered — don't collect a superset.
 
-Before reading anything, identify the minimum data needed:
+If the user named a single version, go straight to its files; enumerate
+versions only when scope is broad. If discovery or text search looks wrong,
+open a representative JSON file directly before concluding the data is
+absent.
 
-- **Support only**
-- **Package-feed availability only**
-- **Native dependencies only**
-- **Combined** support/package/dependency question
+## Canonical join keys
 
-Also identify the requested scope:
+- **Version** — `release-notes/<version>/` directory name (e.g., `8.0`,
+  `10.0`)
+- **Distro** — file name and `id` (e.g., `ubuntu`, `fedora`, `rhel`)
+- **Distro release** — release string (e.g., `26.04`, `9`)
 
-- a **specific .NET version**
-- a **set of versions** named by the user
-- the **current supported versions** for a distro or distro release
+## Canonical JSON paths
 
-Do not collect package or dependency data for support-only questions, and do not scan every version when the user named one.
-
-### 2. Select the smallest authoritative file set
-
-- **Support** -> `release-notes/<version>/supported-os.json`
-- **Package feeds** for supported Linux versions -> `release-notes/<version>/distros/<distro>.json`
-- **Dependencies** for supported Linux versions -> `release-notes/<version>/distros/<distro>.json`
-- **Dependencies** for older versions without `distros/` data -> `release-notes/<version>/os-packages.json`
-
-If the user named a single version, go straight to that version's files. Enumerate versions only when the scope is broad or unspecified.
-
-### 3. Identify versions in scope
-
-For Linux distro questions about supported .NET versions, start with versions that have both `supported-os.json` and `distros/<distro>.json`. That is the default, richest query set. Only fall back to older versions that use `os-packages.json` when the user explicitly asks about older or out-of-support versions, or when the question is dependency-only.
-
-Because the current supported versions share the same file layout and keys, prefer direct JSON extraction over broad repo-wide text search. Use discovery only to enumerate candidate version directories if you do not already know them; once you have that list, read or script against the matching JSON files directly.
-
-If discovery or text search looks wrong, open representative JSON files directly before concluding the data is absent.
-
-### 4. Determine official support
-
-For support-only questions, this is the fast path: read the distro entry from each `release-notes/<version>/supported-os.json` and stop there unless the user also asked about package feeds or dependencies.
-
-For each version:
-
-1. Open `release-notes/<version>/supported-os.json`.
-2. Find the distro or OS entry.
-3. Check whether the requested release appears in `supported-versions` or `unsupported-versions`.
-
-Treat that result as authoritative for support status. The absense of a version means "unsupported".
-
-### 5. Determine package-feed availability
-
-For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
-
-1. Prefer `release-notes/<version>/distros/<distro>.json`.
-2. Find the matching release in `releases[]`.
-3. Use:
-   - `dotnet_packages` for the base distro feed; treat this as built-in package availability
-   - `dotnet_packages_other` for alternative feeds that require a registration step
-4. If both fields are null, apply rule #4 in [Critical rules](#critical-rules): use `releases-index.json` `support-phase` to choose between **not yet available** (preview), **not available** (active GA), or **not documented** (stale or missing schema).
-
-### 6. Determine native dependencies
-
-For manual installs or self-contained deployments:
-
-1. Prefer `release-notes/<version>/distros/<distro>.json` and use `dependencies`.
-2. If that schema is not present for the version, fall back to `release-notes/<version>/os-packages.json` and use the distro release's `packages` list.
-3. Use the distro's `install_command` only as a formatting template for the package list; do not confuse it with a .NET package feed command.
-
-## Important distinctions
-
-### Support vs packages
-
-A distro release can appear in package metadata without being officially supported. Answer these separately.
-
-### Built-in vs alternative feeds
-
-`dotnet_packages` means the packages are available from the distro's base or normal package feeds; treat that as built-in availability. `dotnet_packages_other` means an extra feed-registration step is required before installation.
-
-### Dependencies vs .NET packages
-
-Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `tzdata`. They are separate from `.NET` packages like `dotnet-sdk-10.0` or `aspnetcore-runtime-10.0`.
-
-## Automation hints
-
-Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, `python3`, or shell snippet locally and discard it after use.
-
-Prefer JSON-oriented extraction over `rg`/`grep` when you already know which files and fields you need. Favor a single structured pass that emits only the columns needed for the question rather than collecting a superset "just in case."
-
-### Canonical join keys
-
-- **Version**: the `release-notes/<version>/` directory name, such as `8.0`, `9.0`, or `10.0`
-- **Distro**: the distro file name and distribution `id`, such as `ubuntu`, `fedora`, or `rhel`
-- **Distro release**: the release string, such as `26.04`, `24.04`, or `9`
-
-### Canonical JSON paths
-
-- Official support:
-  - `families[]`
-  - `families[].distributions[]`
-  - distro match: `.id == "<distro>"`
-  - status fields: `.supported-versions[]` and `.unsupported-versions[]`
-- Newer package/dependency schema:
-  - `releases[]`
-  - release match: `.release == "<distro-release>"`
+- **Official support** in `supported-os.json`:
+  - `families[].distributions[]` matched by `.id == "<distro>"`
+  - status from `.supported-versions[]` and `.unsupported-versions[]`
+- **Current package/dependency schema** in `distros/<distro>.json`:
+  - `releases[]` matched by `.release == "<distro-release>"`
   - dependencies: `.dependencies[]`
-  - built-in/base feed packages: `.dotnet_packages[]`
+  - built-in feed: `.dotnet_packages[]`
   - extra-feed options: `.dotnet_packages_other`
-- Legacy dependency schema:
-  - use the matching distro and release entry in `os-packages.json`
-  - package list comes from that release's `packages[]`
+- **Legacy dependency schema** in `os-packages.json`:
+  - matching distro and release entry's `packages[]`
 
-### Extraction tips
+## Automation
 
-- Run one structured `jq` or `python3` pass across the resolved file set; emit one compact row per version with only the fields the user asked for (support, built-in packages, extra-feed packages, dependencies).
-- Stop as soon as all requested facets are answered — do not collect a superset "just in case."
+Don't add a checked-in helper script for read-only questions — use a one-off
+`jq` / `python3` / shell snippet locally and discard. Prefer a single
+structured JSON pass over `rg`/`grep` text scans, emitting only the fields
+needed (one compact row per version).
 
 ## Output guidance
 
-- Lead with the support answer.
-- Then list package-feed availability, distinguishing built-in feeds from extra-feed cases.
-- Then list native dependencies for manual or self-contained scenarios.
-- For multi-version Linux questions, prefer a table. If dependencies are identical across versions, list them once.
-- For single-version or single-facet questions, prefer a short direct answer over a full table.
-- Call out uncertainty explicitly when the repo has incomplete data for a version.
-
+- Lead with support, then package-feed availability (built-in vs
+  extra-feed), then native dependencies.
+- For multi-version Linux questions, prefer a table; if dependencies are
+  identical across versions, list them once.
+- For single-version or single-facet questions, use a short direct answer
+  instead of a full table.
+- Call out uncertainty when the repo has incomplete data for a version.

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -45,6 +45,11 @@ For maintenance work, use:
 | Native dependencies, legacy schema | `release-notes/<version>/os-packages.json` | Use when the version does not have `distros/` data for that question. `os-packages.md` is a generated view. |
 | Rendered docs | `supported-os.md`, `dotnet-dependencies.md`, `dotnet-packages.md`, `os-packages.md` | Useful for quoting commands, but prefer JSON as the canonical source. |
 
+## Version-specific schema notes
+
+- **8.0, 9.0, 10.0** may have both `distros/` and `os-packages.*`. For read-only answers, prefer `distros/` for Linux dependencies and package-feed availability, but remember maintenance must keep both schemes in sync.
+- **11.0+** uses `distros/` as the Linux package metadata source; there is no companion `os-packages.*` maintenance track.
+
 ## Critical rules
 
 1. Never infer **official support** from package data.

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -48,7 +48,7 @@ For maintenance work, use:
 ## Version-specific schema notes
 
 - **Supported .NET versions** use a uniform pattern: `supported-os.json` for official support and `distros/<distro>.json` for Linux package-feed availability and native dependencies.
-- Because that supported-version layout is uniform, **support-only** queries should usually be answered with a direct pass over the relevant `supported-os.json` files instead of broad text discovery. Enumerate the current version directories once, then read the same distro entry from each file.
+- Because that layout is uniform, many queries can be answered by reading the same small set of JSON fields across versions instead of doing broad discovery or repeated text search.
 - **Older .NET versions** may have `supported-os.json` plus legacy `os-packages.json`. That legacy file documents native dependencies only; it does **not** document `.NET` package-feed availability.
 
 ## Critical rules
@@ -61,7 +61,33 @@ For maintenance work, use:
 
 ## Process
 
-### 1. Identify versions in scope
+### 1. Classify the query
+
+Before reading anything, identify the minimum data needed:
+
+- **Support only**
+- **Package-feed availability only**
+- **Native dependencies only**
+- **Combined** support/package/dependency question
+
+Also identify the requested scope:
+
+- a **specific .NET version**
+- a **set of versions** named by the user
+- the **current supported versions** for a distro or distro release
+
+Do not collect package or dependency data for support-only questions, and do not scan every version when the user named one.
+
+### 2. Select the smallest authoritative file set
+
+- **Support** -> `release-notes/<version>/supported-os.json`
+- **Package feeds** for supported Linux versions -> `release-notes/<version>/distros/<distro>.json`
+- **Dependencies** for supported Linux versions -> `release-notes/<version>/distros/<distro>.json`
+- **Dependencies** for older versions without `distros/` data -> `release-notes/<version>/os-packages.json`
+
+If the user named a single version, go straight to that version's files. Enumerate versions only when the scope is broad or unspecified.
+
+### 3. Identify versions in scope
 
 For Linux distro questions about supported .NET versions, start with versions that have both `supported-os.json` and `distros/<distro>.json`. That is the default, richest query set. Only fall back to older versions that use `os-packages.json` when the user explicitly asks about older or out-of-support versions, or when the question is dependency-only.
 
@@ -69,7 +95,7 @@ Because the current supported versions share the same file layout and keys, pref
 
 If discovery or text search looks wrong, open representative JSON files directly before concluding the data is absent.
 
-### 2. Determine official support
+### 4. Determine official support
 
 For support-only questions, this is the fast path: read the distro entry from each `release-notes/<version>/supported-os.json` and stop there unless the user also asked about package feeds or dependencies.
 
@@ -81,7 +107,7 @@ For each version:
 
 Treat that result as authoritative for support status.
 
-### 3. Determine package-feed availability
+### 5. Determine package-feed availability
 
 For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
 
@@ -92,7 +118,7 @@ For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
    - `dotnet_packages_other` for alternative feeds that require a registration step
 4. If those fields are absent, the repo may not document package-feed availability for that version or release. Do not infer "not available" from absence alone.
 
-### 4. Determine native dependencies
+### 6. Determine native dependencies
 
 For manual installs or self-contained deployments:
 
@@ -116,7 +142,9 @@ Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `t
 
 ## Automation hints
 
-Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, `python3`, or shell snippet locally and discard it after use. Prefer JSON-oriented extraction over `rg`/`grep` when you already know which files and fields you need.
+Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, `python3`, or shell snippet locally and discard it after use.
+
+Prefer JSON-oriented extraction over `rg`/`grep` when you already know which files and fields you need. Favor a single structured pass that emits only the columns needed for the question rather than collecting a superset "just in case."
 
 ### Canonical join keys
 
@@ -141,23 +169,24 @@ Do not add a checked-in helper script just to answer a read-only question. If ad
   - use the matching distro and release entry in `os-packages.json`
   - package list comes from that release's `packages[]`
 
-### Minimal extraction recipe
+### Generic extraction recipe
 
-1. Enumerate candidate versions from `release-notes/*/supported-os.json` once.
-2. For current supported Linux versions, prefer the subset that also has `release-notes/<version>/distros/<distro>.json`.
-3. For support-only questions, stop after step 3 unless the user also asked about packages or dependencies.
-4. In each `supported-os.json`, find the distro entry and test whether the requested distro release is in `supported-versions` or `unsupported-versions`.
-5. In each `distros/<distro>.json`, find `releases[] | select(.release == "<distro-release>")`.
-6. Read:
-   - `.dotnet_packages` as built-in/base-feed availability
-   - `.dotnet_packages_other` as additional feed-registration options
-   - `.dependencies` for manual-install or self-contained native requirements
-7. Prefer a single ad hoc `jq` or `python3` extraction pass over those JSON files instead of repeating `rg`/`grep` queries against known paths.
-8. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
+1. Normalize the request into:
+   - version scope
+   - distro id
+   - distro release, if any
+   - requested facets: support, packages, dependencies
+2. Resolve the minimum version set:
+   - if the user named a version, use it
+   - otherwise enumerate candidate versions once
+3. Resolve the minimum file set from the requested facets.
+4. Run one ad hoc `jq` or `python3` pass across those files and emit one compact row or object per version.
+5. Stop as soon as all requested facets are answered.
+6. If a needed field or distro release entry is absent, report that facet as **not documented** rather than inferring absence.
 
 ### Good ad hoc output shape
 
-For multi-version questions, script toward a compact row per version:
+For multi-version questions, script toward a compact row per version, but only include the fields the user asked for:
 
 - version
 - support status
@@ -171,12 +200,14 @@ For multi-version questions, script toward a compact row per version:
 - Then list package-feed availability, distinguishing built-in feeds from extra-feed cases.
 - Then list native dependencies for manual or self-contained scenarios.
 - For multi-version Linux questions, prefer a table. If dependencies are identical across versions, list them once.
+- For single-version or single-facet questions, prefer a short direct answer over a full table.
 - Call out uncertainty explicitly when the repo has incomplete data for a version.
 
 ## Example framing
 
-For a question like "I'm using Ubuntu 26.04. Which .NET versions are supported, which can I install via `apt`, and what dependencies are required for manual install?":
+For a combined Linux distro query:
 
-1. Start with supported versions that have both `supported-os.json` and `distros/ubuntu.json`.
-2. Use `supported-os.json` for support, `distros/ubuntu.json` for package-feed availability, and `distros/ubuntu.json` for dependencies.
-3. Only use `os-packages.json` for older dependency-only fallback cases.
+1. Resolve whether the user asked about one version or many.
+2. Use `supported-os.json` for support.
+3. Use `distros/<distro>.json` for package-feed availability and dependencies when that schema exists.
+4. Only use `os-packages.json` for older dependency-only fallback cases.

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -47,23 +47,24 @@ For maintenance work, use:
 
 ## Version-specific schema notes
 
-- **8.0, 9.0, 10.0** may have both `distros/` and `os-packages.*`. For read-only answers, prefer `distros/` for Linux dependencies and package-feed availability, but remember maintenance must keep both schemes in sync.
-- **11.0+** uses `distros/` as the Linux package metadata source; there is no companion `os-packages.*` maintenance track.
+- **Supported .NET versions** use a uniform pattern: `supported-os.json` for official support and `distros/<distro>.json` for Linux package-feed availability and native dependencies.
+- **Older .NET versions** may have `supported-os.json` plus legacy `os-packages.json`. That legacy file documents native dependencies only; it does **not** document `.NET` package-feed availability.
 
 ## Critical rules
 
 1. Never infer **official support** from package data.
-2. Never infer **package availability** from `supported-os.json`.
-3. Never infer **package availability** from `os-packages.json`. That file documents native dependencies, not which `.NET` packages a distro feed carries.
-4. If the repo does not document package-feed availability for a version, say that plainly instead of claiming the packages are unavailable.
-5. If a question spans versions that use different schemas, answer each version separately and state which source was used.
-6. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
+2. Never infer **package availability** from `supported-os.json` or `os-packages.json`.
+3. If the repo does not document package-feed availability for a version or release, say that plainly instead of claiming the packages are unavailable.
+4. Quote package names exactly as documented.
+5. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
 
 ## Process
 
 ### 1. Identify versions in scope
 
-If the user asks "which versions", check the active release directories that could reasonably apply. For package questions, only versions with relevant package metadata can be answered authoritatively from this repo.
+For Linux distro questions about supported .NET versions, start with versions that have both `supported-os.json` and `distros/<distro>.json`. That is the default, richest query set. Only fall back to older versions that use `os-packages.json` when the user explicitly asks about older or out-of-support versions, or when the question is dependency-only.
+
+If discovery or text search looks wrong, open representative JSON files directly before concluding the data is absent.
 
 ### 2. Determine official support
 
@@ -79,7 +80,7 @@ Treat that result as authoritative for support status.
 
 For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
 
-1. Prefer `release-notes/<version>/distros/<distro>.json` when it exists.
+1. Prefer `release-notes/<version>/distros/<distro>.json`.
 2. Find the matching release in `releases[]`.
 3. Use:
    - `dotnet_packages` for built-in distro feeds
@@ -108,22 +109,18 @@ A distro release can appear in package metadata without being officially support
 
 Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `tzdata`. They are separate from `.NET` packages like `dotnet-sdk-10.0` or `aspnetcore-runtime-10.0`.
 
-### Linux vs non-Linux
-
-Package and dependency questions are mainly Linux-specific in this repo. For Windows and macOS, `supported-os.json` is usually the only relevant source.
-
 ## Output guidance
 
 - Lead with the support answer.
-- Then list package-feed availability, if documented.
+- Then list package-feed availability, distinguishing built-in feeds from extra-feed cases.
 - Then list native dependencies for manual or self-contained scenarios.
+- For multi-version Linux questions, prefer a table. If dependencies are identical across versions, list them once.
 - Call out uncertainty explicitly when the repo has incomplete data for a version.
 
 ## Example framing
 
 For a question like "I'm using Ubuntu 26.04. Which .NET versions are supported, which can I install via `apt`, and what dependencies are required for manual install?":
 
-1. Use each version's `supported-os.json` for support.
-2. Use `distros/ubuntu.json` for package-feed availability when that file exists.
-3. Use `distros/ubuntu.json` or `os-packages.json` for native dependencies.
-4. Present support, packages, and dependencies as separate answers so the user can see where the results differ.
+1. Start with supported versions that have both `supported-os.json` and `distros/ubuntu.json`.
+2. Use `supported-os.json` for support, `distros/ubuntu.json` for package-feed availability, and `distros/ubuntu.json` for dependencies.
+3. Only use `os-packages.json` for older dependency-only fallback cases.

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -41,7 +41,7 @@ For maintenance work, use:
 | --- | --- | --- |
 | Official OS support | `release-notes/<version>/supported-os.json` | The only authoritative source for whether a .NET version officially supports an OS or distro release. |
 | Native dependencies, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `releases[].dependencies`. `dotnet-dependencies.md` is a generated view of this data. |
-| Package feed availability, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `dotnet_packages` and `dotnet_packages_other`. `dotnet-packages.md` is a generated view of this data. |
+| Package feed availability, newer schema | `release-notes/<version>/distros/<distro>.json` | Use `dotnet_packages` for the base/built-in distro feed and `dotnet_packages_other` for additional feed-registration options. `dotnet-packages.md` is a generated view of this data. |
 | Native dependencies, legacy schema | `release-notes/<version>/os-packages.json` | Use when the version does not have `distros/` data for that question. `os-packages.md` is a generated view. |
 | Rendered docs | `supported-os.md`, `dotnet-dependencies.md`, `dotnet-packages.md`, `os-packages.md` | Useful for quoting commands, but prefer JSON as the canonical source. |
 
@@ -83,7 +83,7 @@ For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
 1. Prefer `release-notes/<version>/distros/<distro>.json`.
 2. Find the matching release in `releases[]`.
 3. Use:
-   - `dotnet_packages` for built-in distro feeds
+   - `dotnet_packages` for the base distro feed; treat this as built-in package availability
    - `dotnet_packages_other` for alternative feeds that require a registration step
 4. If those fields are absent, the repo may not document package-feed availability for that version or release. Do not infer "not available" from absence alone.
 
@@ -103,11 +103,60 @@ A distro release can appear in package metadata without being officially support
 
 ### Built-in vs alternative feeds
 
-`dotnet_packages` means the packages are available from the distro's normal package feeds. `dotnet_packages_other` means an extra feed-registration step is required before installation.
+`dotnet_packages` means the packages are available from the distro's base or normal package feeds; treat that as built-in availability. `dotnet_packages_other` means an extra feed-registration step is required before installation.
 
 ### Dependencies vs .NET packages
 
 Native dependencies are OS packages like `libicu`, `libssl`, `libstdc++`, and `tzdata`. They are separate from `.NET` packages like `dotnet-sdk-10.0` or `aspnetcore-runtime-10.0`.
+
+## Automation hints
+
+Do not add a checked-in helper script just to answer a read-only question. If ad hoc automation helps, write a one-off `jq`, Python, or shell snippet locally and discard it after use.
+
+### Canonical join keys
+
+- **Version**: the `release-notes/<version>/` directory name, such as `8.0`, `9.0`, or `10.0`
+- **Distro**: the distro file name and distribution `id`, such as `ubuntu`, `fedora`, or `rhel`
+- **Distro release**: the release string, such as `26.04`, `24.04`, or `9`
+
+### Canonical JSON paths
+
+- Official support:
+  - `families[]`
+  - `families[].distributions[]`
+  - distro match: `.id == "<distro>"`
+  - status fields: `.supported-versions[]` and `.unsupported-versions[]`
+- Newer package/dependency schema:
+  - `releases[]`
+  - release match: `.release == "<distro-release>"`
+  - dependencies: `.dependencies[]`
+  - built-in/base feed packages: `.dotnet_packages[]`
+  - extra-feed options: `.dotnet_packages_other`
+- Legacy dependency schema:
+  - use the matching distro and release entry in `os-packages.json`
+  - package list comes from that release's `packages[]`
+
+### Minimal extraction recipe
+
+1. Enumerate candidate versions from `release-notes/*/supported-os.json`.
+2. For current supported Linux versions, prefer the subset that also has `release-notes/<version>/distros/<distro>.json`.
+3. In each `supported-os.json`, find the distro entry and test whether the requested distro release is in `supported-versions` or `unsupported-versions`.
+4. In each `distros/<distro>.json`, find `releases[] | select(.release == "<distro-release>")`.
+5. Read:
+   - `.dotnet_packages` as built-in/base-feed availability
+   - `.dotnet_packages_other` as additional feed-registration options
+   - `.dependencies` for manual-install or self-contained native requirements
+6. If the distro release is missing from `distros/<distro>.json`, say the repo does not document package-feed availability or dependencies for that version/release instead of inferring absence.
+
+### Good ad hoc output shape
+
+For multi-version questions, script toward a compact row per version:
+
+- version
+- support status
+- built-in packages
+- extra-feed packages and registration command
+- dependency package names
 
 ## Output guidance
 

--- a/.github/skills/query-os-support-packages/SKILL.md
+++ b/.github/skills/query-os-support-packages/SKILL.md
@@ -17,23 +17,11 @@ and Linux package metadata without changing any files.
 
 ## When to use
 
-- "Which .NET versions support Ubuntu 26.04?"
+- "Which .NET versions support Ubuntu RHEL 10?"
 - "Which .NET versions can I install via `apt` on Ubuntu 26.04?"
 - "What dependencies are required if I install .NET manually?"
 - "What native packages are still required for a self-contained deployment?"
 - "Is this distro supported, installable, both, or neither?"
-
-## Do not use
-
-- Updating `supported-os.json` / `supported-os.md`
-- Updating `os-packages.json` / `os-packages.md`
-- Updating `release-notes/{version}/distros/`
-
-For maintenance work, use:
-
-- [`update-supported-os`](../update-supported-os/SKILL.md)
-- [`update-os-packages`](../update-os-packages/SKILL.md)
-- [`update-distro-packages`](../update-distro-packages/SKILL.md)
 
 ## Source precedence
 
@@ -45,18 +33,19 @@ For maintenance work, use:
 | Native dependencies, legacy schema | `release-notes/<version>/os-packages.json` | Use when the version does not have `distros/` data for that question. `os-packages.md` is a generated view. |
 | Rendered docs | `supported-os.md`, `dotnet-dependencies.md`, `dotnet-packages.md`, `os-packages.md` | Useful for quoting commands, but prefer JSON as the canonical source. |
 
-## Version-specific schema notes
+## Schema notes
 
-- **Supported .NET versions** use a uniform pattern: `supported-os.json` for official support and `distros/<distro>.json` for Linux package-feed availability and native dependencies.
-- Because that layout is uniform, many queries can be answered by reading the same small set of JSON fields across versions instead of doing broad discovery or repeated text search.
-- **Older .NET versions** may have `supported-os.json` plus legacy `os-packages.json`. That legacy file documents native dependencies only; it does **not** document `.NET` package-feed availability.
+Currently supported .NET versions share a uniform layout (`supported-os.json` + `distros/<distro>.json`), so most queries reduce to reading the same fields across versions. Older versions may only have `supported-os.json` + legacy `os-packages.json`, which documents native dependencies but **not** package-feed availability.
 
 ## Critical rules
 
 1. Never infer **official support** from package data.
 2. Never infer **package availability** from `supported-os.json` or `os-packages.json`.
-3. Do not reason from preview/GA status when answering support or package questions; use the documented JSON fields only.
-4. If the repo does not document package-feed availability for a version or release, say that plainly instead of claiming the packages are unavailable.
+3. Do not substitute preview/GA status for the documented JSON fields when those fields have a value. Preview/GA status is only a tiebreaker for interpreting null fields (see rule #4).
+4. When `dotnet_packages` and `dotnet_packages_other` are both null, distinguish three cases by cross-checking `releases-index.json` for the channel's `support-phase`:
+   - **Preview** channel: report as **not yet available** — packages may land before GA.
+   - **Active** (or other GA) channel with current `distros/<distro>.json` data: report as **not available** from the distro package manager.
+   - **No `distros/<distro>.json` for that version, or the file predates the distro release**: report as **not documented**.
 5. Quote package names exactly as documented.
 6. When the user asks both support and installation questions, split the answer into **Support**, **Packages**, and **Dependencies**.
 
@@ -106,7 +95,7 @@ For each version:
 2. Find the distro or OS entry.
 3. Check whether the requested release appears in `supported-versions` or `unsupported-versions`.
 
-Treat that result as authoritative for support status.
+Treat that result as authoritative for support status. The absense of a version means "unsupported".
 
 ### 5. Determine package-feed availability
 
@@ -117,7 +106,7 @@ For Linux distro package-manager questions (`apt`, `dnf`, `zypper`, and so on):
 3. Use:
    - `dotnet_packages` for the base distro feed; treat this as built-in package availability
    - `dotnet_packages_other` for alternative feeds that require a registration step
-4. If those fields are absent, the repo may not document package-feed availability for that version or release. Do not infer "not available" from absence alone.
+4. If both fields are null, apply rule #4 in [Critical rules](#critical-rules): use `releases-index.json` `support-phase` to choose between **not yet available** (preview), **not available** (active GA), or **not documented** (stale or missing schema).
 
 ### 6. Determine native dependencies
 
@@ -170,30 +159,10 @@ Prefer JSON-oriented extraction over `rg`/`grep` when you already know which fil
   - use the matching distro and release entry in `os-packages.json`
   - package list comes from that release's `packages[]`
 
-### Generic extraction recipe
+### Extraction tips
 
-1. Normalize the request into:
-   - version scope
-   - distro id
-   - distro release, if any
-   - requested facets: support, packages, dependencies
-2. Resolve the minimum version set:
-   - if the user named a version, use it
-   - otherwise enumerate candidate versions once
-3. Resolve the minimum file set from the requested facets.
-4. Run one ad hoc `jq` or `python3` pass across those files and emit one compact row or object per version.
-5. Stop as soon as all requested facets are answered.
-6. If a needed field or distro release entry is absent, report that facet as **not documented** rather than inferring absence.
-
-### Good ad hoc output shape
-
-For multi-version questions, script toward a compact row per version, but only include the fields the user asked for:
-
-- version
-- support status
-- built-in packages
-- extra-feed packages and registration command
-- dependency package names
+- Run one structured `jq` or `python3` pass across the resolved file set; emit one compact row per version with only the fields the user asked for (support, built-in packages, extra-feed packages, dependencies).
+- Stop as soon as all requested facets are answered — do not collect a superset "just in case."
 
 ## Output guidance
 
@@ -204,11 +173,3 @@ For multi-version questions, script toward a compact row per version, but only i
 - For single-version or single-facet questions, prefer a short direct answer over a full table.
 - Call out uncertainty explicitly when the repo has incomplete data for a version.
 
-## Example framing
-
-For a combined Linux distro query:
-
-1. Resolve whether the user asked about one version or many.
-2. Use `supported-os.json` for support.
-3. Use `distros/<distro>.json` for package-feed availability and dependencies when that schema exists.
-4. Only use `os-packages.json` for older dependency-only fallback cases.

--- a/.github/skills/update-distro-packages/SKILL.md
+++ b/.github/skills/update-distro-packages/SKILL.md
@@ -5,7 +5,8 @@ description: >
   that document .NET runtime dependencies and package availability for each
   Linux distribution. USE FOR: setting up distros/ for a new .NET version,
   updating dependency package names when distro versions change, auditing
-  package data. DO NOT USE FOR: supported-os.json changes (use
+  package data. DO NOT USE FOR: read-only support/package questions (use
+  query-os-support-packages skill), supported-os.json changes (use
   update-supported-os skill), os-packages.json (legacy format).
 ---
 

--- a/.github/skills/update-distro-packages/SKILL.md
+++ b/.github/skills/update-distro-packages/SKILL.md
@@ -7,7 +7,9 @@ description: >
   updating dependency package names when distro versions change, auditing
   package data. DO NOT USE FOR: read-only support/package questions (use
   query-os-support-packages skill), supported-os.json changes (use
-  update-supported-os skill), os-packages.json (legacy format).
+  update-supported-os skill), or standalone legacy os-packages maintenance.
+  For 8.0-10.0, pair distros updates with update-os-packages; for 11.0+,
+  distros/ is the only Linux package metadata scheme.
 ---
 
 # Update Distro Packages
@@ -32,6 +34,11 @@ release-notes/{version}/distros/
 - A distro release is added or removed from the support matrix
 - A dependency package name changes (e.g. `libicu74` → `libicu76` on a new Ubuntu)
 - Periodic audit to keep dependency data current
+
+## Version-specific maintenance rules
+
+- **8.0, 9.0, 10.0** — keep both `release-notes/{version}/distros/` **and** `os-packages.json` / `os-packages.md` in sync. Use this skill for the `distros/` side and run the companion legacy updates with [`update-os-packages`](../update-os-packages/SKILL.md) in the same change.
+- **11.0+** — update only `release-notes/{version}/distros/` and its generated `dotnet-dependencies.md` / `dotnet-packages.md` outputs. Do not create new `os-packages.*` data for these versions.
 
 ## Prerequisites
 
@@ -99,15 +106,15 @@ Omit `min_version` and `references` when null/empty.
 ```json
 {
   "channel_version": "11.0",
-  "distros": [
-    "alpine.json",
-    "azure_linux.json",
-    "ubuntu.json"
-  ]
+  "distros": {
+    "alpine.json": "Alpine",
+    "azure_linux.json": "Azure Linux",
+    "ubuntu.json": "Ubuntu"
+  }
 }
 ```
 
-Alphabetically sorted list of per-distro file names.
+Filename-to-display-name map, sorted by filename.
 
 ### Per-distro files (e.g. ubuntu.json)
 
@@ -417,6 +424,8 @@ git add release-notes/{version}/distros/ release-notes/{version}/dotnet-dependen
 git commit -m "Update {version} distro packages — <summary>"
 ```
 
+For **8.0-10.0**, include the companion `os-packages.json` / `os-packages.md` updates in the same PR or commit so both Linux package metadata schemes stay aligned.
+
 ## Known alternative feed commands
 
 When packages come from a non-builtin feed, the `install_command` field tells users how to register that feed before installing packages. Use the exact commands below.
@@ -448,6 +457,8 @@ If the query returns a feed name not listed above, ask the user for the registra
 ## Key facts
 
 - Files are version-scoped — `release-notes/11.0/distros/ubuntu.json` is about .NET 11.0 on Ubuntu
+- Versions **8.0-10.0** still have two maintained Linux package metadata schemes: `distros/` and `os-packages.*`
+- Versions **11.0+** use only the `distros/` scheme for Linux package metadata
 - Dependencies use an agnostic `id` (e.g. `libicu`) with a distro-specific `name` (e.g. `libicu74`)
 - `dependencies.json` is the "what .NET needs" list; per-distro files map those to real package names
 - Package names like `libicu` are versioned on Debian/Ubuntu (e.g. `libicu76`) but not on Fedora/RHEL (just `libicu`)

--- a/.github/skills/update-os-packages/SKILL.md
+++ b/.github/skills/update-os-packages/SKILL.md
@@ -17,8 +17,11 @@ Audit and update `os-packages.json` files in this repository. These files declar
 
 The scope of `os-packages.json` is broader than `supported-os.json`. It includes any distro version where the package information is helpful — including pre-release versions of supported distros (e.g. Fedora 44 beta) and permanent unstable channels (Alpine edge, Debian sid).
 
+`os-packages.*` remains an active maintenance surface only for **8.0, 9.0, and 10.0**. For those versions, keep the newer `release-notes/{version}/distros/` data in sync in the same change by also following [`update-distro-packages`](../update-distro-packages/SKILL.md). For **11.0+**, use only the `distros/` scheme and do not add new `os-packages.*` entries.
+
 ## When to use
 
+- Updating Linux package metadata for **8.0, 9.0, or 10.0**
 - A new distro version is added to `supported-os.json` and needs package entries
 - A pre-release distro version is available and package info would be helpful (e.g. Fedora beta, Ubuntu interim release)
 - A package name changes between distro releases (e.g. `libicu74` → `libicu76`)
@@ -218,6 +221,9 @@ CI runs markdownlint via super-linter. If linting fails, fix the generator or Ma
 ## Key facts
 
 - The scope of `os-packages.json` is broader than `supported-os.json` — it includes pre-release and unstable versions
+- `os-packages.*` is still maintained for **8.0, 9.0, and 10.0** only
+- For **8.0-10.0**, any Linux package metadata update should keep `distros/`, `dotnet-dependencies.md`, and `dotnet-packages.md` aligned in the same change
+- For **11.0+**, update `distros/` only — do not add or revive `os-packages.*`
 - Alpine edge and Debian sid are permanent entries — they should always be present and kept up to date
 - Any pre-release version of a supported distro is OK to add (e.g. Fedora beta, Ubuntu interim)
 - Package names vary across distro versions — e.g. `libicu74` on Ubuntu 24.04 vs `libicu76` on Ubuntu 26.04

--- a/.github/skills/update-os-packages/SKILL.md
+++ b/.github/skills/update-os-packages/SKILL.md
@@ -5,8 +5,9 @@ description: >
   packages for each .NET release. Uses the release-notes tool to verify
   package names against distro archives and regenerate markdown. USE FOR:
   adding packages for new distro versions, fixing incorrect package names,
-  periodic package audits. DO NOT USE FOR: supported-os.json changes (use
-  update-supported-os skill), editing os-packages.md directly (it is
+  periodic package audits. DO NOT USE FOR: read-only support/package
+  questions (use query-os-support-packages skill), supported-os.json changes
+  (use update-supported-os skill), editing os-packages.md directly (it is
   generated from JSON).
 ---
 

--- a/.github/skills/update-supported-os/SKILL.md
+++ b/.github/skills/update-supported-os/SKILL.md
@@ -5,8 +5,10 @@ description: >
   support. Uses the release-notes tool for automated verification against
   upstream lifecycle data and markdown regeneration. USE FOR: adding new OS
   versions, moving EOL versions to unsupported, periodic support matrix audits.
-  DO NOT USE FOR: os-packages.json changes (use update-os-packages skill),
-  editing supported-os.md directly (it is generated from JSON).
+  DO NOT USE FOR: read-only support/package questions (use
+  query-os-support-packages skill), os-packages.json changes (use
+  update-os-packages skill), editing supported-os.md directly (it is generated
+  from JSON).
 ---
 
 # Update Supported OS

--- a/release-notes/10.0/distros/ubuntu.json
+++ b/release-notes/10.0/distros/ubuntu.json
@@ -208,7 +208,7 @@
             },
             {
               "component": "aspnetcore-runtime",
-              "name": "dotnet-aspnetcore-runtime-10.0"
+              "name": "aspnetcore-runtime-10.0"
             }
           ],
           "install_command": "sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update"

--- a/release-notes/10.0/dotnet-packages.md
+++ b/release-notes/10.0/dotnet-packages.md
@@ -224,7 +224,7 @@ sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
 ```bash
 sudo apt-get update && \
 sudo apt-get install -y \
-    dotnet-aspnetcore-runtime-10.0 \
+    aspnetcore-runtime-10.0 \
     dotnet-runtime-10.0 \
     dotnet-sdk-10.0
 ```

--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -1,6 +1,6 @@
 {
   "channel-version": "10.0",
-  "last-updated": "2026-04-06",
+  "last-updated": "2026-04-17",
   "families": [
     {
       "name": "Android",
@@ -65,7 +65,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20"]
         },
         {
           "id": "azure-linux",
@@ -132,7 +133,7 @@
           "link": "https://ubuntu.com/",
           "lifecycle": "https://wiki.ubuntu.com/Releases",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["25.10", "24.04", "22.04"]
+          "supported-versions": ["26.04", "25.10", "24.04", "22.04"]
         }
       ]
     },

--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 10.0 - Supported OS versions
 
-Last Updated: 2026/04/06; Support phase: Active
+Last Updated: 2026/04/17; Support phase: Active
 
 [.NET 10.0](README.md) is an [LTS](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions                   | Architectures              | Lifecycle       |
+| ------------------------------ | -------------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21           | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12                     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 43, 42                     | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6                 | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7                 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 26.04, 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -113,8 +113,9 @@ Notes:
 
 OS versions that are out of support by the OS publisher are not tested or supported by .NET.
 
-| OS      | Version     | End of Life       |
-| ------- | ----------- | ----------------- |
-| Android | 13          | 2026-03-02        |
+| OS      | Version | End of Life           |
+| ------- | ------- | --------------------- |
+| Alpine  | 3.20    | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)      |
+| Android | 13      | 2026-03-02            |
 | SUSE Linux Enterprise | 15.6 | 2025-12-31 |
 | Windows | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |

--- a/release-notes/11.0/distros/ubuntu.json
+++ b/release-notes/11.0/distros/ubuntu.json
@@ -24,7 +24,7 @@
         },
         {
           "id": "libicu",
-          "name": "libicu76"
+          "name": "libicu78"
         },
         {
           "id": "libstdc++",

--- a/release-notes/11.0/dotnet-dependencies.md
+++ b/release-notes/11.0/dotnet-dependencies.md
@@ -223,23 +223,9 @@ sudo zypper install -y \
     timezone
 ```
 
-## RHEL
+## Red Hat Enterprise Linux
 
-### RHEL 10
-
-```bash
-sudo dnf install -y \
-    ca-certificates \
-    glibc \
-    krb5-libs \
-    libgcc \
-    libicu \
-    libstdc++ \
-    openssl-libs \
-    tzdata
-```
-
-### RHEL 9
+### Red Hat Enterprise Linux 10
 
 ```bash
 sudo dnf install -y \
@@ -253,7 +239,7 @@ sudo dnf install -y \
     tzdata
 ```
 
-### RHEL 8
+### Red Hat Enterprise Linux 9
 
 ```bash
 sudo dnf install -y \
@@ -267,9 +253,23 @@ sudo dnf install -y \
     tzdata
 ```
 
-## SLES
+### Red Hat Enterprise Linux 8
 
-### SLES 16.0
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## SUSE Linux Enterprise Server
+
+### SUSE Linux Enterprise Server 16.0
 
 ```bash
 sudo zypper install -y \
@@ -283,7 +283,7 @@ sudo zypper install -y \
     timezone
 ```
 
-### SLES 15.7
+### SUSE Linux Enterprise Server 15.7
 
 ```bash
 sudo zypper install -y \
@@ -297,7 +297,7 @@ sudo zypper install -y \
     timezone
 ```
 
-### SLES 15.6
+### SUSE Linux Enterprise Server 15.6
 
 ```bash
 sudo zypper install -y \
@@ -322,7 +322,7 @@ sudo apt-get install -y \
     libc6 \
     libgcc-s1 \
     libgssapi-krb5-2 \
-    libicu76 \
+    libicu78 \
     libssl3t64 \
     libstdc++6 \
     tzdata

--- a/release-notes/8.0/distros/alpine.json
+++ b/release-notes/8.0/distros/alpine.json
@@ -1,0 +1,266 @@
+{
+  "name": "Alpine",
+  "install_command": "apk add {packages}",
+  "releases": [
+    {
+      "name": "Alpine edge",
+      "release": "edge",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet8-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet8-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore8-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.23",
+      "release": "3.23",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet8-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet8-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore8-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.22",
+      "release": "3.22",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet8-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet8-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore8-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.21",
+      "release": "3.21",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet8-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet8-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore8-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.20",
+      "release": "3.20",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet8-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet8-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore8-runtime"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/azure_linux.json
+++ b/release-notes/8.0/distros/azure_linux.json
@@ -1,0 +1,44 @@
+{
+  "name": "Azure Linux",
+  "install_command": "tdnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Azure Linux 3.0",
+      "release": "3.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "icu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/centos_stream.json
+++ b/release-notes/8.0/distros/centos_stream.json
@@ -1,0 +1,148 @@
+{
+  "name": "CentOS Stream",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "CentOS Stream 10",
+      "release": "10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "CentOS Stream 9",
+      "release": "9",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "CentOS Stream 8",
+      "release": "8",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/debian.json
+++ b/release-notes/8.0/distros/debian.json
@@ -1,0 +1,120 @@
+{
+  "name": "Debian",
+  "install_command": "apt-get install -y {packages}",
+  "releases": [
+    {
+      "name": "Debian sid (Unstable)",
+      "release": "sid",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Debian 13 (Trixie)",
+      "release": "13",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Debian 12 (Bookworm)",
+      "release": "12",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu72"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/dependencies.json
+++ b/release-notes/8.0/distros/dependencies.json
@@ -1,0 +1,90 @@
+{
+  "channel_version": "8.0",
+  "packages": [
+    {
+      "id": "libc",
+      "name": "C Library",
+      "required_scenarios": [
+        "all"
+      ],
+      "references": [
+        "https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#linux-compatibility",
+        "https://www.gnu.org/software/libc/libc.html",
+        "https://musl.libc.org/"
+      ]
+    },
+    {
+      "id": "libgcc",
+      "name": "GCC low-level runtime library",
+      "required_scenarios": [
+        "all"
+      ],
+      "references": [
+        "https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html"
+      ]
+    },
+    {
+      "id": "ca-certificates",
+      "name": "CA Certificates",
+      "required_scenarios": [
+        "https"
+      ],
+      "references": [
+        "https://www.redhat.com/sysadmin/ca-certificates-cli"
+      ]
+    },
+    {
+      "id": "openssl",
+      "name": "OpenSSL",
+      "required_scenarios": [
+        "https",
+        "cryptography"
+      ],
+      "min_version": "1.1.1",
+      "references": [
+        "https://www.openssl.org/"
+      ]
+    },
+    {
+      "id": "libstdc++",
+      "name": "C++ Library",
+      "required_scenarios": [
+        "runtime"
+      ],
+      "references": [
+        "https://gcc.gnu.org/onlinedocs/libstdc++/"
+      ]
+    },
+    {
+      "id": "libicu",
+      "name": "ICU",
+      "required_scenarios": [
+        "globalization"
+      ],
+      "references": [
+        "https://icu.unicode.org",
+        "https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md"
+      ]
+    },
+    {
+      "id": "tzdata",
+      "name": "tz database",
+      "required_scenarios": [
+        "globalization"
+      ],
+      "references": [
+        "https://data.iana.org/time-zones/tz-link.html"
+      ]
+    },
+    {
+      "id": "krb5",
+      "name": "Kerberos",
+      "required_scenarios": [
+        "kerberos"
+      ],
+      "references": [
+        "https://web.mit.edu/kerberos"
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/fedora.json
+++ b/release-notes/8.0/distros/fedora.json
@@ -1,0 +1,186 @@
+{
+  "name": "Fedora",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Fedora 44",
+      "release": "44",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 43",
+      "release": "43",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 42",
+      "release": "42",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 41",
+      "release": "41",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/freebsd.json
+++ b/release-notes/8.0/distros/freebsd.json
@@ -1,0 +1,20 @@
+{
+  "name": "FreeBSD",
+  "install_command": "pkg install -A {packages}",
+  "releases": [
+    {
+      "name": "FreeBSD 14.1",
+      "release": "14.1",
+      "dependencies": [
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libicu",
+          "name": "icu"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/index.json
+++ b/release-notes/8.0/distros/index.json
@@ -1,0 +1,15 @@
+{
+  "channel_version": "8.0",
+  "distros": {
+    "alpine.json": "Alpine",
+    "azure_linux.json": "Azure Linux",
+    "centos_stream.json": "CentOS Stream",
+    "debian.json": "Debian",
+    "fedora.json": "Fedora",
+    "freebsd.json": "FreeBSD",
+    "opensuse_leap.json": "openSUSE Leap",
+    "rhel.json": "Red Hat Enterprise Linux",
+    "sles.json": "SUSE Linux Enterprise Server",
+    "ubuntu.json": "Ubuntu"
+  }
+}

--- a/release-notes/8.0/distros/opensuse_leap.json
+++ b/release-notes/8.0/distros/opensuse_leap.json
@@ -1,0 +1,82 @@
+{
+  "name": "openSUSE Leap",
+  "install_command": "zypper install -y {packages}",
+  "releases": [
+    {
+      "name": "openSUSE Leap 16.0",
+      "release": "16.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "openSUSE Leap 15.6",
+      "release": "15.6",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/rhel.json
+++ b/release-notes/8.0/distros/rhel.json
@@ -1,0 +1,162 @@
+{
+  "name": "Red Hat Enterprise Linux",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Red Hat Enterprise Linux 10",
+      "release": "10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Red Hat Enterprise Linux 9",
+      "release": "9",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Red Hat Enterprise Linux 8",
+      "release": "8",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/sles.json
+++ b/release-notes/8.0/distros/sles.json
@@ -1,0 +1,120 @@
+{
+  "name": "SUSE Linux Enterprise Server",
+  "install_command": "zypper install -y {packages}",
+  "releases": [
+    {
+      "name": "SUSE Linux Enterprise Server 16.0",
+      "release": "16.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "SUSE Linux Enterprise Server 15.7",
+      "release": "15.7",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "SUSE Linux Enterprise Server 15.6",
+      "release": "15.6",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/distros/ubuntu.json
+++ b/release-notes/8.0/distros/ubuntu.json
@@ -53,7 +53,7 @@
             },
             {
               "component": "aspnetcore-runtime",
-              "name": "dotnet-aspnetcore-runtime-8.0"
+              "name": "aspnetcore-runtime-8.0"
             }
           ]
         }

--- a/release-notes/8.0/distros/ubuntu.json
+++ b/release-notes/8.0/distros/ubuntu.json
@@ -1,0 +1,219 @@
+{
+  "name": "Ubuntu",
+  "install_command": "apt-get install -y {packages}",
+  "releases": [
+    {
+      "name": "Ubuntu 26.04 LTS (Resolute Raccoon)",
+      "release": "26.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu78"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages_other": {
+        "backports": {
+          "install_command": "sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update",
+          "packages": [
+            {
+              "component": "sdk",
+              "name": "dotnet-sdk-8.0"
+            },
+            {
+              "component": "runtime",
+              "name": "dotnet-runtime-8.0"
+            },
+            {
+              "component": "aspnetcore-runtime",
+              "name": "dotnet-aspnetcore-runtime-8.0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ubuntu 25.10 (Questing Quokka)",
+      "release": "25.10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Ubuntu 24.04 (Noble Numbat)",
+      "release": "24.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu74"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    },
+    {
+      "name": "Ubuntu 22.04.4 LTS (Jammy Jellyfish)",
+      "release": "22.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu70"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-8.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-8.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-8.0"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/8.0/dotnet-dependencies.md
+++ b/release-notes/8.0/dotnet-dependencies.md
@@ -1,0 +1,459 @@
+# .NET 8.0 Linux package dependencies
+
+.NET 8.0 has several dependencies that must be installed to run .NET apps. The install commands for each supported Linux distribution are listed below.
+
+Tips:
+
+- [runtime-deps container images](https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps) install these same packages.
+- [pkgs.org](https://pkgs.org/) is useful for searching packages across distributions.
+
+## Packages
+
+- [C Library][0]
+- [GCC low-level runtime library][1]
+- [CA Certificates][2]
+- [OpenSSL][3]
+- [C++ Library][4]
+- [ICU][5]
+- [tz database][6]
+- [Kerberos][7]
+
+You do not need to install ICU if you [enable globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode).
+
+If your app relies on `https` endpoints, you'll also need to install `ca-certificates`.
+
+[0]: https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#linux-compatibility
+[1]: https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html
+[2]: https://www.redhat.com/sysadmin/ca-certificates-cli
+[3]: https://www.openssl.org/
+[4]: https://gcc.gnu.org/onlinedocs/libstdc++/
+[5]: https://icu.unicode.org
+[6]: https://data.iana.org/time-zones/tz-link.html
+[7]: https://web.mit.edu/kerberos
+
+## Alpine
+
+### Alpine edge
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.23
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.22
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.21
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.20
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+## Azure Linux
+
+### Azure Linux 3.0
+
+```bash
+sudo tdnf install -y \
+    ca-certificates \
+    glibc \
+    icu \
+    krb5 \
+    libgcc \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## CentOS Stream
+
+### CentOS Stream 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## Debian
+
+### Debian sid (Unstable)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Debian 13 (Trixie)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Debian 12 (Bookworm)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu72 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```
+
+## Fedora
+
+### Fedora 44
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 43
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 42
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 41
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## FreeBSD
+
+### FreeBSD 14.1
+
+```bash
+sudo pkg install -A \
+    icu \
+    krb5
+```
+
+## openSUSE Leap
+
+### openSUSE Leap 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### openSUSE Leap 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## Red Hat Enterprise Linux
+
+### Red Hat Enterprise Linux 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Red Hat Enterprise Linux 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Red Hat Enterprise Linux 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## SUSE Linux Enterprise Server
+
+### SUSE Linux Enterprise Server 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SUSE Linux Enterprise Server 15.7
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SUSE Linux Enterprise Server 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## Ubuntu
+
+### Ubuntu 26.04 LTS (Resolute Raccoon)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu78 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 25.10 (Questing Quokka)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 24.04 (Noble Numbat)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu74 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu70 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```

--- a/release-notes/8.0/dotnet-packages.md
+++ b/release-notes/8.0/dotnet-packages.md
@@ -1,0 +1,188 @@
+# .NET 8.0 Linux packages
+
+.NET 8.0 is available in the package feeds of the following Linux distributions.
+
+| Distribution | Version | Feed |
+| ------------ | ------- | ---- |
+| Alpine       | Alpine edge | Built-in |
+| Alpine       | Alpine 3.23 | Built-in |
+| Alpine       | Alpine 3.22 | Built-in |
+| Alpine       | Alpine 3.21 | Built-in |
+| Alpine       | Alpine 3.20 | Built-in |
+| CentOS Stream | CentOS Stream 10 | Built-in |
+| CentOS Stream | CentOS Stream 9 | Built-in |
+| Fedora       | Fedora 43 | Built-in |
+| Fedora       | Fedora 42 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 10 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 9 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 8 | Built-in |
+| Ubuntu       | Ubuntu 26.04 LTS (Resolute Raccoon) | Backports PPA |
+| Ubuntu       | Ubuntu 25.10 (Questing Quokka) | Built-in |
+| Ubuntu       | Ubuntu 24.04 (Noble Numbat) | Built-in |
+| Ubuntu       | Ubuntu 22.04.4 LTS (Jammy Jellyfish) | Built-in |
+
+## Alpine
+
+### Alpine edge
+
+```bash
+sudo apk add \
+    aspnetcore8-runtime \
+    dotnet8-runtime \
+    dotnet8-sdk
+```
+
+### Alpine 3.23
+
+```bash
+sudo apk add \
+    aspnetcore8-runtime \
+    dotnet8-runtime \
+    dotnet8-sdk
+```
+
+### Alpine 3.22
+
+```bash
+sudo apk add \
+    aspnetcore8-runtime \
+    dotnet8-runtime \
+    dotnet8-sdk
+```
+
+### Alpine 3.21
+
+```bash
+sudo apk add \
+    aspnetcore8-runtime \
+    dotnet8-runtime \
+    dotnet8-sdk
+```
+
+### Alpine 3.20
+
+```bash
+sudo apk add \
+    aspnetcore8-runtime \
+    dotnet8-runtime \
+    dotnet8-sdk
+```
+
+## CentOS Stream
+
+### CentOS Stream 10
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### CentOS Stream 9
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+## Fedora
+
+### Fedora 43
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Fedora 42
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+## Red Hat Enterprise Linux
+
+### Red Hat Enterprise Linux 10
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Red Hat Enterprise Linux 9
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Red Hat Enterprise Linux 8
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+## Ubuntu
+
+### Ubuntu 26.04 LTS (Resolute Raccoon)
+
+**Backports PPA:**
+
+Register the feed:
+
+```bash
+sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
+```
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    dotnet-aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Ubuntu 25.10 (Questing Quokka)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Ubuntu 24.04 (Noble Numbat)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```
+
+### Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    aspnetcore-runtime-8.0 \
+    dotnet-runtime-8.0 \
+    dotnet-sdk-8.0
+```

--- a/release-notes/8.0/dotnet-packages.md
+++ b/release-notes/8.0/dotnet-packages.md
@@ -152,7 +152,7 @@ sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
 ```bash
 sudo apt-get update && \
 sudo apt-get install -y \
-    dotnet-aspnetcore-runtime-8.0 \
+    aspnetcore-runtime-8.0 \
     dotnet-runtime-8.0 \
     dotnet-sdk-8.0
 ```

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -1,6 +1,6 @@
 {
   "channel-version": "8.0",
-  "last-updated": "2026-04-07",
+  "last-updated": "2026-04-17",
   "families": [
     {
       "name": "Android",
@@ -69,8 +69,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"],
-          "unsupported-versions": ["3.19", "3.18", "3.17", "3.16"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20", "3.19", "3.18", "3.17", "3.16"]
         },
         {
           "id": "azure-linux",
@@ -140,7 +140,7 @@
           "link": "https://ubuntu.com/",
           "lifecycle": "https://wiki.ubuntu.com/Releases",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["25.10", "24.04", "22.04"],
+          "supported-versions": ["26.04", "25.10", "24.04", "22.04"],
           "unsupported-versions": ["25.04", "24.10", "20.04", "23.10", "23.04"]
         }
       ]

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 8.0 - Supported OS versions
 
-Last Updated: 2026/04/06; Support phase: Active
+Last Updated: 2026/04/17; Support phase: Active
 
 [.NET 8.0](README.md) is an [LTS](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions                   | Architectures              | Lifecycle       |
+| ------------------------------ | -------------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21           | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12                     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 43, 42                     | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6                 | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7                 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 26.04, 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -114,12 +114,13 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 
 | OS                    | Version     | End of Life   |
 | --------------------- | ----------- | ------------- |
+| Alpine                | 3.20        | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.19        | [2025-11-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.18        | [2025-05-09](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.17        | [2024-11-22](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.16        | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)            |
 | Android               | 13          | 2026-03-02    |
-| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L/summary)                        |
+| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L)                                |
 | Android               | 12          | 2025-03-03    |
 | Android               | 11          | 2024-02-05    |
 | Debian                | 11          | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)                      |

--- a/release-notes/9.0/distros/alpine.json
+++ b/release-notes/9.0/distros/alpine.json
@@ -1,0 +1,252 @@
+{
+  "name": "Alpine",
+  "install_command": "apk add {packages}",
+  "releases": [
+    {
+      "name": "Alpine edge",
+      "release": "edge",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet9-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet9-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore9-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.23",
+      "release": "3.23",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet9-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet9-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore9-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.22",
+      "release": "3.22",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet9-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet9-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore9-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.21",
+      "release": "3.21",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet9-sdk"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet9-runtime"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore9-runtime"
+        }
+      ]
+    },
+    {
+      "name": "Alpine 3.20",
+      "release": "3.20",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "icu",
+          "name": "icu-data-full"
+        },
+        {
+          "id": "icu",
+          "name": "icu-libs"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/azure_linux.json
+++ b/release-notes/9.0/distros/azure_linux.json
@@ -1,0 +1,44 @@
+{
+  "name": "Azure Linux",
+  "install_command": "tdnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Azure Linux 3.0",
+      "release": "3.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "icu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/centos_stream.json
+++ b/release-notes/9.0/distros/centos_stream.json
@@ -1,0 +1,148 @@
+{
+  "name": "CentOS Stream",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "CentOS Stream 10",
+      "release": "10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "CentOS Stream 9",
+      "release": "9",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "CentOS Stream 8",
+      "release": "8",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/debian.json
+++ b/release-notes/9.0/distros/debian.json
@@ -1,0 +1,120 @@
+{
+  "name": "Debian",
+  "install_command": "apt-get install -y {packages}",
+  "releases": [
+    {
+      "name": "Debian sid (Unstable)",
+      "release": "sid",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Debian 13 (Trixie)",
+      "release": "13",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Debian 12 (Bookworm)",
+      "release": "12",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu72"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/dependencies.json
+++ b/release-notes/9.0/distros/dependencies.json
@@ -1,0 +1,90 @@
+{
+  "channel_version": "9.0",
+  "packages": [
+    {
+      "id": "libc",
+      "name": "C Library",
+      "required_scenarios": [
+        "all"
+      ],
+      "references": [
+        "https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md#linux-compatibility",
+        "https://www.gnu.org/software/libc/libc.html",
+        "https://musl.libc.org/"
+      ]
+    },
+    {
+      "id": "libgcc",
+      "name": "GCC low-level runtime library",
+      "required_scenarios": [
+        "all"
+      ],
+      "references": [
+        "https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html"
+      ]
+    },
+    {
+      "id": "ca-certificates",
+      "name": "CA Certificates",
+      "required_scenarios": [
+        "https"
+      ],
+      "references": [
+        "https://www.redhat.com/sysadmin/ca-certificates-cli"
+      ]
+    },
+    {
+      "id": "openssl",
+      "name": "OpenSSL",
+      "required_scenarios": [
+        "https",
+        "cryptography"
+      ],
+      "min_version": "1.1.1",
+      "references": [
+        "https://www.openssl.org/"
+      ]
+    },
+    {
+      "id": "libstdc++",
+      "name": "C++ Library",
+      "required_scenarios": [
+        "runtime"
+      ],
+      "references": [
+        "https://gcc.gnu.org/onlinedocs/libstdc++/"
+      ]
+    },
+    {
+      "id": "libicu",
+      "name": "ICU",
+      "required_scenarios": [
+        "globalization"
+      ],
+      "references": [
+        "https://icu.unicode.org",
+        "https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md"
+      ]
+    },
+    {
+      "id": "tzdata",
+      "name": "tz database",
+      "required_scenarios": [
+        "globalization"
+      ],
+      "references": [
+        "https://data.iana.org/time-zones/tz-link.html"
+      ]
+    },
+    {
+      "id": "krb5",
+      "name": "Kerberos",
+      "required_scenarios": [
+        "kerberos"
+      ],
+      "references": [
+        "https://web.mit.edu/kerberos"
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/fedora.json
+++ b/release-notes/9.0/distros/fedora.json
@@ -1,0 +1,186 @@
+{
+  "name": "Fedora",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Fedora 44",
+      "release": "44",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 43",
+      "release": "43",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 42",
+      "release": "42",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "Fedora 41",
+      "release": "41",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/freebsd.json
+++ b/release-notes/9.0/distros/freebsd.json
@@ -1,0 +1,20 @@
+{
+  "name": "FreeBSD",
+  "install_command": "pkg install -A {packages}",
+  "releases": [
+    {
+      "name": "FreeBSD 14.1",
+      "release": "14.1",
+      "dependencies": [
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libicu",
+          "name": "icu"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/index.json
+++ b/release-notes/9.0/distros/index.json
@@ -1,0 +1,15 @@
+{
+  "channel_version": "9.0",
+  "distros": {
+    "alpine.json": "Alpine",
+    "azure_linux.json": "Azure Linux",
+    "centos_stream.json": "CentOS Stream",
+    "debian.json": "Debian",
+    "fedora.json": "Fedora",
+    "freebsd.json": "FreeBSD",
+    "opensuse_leap.json": "openSUSE Leap",
+    "rhel.json": "Red Hat Enterprise Linux",
+    "sles.json": "SUSE Linux Enterprise Server",
+    "ubuntu.json": "Ubuntu"
+  }
+}

--- a/release-notes/9.0/distros/opensuse_leap.json
+++ b/release-notes/9.0/distros/opensuse_leap.json
@@ -1,0 +1,82 @@
+{
+  "name": "openSUSE Leap",
+  "install_command": "zypper install -y {packages}",
+  "releases": [
+    {
+      "name": "openSUSE Leap 16.0",
+      "release": "16.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "openSUSE Leap 15.6",
+      "release": "15.6",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/rhel.json
+++ b/release-notes/9.0/distros/rhel.json
@@ -1,0 +1,162 @@
+{
+  "name": "Red Hat Enterprise Linux",
+  "install_command": "dnf install -y {packages}",
+  "releases": [
+    {
+      "name": "Red Hat Enterprise Linux 10",
+      "release": "10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "Red Hat Enterprise Linux 9",
+      "release": "9",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "Red Hat Enterprise Linux 8",
+      "release": "8",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/sles.json
+++ b/release-notes/9.0/distros/sles.json
@@ -1,0 +1,120 @@
+{
+  "name": "SUSE Linux Enterprise Server",
+  "install_command": "zypper install -y {packages}",
+  "releases": [
+    {
+      "name": "SUSE Linux Enterprise Server 16.0",
+      "release": "16.0",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "SUSE Linux Enterprise Server 15.7",
+      "release": "15.7",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    },
+    {
+      "name": "SUSE Linux Enterprise Server 15.6",
+      "release": "15.6",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc_s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libopenssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "timezone"
+        }
+      ]
+    }
+  ]
+}

--- a/release-notes/9.0/distros/ubuntu.json
+++ b/release-notes/9.0/distros/ubuntu.json
@@ -53,7 +53,7 @@
             },
             {
               "component": "aspnetcore-runtime",
-              "name": "dotnet-aspnetcore-runtime-9.0"
+              "name": "aspnetcore-runtime-9.0"
             }
           ]
         }
@@ -162,7 +162,7 @@
             },
             {
               "component": "aspnetcore-runtime",
-              "name": "dotnet-aspnetcore-runtime-9.0"
+              "name": "aspnetcore-runtime-9.0"
             }
           ]
         }
@@ -219,7 +219,7 @@
             },
             {
               "component": "aspnetcore-runtime",
-              "name": "dotnet-aspnetcore-runtime-9.0"
+              "name": "aspnetcore-runtime-9.0"
             }
           ]
         }

--- a/release-notes/9.0/distros/ubuntu.json
+++ b/release-notes/9.0/distros/ubuntu.json
@@ -1,0 +1,229 @@
+{
+  "name": "Ubuntu",
+  "install_command": "apt-get install -y {packages}",
+  "releases": [
+    {
+      "name": "Ubuntu 26.04 LTS (Resolute Raccoon)",
+      "release": "26.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu78"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages_other": {
+        "backports": {
+          "install_command": "sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update",
+          "packages": [
+            {
+              "component": "sdk",
+              "name": "dotnet-sdk-9.0"
+            },
+            {
+              "component": "runtime",
+              "name": "dotnet-runtime-9.0"
+            },
+            {
+              "component": "aspnetcore-runtime",
+              "name": "dotnet-aspnetcore-runtime-9.0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ubuntu 25.10 (Questing Quokka)",
+      "release": "25.10",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu76"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages": [
+        {
+          "component": "sdk",
+          "name": "dotnet-sdk-9.0"
+        },
+        {
+          "component": "runtime",
+          "name": "dotnet-runtime-9.0"
+        },
+        {
+          "component": "aspnetcore-runtime",
+          "name": "aspnetcore-runtime-9.0"
+        }
+      ]
+    },
+    {
+      "name": "Ubuntu 24.04 (Noble Numbat)",
+      "release": "24.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu74"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3t64"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages_other": {
+        "backports": {
+          "install_command": "sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update",
+          "packages": [
+            {
+              "component": "sdk",
+              "name": "dotnet-sdk-9.0"
+            },
+            {
+              "component": "runtime",
+              "name": "dotnet-runtime-9.0"
+            },
+            {
+              "component": "aspnetcore-runtime",
+              "name": "dotnet-aspnetcore-runtime-9.0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ubuntu 22.04.4 LTS (Jammy Jellyfish)",
+      "release": "22.04",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "libgssapi-krb5-2"
+        },
+        {
+          "id": "libc",
+          "name": "libc6"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc-s1"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu70"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++6"
+        },
+        {
+          "id": "openssl",
+          "name": "libssl3"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ],
+      "dotnet_packages_other": {
+        "backports": {
+          "install_command": "sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update",
+          "packages": [
+            {
+              "component": "sdk",
+              "name": "dotnet-sdk-9.0"
+            },
+            {
+              "component": "runtime",
+              "name": "dotnet-runtime-9.0"
+            },
+            {
+              "component": "aspnetcore-runtime",
+              "name": "dotnet-aspnetcore-runtime-9.0"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/release-notes/9.0/dotnet-dependencies.md
+++ b/release-notes/9.0/dotnet-dependencies.md
@@ -1,0 +1,459 @@
+# .NET 9.0 Linux package dependencies
+
+.NET 9.0 has several dependencies that must be installed to run .NET apps. The install commands for each supported Linux distribution are listed below.
+
+Tips:
+
+- [runtime-deps container images](https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps) install these same packages.
+- [pkgs.org](https://pkgs.org/) is useful for searching packages across distributions.
+
+## Packages
+
+- [C Library][0]
+- [GCC low-level runtime library][1]
+- [CA Certificates][2]
+- [OpenSSL][3]
+- [C++ Library][4]
+- [ICU][5]
+- [tz database][6]
+- [Kerberos][7]
+
+You do not need to install ICU if you [enable globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode).
+
+If your app relies on `https` endpoints, you'll also need to install `ca-certificates`.
+
+[0]: https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md#linux-compatibility
+[1]: https://gcc.gnu.org/onlinedocs/gccint/Libgcc.html
+[2]: https://www.redhat.com/sysadmin/ca-certificates-cli
+[3]: https://www.openssl.org/
+[4]: https://gcc.gnu.org/onlinedocs/libstdc++/
+[5]: https://icu.unicode.org
+[6]: https://data.iana.org/time-zones/tz-link.html
+[7]: https://web.mit.edu/kerberos
+
+## Alpine
+
+### Alpine edge
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.23
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.22
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.21
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+### Alpine 3.20
+
+```bash
+sudo apk add \
+    ca-certificates \
+    icu-data-full \
+    icu-libs \
+    krb5 \
+    libgcc \
+    libssl3 \
+    libstdc++ \
+    tzdata
+```
+
+## Azure Linux
+
+### Azure Linux 3.0
+
+```bash
+sudo tdnf install -y \
+    ca-certificates \
+    glibc \
+    icu \
+    krb5 \
+    libgcc \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## CentOS Stream
+
+### CentOS Stream 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### CentOS Stream 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## Debian
+
+### Debian sid (Unstable)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Debian 13 (Trixie)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Debian 12 (Bookworm)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu72 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```
+
+## Fedora
+
+### Fedora 44
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 43
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 42
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Fedora 41
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## FreeBSD
+
+### FreeBSD 14.1
+
+```bash
+sudo pkg install -A \
+    icu \
+    krb5
+```
+
+## openSUSE Leap
+
+### openSUSE Leap 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### openSUSE Leap 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## Red Hat Enterprise Linux
+
+### Red Hat Enterprise Linux 10
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Red Hat Enterprise Linux 9
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+### Red Hat Enterprise Linux 8
+
+```bash
+sudo dnf install -y \
+    ca-certificates \
+    glibc \
+    krb5-libs \
+    libgcc \
+    libicu \
+    libstdc++ \
+    openssl-libs \
+    tzdata
+```
+
+## SUSE Linux Enterprise Server
+
+### SUSE Linux Enterprise Server 16.0
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SUSE Linux Enterprise Server 15.7
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+### SUSE Linux Enterprise Server 15.6
+
+```bash
+sudo zypper install -y \
+    ca-certificates \
+    glibc \
+    krb5 \
+    libgcc_s1 \
+    libicu \
+    libopenssl3 \
+    libstdc++6 \
+    timezone
+```
+
+## Ubuntu
+
+### Ubuntu 26.04 LTS (Resolute Raccoon)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu78 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 25.10 (Questing Quokka)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu76 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 24.04 (Noble Numbat)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu74 \
+    libssl3t64 \
+    libstdc++6 \
+    tzdata
+```
+
+### Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    ca-certificates \
+    libc6 \
+    libgcc-s1 \
+    libgssapi-krb5-2 \
+    libicu70 \
+    libssl3 \
+    libstdc++6 \
+    tzdata
+```

--- a/release-notes/9.0/dotnet-packages.md
+++ b/release-notes/9.0/dotnet-packages.md
@@ -142,7 +142,7 @@ sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
 ```bash
 sudo apt-get update && \
 sudo apt-get install -y \
-    dotnet-aspnetcore-runtime-9.0 \
+    aspnetcore-runtime-9.0 \
     dotnet-runtime-9.0 \
     dotnet-sdk-9.0
 ```
@@ -170,7 +170,7 @@ sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
 ```bash
 sudo apt-get update && \
 sudo apt-get install -y \
-    dotnet-aspnetcore-runtime-9.0 \
+    aspnetcore-runtime-9.0 \
     dotnet-runtime-9.0 \
     dotnet-sdk-9.0
 ```
@@ -188,7 +188,7 @@ sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
 ```bash
 sudo apt-get update && \
 sudo apt-get install -y \
-    dotnet-aspnetcore-runtime-9.0 \
+    aspnetcore-runtime-9.0 \
     dotnet-runtime-9.0 \
     dotnet-sdk-9.0
 ```

--- a/release-notes/9.0/dotnet-packages.md
+++ b/release-notes/9.0/dotnet-packages.md
@@ -1,0 +1,194 @@
+# .NET 9.0 Linux packages
+
+.NET 9.0 is available in the package feeds of the following Linux distributions.
+
+| Distribution | Version | Feed |
+| ------------ | ------- | ---- |
+| Alpine       | Alpine edge | Built-in |
+| Alpine       | Alpine 3.23 | Built-in |
+| Alpine       | Alpine 3.22 | Built-in |
+| Alpine       | Alpine 3.21 | Built-in |
+| CentOS Stream | CentOS Stream 10 | Built-in |
+| CentOS Stream | CentOS Stream 9 | Built-in |
+| Fedora       | Fedora 43 | Built-in |
+| Fedora       | Fedora 42 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 10 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 9 | Built-in |
+| Red Hat Enterprise Linux | Red Hat Enterprise Linux 8 | Built-in |
+| Ubuntu       | Ubuntu 26.04 LTS (Resolute Raccoon) | Backports PPA |
+| Ubuntu       | Ubuntu 25.10 (Questing Quokka) | Built-in |
+| Ubuntu       | Ubuntu 24.04 (Noble Numbat) | Backports PPA |
+| Ubuntu       | Ubuntu 22.04.4 LTS (Jammy Jellyfish) | Backports PPA |
+
+## Alpine
+
+### Alpine edge
+
+```bash
+sudo apk add \
+    aspnetcore9-runtime \
+    dotnet9-runtime \
+    dotnet9-sdk
+```
+
+### Alpine 3.23
+
+```bash
+sudo apk add \
+    aspnetcore9-runtime \
+    dotnet9-runtime \
+    dotnet9-sdk
+```
+
+### Alpine 3.22
+
+```bash
+sudo apk add \
+    aspnetcore9-runtime \
+    dotnet9-runtime \
+    dotnet9-sdk
+```
+
+### Alpine 3.21
+
+```bash
+sudo apk add \
+    aspnetcore9-runtime \
+    dotnet9-runtime \
+    dotnet9-sdk
+```
+
+## CentOS Stream
+
+### CentOS Stream 10
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### CentOS Stream 9
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+## Fedora
+
+### Fedora 43
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Fedora 42
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+## Red Hat Enterprise Linux
+
+### Red Hat Enterprise Linux 10
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Red Hat Enterprise Linux 9
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Red Hat Enterprise Linux 8
+
+```bash
+sudo dnf install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+## Ubuntu
+
+### Ubuntu 26.04 LTS (Resolute Raccoon)
+
+**Backports PPA:**
+
+Register the feed:
+
+```bash
+sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
+```
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    dotnet-aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Ubuntu 25.10 (Questing Quokka)
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Ubuntu 24.04 (Noble Numbat)
+
+**Backports PPA:**
+
+Register the feed:
+
+```bash
+sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
+```
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    dotnet-aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```
+
+### Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+
+**Backports PPA:**
+
+Register the feed:
+
+```bash
+sudo add-apt-repository ppa:dotnet/backports && sudo apt-get update
+```
+
+```bash
+sudo apt-get update && \
+sudo apt-get install -y \
+    dotnet-aspnetcore-runtime-9.0 \
+    dotnet-runtime-9.0 \
+    dotnet-sdk-9.0
+```

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -1,6 +1,6 @@
 {
   "channel-version": "9.0",
-  "last-updated": "2026-04-06",
+  "last-updated": "2026-04-17",
   "families": [
     {
       "name": "Android",
@@ -69,8 +69,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"],
-          "unsupported-versions": ["3.19"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20", "3.19"]
         },
         {
           "id": "azure-linux",
@@ -139,7 +139,7 @@
           "link": "https://ubuntu.com/",
           "lifecycle": "https://wiki.ubuntu.com/Releases",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["25.10", "24.04", "22.04"],
+          "supported-versions": ["26.04", "25.10", "24.04", "22.04"],
           "unsupported-versions": ["25.04", "24.10"]
         }
       ]

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 9.0 - Supported OS versions
 
-Last Updated: 2026/04/06; Support phase: Active
+Last Updated: 2026/04/17; Support phase: Active
 
 [.NET 9.0](README.md) is an [STS](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions                   | Architectures              | Lifecycle       |
+| ------------------------------ | -------------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21           | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12                     | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 43, 42                     | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0, 15.6                 | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7                 | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 26.04, 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -115,9 +115,10 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 
 | OS                    | Version     | End of Life   |
 | --------------------- | ----------- | ------------- |
+| Alpine                | 3.20        | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)  |
 | Alpine                | 3.19        | [2025-11-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)  |
 | Android               | 13          | 2026-03-02    |
-| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L/summary)                      |
+| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L)                              |
 | Android               | 12          | 2025-03-03    |
 | Fedora                | 41          | 2025-12-15    |
 | Fedora                | 40          | 2025-05-13    |


### PR DESCRIPTION
Adds a new read-only skill for answering .NET OS support, package availability, and native dependency questions, and brings the 8.0 and 9.0 release-notes metadata up to the current `distros/<distro>.json` schema. Also corrects the Ubuntu 26.04 ICU package name and refreshes related generated markdown.

## Changes

### New skill
- `.github/skills/query-os-support-packages/SKILL.md` — read-only skill covering support, package feeds (built-in vs extra-feed), and native dependencies, with source precedence, critical rules, canonical JSON paths, and JSON-first automation guidance.

### Related skill updates
- Minor clarifications to `update-supported-os`, `update-os-packages`, and `update-distro-packages` SKILL.md files.

### Data: new `distros/` metadata for 8.0 and 9.0
- Adds `release-notes/8.0/distros/` and `release-notes/9.0/distros/` with per-distro JSON for alpine, azure_linux, centos_stream, debian, fedora, freebsd, opensuse_leap, rhel, sles, ubuntu, plus `dependencies.json` and `index.json`.
- Regenerated `dotnet-dependencies.md` and `dotnet-packages.md` for 8.0 and 9.0.

### Data fixes
- Ubuntu 26.04 ICU dependency corrected to `libicu78` in 10.0 and 11.0 `distros/ubuntu.json`.
- `supported-os.json` / `supported-os.md` refreshed across 8.0, 9.0, and 10.0.
- Regenerated `release-notes/11.0/dotnet-dependencies.md` and `release-notes/10.0/dotnet-packages.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>