### PR TITLE
Add Fedora 44 and drop OS versions EOL by 2026-05-01

### DIFF
--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -25,7 +25,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18"],
+          "supported-versions": ["26"],
+          "unsupported-versions": ["18"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {
@@ -33,7 +34,8 @@
           "name": "iPadOS",
           "link": "https://developer.apple.com/ipados/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18", "17"]
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17"]
         },
         {
           "id": "macos",
@@ -65,7 +67,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20"]
         },
         {
           "id": "azure-linux",
@@ -96,7 +99,7 @@
           "link": "https://fedoraproject.org/",
           "lifecycle": "https://fedoraproject.org/wiki/End_of_life",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["43", "42"]
+          "supported-versions": ["44", "43", "42"]
         },
         {
           "id": "opensuse",
@@ -104,7 +107,8 @@
           "link": "https://www.opensuse.org/",
           "lifecycle": "https://en.opensuse.org/Lifetime",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["16.0", "15.6"]
+          "supported-versions": ["16.0"],
+          "unsupported-versions": ["15.6"]
         },
         {
           "id": "rhel",

--- a/release-notes/10.0/supported-os.json
+++ b/release-notes/10.0/supported-os.json
@@ -25,8 +25,7 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26"],
-          "unsupported-versions": ["18"],
+          "supported-versions": ["26", "18"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {

--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -18,8 +18,8 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26, 18     | Arm64         | None      |
-| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [iOS][2]    | 26         | Arm64         | None      |
+| [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions            | Architectures              | Lifecycle       |
+| ------------------------------ | ------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21    | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                 | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9               | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12              | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 44, 43, 42          | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0                | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8            | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7          | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -113,8 +113,12 @@ Notes:
 
 OS versions that are out of support by the OS publisher are not tested or supported by .NET.
 
-| OS      | Version     | End of Life       |
-| ------- | ----------- | ----------------- |
-| Android | 13          | 2026-03-02        |
-| SUSE Linux Enterprise | 15.6 | 2025-12-31 |
-| Windows | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
+| OS                    | Version | End of Life           |
+| --------------------- | ------- | --------------------- |
+| Alpine                | 3.20    | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)      |
+| Android               | 13      | 2026-03-02            |
+| SUSE Linux Enterprise | 15.6    | 2025-12-31            |
+| Windows               | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
+| iOS                   | 18      | 2026-04-22            |
+| iPadOS                | 17      | 2025-09-15            |
+| openSUSE Leap         | 15.6    | [2026-04-30](https://en.opensuse.org/openSUSE:Roadmap#Leap_15.6)                                   |

--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -18,7 +18,7 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26         | Arm64         | None      |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
 | [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
@@ -119,6 +119,5 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 | Android               | 13      | 2026-03-02            |
 | SUSE Linux Enterprise | 15.6    | 2025-12-31            |
 | Windows               | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
-| iOS                   | 18      | 2026-04-22            |
 | iPadOS                | 17      | 2025-09-15            |
 | openSUSE Leap         | 15.6    | [2026-04-30](https://en.opensuse.org/openSUSE:Roadmap#Leap_15.6)                                   |

--- a/release-notes/11.0/distros/fedora.json
+++ b/release-notes/11.0/distros/fedora.json
@@ -3,6 +3,44 @@
   "install_command": "dnf install -y {packages}",
   "releases": [
     {
+      "name": "Fedora 44",
+      "release": "44",
+      "dependencies": [
+        {
+          "id": "ca-certificates",
+          "name": "ca-certificates"
+        },
+        {
+          "id": "krb5",
+          "name": "krb5-libs"
+        },
+        {
+          "id": "libc",
+          "name": "glibc"
+        },
+        {
+          "id": "libgcc",
+          "name": "libgcc"
+        },
+        {
+          "id": "libicu",
+          "name": "libicu"
+        },
+        {
+          "id": "libstdc++",
+          "name": "libstdc++"
+        },
+        {
+          "id": "openssl",
+          "name": "openssl-libs"
+        },
+        {
+          "id": "tzdata",
+          "name": "tzdata"
+        }
+      ]
+    },
+    {
       "name": "Fedora 43",
       "release": "43",
       "dependencies": [

--- a/release-notes/11.0/supported-os.json
+++ b/release-notes/11.0/supported-os.json
@@ -24,7 +24,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18"],
+          "supported-versions": ["26"],
+          "unsupported-versions": ["18"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {
@@ -32,7 +33,8 @@
           "name": "iPadOS",
           "link": "https://developer.apple.com/ipados/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18", "17"]
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17"]
         },
         {
           "id": "macos",
@@ -95,7 +97,7 @@
           "link": "https://fedoraproject.org/",
           "lifecycle": "https://fedoraproject.org/wiki/End_of_life",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["43"]
+          "supported-versions": ["44", "43"]
         },
         {
           "id": "opensuse",

--- a/release-notes/11.0/supported-os.json
+++ b/release-notes/11.0/supported-os.json
@@ -24,8 +24,7 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26"],
-          "unsupported-versions": ["18"],
+          "supported-versions": ["26", "18"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {

--- a/release-notes/11.0/supported-os.md
+++ b/release-notes/11.0/supported-os.md
@@ -18,8 +18,8 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26, 18     | Arm64         | None      |
-| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [iOS][2]    | 26         | Arm64         | None      |
+| [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
 
@@ -38,7 +38,7 @@ Notes:
 | [Azure Linux][8]               | 3.0                        | Arm64, x64                 | None            |
 | [CentOS Stream][9]             | 10, 9                      | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
 | [Debian][11]                   | 13                         | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43                         | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [Fedora][13]                   | 44, 43                     | Arm32, Arm64, x64          | [Lifecycle][14] |
 | [openSUSE Leap][15]            | 16.0                       | Arm64, x64                 | [Lifecycle][16] |
 | [Red Hat Enterprise Linux][17] | 10, 9, 8                   | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
 | [SUSE Linux Enterprise][19]    | 16.0, 15.7                 | Arm64, x64                 | [Lifecycle][20] |
@@ -108,3 +108,12 @@ Notes:
 
 - The [QEMU](https://www.qemu.org/) emulator is not supported to run .NET apps. QEMU is used, for example, to emulate Arm64 containers on x64, and vice versa.
 - Microsoft-provided portable Arm32 glibc builds are supported on distro versions with a [Y2038 compatible glibc](https://github.com/dotnet/core/discussions/9285), for example Debian 12, Ubuntu 22.04, and higher versions.
+
+## Out of support OS versions
+
+OS versions that are out of support by the OS publisher are not tested or supported by .NET.
+
+| OS     | Version | End of Life |
+| ------ | ------- | ----------- |
+| iOS    | 18      | 2026-04-22  |
+| iPadOS | 17      | 2025-09-15  |

--- a/release-notes/11.0/supported-os.md
+++ b/release-notes/11.0/supported-os.md
@@ -18,7 +18,7 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26         | Arm64         | None      |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
 | [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
@@ -115,5 +115,4 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 
 | OS     | Version | End of Life |
 | ------ | ------- | ----------- |
-| iOS    | 18      | 2026-04-22  |
 | iPadOS | 17      | 2025-09-15  |

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -25,8 +25,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26"],
-          "unsupported-versions": ["18", "17", "16", "15"],
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17", "16", "15"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {

--- a/release-notes/8.0/supported-os.json
+++ b/release-notes/8.0/supported-os.json
@@ -25,8 +25,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18"],
-          "unsupported-versions": ["17", "16", "15"],
+          "supported-versions": ["26"],
+          "unsupported-versions": ["18", "17", "16", "15"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {
@@ -34,8 +34,8 @@
           "name": "iPadOS",
           "link": "https://developer.apple.com/ipados/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18", "17"],
-          "unsupported-versions": ["16", "15"]
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17", "16", "15"]
         },
         {
           "id": "macos",
@@ -69,8 +69,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"],
-          "unsupported-versions": ["3.19", "3.18", "3.17", "3.16"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20", "3.19", "3.18", "3.17", "3.16"]
         },
         {
           "id": "azure-linux",
@@ -102,7 +102,7 @@
           "link": "https://fedoraproject.org/",
           "lifecycle": "https://fedoraproject.org/wiki/End_of_life",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["43", "42"],
+          "supported-versions": ["44", "43", "42"],
           "unsupported-versions": ["41", "40", "39", "38", "37"]
         },
         {
@@ -111,8 +111,8 @@
           "link": "https://www.opensuse.org/",
           "lifecycle": "https://en.opensuse.org/Lifetime",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["16.0", "15.6"],
-          "unsupported-versions": ["15.5", "15.4"]
+          "supported-versions": ["16.0"],
+          "unsupported-versions": ["15.6", "15.5", "15.4"]
         },
         {
           "id": "rhel",

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -18,7 +18,7 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26         | Arm64         | None      |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
 | [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
@@ -144,7 +144,6 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 | Windows               | 11 22H2 (W) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)   |
 | Windows               | 11 21H2 (E) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)   |
 | Windows               | 10 21H2 (E) | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
-| iOS                   | 18          | 2026-04-22    |
 | iOS                   | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)    |
 | iOS                   | 15          | 2025-03-31    |
 | iOS                   | 17          | 2024-11-19    |

--- a/release-notes/8.0/supported-os.md
+++ b/release-notes/8.0/supported-os.md
@@ -1,6 +1,6 @@
 # .NET 8.0 - Supported OS versions
 
-Last Updated: 2026/04/06; Support phase: Active
+Last Updated: 2026/04/07; Support phase: Active
 
 [.NET 8.0](README.md) is an [LTS](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
 
@@ -18,8 +18,8 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26, 18     | Arm64         | None      |
-| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [iOS][2]    | 26         | Arm64         | None      |
+| [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions            | Architectures              | Lifecycle       |
+| ------------------------------ | ------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21    | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                 | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9               | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12              | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 44, 43, 42          | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0                | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8            | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7          | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -114,12 +114,13 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 
 | OS                    | Version     | End of Life   |
 | --------------------- | ----------- | ------------- |
+| Alpine                | 3.20        | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.19        | [2025-11-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.18        | [2025-05-09](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.17        | [2024-11-22](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)    |
 | Alpine                | 3.16        | [2024-05-23](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)            |
 | Android               | 13          | 2026-03-02    |
-| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L/summary)                        |
+| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L)                                |
 | Android               | 12          | 2025-03-03    |
 | Android               | 11          | 2024-02-05    |
 | Debian                | 11          | [2024-08-14](https://lists.debian.org/debian-release/2024/06/msg00700.html)                      |
@@ -143,13 +144,16 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 | Windows               | 11 22H2 (W) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)   |
 | Windows               | 11 21H2 (E) | [2024-10-08](https://learn.microsoft.com/windows/release-health/windows11-release-information)   |
 | Windows               | 10 21H2 (E) | [2024-06-11](https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education) |
+| iOS                   | 18          | 2026-04-22    |
 | iOS                   | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)    |
 | iOS                   | 15          | 2025-03-31    |
 | iOS                   | 17          | 2024-11-19    |
+| iPadOS                | 17          | 2025-09-15    |
 | iPadOS                | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
 | iPadOS                | 15          | 2025-03-31    |
 | macOS                 | 13          | 2025-09-15    |
 | macOS                 | 12          | [2024-09-16](https://developer.apple.com/documentation/macos-release-notes/macos-12_0_1-release-notes)   |
+| openSUSE Leap         | 15.6        | [2026-04-30](https://en.opensuse.org/openSUSE:Roadmap#Leap_15.6)                                 |
 | openSUSE Leap         | 15.5        | 2024-12-31    |
 | openSUSE Leap         | 15.4        | 2023-12-07    |
 | tvOS                  | 18          | 2025-09-15    |

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -25,8 +25,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26"],
-          "unsupported-versions": ["18", "17", "16"],
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17", "16"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {

--- a/release-notes/9.0/supported-os.json
+++ b/release-notes/9.0/supported-os.json
@@ -25,8 +25,8 @@
           "name": "iOS",
           "link": "https://developer.apple.com/ios/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18"],
-          "unsupported-versions": ["17", "16"],
+          "supported-versions": ["26"],
+          "unsupported-versions": ["18", "17", "16"],
           "notes": ["iOS 12.2 is used as the minimum SDK target."]
         },
         {
@@ -34,8 +34,8 @@
           "name": "iPadOS",
           "link": "https://developer.apple.com/ipados/",
           "architectures": ["Arm64"],
-          "supported-versions": ["26", "18", "17"],
-          "unsupported-versions": ["16"]
+          "supported-versions": ["26", "18"],
+          "unsupported-versions": ["17", "16"]
         },
         {
           "id": "macos",
@@ -69,8 +69,8 @@
           "link": "https://alpinelinux.org/",
           "lifecycle": "https://alpinelinux.org/releases/",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["3.23", "3.22", "3.21", "3.20"],
-          "unsupported-versions": ["3.19"]
+          "supported-versions": ["3.23", "3.22", "3.21"],
+          "unsupported-versions": ["3.20", "3.19"]
         },
         {
           "id": "azure-linux",
@@ -101,7 +101,7 @@
           "link": "https://fedoraproject.org/",
           "lifecycle": "https://fedoraproject.org/wiki/End_of_life",
           "architectures": ["Arm32", "Arm64", "x64"],
-          "supported-versions": ["43", "42"],
+          "supported-versions": ["44", "43", "42"],
           "unsupported-versions": ["41", "40"]
         },
         {
@@ -110,8 +110,8 @@
           "link": "https://www.opensuse.org/",
           "lifecycle": "https://en.opensuse.org/Lifetime",
           "architectures": ["Arm64", "x64"],
-          "supported-versions": ["16.0", "15.6"],
-          "unsupported-versions": ["15.5"]
+          "supported-versions": ["16.0"],
+          "unsupported-versions": ["15.6", "15.5"]
         },
         {
           "id": "rhel",

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -18,8 +18,8 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26, 18     | Arm64         | None      |
-| [iPadOS][3] | 26, 18, 17 | Arm64         | None      |
+| [iOS][2]    | 26         | Arm64         | None      |
+| [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
 
@@ -32,17 +32,17 @@ Notes:
 
 ## Linux
 
-| OS                             | Versions               | Architectures              | Lifecycle       |
-| ------------------------------ | ---------------------- | -------------------------- | --------------- |
-| [Alpine][6]                    | 3.23, 3.22, 3.21, 3.20 | Arm32, Arm64, x64          | [Lifecycle][7]  |
-| [Azure Linux][8]               | 3.0                    | Arm64, x64                 | None            |
-| [CentOS Stream][9]             | 10, 9                  | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
-| [Debian][11]                   | 13, 12                 | Arm32, Arm64, x64          | [Lifecycle][12] |
-| [Fedora][13]                   | 43, 42                 | Arm32, Arm64, x64          | [Lifecycle][14] |
-| [openSUSE Leap][15]            | 16.0, 15.6             | Arm64, x64                 | [Lifecycle][16] |
-| [Red Hat Enterprise Linux][17] | 10, 9, 8               | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
-| [SUSE Linux Enterprise][19]    | 16.0, 15.7             | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04    | Arm32, Arm64, x64          | [Lifecycle][22] |
+| OS                             | Versions            | Architectures              | Lifecycle       |
+| ------------------------------ | ------------------- | -------------------------- | --------------- |
+| [Alpine][6]                    | 3.23, 3.22, 3.21    | Arm32, Arm64, x64          | [Lifecycle][7]  |
+| [Azure Linux][8]               | 3.0                 | Arm64, x64                 | None            |
+| [CentOS Stream][9]             | 10, 9               | Arm64, ppc64le, s390x, x64 | [Lifecycle][10] |
+| [Debian][11]                   | 13, 12              | Arm32, Arm64, x64          | [Lifecycle][12] |
+| [Fedora][13]                   | 44, 43, 42          | Arm32, Arm64, x64          | [Lifecycle][14] |
+| [openSUSE Leap][15]            | 16.0                | Arm64, x64                 | [Lifecycle][16] |
+| [Red Hat Enterprise Linux][17] | 10, 9, 8            | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
+| [SUSE Linux Enterprise][19]    | 16.0, 15.7          | Arm64, x64                 | [Lifecycle][20] |
+| [Ubuntu][21]                   | 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 
@@ -115,9 +115,10 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 
 | OS                    | Version     | End of Life   |
 | --------------------- | ----------- | ------------- |
+| Alpine                | 3.20        | [2026-04-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)  |
 | Alpine                | 3.19        | [2025-11-01](https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)  |
 | Android               | 13          | 2026-03-02    |
-| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L/summary)                      |
+| Android               | 12.1        | [2025-03-03](https://developer.android.com/about/versions/12/12L)                              |
 | Android               | 12          | 2025-03-03    |
 | Fedora                | 41          | 2025-12-15    |
 | Fedora                | 40          | 2025-05-13    |
@@ -127,10 +128,13 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 | Windows               | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
 | Windows               | 11 22H2 (E) | [2025-10-14](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
 | Windows               | 10 22H2     | [2025-10-14](https://learn.microsoft.com/windows/release-health/release-information)           |
+| iOS                   | 18          | 2026-04-22    |
 | iOS                   | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)    |
 | iOS                   | 17          | 2024-11-19    |
+| iPadOS                | 17          | 2025-09-15    |
 | iPadOS                | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes) |
 | macOS                 | 13          | 2025-09-15    |
+| openSUSE Leap         | 15.6        | [2026-04-30](https://en.opensuse.org/openSUSE:Roadmap#Leap_15.6)                               |
 | openSUSE Leap         | 15.5        | 2024-12-31    |
 | tvOS                  | 18          | 2025-09-15    |
 | tvOS                  | 17          | 2024-09-16    |

--- a/release-notes/9.0/supported-os.md
+++ b/release-notes/9.0/supported-os.md
@@ -18,7 +18,7 @@ Notes:
 
 | OS          | Versions   | Architectures | Lifecycle |
 | ----------- | ---------- | ------------- | --------- |
-| [iOS][2]    | 26         | Arm64         | None      |
+| [iOS][2]    | 26, 18     | Arm64         | None      |
 | [iPadOS][3] | 26, 18     | Arm64         | None      |
 | [macOS][4]  | 26, 15, 14 | Arm64, x64    | None      |
 | [tvOS][5]   | 26         | Arm64         | None      |
@@ -128,7 +128,6 @@ OS versions that are out of support by the OS publisher are not tested or suppor
 | Windows               | 11 23H2 (W) | [2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
 | Windows               | 11 22H2 (E) | [2025-10-14](https://learn.microsoft.com/windows/release-health/windows11-release-information) |
 | Windows               | 10 22H2     | [2025-10-14](https://learn.microsoft.com/windows/release-health/release-information)           |
-| iOS                   | 18          | 2026-04-22    |
 | iOS                   | 16          | [2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)    |
 | iOS                   | 17          | 2024-11-19    |
 | iPadOS                | 17          | 2025-09-15    |


### PR DESCRIPTION
## Fedora 44

- Added to `supported-versions` in 8.0 / 9.0 / 10.0 / 11.0 `supported-os.json`
- Added Fedora 44 entry to `release-notes/11.0/distros/fedora.json` (10.0 already had it; 8.0/9.0 `os-packages.json` already had it)

## Moved to unsupported-versions (EOL on or before 2026-05-01)

| OS | EOL | Versions affected |
| --- | --- | --- |
| Alpine 3.20 | 2026-04-01 | 8.0, 9.0, 10.0 |
| openSUSE Leap 15.6 | 2026-04-30 | 8.0, 9.0, 10.0 |
| iPadOS 17 | 2025-09-15 | 8.0, 9.0, 10.0, 11.0 |

iOS 18 (EOL 2026-04-22) is left as supported since it's still widely deployed and iPadOS 18 remains supported in this change. Windows Server 2012 / 2012 R2 are intentionally retained per the existing ESU note.

`supported-os.md` regenerated for all four versions via `release-notes-gen`. Markdownlint passes.