### PR TITLE
[release-notes] Windows Forms in .NET 11 Preview 5

### DIFF
--- a/release-notes/11.0/preview/preview5/winforms.md
+++ b/release-notes/11.0/preview/preview5/winforms.md
@@ -43,9 +43,3 @@ ToolStrip, layout, designer, and dark mode scenarios.
     rendering
     ([dotnet/winforms #14339](https://github.com/dotnet/winforms/pull/14339)).
 
-## Community contributors
-
-Thank you contributors! ❤️
-
-- [@LeafShi1](https://github.com/dotnet/winforms/pulls?q=is%3Apr+is%3Amerged+author%3ALeafShi1)
-- [@SimonZhao888](https://github.com/dotnet/winforms/pulls?q=is%3Apr+is%3Amerged+author%3ASimonZhao888)

--- a/release-notes/11.0/preview/preview5/winforms.md
+++ b/release-notes/11.0/preview/preview5/winforms.md
@@ -42,4 +42,3 @@ ToolStrip, layout, designer, and dark mode scenarios.
   - `ProgressBar` now has default foreground and background colors for dark mode
     rendering
     ([dotnet/winforms #14339](https://github.com/dotnet/winforms/pull/14339)).
-

--- a/release-notes/11.0/preview/preview5/winforms.md
+++ b/release-notes/11.0/preview/preview5/winforms.md
@@ -1,0 +1,51 @@
+# Windows Forms in .NET 11 Preview 5 - Release Notes
+
+.NET 11 Preview 5 does not introduce new Windows Forms feature additions. The
+notable user-facing changes in this preview are regression fixes for clipboard,
+ToolStrip, layout, designer, and dark mode scenarios.
+
+## Bug fixes
+
+- **System.Windows.Forms.Clipboard**
+  - `Clipboard.GetText(TextDataFormat.Rtf)` now reads RTF clipboard data that
+    doesn't include a null terminator. This fixes valid RTF content copied by
+    applications such as PowerPoint returning an empty string
+    ([dotnet/winforms #14461](https://github.com/dotnet/winforms/pull/14461)).
+- **System.Windows.Forms.ToolStrip**
+  - `ToolStrip` controls with `TabStop=true` no longer activate menu handling
+    after tab navigation in a way that prevents controls such as `TreeView` from
+    receiving arrow keys
+    ([dotnet/winforms #14491](https://github.com/dotnet/winforms/pull/14491)).
+  - `ToolStripDropDownMenu` scrolling now handles menu boundaries without
+    out-of-range scrolling or unintentionally dismissing the dropdown
+    ([dotnet/winforms #14490](https://github.com/dotnet/winforms/pull/14490)).
+  - `ToolStrip` DPI changes now preserve the previous device DPI during the DPI
+    change path, so scaling logic can run when moving controls between displays
+    with different DPI settings
+    ([dotnet/winforms #14454](https://github.com/dotnet/winforms/pull/14454)).
+- **System.Windows.Forms.Layout**
+  - `AnchorLayoutV2` now initializes missing anchor metadata when anchored
+    controls are replaced during a suspended layout pass
+    ([dotnet/winforms #14505](https://github.com/dotnet/winforms/pull/14505)).
+- **System.Windows.Forms.Design**
+  - Hosted WinForms designers can paste controls through `CommandSet.OnMenuPaste`
+    again
+    ([dotnet/winforms #14403](https://github.com/dotnet/winforms/pull/14403)).
+  - Collection editor captions for custom controls now use the underlying control
+    type instead of the generated `ControlProxy<T>` wrapper name
+    ([dotnet/winforms #14375](https://github.com/dotnet/winforms/pull/14375)).
+- **System.Windows.Forms.PropertyGrid**
+  - `PropertyGrid.SelectedTab` now updates correctly when `SelectedObject` is
+    assigned
+    ([dotnet/winforms #14438](https://github.com/dotnet/winforms/pull/14438)).
+- **System.Windows.Forms.ProgressBar**
+  - `ProgressBar` now has default foreground and background colors for dark mode
+    rendering
+    ([dotnet/winforms #14339](https://github.com/dotnet/winforms/pull/14339)).
+
+## Community contributors
+
+Thank you contributors! ❤️
+
+- [@LeafShi1](https://github.com/dotnet/winforms/pulls?q=is%3Apr+is%3Amerged+author%3ALeafShi1)
+- [@SimonZhao888](https://github.com/dotnet/winforms/pulls?q=is%3Apr+is%3Amerged+author%3ASimonZhao888)


### PR DESCRIPTION
Windows Forms release notes for .NET 11 Preview 5.

This component PR targets the base milestone branch `release-notes/11.0-preview5` (umbrella PR: #10421). Review and edit the markdown here in isolation — when this PR merges into the base branch, the changes roll up into the umbrella PR.

Draft generated with the `release-notes` skill in this repo. Verify feature selection, code samples, API names, and contributor attributions before marking ready for review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
