### PR TITLE
[release-notes] Windows Forms in .NET 11 Preview 6

### DIFF
--- a/release-notes/11.0/preview/preview6/winforms.md
+++ b/release-notes/11.0/preview/preview6/winforms.md
@@ -1,0 +1,15 @@
+# Windows Forms in .NET 11 Preview 6 - Release Notes
+
+<!-- Verified against Microsoft.WindowsDesktop.App.Ref@11.0.0-preview.6.26328.106; API diff showed no public API changes. -->
+
+.NET 11 Preview 6 does not introduce new Windows Forms feature additions. The
+notable user-facing change in this preview is a regression fix for
+ToolStripDropDown focus handling in SmartTag and dropdown scenarios.
+
+## Bug fixes
+
+- **System.Windows.Forms.ToolStrip**
+  - `ToolStripDropDown` now preserves modal menu tracking during focus changes.
+    This lets SmartTag and dropdown UI close normally when users switch tab
+    pages or otherwise move focus
+    ([dotnet/winforms #14606](https://github.com/dotnet/winforms/pull/14606)).

--- a/release-notes/11.0/preview/preview6/winforms.md
+++ b/release-notes/11.0/preview/preview6/winforms.md
@@ -2,14 +2,42 @@
 
 <!-- Verified against Microsoft.WindowsDesktop.App.Ref@11.0.0-preview.6.26328.106; API diff showed no public API changes. -->
 
-.NET 11 Preview 6 does not introduce new Windows Forms feature additions. The
-notable user-facing change in this preview is a regression fix for
-ToolStripDropDown focus handling in SmartTag and dropdown scenarios.
+.NET 11 Preview 6 does not introduce new Windows Forms feature additions.
 
 ## Bug fixes
 
-- **System.Windows.Forms.ToolStrip**
-  - `ToolStripDropDown` now preserves modal menu tracking during focus changes.
-    This lets SmartTag and dropdown UI close normally when users switch tab
-    pages or otherwise move focus
-    ([dotnet/winforms #14606](https://github.com/dotnet/winforms/pull/14606)).
+**`System.Windows.Forms.PropertyGrid`**
+* `SelectedObjects` now displays typed arrays correctly when `PropertySort` is set to `NoSort`
+(dotnet/winforms #14190).
+• `SelectedTab` now changes correctly when a new `SelectedObject` is assigned
+(dotnet/winforms #14438).
+• The cursor editor now caches its scaled icon size, preventing GDI resource exhaustion when it is resized
+(dotnet/winforms #14123).
+
+**`System.Windows.Forms.ToolStrip`**
+* `ToolStripDropDown` now preserves modal menu tracking during focus changes. This lets SmartTag and dropdown UI close normally when users switch tab
+pages or otherwise move focus 
+(dotnet/winforms #14606).
+* `ToolStrip` controls now update their layout correctly after a DPI change 
+(dotnet/winforms #14454).
+
+**`System.Windows.Forms.ProgressBar`**
+* `ProgressBar` now applies a default color in Dark Mode to improve visual contrast
+(dotnet/winforms #14339).
+
+**`System.Windows.Forms.Clipboard`**
+* `GetText(TextDataFormat.Rtf)` now retrieves RTF data that does not include a null-terminating character, and restores the previous behavior (dotnet/winforms #14461).
+* `GetDataObject().GetImage()` now returns bitmap images correctly 
+(dotnet/winforms #14427).
+
+**`System.Windows.Forms.Control`**
+* `AnchorLayoutV2` now initializes deferred anchor information correctly when anchored controls are replaced while layout is suspended
+(dotnet/winforms #14505).
+
+**`System.Windows.Forms.CheckBox` and `System.Windows.Forms.RadioButton`**
+* `CheckBox` and `RadioButton` controls now return to their normal appearance when the `Appearance` property is changed in Dark Mode 
+(dotnet/winforms #14194).
+
+**`System.Windows.Forms.StatusStrip`**
+* `StatusStrip` now calculates its default padding and grip width consistently, preventing spring-enabled `ToolStripStatusLabel` controls from disappearing
+(dotnet/winforms #14068).


### PR DESCRIPTION
Draft Windows Forms release notes for .NET 11 Preview 6. This PR targets the milestone base branch `release-notes/11.0-preview6` (see #10455).

Please review the AI-authored content for accuracy, including any code samples and `<!-- TODO -->` / `<!-- Filtered features -->` notes, then mark ready for review. 🤖 Generated with the release-notes skill.