### PR TITLE
Fix markdown lint errors in 11.0.0-preview.6 release notes

### DIFF
--- a/release-notes/11.0/preview/preview6/11.0.0-preview.6.md
+++ b/release-notes/11.0/preview/preview6/11.0.0-preview.6.md
@@ -43,8 +43,6 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 
 ### Notable Changes
 
-
-
 .NET 11.0.0-preview.6 release carries non-security fixes.
 
 ### Visual Studio Compatibility

--- a/releases.md
+++ b/releases.md
@@ -47,5 +47,4 @@ The following table lists end-of-life releases.
 [2.0.9]: release-notes/2.0/2.0.9.md
 [1.1.13]: release-notes/1.1/1.1.13/1.1.13.md
 [1.0.16]: release-notes/1.0/1.0.16/1.0.16.md
-[11.0.0-preview.6]: release-notes/11.0/preview/preview6/11.0.0-preview.6.md
 [policies]: release-policies.md


### PR DESCRIPTION
Fixes markdown lint errors reported by Super-Linter (`.github/linters/.markdown-lint.yml`) in files that landed with PR #10476 (.NET 11.0.0-preview.6 artifacts).

### Changes
- **MD012 / no-multiple-blanks** — `release-notes/11.0/preview/preview6/11.0.0-preview.6.md`: collapsed three consecutive blank lines under `### Notable Changes` down to one.
- **MD053 / link-image-reference-definitions** — `releases.md`: removed the duplicate `[11.0.0-preview.6]` link reference definition (it is already defined in the supported-releases definition block near the top).

### Scope note
These are the safe, unambiguous lint fixes. The preview6 notes also trip **63 MD053 "unused reference definition"** errors for the download-asset labels (e.g. `[dotnet-sdk-win-x64.tar.gz]`), which appear to be a release-notes generator/template issue (the definitions are emitted but never referenced). Those are intentionally left out of this PR so they can be addressed at the generator level rather than by hand-deleting generated content.