### PR TITLE
Add Preview 6 release note: Blazor Gateway backend API proxying

### DIFF
--- a/release-notes/11.0/preview/preview6/aspnetcore.md
+++ b/release-notes/11.0/preview/preview6/aspnetcore.md
@@ -7,6 +7,7 @@
 - [Automatic cross-origin (CSRF) protection](#automatic-cross-origin-csrf-protection)
 - [Blazor Virtualize can scroll to an item](#blazor-virtualize-can-scroll-to-an-item)
 - [Configure Blazor client behavior from the server](#configure-blazor-client-behavior-from-the-server)
+- [Blazor Gateway can proxy backend API calls](#blazor-gateway-can-proxy-backend-api-calls)
 - [OpenAPI 3.2 by default](#openapi-32-by-default)
 - [Unions in ASP.NET Core](#unions-in-aspnet-core)
 - [Short-circuit endpoints with an attribute](#short-circuit-endpoints-with-an-attribute)
@@ -146,6 +147,25 @@ app.MapRazorComponents<App>()
 You can also set the options from a component with `<ConfigureBrowser>`, or read the resolved options from `HttpContext` with `GetBrowserOptions()`.
 
 The API was introduced in Preview 4 and reshaped in Preview 6 to follow options conventions. If you adopted the earlier shape, `WithBrowserConfiguration` is now `WithBrowserOptions`, `BrowserConfiguration` is now `BrowserOptions`, `ServerBrowserOptions` is now `InteractiveServerBrowserOptions`, `SsrBrowserOptions.DisableDomPreservation` is now `PreserveDom` (with the opposite meaning), and `CircuitInactivityTimeoutMs` is now `CircuitInactivityTimeout` (a `TimeSpan`).
+
+## Blazor Gateway can proxy backend API calls
+
+The [Blazor Gateway](../preview5/aspnetcore.md#blazor-webassembly-gateway) — the development-time host for standalone Blazor WebAssembly apps introduced in Preview 5 — can now proxy the app's HTTP calls to backend services through a built-in [YARP](https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/getting-started) reverse proxy ([dotnet/aspnetcore #67048](https://github.com/dotnet/aspnetcore/pull/67048)). Because the WebAssembly client makes only same-origin requests to the Gateway, which forwards them to the backend server-to-server, **no CORS configuration is needed** on the client or the backend.
+
+Configure the proxy with a standard YARP `ReverseProxy` section describing the routes and clusters to forward. The Gateway runs as a separate process that reads this configuration from environment variables (or command-line arguments) rather than the app project's `appsettings.json`, so the simplest place to set it during development is the app's `launchSettings.json`:
+
+```json
+"environmentVariables": {
+  "ASPNETCORE_ENVIRONMENT": "Development",
+  "ReverseProxy__Routes__weather__ClusterId": "backend",
+  "ReverseProxy__Routes__weather__Match__Path": "/api/{**catch-all}",
+  "ReverseProxy__Clusters__backend__Destinations__backend1__Address": "http://localhost:5100/"
+}
+```
+
+With this configuration the WebAssembly app calls its own origin (for example `Http.GetFromJsonAsync<WeatherForecast[]>("api/weather")`), the Gateway matches the `/api/**` route, and forwards the request to the backend at `http://localhost:5100/`. The Gateway also registers .NET service discovery, so a destination address can be a logical service name resolved from `services:<name>:<endpoint>:<index>` configuration in addition to a literal URL.
+
+A complete end-to-end sample is available at [danroth27/AspNetCore11Samples](https://github.com/danroth27/AspNetCore11Samples): the `BlazorWasmFeatures` app calls the separate `BackendApi` service through the Gateway with no CORS.
 
 ## OpenAPI 3.2 by default
 

--- a/release-notes/11.0/preview/preview6/aspnetcore.md
+++ b/release-notes/11.0/preview/preview6/aspnetcore.md
@@ -152,18 +152,25 @@ The API was introduced in Preview 4 and reshaped in Preview 6 to follow options 
 
 The [Blazor Gateway](../preview5/aspnetcore.md#blazor-webassembly-gateway) — the development-time host for standalone Blazor WebAssembly apps introduced in Preview 5 — can now proxy the app's HTTP calls to backend services through a built-in [YARP](https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/getting-started) reverse proxy ([dotnet/aspnetcore #67048](https://github.com/dotnet/aspnetcore/pull/67048)). Because the WebAssembly client makes only same-origin requests to the Gateway, which forwards them to the backend server-to-server, **no CORS configuration is needed** on the client or the backend.
 
-Configure the proxy with a standard YARP `ReverseProxy` section describing the routes and clusters to forward. The Gateway runs as a separate process that reads this configuration from environment variables (or command-line arguments) rather than the app project's `appsettings.json`, so the simplest place to set it during development is the app's `launchSettings.json`:
+Configure the proxy with a standard YARP `ReverseProxy` section describing the routes and clusters to forward. The Gateway runs as a separate process that reads this configuration from environment variables (or command-line arguments) rather than the app project's `appsettings.json`, so the simplest place to set it during development is the `environmentVariables` of a launch profile in the app's `launchSettings.json`:
 
 ```json
-"environmentVariables": {
-  "ASPNETCORE_ENVIRONMENT": "Development",
-  "ReverseProxy__Routes__weather__ClusterId": "backend",
-  "ReverseProxy__Routes__weather__Match__Path": "/api/{**catch-all}",
-  "ReverseProxy__Clusters__backend__Destinations__backend1__Address": "http://localhost:5100/"
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ReverseProxy__Routes__weather__ClusterId": "backend",
+        "ReverseProxy__Routes__weather__Match__Path": "/api/{**catch-all}",
+        "ReverseProxy__Clusters__backend__Destinations__backend1__Address": "http://localhost:5100/"
+      }
+    }
+  }
 }
 ```
 
-With this configuration the WebAssembly app calls its own origin (for example `Http.GetFromJsonAsync<WeatherForecast[]>("api/weather")`), the Gateway matches the `/api/**` route, and forwards the request to the backend at `http://localhost:5100/`. The Gateway also registers .NET service discovery, so a destination address can be a logical service name resolved from `services:<name>:<endpoint>:<index>` configuration in addition to a literal URL.
+With this configuration the WebAssembly app calls its own origin (for example `Http.GetFromJsonAsync<WeatherForecast[]>("api/weather")`), the Gateway matches the `/api/**` route, and forwards the request to the backend at `http://localhost:5100/`. The Gateway also enables [.NET service discovery](https://learn.microsoft.com/dotnet/core/extensions/service-discovery), so a cluster destination address can be a logical service name that's resolved at request time instead of a literal URL.
 
 A complete end-to-end sample is available at [danroth27/AspNetCore11Samples](https://github.com/danroth27/AspNetCore11Samples): the `BlazorWasmFeatures` app calls the separate `BackendApi` service through the Gateway with no CORS.
 


### PR DESCRIPTION
## Summary

Adds a .NET 11 Preview 6 ASP.NET Core release note documenting that the dev-time **Blazor Gateway** can now proxy a standalone Blazor WebAssembly app's HTTP calls to backend services through a built-in [YARP](https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/getting-started) reverse proxy. Because the WebAssembly client makes only same-origin requests to the Gateway, which forwards them server-to-server, **no CORS configuration is required** on the client or the backend.

This capability landed in [dotnet/aspnetcore#67048](https://github.com/dotnet/aspnetcore/pull/67048) (milestone 11.0-preview6), which made the Gateway's service discovery unconditional so YARP destinations resolve correctly. The Gateway itself was introduced in [Preview 5](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#blazor-webassembly-gateway); this note is the follow-up for the proxying feature, which was previously undocumented.

## Changes

- `release-notes/11.0/preview/preview6/aspnetcore.md`
  - New "Blazor Gateway can proxy backend API calls" section (with table-of-contents entry) showing the `ReverseProxy` configuration via `launchSettings.json` environment variables and the no-CORS behavior.

## Verification

- The scenario was built and run end-to-end against the Preview 6 SDK (`11.0.100-preview.6.26359.118`) using the sample at https://github.com/danroth27/AspNetCore11Samples (`BlazorWasmFeatures` calling `BackendApi` through the Gateway, confirmed no `Access-Control-Allow-Origin` header and no CORS config).

> [!NOTE]
> The note is intentionally honest that the Gateway currently reads its `ReverseProxy` config from environment variables / command-line args rather than the app project's `appsettings.json`. Improving that config experience is tracked in [dotnet/aspnetcore#67887](https://github.com/dotnet/aspnetcore/issues/67887).
