### PR TITLE
Fix missing indentation in generated API diffs

### DIFF
--- a/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Components.md
+++ b/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Components.md
@@ -51,7 +51,7 @@
 +     }
 +     public sealed class RestoreContext
 +     {
-+ public static Microsoft.AspNetCore.Components.RestoreContext InitialValue { get; }
++         public static Microsoft.AspNetCore.Components.RestoreContext InitialValue { get; }
 +         public static Microsoft.AspNetCore.Components.RestoreContext LastSnapshot { get; }
 +         public static Microsoft.AspNetCore.Components.RestoreContext ValueUpdate { get; }
 +     }

--- a/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Http.Results.md
+++ b/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Http.Results.md
@@ -25,7 +25,7 @@
 +     public sealed class ServerSentEventsResult<T> : Microsoft.AspNetCore.Http.IResult, Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider, Microsoft.AspNetCore.Http.IStatusCodeHttpResult
 +     {
 +         public System.Threading.Tasks.Task ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext);
-+ public int? StatusCode { get; }
++         public int? StatusCode { get; }
 +     }
   }
 ```

--- a/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Identity.md
+++ b/release-notes/10.0/api-diff/Microsoft.AspNetCore.App/10.0.0_Microsoft.AspNetCore.Identity.md
@@ -49,7 +49,7 @@
 +     }
 +     public sealed class PasskeyAssertionResult<TUser> where TUser : class
 +     {
-+ public Microsoft.AspNetCore.Identity.PasskeyException? Failure { get; }
++         public Microsoft.AspNetCore.Identity.PasskeyException? Failure { get; }
 +         public Microsoft.AspNetCore.Identity.UserPasskeyInfo? Passkey { get; }
 +         [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Passkey")]
 +         [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "User")]
@@ -68,7 +68,7 @@
 +     {
 +         public static Microsoft.AspNetCore.Identity.PasskeyAttestationResult Fail(Microsoft.AspNetCore.Identity.PasskeyException failure);
 +         public static Microsoft.AspNetCore.Identity.PasskeyAttestationResult Success(Microsoft.AspNetCore.Identity.UserPasskeyInfo passkey, Microsoft.AspNetCore.Identity.PasskeyUserEntity userEntity);
-+ public Microsoft.AspNetCore.Identity.PasskeyException? Failure { get; }
++         public Microsoft.AspNetCore.Identity.PasskeyException? Failure { get; }
 +         public Microsoft.AspNetCore.Identity.UserPasskeyInfo? Passkey { get; }
 +         [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Passkey")]
 +         [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "UserEntity")]

--- a/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Net.ServerSentEvents.md
+++ b/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Net.ServerSentEvents.md
@@ -27,7 +27,7 @@
 +     {
 +         public System.Collections.Generic.IEnumerable<System.Net.ServerSentEvents.SseItem<T>> Enumerate();
 +         public System.Collections.Generic.IAsyncEnumerable<System.Net.ServerSentEvents.SseItem<T>> EnumerateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-+ public string LastEventId { get; }
++         public string LastEventId { get; }
 +         public System.TimeSpan ReconnectionInterval { get; }
 +     }
 + }

--- a/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Net.WebSockets.md
+++ b/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Net.WebSockets.md
@@ -25,7 +25,7 @@
 +         public override void Write(byte[] buffer, int offset, int count);
 +         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken);
 +         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
-+ public override bool CanRead { get; }
++         public override bool CanRead { get; }
 +         public override bool CanSeek { get; }
 +         public override bool CanWrite { get; }
 +         public override long Length { get; }

--- a/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Runtime.Intrinsics.md
+++ b/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Runtime.Intrinsics.md
@@ -1224,10 +1224,10 @@
 +         public static System.Numerics.Vector<ushort> XorRotateRight(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right, byte count);
 +         public static System.Numerics.Vector<uint> XorRotateRight(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right, byte count);
 +         public static System.Numerics.Vector<ulong> XorRotateRight(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right, byte count);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract new class Arm64 : System.Runtime.Intrinsics.Arm.Sve.Arm64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
   }
@@ -1852,13 +1852,13 @@
 +         {
 +             public static System.Runtime.Intrinsics.Vector256<long> CarrylessMultiply(System.Runtime.Intrinsics.Vector256<long> left, System.Runtime.Intrinsics.Vector256<long> right, byte control);
 +             public static System.Runtime.Intrinsics.Vector256<ulong> CarrylessMultiply(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, byte control);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
 +         public abstract class V512
 +         {
 +             public static System.Runtime.Intrinsics.Vector512<long> CarrylessMultiply(System.Runtime.Intrinsics.Vector512<long> left, System.Runtime.Intrinsics.Vector512<long> right, byte control);
 +             public static System.Runtime.Intrinsics.Vector512<ulong> CarrylessMultiply(System.Runtime.Intrinsics.Vector512<ulong> left, System.Runtime.Intrinsics.Vector512<ulong> right, byte control);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
       }
 +     [System.CLSCompliantAttribute(false)]
@@ -1884,7 +1884,7 @@
 +         public static System.Runtime.Intrinsics.Vector128<uint> MoveScalar(System.Runtime.Intrinsics.Vector128<uint> value);
 +         public static unsafe void StoreScalar(short* address, System.Runtime.Intrinsics.Vector128<short> source);
 +         public static unsafe void StoreScalar(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract new class V512 : System.Runtime.Intrinsics.X86.Avx10v1.V512
 +         {
 +             public static System.Runtime.Intrinsics.Vector512<int> ConvertToByteWithSaturationAndZeroExtendToInt32(System.Runtime.Intrinsics.Vector512<float> value, System.Runtime.Intrinsics.X86.FloatRoundingMode mode);
@@ -1896,15 +1896,15 @@
 +             public static System.Runtime.Intrinsics.Vector512<double> MinMax(System.Runtime.Intrinsics.Vector512<double> left, System.Runtime.Intrinsics.Vector512<double> right, byte control);
 +             public static System.Runtime.Intrinsics.Vector512<float> MinMax(System.Runtime.Intrinsics.Vector512<float> left, System.Runtime.Intrinsics.Vector512<float> right, byte control);
 +             public static System.Runtime.Intrinsics.Vector512<ushort> MultipleSumAbsoluteDifferences(System.Runtime.Intrinsics.Vector512<byte> left, System.Runtime.Intrinsics.Vector512<byte> right, byte mask);
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +             public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx10v1.V512.X64
 +             {
-+ public new static bool IsSupported { get; }
++                 public new static bool IsSupported { get; }
 +             }
 +         }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx10v1.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
 +     [System.CLSCompliantAttribute(false)]
@@ -1926,7 +1926,7 @@
 +         public static unsafe System.Runtime.Intrinsics.Vector512<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> merge);
 +         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> merge);
 +         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> merge);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract new class VL : System.Runtime.Intrinsics.X86.Avx512Vbmi.VL
 +         {
 +             public static System.Runtime.Intrinsics.Vector128<byte> Compress(System.Runtime.Intrinsics.Vector128<byte> merge, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> value);
@@ -1961,11 +1961,11 @@
 +             public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> merge);
 +             public static unsafe System.Runtime.Intrinsics.Vector128<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> merge);
 +             public static unsafe System.Runtime.Intrinsics.Vector256<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> merge);
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx512Vbmi.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
 +     [System.CLSCompliantAttribute(false)]
@@ -1983,7 +1983,7 @@
 +         public static System.Runtime.Intrinsics.Vector256<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<int> addend, System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<ushort> right);
 +         public static System.Runtime.Intrinsics.Vector256<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<int> addend, System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<short> right);
 +         public static System.Runtime.Intrinsics.Vector256<uint> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<uint> addend, System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract class V512
 +         {
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAdd(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<short> left, System.Runtime.Intrinsics.Vector512<ushort> right);
@@ -1992,11 +1992,11 @@
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<short> left, System.Runtime.Intrinsics.Vector512<ushort> right);
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<ushort> left, System.Runtime.Intrinsics.Vector512<short> right);
 +             public static System.Runtime.Intrinsics.Vector512<uint> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<uint> addend, System.Runtime.Intrinsics.Vector512<ushort> left, System.Runtime.Intrinsics.Vector512<ushort> right);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx2.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
 +     [System.CLSCompliantAttribute(false)]
@@ -2014,7 +2014,7 @@
 +         public static System.Runtime.Intrinsics.Vector256<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<int> addend, System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<byte> right);
 +         public static System.Runtime.Intrinsics.Vector256<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<int> addend, System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right);
 +         public static System.Runtime.Intrinsics.Vector256<uint> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector256<uint> addend, System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract class V512
 +         {
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAdd(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<sbyte> left, System.Runtime.Intrinsics.Vector512<byte> right);
@@ -2023,11 +2023,11 @@
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<sbyte> left, System.Runtime.Intrinsics.Vector512<byte> right);
 +             public static System.Runtime.Intrinsics.Vector512<int> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<int> addend, System.Runtime.Intrinsics.Vector512<sbyte> left, System.Runtime.Intrinsics.Vector512<sbyte> right);
 +             public static System.Runtime.Intrinsics.Vector512<uint> MultiplyWideningAndAddSaturate(System.Runtime.Intrinsics.Vector512<uint> addend, System.Runtime.Intrinsics.Vector512<byte> left, System.Runtime.Intrinsics.Vector512<byte> right);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx2.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
 +     [System.CLSCompliantAttribute(false)]
@@ -2036,24 +2036,24 @@
 +         public static System.Runtime.Intrinsics.Vector128<byte> GaloisFieldAffineTransform(System.Runtime.Intrinsics.Vector128<byte> x, System.Runtime.Intrinsics.Vector128<byte> a, byte b);
 +         public static System.Runtime.Intrinsics.Vector128<byte> GaloisFieldAffineTransformInverse(System.Runtime.Intrinsics.Vector128<byte> x, System.Runtime.Intrinsics.Vector128<byte> a, byte b);
 +         public static System.Runtime.Intrinsics.Vector128<byte> GaloisFieldMultiply(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract class V256
 +         {
 +             public static System.Runtime.Intrinsics.Vector256<byte> GaloisFieldAffineTransform(System.Runtime.Intrinsics.Vector256<byte> x, System.Runtime.Intrinsics.Vector256<byte> a, byte b);
 +             public static System.Runtime.Intrinsics.Vector256<byte> GaloisFieldAffineTransformInverse(System.Runtime.Intrinsics.Vector256<byte> x, System.Runtime.Intrinsics.Vector256<byte> a, byte b);
 +             public static System.Runtime.Intrinsics.Vector256<byte> GaloisFieldMultiply(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
 +         public abstract class V512
 +         {
 +             public static System.Runtime.Intrinsics.Vector512<byte> GaloisFieldAffineTransform(System.Runtime.Intrinsics.Vector512<byte> x, System.Runtime.Intrinsics.Vector512<byte> a, byte b);
 +             public static System.Runtime.Intrinsics.Vector512<byte> GaloisFieldAffineTransformInverse(System.Runtime.Intrinsics.Vector512<byte> x, System.Runtime.Intrinsics.Vector512<byte> a, byte b);
 +             public static System.Runtime.Intrinsics.Vector512<byte> GaloisFieldMultiply(System.Runtime.Intrinsics.Vector512<byte> left, System.Runtime.Intrinsics.Vector512<byte> right);
-+ public static bool IsSupported { get; }
++             public static bool IsSupported { get; }
 +         }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Sse41.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
   }

--- a/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Runtime.Serialization.Xml.md
+++ b/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Runtime.Serialization.Xml.md
@@ -10,7 +10,7 @@
       }
       public sealed class XmlDataContract : System.Runtime.Serialization.DataContracts.DataContract
       {
-+ public override string? ContractType { get; }
++         public override string? ContractType { get; }
 +         public override bool IsBuiltInDataContract { get; }
 +         public override System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContracts.DataContract>? KnownDataContracts { get; }
 +         public override System.Xml.XmlDictionaryString? TopLevelElementName { get; }

--- a/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Security.Cryptography.md
+++ b/release-notes/10.0/api-diff/Microsoft.NETCore.App/10.0.0_System.Security.Cryptography.md
@@ -147,7 +147,7 @@
 +         public static bool operator ==(System.Security.Cryptography.CompositeMLDsaAlgorithm? left, System.Security.Cryptography.CompositeMLDsaAlgorithm? right);
 +         public static bool operator !=(System.Security.Cryptography.CompositeMLDsaAlgorithm? left, System.Security.Cryptography.CompositeMLDsaAlgorithm? right);
 +         public override string ToString();
-+ public int MaxSignatureSizeInBytes { get; }
++         public int MaxSignatureSizeInBytes { get; }
 +         public static System.Security.Cryptography.CompositeMLDsaAlgorithm MLDsa44WithECDsaP256 { get; }
 +         public static System.Security.Cryptography.CompositeMLDsaAlgorithm MLDsa44WithEd25519 { get; }
 +         public static System.Security.Cryptography.CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pkcs15 { get; }
@@ -302,7 +302,7 @@
 +         public static bool operator ==(System.Security.Cryptography.MLDsaAlgorithm? left, System.Security.Cryptography.MLDsaAlgorithm? right);
 +         public static bool operator !=(System.Security.Cryptography.MLDsaAlgorithm? left, System.Security.Cryptography.MLDsaAlgorithm? right);
 +         public override string ToString();
-+ public static System.Security.Cryptography.MLDsaAlgorithm MLDsa44 { get; }
++         public static System.Security.Cryptography.MLDsaAlgorithm MLDsa44 { get; }
 +         public static System.Security.Cryptography.MLDsaAlgorithm MLDsa65 { get; }
 +         public static System.Security.Cryptography.MLDsaAlgorithm MLDsa87 { get; }
 +         public int MuSizeInBytes { get; }
@@ -447,7 +447,7 @@
 +         public static bool operator ==(System.Security.Cryptography.MLKemAlgorithm? left, System.Security.Cryptography.MLKemAlgorithm? right);
 +         public static bool operator !=(System.Security.Cryptography.MLKemAlgorithm? left, System.Security.Cryptography.MLKemAlgorithm? right);
 +         public override string ToString();
-+ public int CiphertextSizeInBytes { get; }
++         public int CiphertextSizeInBytes { get; }
 +         public int DecapsulationKeySizeInBytes { get; }
 +         public int EncapsulationKeySizeInBytes { get; }
 +         public static System.Security.Cryptography.MLKemAlgorithm MLKem1024 { get; }
@@ -558,7 +558,7 @@
 +         public static bool operator ==(System.Security.Cryptography.SlhDsaAlgorithm? left, System.Security.Cryptography.SlhDsaAlgorithm? right);
 +         public static bool operator !=(System.Security.Cryptography.SlhDsaAlgorithm? left, System.Security.Cryptography.SlhDsaAlgorithm? right);
 +         public override string ToString();
-+ public string Name { get; }
++         public string Name { get; }
 +         public int PrivateKeySizeInBytes { get; }
 +         public int PublicKeySizeInBytes { get; }
 +         public int SignatureSizeInBytes { get; }

--- a/release-notes/10.0/api-diff/Microsoft.WindowsDesktop.App/10.0.0_Microsoft.VisualBasic.Forms.md
+++ b/release-notes/10.0/api-diff/Microsoft.WindowsDesktop.App/10.0.0_Microsoft.VisualBasic.Forms.md
@@ -5,8 +5,8 @@
   {
       public class ApplyApplicationDefaultsEventArgs : System.EventArgs
       {
-- [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-experimental/{0}")]
-  public System.Windows.Forms.SystemColorMode ColorMode { get; set; }
+-         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-experimental/{0}")]
+          public System.Windows.Forms.SystemColorMode ColorMode { get; set; }
       }
       public class WindowsFormsApplicationBase : Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase
       {

--- a/release-notes/10.0/api-diff/Microsoft.WindowsDesktop.App/10.0.0_System.Windows.Forms.md
+++ b/release-notes/10.0/api-diff/Microsoft.WindowsDesktop.App/10.0.0_System.Windows.Forms.md
@@ -383,7 +383,7 @@
 +         [System.ComponentModel.BrowsableAttribute(false)]
 +         public sealed class HitTestInfo
 +         {
-+ public static readonly System.Windows.Forms.DataGrid.HitTestInfo Nowhere;
++             public static readonly System.Windows.Forms.DataGrid.HitTestInfo Nowhere;
 +             public int Column { get; }
 +             public int Row { get; }
 +             public System.Windows.Forms.DataGrid.HitTestType Type { get; }
@@ -736,7 +736,7 @@
 +         public void Remove(System.Windows.Forms.DataGridColumnStyle column);
 +         public void RemoveAt(int index);
 +         public void ResetPropertyDescriptors();
-+ public System.Windows.Forms.DataGridColumnStyle this[System.ComponentModel.PropertyDescriptor propertyDesciptor] {
++         public System.Windows.Forms.DataGridColumnStyle this[System.ComponentModel.PropertyDescriptor propertyDesciptor] {
 +             get { }
 +         }
 +         public System.Windows.Forms.DataGridColumnStyle this[int index] {
@@ -750,7 +750,7 @@
 +     [System.ComponentModel.BrowsableAttribute(false)]
 +     public sealed class GridTablesFactory
 +     {
-+ public static System.Windows.Forms.DataGridTableStyle[] CreateGridTables(System.Windows.Forms.DataGridTableStyle gridTable, object dataSource, string dataMember, System.Windows.Forms.BindingContext bindingManager);
++         public static System.Windows.Forms.DataGridTableStyle[] CreateGridTables(System.Windows.Forms.DataGridTableStyle gridTable, object dataSource, string dataMember, System.Windows.Forms.BindingContext bindingManager);
 +     }
 +     [System.ObsoleteAttribute("`DataGrid` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `DataGridView` instead.", false, DiagnosticId = "WFDEV006", UrlFormat = "https://aka.ms/winforms-warnings/{0}")]
 +     [System.ComponentModel.BrowsableAttribute(false)]
@@ -766,7 +766,7 @@
 +         protected void OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs e);
 +         public void Remove(System.Windows.Forms.DataGridTableStyle table);
 +         public void RemoveAt(int index);
-+ public System.Windows.Forms.DataGridTableStyle this[int index] {
++         public System.Windows.Forms.DataGridTableStyle this[int index] {
 +             get { }
 +         }
 +         public System.Windows.Forms.DataGridTableStyle this[string tableName] {

--- a/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_Microsoft.VisualBasic.Forms.md
+++ b/release-notes/10.0/preview/preview3/api-diff/Microsoft.WindowsDesktop.App/10.0-preview3_Microsoft.VisualBasic.Forms.md
@@ -5,9 +5,9 @@
   {
       public class ApplyApplicationDefaultsEventArgs : System.EventArgs
       {
-- [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-experimental/{0}")]
-+ [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-warnings/{0}")]
-  public System.Windows.Forms.SystemColorMode ColorMode { get; set; }
+-         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-experimental/{0}")]
++         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("WFO5001", UrlFormat = "https://aka.ms/winforms-warnings/{0}")]
+          public System.Windows.Forms.SystemColorMode ColorMode { get; set; }
       }
       public class WindowsFormsApplicationBase : Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase
       {

--- a/release-notes/11.0/preview/preview1/api-diff/Microsoft.AspNetCore.App/11.0-preview1_System.Security.Cryptography.Pkcs.md
+++ b/release-notes/11.0/preview/preview1/api-diff/Microsoft.AspNetCore.App/11.0-preview1_System.Security.Cryptography.Pkcs.md
@@ -30,7 +30,7 @@
 +     {
 +         public bool MoveNext();
 +         public void Reset();
-+ public System.Security.Cryptography.CryptographicAttributeObject Current { get; }
++         public System.Security.Cryptography.CryptographicAttributeObject Current { get; }
 +     }
 + }
 + namespace System.Security.Cryptography.Pkcs
@@ -75,7 +75,7 @@
 +     {
 +         public bool MoveNext();
 +         public void Reset();
-+ public System.Security.Cryptography.Pkcs.CmsRecipient Current { get; }
++         public System.Security.Cryptography.Pkcs.CmsRecipient Current { get; }
 +     }
 +     public sealed class CmsSigner
 +     {
@@ -136,7 +136,7 @@
 +     }
 +     public sealed class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
 +     {
-+ public System.DateTime Date { get; }
++         public System.DateTime Date { get; }
 +         public override byte[] EncryptedKey { get; }
 +         public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
 +         public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get; }
@@ -146,7 +146,7 @@
 +     }
 +     public sealed class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
 +     {
-+ public override byte[] EncryptedKey { get; }
++         public override byte[] EncryptedKey { get; }
 +         public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
 +         public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
 +         public override int Version { get; }
@@ -186,7 +186,7 @@
 +         public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false);
 +         public bool VerifyMac(System.ReadOnlySpan<char> password);
 +         public bool VerifyMac(string? password);
-+ public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get; }
++         public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get; }
 +         public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get; }
 +     }
 +     public enum Pkcs12IntegrityMode
@@ -232,12 +232,12 @@
 +     }
 +     public sealed class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
 +     {
-+ public System.Security.Cryptography.Pkcs.Pkcs12SafeContents? SafeContents { get; }
++         public System.Security.Cryptography.Pkcs.Pkcs12SafeContents? SafeContents { get; }
 +     }
 +     public sealed class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
 +     {
 +         public System.Security.Cryptography.Oid GetSecretType();
-+ public System.ReadOnlyMemory<byte> SecretValue { get; }
++         public System.ReadOnlyMemory<byte> SecretValue { get; }
 +     }
 +     public sealed class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
 +     {
@@ -316,12 +316,12 @@
 +     }
 +     public sealed class PublicKeyInfo
 +     {
-+ public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get; }
++         public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get; }
 +         public byte[] KeyValue { get; }
 +     }
 +     public abstract class RecipientInfo
 +     {
-+ public abstract byte[] EncryptedKey { get; }
++         public abstract byte[] EncryptedKey { get; }
 +         public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
 +         public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
 +         public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get; }
@@ -332,7 +332,7 @@
 +         public void CopyTo(System.Array array, int index);
 +         public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index);
 +         public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator();
-+ public int Count { get; }
++         public int Count { get; }
 +         public bool IsSynchronized { get; }
 +         public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] {
 +             get { }
@@ -343,7 +343,7 @@
 +     {
 +         public bool MoveNext();
 +         public void Reset();
-+ public System.Security.Cryptography.Pkcs.RecipientInfo Current { get; }
++         public System.Security.Cryptography.Pkcs.RecipientInfo Current { get; }
 +     }
 +     public enum RecipientInfoType
 +     {
@@ -364,7 +364,7 @@
 +         public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed);
 +         public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest? request, out int bytesConsumed);
 +         public bool TryEncode(System.Span<byte> destination, out int bytesWritten);
-+ public bool HasExtensions { get; }
++         public bool HasExtensions { get; }
 +         public System.Security.Cryptography.Oid HashAlgorithmId { get; }
 +         public System.Security.Cryptography.Oid? RequestedPolicyId { get; }
 +         public bool RequestSignerCertificate { get; }
@@ -378,7 +378,7 @@
 +         public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2? signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection? extraCandidates = null);
 +         public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2? signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection? extraCandidates = null);
 +         public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2? signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection? extraCandidates = null);
-+ public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get; }
++         public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get; }
 +     }
 +     public sealed class Rfc3161TimestampTokenInfo
 +     {
@@ -439,7 +439,7 @@
 +         public void RemoveCounterSignature(int index);
 +         public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo);
 +         public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData unsignedAttribute);
-+ public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get; }
++         public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get; }
 +         public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get; }
 +         public System.Security.Cryptography.Oid DigestAlgorithm { get; }
 +         public System.Security.Cryptography.Oid SignatureAlgorithm { get; }
@@ -453,7 +453,7 @@
 +         public void CopyTo(System.Array array, int index);
 +         public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index);
 +         public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator();
-+ public int Count { get; }
++         public int Count { get; }
 +         public bool IsSynchronized { get; }
 +         public System.Security.Cryptography.Pkcs.SignerInfo this[int index] {
 +             get { }
@@ -464,17 +464,17 @@
 +     {
 +         public bool MoveNext();
 +         public void Reset();
-+ public System.Security.Cryptography.Pkcs.SignerInfo Current { get; }
++         public System.Security.Cryptography.Pkcs.SignerInfo Current { get; }
 +     }
 +     public sealed class SubjectIdentifier
 +     {
 +         public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate);
-+ public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get; }
++         public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get; }
 +         public object? Value { get; }
 +     }
 +     public sealed class SubjectIdentifierOrKey
 +     {
-+ public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get; }
++         public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get; }
 +         public object Value { get; }
 +     }
 +     public enum SubjectIdentifierOrKeyType

--- a/release-notes/11.0/preview/preview1/api-diff/Microsoft.NETCore.App/11.0-preview1_System.IO.Compression.Zstandard.md
+++ b/release-notes/11.0/preview/preview1/api-diff/Microsoft.NETCore.App/11.0-preview1_System.IO.Compression.Zstandard.md
@@ -39,7 +39,7 @@
 +         public static System.IO.Compression.ZstandardDictionary Create(System.ReadOnlySpan<byte> buffer);
 +         public void Dispose();
 +         public static System.IO.Compression.ZstandardDictionary Train(System.ReadOnlySpan<byte> samples, System.ReadOnlySpan<int> sampleLengths, int maxDictionarySize);
-+ public System.ReadOnlyMemory<byte> Data { get; }
++         public System.ReadOnlyMemory<byte> Data { get; }
 +     }
 +     public sealed class ZstandardEncoder : System.IDisposable
 +     {

--- a/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.IO.Compression.Zstandard.md
+++ b/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.IO.Compression.Zstandard.md
@@ -39,7 +39,7 @@
 -         public static System.IO.Compression.ZstandardDictionary Create(System.ReadOnlySpan<byte> buffer);
 -         public void Dispose();
 -         public static System.IO.Compression.ZstandardDictionary Train(System.ReadOnlySpan<byte> samples, System.ReadOnlySpan<int> sampleLengths, int maxDictionarySize);
-- public System.ReadOnlyMemory<byte> Data { get; }
+-         public System.ReadOnlyMemory<byte> Data { get; }
 -     }
 -     public sealed class ZstandardEncoder : System.IDisposable
 -     {

--- a/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.IO.Compression.md
+++ b/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.IO.Compression.md
@@ -39,7 +39,7 @@
 +         public static System.IO.Compression.ZstandardDictionary Create(System.ReadOnlySpan<byte> buffer);
 +         public void Dispose();
 +         public static System.IO.Compression.ZstandardDictionary Train(System.ReadOnlySpan<byte> samples, System.ReadOnlySpan<int> sampleLengths, int maxDictionarySize);
-+ public System.ReadOnlyMemory<byte> Data { get; }
++         public System.ReadOnlyMemory<byte> Data { get; }
 +     }
 +     public sealed class ZstandardEncoder : System.IDisposable
 +     {

--- a/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.Runtime.Intrinsics.md
+++ b/release-notes/11.0/preview/preview3/api-diff/Microsoft.NETCore.App/11.0-preview3_System.Runtime.Intrinsics.md
@@ -3853,10 +3853,10 @@
 +         public static System.Runtime.Intrinsics.Vector128<byte> ReverseBits(System.Runtime.Intrinsics.Vector128<byte> values);
 +         public static System.Runtime.Intrinsics.Vector256<byte> ReverseBits(System.Runtime.Intrinsics.Vector256<byte> values);
 +         public static System.Runtime.Intrinsics.Vector512<byte> ReverseBits(System.Runtime.Intrinsics.Vector512<byte> values);
-+ public new static bool IsSupported { get; }
++         public new static bool IsSupported { get; }
 +         public abstract new class X64 : System.Runtime.Intrinsics.X86.Avx512F.X64
 +         {
-+ public new static bool IsSupported { get; }
++             public new static bool IsSupported { get; }
 +         }
 +     }
   }

--- a/release-notes/11.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/11.0-preview4_System.Diagnostics.EventLog.md
+++ b/release-notes/11.0/preview/preview4/api-diff/Microsoft.AspNetCore.App/11.0-preview4_System.Diagnostics.EventLog.md
@@ -101,15 +101,15 @@
   {
       public sealed class EventKeyword
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
       public sealed class EventLevel
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
@@ -136,8 +136,8 @@
       }
       public sealed class EventLogLink
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string LogName { get; }
 +         public string? LogName { get; }
       }
@@ -220,8 +220,8 @@
       }
       public sealed class EventLogStatus
       {
-- public string LogName { get; }
-+ public string? LogName { get; }
+-         public string LogName { get; }
++         public string? LogName { get; }
       }
       public class EventLogWatcher : System.IDisposable
       {
@@ -234,22 +234,22 @@
       }
       public sealed class EventMetadata
       {
-- public string Description { get; }
-+ public string? Description { get; }
+-         public string Description { get; }
++         public string? Description { get; }
 -         public string Template { get; }
 +         public string? Template { get; }
       }
       public sealed class EventOpcode
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
       public sealed class EventProperty
       {
-- public object Value { get; }
-+ public object? Value { get; }
+-         public object Value { get; }
++         public object? Value { get; }
       }
       public abstract class EventRecord : System.IDisposable
       {
@@ -272,15 +272,15 @@
       }
       public sealed class EventRecordWrittenEventArgs : System.EventArgs
       {
-- public System.Exception EventException { get; }
-+ public System.Exception? EventException { get; }
+-         public System.Exception EventException { get; }
++         public System.Exception? EventException { get; }
 -         public System.Diagnostics.Eventing.Reader.EventRecord EventRecord { get; }
 +         public System.Diagnostics.Eventing.Reader.EventRecord? EventRecord { get; }
       }
       public sealed class EventTask
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }

--- a/release-notes/11.0/preview/preview4/api-diff/Microsoft.NETCore.App/11.0-preview4_Microsoft.Extensions.Logging.Abstractions.md
+++ b/release-notes/11.0/preview/preview4/api-diff/Microsoft.NETCore.App/11.0-preview4_Microsoft.Extensions.Logging.Abstractions.md
@@ -9,7 +9,7 @@ This assembly was moved from [Microsoft.AspNetCore.App](../Microsoft.AspNetCore.
 +     public class NullScope : System.IDisposable
 +     {
 +         public void Dispose();
-+ public static Microsoft.Extensions.Logging.Abstractions.Internal.NullScope Instance { get; }
++         public static Microsoft.Extensions.Logging.Abstractions.Internal.NullScope Instance { get; }
 +     }
 +     [System.ObsoleteAttribute("This type is retained only for compatibility.", true)]
 +     public class TypeNameHelper

--- a/release-notes/11.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/11.0-preview4_System.Diagnostics.EventLog.md
+++ b/release-notes/11.0/preview/preview4/api-diff/Microsoft.WindowsDesktop.App/11.0-preview4_System.Diagnostics.EventLog.md
@@ -101,15 +101,15 @@
   {
       public sealed class EventKeyword
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
       public sealed class EventLevel
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
@@ -136,8 +136,8 @@
       }
       public sealed class EventLogLink
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string LogName { get; }
 +         public string? LogName { get; }
       }
@@ -220,8 +220,8 @@
       }
       public sealed class EventLogStatus
       {
-- public string LogName { get; }
-+ public string? LogName { get; }
+-         public string LogName { get; }
++         public string? LogName { get; }
       }
       public class EventLogWatcher : System.IDisposable
       {
@@ -234,22 +234,22 @@
       }
       public sealed class EventMetadata
       {
-- public string Description { get; }
-+ public string? Description { get; }
+-         public string Description { get; }
++         public string? Description { get; }
 -         public string Template { get; }
 +         public string? Template { get; }
       }
       public sealed class EventOpcode
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }
       public sealed class EventProperty
       {
-- public object Value { get; }
-+ public object? Value { get; }
+-         public object Value { get; }
++         public object? Value { get; }
       }
       public abstract class EventRecord : System.IDisposable
       {
@@ -272,15 +272,15 @@
       }
       public sealed class EventRecordWrittenEventArgs : System.EventArgs
       {
-- public System.Exception EventException { get; }
-+ public System.Exception? EventException { get; }
+-         public System.Exception EventException { get; }
++         public System.Exception? EventException { get; }
 -         public System.Diagnostics.Eventing.Reader.EventRecord EventRecord { get; }
 +         public System.Diagnostics.Eventing.Reader.EventRecord? EventRecord { get; }
       }
       public sealed class EventTask
       {
-- public string DisplayName { get; }
-+ public string? DisplayName { get; }
+-         public string DisplayName { get; }
++         public string? DisplayName { get; }
 -         public string Name { get; }
 +         public string? Name { get; }
       }


### PR DESCRIPTION
The api-diff tool had a bug where the first member of a type could lose its indentation in the generated markdown (dotnet/core#10213). This was caused by a synthesized default constructor lacking a body/semicolon, which fused it with the following member during formatting.

The tool is being fixed in dotnet/sdk#54130, but the already-generated diff files need manual correction. This re-indents the 101 affected member lines across 19 files to align with their sibling members.

Only whitespace (indentation) is changed; no API content is modified.

Contributes to https://github.com/dotnet/core/issues/10213