### PR TITLE
[release-notes] .NET MAUI in .NET 11 Preview 7

### DIFF
--- a/release-notes/11.0/preview/preview7/README.md
+++ b/release-notes/11.0/preview/preview7/README.md
@@ -2,27 +2,17 @@
 
 These notes cover the highest-value changes that shipped in .NET 11 Preview 7:
 
-- [Libraries](./libraries.md)
-- [Runtime](./runtime.md)
-- [SDK](./sdk.md)
-- [Containers](./containers.md)
-
 ## Languages
 
-- [C#](./csharp.md)
 - [F#](./fsharp.md)
 
 ## Web and data
 
 - [.NET MAUI](./dotnetmaui.md)
-- [ASP.NET Core](./aspnetcore.md)
 - [EF Core](./efcore.md)
 
 ## Tooling
 
-- [MSBuild](./msbuild.md)
-- [NuGet](./nuget.md)
-- [Windows Forms](./winforms.md)
 - [WPF](./wpf.md)
 
 ## Release information

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -1,303 +1,230 @@
 # .NET MAUI in .NET 11 Preview 7 - Release Notes
 
-.NET 11 Preview 7 lands a coordinated wave of extension points for third-party
-platform backends, continues the handler-architecture migration on Apple
-platforms, and expands the XAML tooling for AOT and Hot Reload:
+.NET 11 Preview 7 adds cross-platform passkey authentication, opt-in XAML
+Incremental Hot Reload, Shell route templates, and faster device development
+workflows:
 
-- [Third-party platform backend extensibility](#third-party-platform-backend-extensibility)
-- [TabbedPage handler architecture on iOS and Mac Catalyst](#tabbedpage-handler-architecture-on-ios-and-mac-catalyst)
-- [XAML Incremental Hot Reload (opt-in preview)](#xaml-incremental-hot-reload-opt-in-preview)
-- [AOT-safe RelativeSource bindings from the XAML source generator](#aot-safe-relativesource-bindings-from-the-xaml-source-generator)
-- [Platform enhancements](#platform-enhancements)
-- [Trimming and Community Toolkit cleanup](#trimming-and-community-toolkit-cleanup)
+- [Cross-platform passkey authentication](#cross-platform-passkey-authentication)
+- [XAML Incremental Hot Reload](#xaml-incremental-hot-reload)
+- [Shell route templates](#shell-route-templates)
+- [AOT-safe RelativeSource bindings](#aot-safe-relativesource-bindings)
+- [Third-party platform backends](#third-party-platform-backends)
+- [TabbedPage adopts handlers on Apple platforms](#tabbedpage-adopts-handlers-on-apple-platforms)
+- [Platform-specific capabilities](#platform-specific-capabilities)
 - [.NET for Android](#net-for-android)
 - [Apple platforms (.NET for iOS, Mac Catalyst, macOS, tvOS)](#apple-platforms-net-for-ios-mac-catalyst-macos-tvos)
-- [Contributors](#contributors)
+- [Community contributors](#community-contributors)
 
-.NET MAUI updates in .NET 11:
+## Cross-platform passkey authentication
 
-- [What's new in .NET MAUI in .NET 11](https://learn.microsoft.com/dotnet/maui/whats-new/)
+The new Passkeys Essentials API drives the native passkey UI on Android 14+,
+iOS 16+, Mac Catalyst 16+, and Windows 10 version 1903+. Use
+`Passkeys.IsSupported` to check availability, `Passkeys.CreateAsync` to
+register a credential, and `Passkeys.AssertAsync` to authenticate with an
+existing credential
+([dotnet/maui #36837](https://github.com/dotnet/maui/pull/36837)).
 
-## Third-party platform backend extensibility
+The relying-party server supplies the standard WebAuthn options JSON and
+verifies the response JSON returned by MAUI. The API handles the platform
+ceremony, but does not perform server-side verification, attestation
+validation, or challenge generation.
 
-.NET MAUI's programming model has historically assumed a fixed set of
-first-party platform backends (Android, iOS, Mac Catalyst, macOS, Tizen,
-Windows). Preview 7 lands a coordinated set of extension points from the
-platform-extensibility epic
-([dotnet/maui #34099](https://github.com/dotnet/maui/issues/34099)) that let
-third-party or community backends — for example a Linux/GTK head — plug into
-the same MSBuild, DI, and handler machinery the built-in platforms use,
-without patching MAUI itself.
+## XAML Incremental Hot Reload
 
-- **XAML `OnPlatform` recognizes GTK, macOS, and WPF.** The `GTK`, `macOS`, and
-  `WPF` properties on `OnPlatformExtension` are now public, so the inline
-  `{OnPlatform GTK=..., macOS=..., WPF=...}` markup-extension form works for
-  external backends. The `OnPlatform<T>` element form remains the route for
-  arbitrary platform strings such as `Web`
-  ([dotnet/maui #35901](https://github.com/dotnet/maui/pull/35901)).
-- **Public `IAlertManager` extension points.**
-  `Microsoft.Maui.Controls.Platform.IAlertManager` and
-  `IAlertManagerSubscription` are public on `net11.0` so custom platform
-  backends can host alerts, action sheets, and prompts. They were originally
-  introduced in .NET 10 and reverted to internal for servicing; the interface
-  signatures and runtime behavior are unchanged from the .NET 10 shape
-  ([dotnet/maui #36633](https://github.com/dotnet/maui/pull/36633)).
-- **Custom `BlazorWebView` handlers.**
-  `IMauiBlazorWebViewBuilder.UsePlatformHandler<THandler>()` and its factory
-  overload let a third-party backend replace the default `BlazorWebViewHandler`
-  while keeping every service registered by `AddMauiBlazorWebView()` — JSInterop,
-  navigation, static assets, and the rest. Handlers implement the new
-  `IBlazorWebViewHandler` capability interface so shared code no longer
-  hard-casts to the built-in handler
-  ([dotnet/maui #36658](https://github.com/dotnet/maui/pull/36658)).
+> XAML Incremental Hot Reload is an opt-in preview feature in .NET 11.
 
-  ```csharp
-  builder.Services
-      .AddMauiBlazorWebView()
-      .UsePlatformHandler<GtkBlazorWebViewHandler>();
-  ```
+XAML Incremental Hot Reload uses a source generator and a
+`MetadataUpdateHandler` to update already-instantiated pages without rebuilding
+the app. It supports property changes, child additions and removals, structural
+reordering, attached properties, markup extensions, bindings, and
+`ResourceDictionary` updates
+([dotnet/maui #34338](https://github.com/dotnet/maui/pull/34338)).
 
-- **Resizetizer external backends.** A new MSBuild contract —
-  `ResizetizerPlatformType`, `MauiProcessedImage`/`MauiProcessedFont`/`MauiProcessedAsset`,
-  and `ResizetizerAfter{Image,Font,Asset}ProcessingTargets` — lets an
-  out-of-tree backend opt into image, font, and asset processing without
-  teaching MAUI about its platform
-  ([dotnet/maui #36653](https://github.com/dotnet/maui/pull/36653)).
-- **SingleProject neutral-TFM backends.** External backends can register
-  through the existing `MauiPlatformSpecificFolder` item and activate for
-  either a recognized platform TFM or a plain `net11.0` inner build by opting
-  in with a selector property (default `MauiActiveBackend`)
-  ([dotnet/maui #36654](https://github.com/dotnet/maui/pull/36654)).
-
-  ```xml
-  <PropertyGroup>
-    <TargetFrameworks>net11.0-ios;net11.0</TargetFrameworks>
-    <MauiActiveBackend Condition=" '$(TargetFramework)' == 'net11.0' ">gtk</MauiActiveBackend>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="..." />
-  </ItemGroup>
-  ```
-
-- **`GestureManager` factory is public.** The `Microsoft.Maui.Controls`
-  `GestureManager` exposes a public factory, and the built-in gesture manager
-  now skips incompatible handlers instead of throwing, so a third-party backend
-  can register its own gesture manager without breaking apps that mix it with
-  the built-in handlers
-  ([dotnet/maui #36655](https://github.com/dotnet/maui/pull/36655)).
-
-Individually these are small; together they are the difference between a
-community backend being a fork and a community backend being a NuGet package.
-
-## TabbedPage handler architecture on iOS and Mac Catalyst
-
-`TabbedPage` on iOS and Mac Catalyst is re-implemented on top of the standard
-handler architecture. The monolithic `TabbedRenderer` — a single ~600-line
-class that *was* a `UITabBarController` — is replaced by a layered
-`TabbedViewHandler` plus a shared `TabBarControllerManager` in
-`Microsoft.Maui.Core`
-([dotnet/maui #36507](https://github.com/dotnet/maui/pull/36507)). The new
-handler is the unconditional default on iOS and Mac Catalyst; the runtime
-feature switch and MSBuild opt-in used during development have been removed.
-`TabbedRenderer` itself is unchanged and remains in the Compatibility layer as
-a manual fallback.
-
-Together with the earlier Android Shell handler work, this continues the
-effort to converge every control on the same handler pattern across every
-platform. Apps that use `TabbedPage` heavily on iOS or Mac Catalyst are the
-primary audience to try this preview against.
-
-## XAML Incremental Hot Reload (opt-in preview)
-
-Preview 7 introduces **XAML Incremental Hot Reload (XIHR)**: a Roslyn source
-generator plus a `[MetadataUpdateHandler]` runtime that lets XAML edits update
-already-instantiated pages *without rebuilding the app*
-([dotnet/maui #34338](https://github.com/dotnet/maui/pull/34338)). When you
-edit a XAML file, the generator emits a per-version patch method
-(`UpdateComponent`), and the runtime dispatches it against every live instance
-of the affected page, advancing each instance through its accumulated patch
-chain. The generator handles property changes, child add/remove, structural
-reorders, attached properties, markup extensions, bindings, and
-`ResourceDictionary` updates.
-
-XIHR is **off by default** in this preview and gated by a runtime feature
-switch, so trimmed and AOT production builds pay no cost
-([dotnet/maui #36832](https://github.com/dotnet/maui/pull/36832)). To try it in
-Debug, opt in per project:
+The feature is off by default in Preview 7. Enable it for Debug builds with:
 
 ```xml
-<PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
   <EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>
 </PropertyGroup>
 ```
 
-When the switch is off, the existing legacy XAML Hot Reload path is used, so
-nothing changes for existing apps.
+When the switch is off, MAUI continues to use the existing XAML Hot Reload
+path ([dotnet/maui #36832](https://github.com/dotnet/maui/pull/36832)).
 
-## AOT-safe RelativeSource bindings from the XAML source generator
+## Shell route templates
 
-The XAML source generator now compiles `{RelativeSource AncestorType=...}`
-bindings to a trim-safe `TypedBinding<TAncestor, TProperty>` when the ancestor
-type is resolvable at compile time
-([dotnet/maui #34408](https://github.com/dotnet/maui/pull/34408), resolving
-[dotnet/maui #34056](https://github.com/dotnet/maui/issues/34056)).
+Shell routes now support path parameters inspired by ASP.NET Core and Blazor
+routing. Templates can contain required, optional, defaulted, constrained,
+catch-all, and mixed segments. Existing literal routes are unchanged
+([dotnet/maui #35110](https://github.com/dotnet/maui/pull/35110)).
 
-```xaml
-<ContentPage x:DataType="local:PageViewModel">
-    <Label Text="{Binding Title,
-                          Source={RelativeSource AncestorType={x:Type local:PageViewModel}}}" />
-</ContentPage>
+```csharp
+Routing.RegisterRoute("product/{sku}", typeof(ProductDetailPage));
+await Shell.Current.GoToAsync("//products/product/seed-tomato");
 ```
 
-Previously the compiler routed every explicit-source binding to the string-based
-`Binding(string, ...)` constructor — a `[RequiresUnreferencedCode]` API that
-could be trimmed away in AOT Release builds. The generator now recognizes the
-ancestor type and emits a compiled binding, using ambient `x:DataType` only for
-bindings whose source is genuinely unknown (`Self`, `TemplatedParent`,
-unresolved ancestor sources, and `x:Reference`, which continue to fall back to
-the runtime path).
+Values are delivered through the existing `QueryProperty` and
+`IQueryAttributable` mechanisms. Template routes currently require absolute
+navigation; relative navigation is not yet supported.
 
-A related follow-up silences a false-positive `MAUIG2045` diagnostic that the
-new `RelativeSource AncestorType` analyzer produced on unsealed ancestor types
+## AOT-safe RelativeSource bindings
+
+The XAML source generator now compiles
+`{RelativeSource AncestorType=...}` bindings to trim-safe
+`TypedBinding<TAncestor, TProperty>` instances when the ancestor type can be
+resolved at compile time
+([dotnet/maui #34408](https://github.com/dotnet/maui/pull/34408)).
+
+```xaml
+<Label Text="{Binding Title,
+                      Source={RelativeSource AncestorType={x:Type local:PageViewModel}}}" />
+```
+
+This avoids a string-based binding path that relies on reflection and could
+lose bound members during trimming in AOT Release builds. `Self`,
+`TemplatedParent`, unresolved ancestor sources, and unresolved `x:Reference`
+bindings continue to use the runtime binding path. A follow-up also removes a
+false-positive `MAUIG2045` warning for unsealed ancestor types
 ([dotnet/maui #36905](https://github.com/dotnet/maui/pull/36905)).
 
-## Platform enhancements
+## Third-party platform backends
 
-- **Windows `Border` keyboard tap.** A `Border` with a single-tap,
-  primary-button `TapGestureRecognizer` is now keyboard actionable on Windows:
-  `ContentPanel.IsTabStop` is set to `true`, and pressing **Enter** or
-  **Space** while the `Border` has focus invokes the gesture through
-  `SendTapped`. This matches the existing Android keyboard-tap behavior
-  ([dotnet/maui #35578](https://github.com/dotnet/maui/pull/35578)).
-- **Windows single-instance activation.** MAUI apps on Windows expose an
-  `AppInstance` activation lifecycle hook and support redirecting external
-  activations to the running instance, which also enables `WebAuthenticator`
+Preview 7 adds a coordinated set of extension points for out-of-tree platform
+backends. XAML `OnPlatform` recognizes GTK, macOS, and WPF
+([dotnet/maui #35901](https://github.com/dotnet/maui/pull/35901)); alert and
+gesture services expose public extension points
+([dotnet/maui #36633](https://github.com/dotnet/maui/pull/36633),
+[dotnet/maui #36655](https://github.com/dotnet/maui/pull/36655)); and
+`BlazorWebView` supports replacing its platform handler while retaining the
+services registered by `AddMauiBlazorWebView`
+([dotnet/maui #36658](https://github.com/dotnet/maui/pull/36658)).
+
+Resizetizer and SingleProject also expose contracts for processing assets and
+activating a backend for either a recognized platform TFM or a neutral
+`net11.0` inner build
+([dotnet/maui #36653](https://github.com/dotnet/maui/pull/36653),
+[dotnet/maui #36654](https://github.com/dotnet/maui/pull/36654)). Together,
+these APIs let a community backend integrate through a NuGet package instead
+of patching MAUI.
+
+## TabbedPage adopts handlers on Apple platforms
+
+`TabbedPage` on iOS and Mac Catalyst now uses the standard handler
+architecture. `TabbedViewHandler` and a shared `TabBarControllerManager`
+replace the monolithic `TabbedRenderer`
+([dotnet/maui #36507](https://github.com/dotnet/maui/pull/36507)).
+
+The handler is the default in Preview 7. `TabbedRenderer` remains available in
+the Compatibility layer as a manual fallback, so apps with extensive
+`TabbedPage` customizations should test this preview.
+
+## Platform-specific capabilities
+
+- **Status bar appearance** - `Window.StatusBarTheme` controls the icon
+  appearance on Android and iOS independently of the app theme. This is useful
+  when edge-to-edge content places a light or dark surface behind the status
+  bar ([dotnet/maui #34903](https://github.com/dotnet/maui/pull/34903)).
+- **Save captured media to the gallery** - `MediaPickerOptions.SaveToGallery`
+  can save captured photos and videos to the system gallery on Android, iOS,
+  and Mac Catalyst. The option defaults to `false` and is ignored on Windows
+  and Tizen
+  ([dotnet/maui #34641](https://github.com/dotnet/maui/pull/34641)).
+- **Windows single-instance activation** - Windows apps expose an
+  `AppInstance` activation lifecycle hook and can redirect external
+  activations to the running instance. This also enables `WebAuthenticator`
   callbacks in single-instance apps
   ([dotnet/maui #36640](https://github.com/dotnet/maui/pull/36640)).
-- **Android Material 3 Slider events.** The Material 3 Slider handler
-  subscribes to Android's native `Change`, `StartTrackingTouch`, and
-  `StopTrackingTouch` events directly instead of relying on a touch-event
-  workaround, so `ValueChanged`, `DragStarted`, and `DragCompleted` all fire
-  correctly and the floating-label workaround is gone
-  ([dotnet/maui #36448](https://github.com/dotnet/maui/pull/36448)).
 
-## Trimming and Community Toolkit cleanup
+Preview 7 also improves keyboard activation for `Border` on Windows
+([dotnet/maui #35578](https://github.com/dotnet/maui/pull/35578)) and native
+event handling for the Material 3 Slider on Android
+([dotnet/maui #36448](https://github.com/dotnet/maui/pull/36448)).
 
-Preview 7 finishes a set of long-running cleanups that unblock trim-safe apps
-and prepare for the .NET 11 Community Toolkit.
-
-- All `InternalsVisibleTo` grants for the .NET MAUI Community Toolkit
-  (`CommunityToolkit.Maui`, `.Core`, `.Markup`, and their `.UnitTests`
-  assemblies) are removed from `Microsoft.Maui.Core`,
-  `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Xaml`, and
-  `Microsoft.Maui.Essentials` — 22 declarations in total
-  ([dotnet/maui #34070](https://github.com/dotnet/maui/pull/34070)). This has
-  been attempted twice before and reverted because the toolkit had not yet
-  migrated off the internal APIs; making the change in `net11.0` gives the
-  toolkit a full release window to migrate.
-- The `_MauiFixTrimmerRootAssemblyMetadata` workaround target and the
-  corresponding `RootMode="All"` `TrimmerRootAssembly` entries are removed
-  from the AOT test templates
-  ([dotnet/maui #34519](https://github.com/dotnet/maui/pull/34519)).
-- The remaining conversion helpers in `Microsoft.Maui.Controls` are annotated
-  for trim safety, so they no longer produce trim/AOT warnings when used from
-  a fully trimmed app
-  ([dotnet/maui #30875](https://github.com/dotnet/maui/pull/30875)).
+See the [full MAUI compare](https://github.com/dotnet/maui/compare/11.0.0-preview.6.26360.8...release/11.0.1xx-preview7)
+for the complete set of changes.
 
 ## .NET for Android
 
-.NET for Android Preview 7 is dominated by CoreCLR host work and the
-trimmable-typemap migration.
+Preview 7 streamlines the Android development loop. `FastDeploy2` is now the
+default app-install fast deployment strategy and reduces the incremental path
+to three serial `adb` operations; the legacy strategy remains available as a
+fallback ([dotnet/android #11795](https://github.com/dotnet/android/pull/11795)).
+CoreCLR Debug builds also keep typemaps stable across C#-only rebuilds that do
+not change Java-callable mappings, avoiding unnecessary native compilation,
+APK rebuilding, and signing
+([dotnet/android #12260](https://github.com/dotnet/android/pull/12260)).
+Managed stack traces under CoreCLR FastDev now include source file and line
+information ([dotnet/android #11702](https://github.com/dotnet/android/pull/11702)).
 
-The **trimmable typemap is now the default typemap for NativeAOT**
-([dotnet/android #12121](https://github.com/dotnet/android/pull/12121)). The
-reflection-based `managed` typemap is removed entirely
-([dotnet/android #12134](https://github.com/dotnet/android/pull/12134)), so
-`_AndroidTypeMapImplementation` now accepts only `llvm-ir` (Mono and CoreCLR)
-and `trimmable` (NativeAOT). Under NativeAOT the R8 keep rules are extended
-for custom `IJavaObject` types
-([dotnet/android #12132](https://github.com/dotnet/android/pull/12132), which
-emits a new `XA4212` diagnostic), the trimmable ACW map preserves nested Java
-class names
-([dotnet/android #12187](https://github.com/dotnet/android/pull/12187)), and
-`IGCUserPeer` methods are preserved through R8
-([dotnet/android #12100](https://github.com/dotnet/android/pull/12100)).
+For NativeAOT, the trimmable typemap is now the default and the reflection-based
+`managed` implementation has been removed
+([dotnet/android #12121](https://github.com/dotnet/android/pull/12121),
+[dotnet/android #12134](https://github.com/dotnet/android/pull/12134)).
+The trimmable path adds `XA4212` for unsupported custom `IJavaObject` types,
+preserves nested Java class names, and keeps `IGCUserPeer` methods through R8
+([dotnet/android #12132](https://github.com/dotnet/android/pull/12132),
+[dotnet/android #12187](https://github.com/dotnet/android/pull/12187),
+[dotnet/android #12100](https://github.com/dotnet/android/pull/12100)).
 
-CoreCLR gains two important assembly-store changes:
+`AndroidMessageHandler` now preserves `HEAD` requests across `301`, `302`, and
+`303` redirects, and safely aborts in-flight body I/O when a response is
+disposed. The disposal fix prevents a process crash that particularly affected
+gRPC server-streaming cancellation
+([dotnet/android #12102](https://github.com/dotnet/android/pull/12102),
+[dotnet/android #12105](https://github.com/dotnet/android/pull/12105)).
 
-- **`dlopen()`-based assembly-store loading.** Instead of parsing the APK ZIP
-  central directory and walking the wrapper `.so` ELF section headers by hand,
-  the CoreCLR host makes the assembly-store payload a loadable section exposed
-  through the exported `_assembly_store` dynamic symbol and asks the platform
-  linker to `dlopen`/`dlsym` it. MonoVM is unchanged
-  ([dotnet/android #12033](https://github.com/dotnet/android/pull/12033)).
-- **On-device decompressed AssemblyStore cache** (opt-in). Setting
-  `AndroidEnableAssemblyStoreDecompressionCache=true` on a CoreCLR Release
-  build caches Zstd-decompressed assemblies under `codeCacheDir` so subsequent
-  launches skip decompression and use file-backed mappings. The cache
-  self-heals on checksum failure and rejects corrupted entries
-  ([dotnet/android #11967](https://github.com/dotnet/android/pull/11967)).
-
-`AndroidMessageHandler` continues to align with `SocketsHttpHandler`. `HEAD`
-requests are preserved across `301`, `302`, and `303` redirects instead of
-being coerced to `GET`
-([dotnet/android #12102](https://github.com/dotnet/android/pull/12102)), and
-disposing an `HttpResponseMessage` while a body read is still parked in okhttp
-no longer crashes the process with an *Unbalanced enter/exit*
-`IllegalStateException` — the response body's in-flight I/O is aborted first
-([dotnet/android #12105](https://github.com/dotnet/android/pull/12105)). This
-last fix matters most for gRPC server-streaming, which cancels by disposing
-the response.
-
-Finally, a new build-time diagnostic **`XA0132`** flags a missing Fast
-Deployment package on device, so an incremental deploy against a device that
-no longer has the shared runtime package produces an actionable error instead
-of a runtime crash
+The `EnableCrashReport` MSBuild property enables the .NET crash-report writer
+for CoreCLR and NativeAOT apps
+([dotnet/android #12136](https://github.com/dotnet/android/pull/12136)).
+The existing `XA0132` diagnostic now reports when the Fast Deployment package
+is missing from a device after a forced reinstall, replacing the misleading
+`XA0137` deployment diagnostic
 ([dotnet/android #12060](https://github.com/dotnet/android/pull/12060)).
 
 ## Apple platforms (.NET for iOS, Mac Catalyst, macOS, tvOS)
 
-The Apple workloads' Preview 7 changes focus on completing the NativeAOT
-compilation flow and tightening the MSBuild contract.
-
-- **Skip ILLink completes for NativeAOT.** For .NET 11+ builds, the SDK no
-  longer runs a redundant ILLink pass before ILC — ILC now receives the
-  fully-prepared assemblies directly. This removes a whole assembly-modification
-  step from NativeAOT builds
-  ([dotnet/macios #26193](https://github.com/dotnet/macios/pull/26193)).
-- **Native registrar generated after ILC for trimmable-static.** With the
-  trimmable-static registrar, the generated native registrar code is now
-  emitted after ILC has produced its output, so it can see the final trimmed
-  managed surface
-  ([dotnet/macios #26194](https://github.com/dotnet/macios/pull/26194)).
-- **Diagnostic for post-ILC assembly modification.** A new NativeAOT
-  build-time warning fires when a post-ILC step modifies a managed assembly —
-  a common source of hard-to-diagnose runtime failures on NativeAOT — so
-  custom tooling and third-party targets can be caught early
-  ([dotnet/macios #26137](https://github.com/dotnet/macios/pull/26137)).
-- **Missing Objective-C classes no longer break the link.** When
-  `Class.GetHandle` is inlined and the target Objective-C class isn't present
-  in the linked binary, MSBuild now emits a warning and lets the app link
-  instead of failing the build; this backports to the `release/11.0.1xx-preview7`
-  branch as [dotnet/macios #26347](https://github.com/dotnet/macios/pull/26347)
-  ([dotnet/macios #26302](https://github.com/dotnet/macios/pull/26302)).
-- **Invalid IL fix in generated `CreateObject` proxies for generic types.**
-  The tooling that generates `CreateObject` proxies could emit invalid IL for
-  generic types, breaking some binding scenarios; the generator now emits
-  correct IL
-  ([dotnet/macios #26100](https://github.com/dotnet/macios/pull/26100)).
-- **`EnableCrashReport` MSBuild property.** A new
-  `<EnableCrashReport>true</EnableCrashReport>` MSBuild property enables the
-  .NET crash-report writer for iOS, Mac Catalyst, macOS, and tvOS apps
+- **App Store Connect symbolication** - IPA builds now include Apple's
+  `*.symbols` files by default, enabling automatic crash-report symbolication
+  in App Store Connect and Xcode Organizer. Set `IpaIncludeSymbols=false` to
+  opt out ([dotnet/macios #26043](https://github.com/dotnet/macios/pull/26043)).
+  The `EnableCrashReport` MSBuild property separately enables the .NET
+  in-process crash-report writer for CoreCLR apps on iOS, tvOS, and Mac Catalyst
   ([dotnet/macios #26134](https://github.com/dotnet/macios/pull/26134)).
-- **`rgen` UI namespace cache scoped per-compilation** eliminates a source of
-  Roslyn generator flakiness for apps that reference UIKit / AppKit
-  ([dotnet/macios #26187](https://github.com/dotnet/macios/pull/26187)).
+- **Hot Reload on physical devices** - `dotnet watch` now works on physical
+  iOS and tvOS devices over USB or Wi-Fi
+  ([dotnet/macios #26070](https://github.com/dotnet/macios/pull/26070)).
+- **NativeAOT compilation flow** - ILC now receives prepared assemblies
+  directly without a redundant ILLink pass, the trimmable-static registrar is
+  generated after ILC, and a new warning identifies post-ILC assembly changes
+  that can cause runtime failures
+  ([dotnet/macios #26193](https://github.com/dotnet/macios/pull/26193),
+  [dotnet/macios #26194](https://github.com/dotnet/macios/pull/26194),
+  [dotnet/macios #26137](https://github.com/dotnet/macios/pull/26137)).
+- **Binding and linking reliability** - fake-protocol binding classes retain
+  runtime `Class.GetHandle` lookup instead of causing a hard link error when no
+  Objective-C class exists, and generated `CreateObject` proxies for generic
+  types no longer contain invalid IL
+  ([dotnet/macios #26347](https://github.com/dotnet/macios/pull/26347),
+  [dotnet/macios #26100](https://github.com/dotnet/macios/pull/26100)).
 
-See the full Preview 7 changelog for the complete list:
-<https://github.com/dotnet/macios/compare/release/11.0.1xx-preview6...release/11.0.1xx-preview7>
+See the
+[full Apple platforms compare](https://github.com/dotnet/macios/compare/release/11.0.1xx-preview6...release/11.0.1xx-preview7)
+for the complete set of changes.
 
-## Contributors
+<!-- Filtered features (significant engineering work, but too narrow for release notes):
+  - MAUI Community Toolkit and trimming cleanup (#34070, #34519, #30875):
+    important migration and trim-safety work, but primarily relevant to Toolkit
+    maintainers and internal build hygiene.
+  - Avalonia.Controls.Maui template support (#35950): useful for an alternate
+    UI-framework integration, but too specialized for the main highlights.
+  - IViewScreenshot extensibility (#34350) and binding converter culture support
+    (#35821): provider extensibility and incremental binding improvements.
+  - Android dlopen-based assembly-store loading and decompression cache (#12033,
+    #11967): low-level CoreCLR host work and an opt-in advanced performance path.
+  - Apple rgen UI namespace cache (#26187): internal source-generator reliability.
+-->
+
+## Community contributors
 
 Thank you contributors! ❤️
 
@@ -305,11 +232,15 @@ Thank you contributors! ❤️
 - [@BagavathiPerumal](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ABagavathiPerumal)
 - [@devanathan-vaithiyanathan](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Adevanathan-vaithiyanathan)
 - [@Dhivya-SF4094](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ADhivya-SF4094)
+- [@drasticactions](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Adrasticactions)
+- [@durandt](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Adurandt)
 - [@HarishKumarSF4517](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AHarishKumarSF4517)
 - [@HarishwaranVijayakumar](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AHarishwaranVijayakumar)
 - [@IlGalvo](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AIlGalvo)
+- [@jeremy-visionaid](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Ajeremy-visionaid)
 - [@jpd21122012](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Ajpd21122012)
 - [@KarthikRajaKalaimani](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AKarthikRajaKalaimani)
+- [@Kebechet](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AKebechet)
 - [@kevin68](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Akevin68)
 - [@LogishaSelvarajSF4525](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ALogishaSelvarajSF4525)
 - [@NafeelaNazhir](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ANafeelaNazhir)
@@ -318,12 +249,15 @@ Thank you contributors! ❤️
 - [@prakashKannanSf3972](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AprakashKannanSf3972)
 - [@praveenkumarkarunanithi](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Apraveenkumarkarunanithi)
 - [@Shalini-Ashokan](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AShalini-Ashokan)
+- [@sheiksyedm](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Asheiksyedm)
 - [@SubhikshaSf4851](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ASubhikshaSf4851)
 - [@SyedAbdulAzeemSF4852](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ASyedAbdulAzeemSF4852)
 - [@Tamilarasan-Paranthaman](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ATamilarasan-Paranthaman)
 - [@TamilarasanSF4853](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ATamilarasanSF4853)
 - [@Vignesh-SF3580](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AVignesh-SF3580)
 
-<!-- Content derived from merged PRs on release/11.0.1xx-preview7 branches of
-     dotnet/maui, dotnet/android, and dotnet/macios in the 2026-07-14 to
-     2026-07-31 window. -->
+<!-- Mobile source ranges:
+     dotnet/maui 11.0.0-preview.6.26360.8...release/11.0.1xx-preview7
+     dotnet/android release/11.0.1xx-preview6...release/11.0.1xx-preview7
+     dotnet/macios release/11.0.1xx-preview6...release/11.0.1xx-preview7
+-->

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -1,6 +1,6 @@
 # .NET MAUI in .NET 11 Preview 7 - Release Notes
 
-.NET 11 Preview 7 adds cross-platform passkey authentication, opt-in XAML
+.NET 11 Preview 7 adds cross-platform passkey authentication, XAML
 Incremental Hot Reload, Shell route templates, and faster device development
 workflows:
 
@@ -38,7 +38,7 @@ validation, or challenge generation.
 
 ## XAML Incremental Hot Reload
 
-> XAML Incremental Hot Reload is an opt-in preview feature in .NET 11.
+> XAML Incremental Hot Reload is a preview feature in .NET 11.
 
 XAML Incremental Hot Reload uses a source generator and a
 `MetadataUpdateHandler` to update already-instantiated pages without rebuilding
@@ -46,19 +46,23 @@ the app. It supports property changes, child additions and removals, structural
 reordering, attached properties, markup extensions, bindings, and
 `ResourceDictionary` updates
 ([dotnet/maui #34338](https://github.com/dotnet/maui/pull/34338)).
+The same source-generated update path also applies XAML edits during
+`dotnet watch` sessions.
 
-The feature is off by default in Preview 7. Enable it for Debug builds with:
+The feature is enabled by default for Debug builds in Preview 7. Release and
+publish builds remain disabled by default. To opt out for Debug builds and use
+the existing XAML Hot Reload path, set:
 
 ```xml
 <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-  <EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>
+  <EnableMauiIncrementalHotReload>false</EnableMauiIncrementalHotReload>
 </PropertyGroup>
 ```
 
-When the switch is off, MAUI continues to use the existing XAML Hot Reload
-path ([dotnet/maui #36832](https://github.com/dotnet/maui/pull/36832)).
+This Debug default and opt-out behavior was finalized in
+[dotnet/maui #37163](https://github.com/dotnet/maui/pull/37163).
 
-For supported edits and current limitations, see [XAML Hot
+For general XAML Hot Reload background, see [XAML Hot
 Reload](https://learn.microsoft.com/dotnet/maui/xaml/hot-reload?view=net-maui-11.0).
 
 ## Shell route templates
@@ -82,10 +86,9 @@ navigation](https://learn.microsoft.com/dotnet/maui/fundamentals/shell/navigatio
 
 ## AOT-safe RelativeSource bindings
 
-The XAML source generator now compiles
-`{RelativeSource AncestorType=...}` bindings to trim-safe
-`TypedBinding<TAncestor, TProperty>` instances when the ancestor type can be
-resolved at compile time
+The XAML source generator now compiles `{RelativeSource AncestorType=...}`
+bindings to trim-safe `TypedBinding<TAncestor, TProperty>` instances when the
+ancestor type can be resolved at compile time
 ([dotnet/maui #34408](https://github.com/dotnet/maui/pull/34408)).
 
 ```xaml
@@ -94,12 +97,14 @@ resolved at compile time
 ```
 
 This avoids a string-based binding path that relies on reflection and could
-lose bound members during trimming in AOT Release builds. `Self`,
-`TemplatedParent`, and `x:Reference` bindings whose source type can't be
-resolved at compile time continue to use the runtime binding path. An
-`AncestorType` that can't be resolved causes XAML compilation to fail. A
-follow-up also removes a false-positive `MAUIG2045` warning for unsealed
-ancestor types
+lose bound members during trimming in AOT Release builds. `Self` and
+`TemplatedParent` bindings continue to use the runtime binding path. An
+`x:Reference` binding compiles when the referenced element and binding path can
+be resolved; when the element resolves but its binding path can't be compiled,
+the binding falls back to the runtime path. An unresolved `x:Reference` name
+causes XAML compilation to fail with `MAUIG1001`; an `AncestorType` that can't
+be resolved also causes compilation to fail. A follow-up removes a
+false-positive `MAUIG2045` warning for unsealed ancestor types
 ([dotnet/maui #36905](https://github.com/dotnet/maui/pull/36905)).
 
 Learn more about [compiled
@@ -136,9 +141,10 @@ The handler is the default in Preview 7. `TabbedRenderer` remains available in
 the Compatibility layer as a manual fallback, so apps with extensive
 `TabbedPage` customizations should test this preview.
 
-See the [`TabbedPage`
+For background, see the [`TabbedPage`
 documentation](https://learn.microsoft.com/dotnet/maui/user-interface/pages/tabbedpage?view=net-maui-11.0)
-for migration guidance.
+and [reuse custom renderers in .NET
+MAUI](https://learn.microsoft.com/dotnet/maui/migration/custom-renderers?view=net-maui-11.0).
 
 ## Platform-specific capabilities
 
@@ -157,9 +163,11 @@ for migration guidance.
   callbacks in single-instance apps
   ([dotnet/maui #36640](https://github.com/dotnet/maui/pull/36640)).
 
-See the updated [media picker](https://learn.microsoft.com/dotnet/maui/platform-integration/device-media/picker?view=net-maui-11.0),
+For general API background, see the [media
+picker](https://learn.microsoft.com/dotnet/maui/platform-integration/device-media/picker?view=net-maui-11.0),
 [window](https://learn.microsoft.com/dotnet/maui/user-interface/controls/window?view=net-maui-11.0),
-and [app lifecycle](https://learn.microsoft.com/dotnet/maui/fundamentals/app-lifecycle?view=net-maui-11.0)
+and [app
+lifecycle](https://learn.microsoft.com/dotnet/maui/fundamentals/app-lifecycle?view=net-maui-11.0)
 documentation.
 
 Preview 7 also improves keyboard activation for `Border` on Windows

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -9,7 +9,7 @@ workflows:
 - [Shell route templates](#shell-route-templates)
 - [AOT-safe RelativeSource bindings](#aot-safe-relativesource-bindings)
 - [Third-party platform backends](#third-party-platform-backends)
-- [TabbedPage adopts handlers on Apple platforms](#tabbedpage-adopts-handlers-on-apple-platforms)
+- [NavigationPage and TabbedPage adopt handlers on Apple platforms](#navigationpage-and-tabbedpage-adopt-handlers-on-apple-platforms)
 - [Platform-specific capabilities](#platform-specific-capabilities)
 - [.NET for Android](#net-for-android)
 - [Apple platforms (.NET for iOS, Mac Catalyst, macOS, tvOS)](#apple-platforms-net-for-ios-mac-catalyst-macos-tvos)
@@ -130,19 +130,25 @@ activating a backend for either a recognized platform TFM or a neutral
 these APIs let a community backend integrate through a NuGet package instead
 of patching MAUI.
 
-## TabbedPage adopts handlers on Apple platforms
+## NavigationPage and TabbedPage adopt handlers on Apple platforms
 
-`TabbedPage` on iOS and Mac Catalyst now uses the standard handler
-architecture. `TabbedViewHandler` and a shared `TabBarControllerManager`
-replace the monolithic `TabbedRenderer`
+`NavigationPage` and `TabbedPage` on iOS and Mac Catalyst now use the standard
+handler architecture. `NavigationViewHandler` replaces the monolithic
+`NavigationRenderer`
+([dotnet/maui #36109](https://github.com/dotnet/maui/pull/36109)), while
+`TabbedViewHandler` and a shared `TabBarControllerManager` replace
+`TabbedRenderer`
 ([dotnet/maui #36507](https://github.com/dotnet/maui/pull/36507)).
 
-The handler is the default in Preview 7. `TabbedRenderer` remains available in
-the Compatibility layer as a manual fallback, so apps with extensive
-`TabbedPage` customizations should test this preview.
+The handlers are the defaults in Preview 7. `NavigationRenderer` and
+`TabbedRenderer` remain available in the Compatibility layer as manual
+fallbacks, so apps with custom renderers or extensive page customizations
+should test this preview.
 
-For background, see the [`TabbedPage`
-documentation](https://learn.microsoft.com/dotnet/maui/user-interface/pages/tabbedpage?view=net-maui-11.0)
+For background, see the [`NavigationPage`
+documentation](https://learn.microsoft.com/dotnet/maui/user-interface/pages/navigationpage?view=net-maui-11.0),
+[`TabbedPage`
+documentation](https://learn.microsoft.com/dotnet/maui/user-interface/pages/tabbedpage?view=net-maui-11.0),
 and [reuse custom renderers in .NET
 MAUI](https://learn.microsoft.com/dotnet/maui/migration/custom-renderers?view=net-maui-11.0).
 

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -58,6 +58,9 @@ The feature is off by default in Preview 7. Enable it for Debug builds with:
 When the switch is off, MAUI continues to use the existing XAML Hot Reload
 path ([dotnet/maui #36832](https://github.com/dotnet/maui/pull/36832)).
 
+For supported edits and current limitations, see [XAML Hot
+Reload](https://learn.microsoft.com/dotnet/maui/xaml/hot-reload?view=net-maui-11.0).
+
 ## Shell route templates
 
 Shell routes now support path parameters inspired by ASP.NET Core and Blazor
@@ -73,6 +76,9 @@ await Shell.Current.GoToAsync("//products/product/seed-tomato");
 Values are delivered through the existing `QueryProperty` and
 `IQueryAttributable` mechanisms. Template routes currently require absolute
 navigation; relative navigation is not yet supported.
+
+See [Shell
+navigation](https://learn.microsoft.com/dotnet/maui/fundamentals/shell/navigation?view=net-maui-11.0).
 
 ## AOT-safe RelativeSource bindings
 
@@ -95,6 +101,9 @@ resolved at compile time continue to use the runtime binding path. An
 follow-up also removes a false-positive `MAUIG2045` warning for unsealed
 ancestor types
 ([dotnet/maui #36905](https://github.com/dotnet/maui/pull/36905)).
+
+Learn more about [compiled
+bindings](https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings?view=net-maui-11.0).
 
 ## Third-party platform backends
 
@@ -127,6 +136,10 @@ The handler is the default in Preview 7. `TabbedRenderer` remains available in
 the Compatibility layer as a manual fallback, so apps with extensive
 `TabbedPage` customizations should test this preview.
 
+See the [`TabbedPage`
+documentation](https://learn.microsoft.com/dotnet/maui/user-interface/pages/tabbedpage?view=net-maui-11.0)
+for migration guidance.
+
 ## Platform-specific capabilities
 
 - **Status bar appearance** - `Window.StatusBarTheme` controls the icon
@@ -143,6 +156,11 @@ the Compatibility layer as a manual fallback, so apps with extensive
   activations to the running instance. This also enables `WebAuthenticator`
   callbacks in single-instance apps
   ([dotnet/maui #36640](https://github.com/dotnet/maui/pull/36640)).
+
+See the updated [media picker](https://learn.microsoft.com/dotnet/maui/platform-integration/device-media/picker?view=net-maui-11.0),
+[window](https://learn.microsoft.com/dotnet/maui/user-interface/controls/window?view=net-maui-11.0),
+and [app lifecycle](https://learn.microsoft.com/dotnet/maui/fundamentals/app-lifecycle?view=net-maui-11.0)
+documentation.
 
 Preview 7 also improves keyboard activation for `Border` on Windows
 ([dotnet/maui #35578](https://github.com/dotnet/maui/pull/35578)) and native

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -24,6 +24,13 @@ register a credential, and `Passkeys.AssertAsync` to authenticate with an
 existing credential
 ([dotnet/maui #36837](https://github.com/dotnet/maui/pull/36837)).
 
+`IsSupported` checks the platform version, but successful registration also
+requires platform trust configuration. Apple apps need Associated Domains,
+an Apple App Site Association file, and signing; Android apps need Digital
+Asset Links. See the
+[Passkeys setup guide](https://github.com/dotnet/maui/blob/release/11.0.1xx-preview7/src/Essentials/samples/README-Passkeys.md)
+for the platform prerequisites.
+
 The relying-party server supplies the standard WebAuthn options JSON and
 verifies the response JSON returned by MAUI. The API handles the platform
 ceremony, but does not perform server-side verification, attestation
@@ -146,9 +153,10 @@ for the complete set of changes.
 ## .NET for Android
 
 Preview 7 streamlines the Android development loop. `FastDeploy2` is now the
-default app-install fast deployment strategy and reduces the incremental path
-to three serial `adb` operations; the legacy strategy remains available as a
-fallback ([dotnet/android #11795](https://github.com/dotnet/android/pull/11795)).
+default app-install fast deployment strategy and can reduce the healthy warm
+incremental path to as few as three serial `adb` operations; the legacy
+strategy remains available as a fallback
+([dotnet/android #11795](https://github.com/dotnet/android/pull/11795)).
 CoreCLR Debug builds also keep typemaps stable across C#-only rebuilds that do
 not change Java-callable mappings, avoiding unnecessary native compilation,
 APK rebuilding, and signing

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -1,0 +1,329 @@
+# .NET MAUI in .NET 11 Preview 7 - Release Notes
+
+.NET 11 Preview 7 lands a coordinated wave of extension points for third-party
+platform backends, continues the handler-architecture migration on Apple
+platforms, and expands the XAML tooling for AOT and Hot Reload:
+
+- [Third-party platform backend extensibility](#third-party-platform-backend-extensibility)
+- [TabbedPage handler architecture on iOS and Mac Catalyst](#tabbedpage-handler-architecture-on-ios-and-mac-catalyst)
+- [XAML Incremental Hot Reload (opt-in preview)](#xaml-incremental-hot-reload-opt-in-preview)
+- [AOT-safe RelativeSource bindings from the XAML source generator](#aot-safe-relativesource-bindings-from-the-xaml-source-generator)
+- [Platform enhancements](#platform-enhancements)
+- [Trimming and Community Toolkit cleanup](#trimming-and-community-toolkit-cleanup)
+- [.NET for Android](#net-for-android)
+- [Apple platforms (.NET for iOS, Mac Catalyst, macOS, tvOS)](#apple-platforms-net-for-ios-mac-catalyst-macos-tvos)
+- [Contributors](#contributors)
+
+.NET MAUI updates in .NET 11:
+
+- [What's new in .NET MAUI in .NET 11](https://learn.microsoft.com/dotnet/maui/whats-new/)
+
+## Third-party platform backend extensibility
+
+.NET MAUI's programming model has historically assumed a fixed set of
+first-party platform backends (Android, iOS, Mac Catalyst, macOS, Tizen,
+Windows). Preview 7 lands a coordinated set of extension points from the
+platform-extensibility epic
+([dotnet/maui #34099](https://github.com/dotnet/maui/issues/34099)) that let
+third-party or community backends — for example a Linux/GTK head — plug into
+the same MSBuild, DI, and handler machinery the built-in platforms use,
+without patching MAUI itself.
+
+- **XAML `OnPlatform` recognizes GTK, macOS, and WPF.** The `GTK`, `macOS`, and
+  `WPF` properties on `OnPlatformExtension` are now public, so the inline
+  `{OnPlatform GTK=..., macOS=..., WPF=...}` markup-extension form works for
+  external backends. The `OnPlatform<T>` element form remains the route for
+  arbitrary platform strings such as `Web`
+  ([dotnet/maui #35901](https://github.com/dotnet/maui/pull/35901)).
+- **Public `IAlertManager` extension points.**
+  `Microsoft.Maui.Controls.Platform.IAlertManager` and
+  `IAlertManagerSubscription` are public on `net11.0` so custom platform
+  backends can host alerts, action sheets, and prompts. They were originally
+  introduced in .NET 10 and reverted to internal for servicing; the interface
+  signatures and runtime behavior are unchanged from the .NET 10 shape
+  ([dotnet/maui #36633](https://github.com/dotnet/maui/pull/36633)).
+- **Custom `BlazorWebView` handlers.**
+  `IMauiBlazorWebViewBuilder.UsePlatformHandler<THandler>()` and its factory
+  overload let a third-party backend replace the default `BlazorWebViewHandler`
+  while keeping every service registered by `AddMauiBlazorWebView()` — JSInterop,
+  navigation, static assets, and the rest. Handlers implement the new
+  `IBlazorWebViewHandler` capability interface so shared code no longer
+  hard-casts to the built-in handler
+  ([dotnet/maui #36658](https://github.com/dotnet/maui/pull/36658)).
+
+  ```csharp
+  builder.Services
+      .AddMauiBlazorWebView()
+      .UsePlatformHandler<GtkBlazorWebViewHandler>();
+  ```
+
+- **Resizetizer external backends.** A new MSBuild contract —
+  `ResizetizerPlatformType`, `MauiProcessedImage`/`MauiProcessedFont`/`MauiProcessedAsset`,
+  and `ResizetizerAfter{Image,Font,Asset}ProcessingTargets` — lets an
+  out-of-tree backend opt into image, font, and asset processing without
+  teaching MAUI about its platform
+  ([dotnet/maui #36653](https://github.com/dotnet/maui/pull/36653)).
+- **SingleProject neutral-TFM backends.** External backends can register
+  through the existing `MauiPlatformSpecificFolder` item and activate for
+  either a recognized platform TFM or a plain `net11.0` inner build by opting
+  in with a selector property (default `MauiActiveBackend`)
+  ([dotnet/maui #36654](https://github.com/dotnet/maui/pull/36654)).
+
+  ```xml
+  <PropertyGroup>
+    <TargetFrameworks>net11.0-ios;net11.0</TargetFrameworks>
+    <MauiActiveBackend Condition=" '$(TargetFramework)' == 'net11.0' ">gtk</MauiActiveBackend>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Platform.Maui.Linux.Gtk4" Version="..." />
+  </ItemGroup>
+  ```
+
+- **`GestureManager` factory is public.** The `Microsoft.Maui.Controls`
+  `GestureManager` exposes a public factory, and the built-in gesture manager
+  now skips incompatible handlers instead of throwing, so a third-party backend
+  can register its own gesture manager without breaking apps that mix it with
+  the built-in handlers
+  ([dotnet/maui #36655](https://github.com/dotnet/maui/pull/36655)).
+
+Individually these are small; together they are the difference between a
+community backend being a fork and a community backend being a NuGet package.
+
+## TabbedPage handler architecture on iOS and Mac Catalyst
+
+`TabbedPage` on iOS and Mac Catalyst is re-implemented on top of the standard
+handler architecture. The monolithic `TabbedRenderer` — a single ~600-line
+class that *was* a `UITabBarController` — is replaced by a layered
+`TabbedViewHandler` plus a shared `TabBarControllerManager` in
+`Microsoft.Maui.Core`
+([dotnet/maui #36507](https://github.com/dotnet/maui/pull/36507)). The new
+handler is the unconditional default on iOS and Mac Catalyst; the runtime
+feature switch and MSBuild opt-in used during development have been removed.
+`TabbedRenderer` itself is unchanged and remains in the Compatibility layer as
+a manual fallback.
+
+Together with the earlier Android Shell handler work, this continues the
+effort to converge every control on the same handler pattern across every
+platform. Apps that use `TabbedPage` heavily on iOS or Mac Catalyst are the
+primary audience to try this preview against.
+
+## XAML Incremental Hot Reload (opt-in preview)
+
+Preview 7 introduces **XAML Incremental Hot Reload (XIHR)**: a Roslyn source
+generator plus a `[MetadataUpdateHandler]` runtime that lets XAML edits update
+already-instantiated pages *without rebuilding the app*
+([dotnet/maui #34338](https://github.com/dotnet/maui/pull/34338)). When you
+edit a XAML file, the generator emits a per-version patch method
+(`UpdateComponent`), and the runtime dispatches it against every live instance
+of the affected page, advancing each instance through its accumulated patch
+chain. The generator handles property changes, child add/remove, structural
+reorders, attached properties, markup extensions, bindings, and
+`ResourceDictionary` updates.
+
+XIHR is **off by default** in this preview and gated by a runtime feature
+switch, so trimmed and AOT production builds pay no cost
+([dotnet/maui #36832](https://github.com/dotnet/maui/pull/36832)). To try it in
+Debug, opt in per project:
+
+```xml
+<PropertyGroup>
+  <EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>
+</PropertyGroup>
+```
+
+When the switch is off, the existing legacy XAML Hot Reload path is used, so
+nothing changes for existing apps.
+
+## AOT-safe RelativeSource bindings from the XAML source generator
+
+The XAML source generator now compiles `{RelativeSource AncestorType=...}`
+bindings to a trim-safe `TypedBinding<TAncestor, TProperty>` when the ancestor
+type is resolvable at compile time
+([dotnet/maui #34408](https://github.com/dotnet/maui/pull/34408), resolving
+[dotnet/maui #34056](https://github.com/dotnet/maui/issues/34056)).
+
+```xaml
+<ContentPage x:DataType="local:PageViewModel">
+    <Label Text="{Binding Title,
+                          Source={RelativeSource AncestorType={x:Type local:PageViewModel}}}" />
+</ContentPage>
+```
+
+Previously the compiler routed every explicit-source binding to the string-based
+`Binding(string, ...)` constructor — a `[RequiresUnreferencedCode]` API that
+could be trimmed away in AOT Release builds. The generator now recognizes the
+ancestor type and emits a compiled binding, using ambient `x:DataType` only for
+bindings whose source is genuinely unknown (`Self`, `TemplatedParent`,
+unresolved ancestor sources, and `x:Reference`, which continue to fall back to
+the runtime path).
+
+A related follow-up silences a false-positive `MAUIG2045` diagnostic that the
+new `RelativeSource AncestorType` analyzer produced on unsealed ancestor types
+([dotnet/maui #36905](https://github.com/dotnet/maui/pull/36905)).
+
+## Platform enhancements
+
+- **Windows `Border` keyboard tap.** A `Border` with a single-tap,
+  primary-button `TapGestureRecognizer` is now keyboard actionable on Windows:
+  `ContentPanel.IsTabStop` is set to `true`, and pressing **Enter** or
+  **Space** while the `Border` has focus invokes the gesture through
+  `SendTapped`. This matches the existing Android keyboard-tap behavior
+  ([dotnet/maui #35578](https://github.com/dotnet/maui/pull/35578)).
+- **Windows single-instance activation.** MAUI apps on Windows expose an
+  `AppInstance` activation lifecycle hook and support redirecting external
+  activations to the running instance, which also enables `WebAuthenticator`
+  callbacks in single-instance apps
+  ([dotnet/maui #36640](https://github.com/dotnet/maui/pull/36640)).
+- **Android Material 3 Slider events.** The Material 3 Slider handler
+  subscribes to Android's native `Change`, `StartTrackingTouch`, and
+  `StopTrackingTouch` events directly instead of relying on a touch-event
+  workaround, so `ValueChanged`, `DragStarted`, and `DragCompleted` all fire
+  correctly and the floating-label workaround is gone
+  ([dotnet/maui #36448](https://github.com/dotnet/maui/pull/36448)).
+
+## Trimming and Community Toolkit cleanup
+
+Preview 7 finishes a set of long-running cleanups that unblock trim-safe apps
+and prepare for the .NET 11 Community Toolkit.
+
+- All `InternalsVisibleTo` grants for the .NET MAUI Community Toolkit
+  (`CommunityToolkit.Maui`, `.Core`, `.Markup`, and their `.UnitTests`
+  assemblies) are removed from `Microsoft.Maui.Core`,
+  `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Xaml`, and
+  `Microsoft.Maui.Essentials` — 22 declarations in total
+  ([dotnet/maui #34070](https://github.com/dotnet/maui/pull/34070)). This has
+  been attempted twice before and reverted because the toolkit had not yet
+  migrated off the internal APIs; making the change in `net11.0` gives the
+  toolkit a full release window to migrate.
+- The `_MauiFixTrimmerRootAssemblyMetadata` workaround target and the
+  corresponding `RootMode="All"` `TrimmerRootAssembly` entries are removed
+  from the AOT test templates
+  ([dotnet/maui #34519](https://github.com/dotnet/maui/pull/34519)).
+- The remaining conversion helpers in `Microsoft.Maui.Controls` are annotated
+  for trim safety, so they no longer produce trim/AOT warnings when used from
+  a fully trimmed app
+  ([dotnet/maui #30875](https://github.com/dotnet/maui/pull/30875)).
+
+## .NET for Android
+
+.NET for Android Preview 7 is dominated by CoreCLR host work and the
+trimmable-typemap migration.
+
+The **trimmable typemap is now the default typemap for NativeAOT**
+([dotnet/android #12121](https://github.com/dotnet/android/pull/12121)). The
+reflection-based `managed` typemap is removed entirely
+([dotnet/android #12134](https://github.com/dotnet/android/pull/12134)), so
+`_AndroidTypeMapImplementation` now accepts only `llvm-ir` (Mono and CoreCLR)
+and `trimmable` (NativeAOT). Under NativeAOT the R8 keep rules are extended
+for custom `IJavaObject` types
+([dotnet/android #12132](https://github.com/dotnet/android/pull/12132), which
+emits a new `XA4212` diagnostic), the trimmable ACW map preserves nested Java
+class names
+([dotnet/android #12187](https://github.com/dotnet/android/pull/12187)), and
+`IGCUserPeer` methods are preserved through R8
+([dotnet/android #12100](https://github.com/dotnet/android/pull/12100)).
+
+CoreCLR gains two important assembly-store changes:
+
+- **`dlopen()`-based assembly-store loading.** Instead of parsing the APK ZIP
+  central directory and walking the wrapper `.so` ELF section headers by hand,
+  the CoreCLR host makes the assembly-store payload a loadable section exposed
+  through the exported `_assembly_store` dynamic symbol and asks the platform
+  linker to `dlopen`/`dlsym` it. MonoVM is unchanged
+  ([dotnet/android #12033](https://github.com/dotnet/android/pull/12033)).
+- **On-device decompressed AssemblyStore cache** (opt-in). Setting
+  `AndroidEnableAssemblyStoreDecompressionCache=true` on a CoreCLR Release
+  build caches Zstd-decompressed assemblies under `codeCacheDir` so subsequent
+  launches skip decompression and use file-backed mappings. The cache
+  self-heals on checksum failure and rejects corrupted entries
+  ([dotnet/android #11967](https://github.com/dotnet/android/pull/11967)).
+
+`AndroidMessageHandler` continues to align with `SocketsHttpHandler`. `HEAD`
+requests are preserved across `301`, `302`, and `303` redirects instead of
+being coerced to `GET`
+([dotnet/android #12102](https://github.com/dotnet/android/pull/12102)), and
+disposing an `HttpResponseMessage` while a body read is still parked in okhttp
+no longer crashes the process with an *Unbalanced enter/exit*
+`IllegalStateException` — the response body's in-flight I/O is aborted first
+([dotnet/android #12105](https://github.com/dotnet/android/pull/12105)). This
+last fix matters most for gRPC server-streaming, which cancels by disposing
+the response.
+
+Finally, a new build-time diagnostic **`XA0132`** flags a missing Fast
+Deployment package on device, so an incremental deploy against a device that
+no longer has the shared runtime package produces an actionable error instead
+of a runtime crash
+([dotnet/android #12060](https://github.com/dotnet/android/pull/12060)).
+
+## Apple platforms (.NET for iOS, Mac Catalyst, macOS, tvOS)
+
+The Apple workloads' Preview 7 changes focus on completing the NativeAOT
+compilation flow and tightening the MSBuild contract.
+
+- **Skip ILLink completes for NativeAOT.** For .NET 11+ builds, the SDK no
+  longer runs a redundant ILLink pass before ILC — ILC now receives the
+  fully-prepared assemblies directly. This removes a whole assembly-modification
+  step from NativeAOT builds
+  ([dotnet/macios #26193](https://github.com/dotnet/macios/pull/26193)).
+- **Native registrar generated after ILC for trimmable-static.** With the
+  trimmable-static registrar, the generated native registrar code is now
+  emitted after ILC has produced its output, so it can see the final trimmed
+  managed surface
+  ([dotnet/macios #26194](https://github.com/dotnet/macios/pull/26194)).
+- **Diagnostic for post-ILC assembly modification.** A new NativeAOT
+  build-time warning fires when a post-ILC step modifies a managed assembly —
+  a common source of hard-to-diagnose runtime failures on NativeAOT — so
+  custom tooling and third-party targets can be caught early
+  ([dotnet/macios #26137](https://github.com/dotnet/macios/pull/26137)).
+- **Missing Objective-C classes no longer break the link.** When
+  `Class.GetHandle` is inlined and the target Objective-C class isn't present
+  in the linked binary, MSBuild now emits a warning and lets the app link
+  instead of failing the build; this backports to the `release/11.0.1xx-preview7`
+  branch as [dotnet/macios #26347](https://github.com/dotnet/macios/pull/26347)
+  ([dotnet/macios #26302](https://github.com/dotnet/macios/pull/26302)).
+- **Invalid IL fix in generated `CreateObject` proxies for generic types.**
+  The tooling that generates `CreateObject` proxies could emit invalid IL for
+  generic types, breaking some binding scenarios; the generator now emits
+  correct IL
+  ([dotnet/macios #26100](https://github.com/dotnet/macios/pull/26100)).
+- **`EnableCrashReport` MSBuild property.** A new
+  `<EnableCrashReport>true</EnableCrashReport>` MSBuild property enables the
+  .NET crash-report writer for iOS, Mac Catalyst, macOS, and tvOS apps
+  ([dotnet/macios #26134](https://github.com/dotnet/macios/pull/26134)).
+- **`rgen` UI namespace cache scoped per-compilation** eliminates a source of
+  Roslyn generator flakiness for apps that reference UIKit / AppKit
+  ([dotnet/macios #26187](https://github.com/dotnet/macios/pull/26187)).
+
+See the full Preview 7 changelog for the complete list:
+<https://github.com/dotnet/macios/compare/release/11.0.1xx-preview6...release/11.0.1xx-preview7>
+
+## Contributors
+
+Thank you contributors! ❤️
+
+- [@baaaaif](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Abaaaaif)
+- [@BagavathiPerumal](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ABagavathiPerumal)
+- [@devanathan-vaithiyanathan](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Adevanathan-vaithiyanathan)
+- [@Dhivya-SF4094](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ADhivya-SF4094)
+- [@HarishKumarSF4517](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AHarishKumarSF4517)
+- [@HarishwaranVijayakumar](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AHarishwaranVijayakumar)
+- [@IlGalvo](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AIlGalvo)
+- [@jpd21122012](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Ajpd21122012)
+- [@KarthikRajaKalaimani](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AKarthikRajaKalaimani)
+- [@kevin68](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Akevin68)
+- [@LogishaSelvarajSF4525](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ALogishaSelvarajSF4525)
+- [@NafeelaNazhir](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ANafeelaNazhir)
+- [@NirmalKumarYuvaraj](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ANirmalKumarYuvaraj)
+- [@pictos](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Apictos)
+- [@prakashKannanSf3972](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AprakashKannanSf3972)
+- [@praveenkumarkarunanithi](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3Apraveenkumarkarunanithi)
+- [@Shalini-Ashokan](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AShalini-Ashokan)
+- [@SubhikshaSf4851](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ASubhikshaSf4851)
+- [@SyedAbdulAzeemSF4852](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ASyedAbdulAzeemSF4852)
+- [@Tamilarasan-Paranthaman](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ATamilarasan-Paranthaman)
+- [@TamilarasanSF4853](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3ATamilarasanSF4853)
+- [@Vignesh-SF3580](https://github.com/dotnet/maui/pulls?q=is%3Apr+is%3Amerged+author%3AVignesh-SF3580)
+
+<!-- Content derived from merged PRs on release/11.0.1xx-preview7 branches of
+     dotnet/maui, dotnet/android, and dotnet/macios in the 2026-07-14 to
+     2026-07-31 window. -->

--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -89,9 +89,11 @@ resolved at compile time
 
 This avoids a string-based binding path that relies on reflection and could
 lose bound members during trimming in AOT Release builds. `Self`,
-`TemplatedParent`, unresolved ancestor sources, and unresolved `x:Reference`
-bindings continue to use the runtime binding path. A follow-up also removes a
-false-positive `MAUIG2045` warning for unsealed ancestor types
+`TemplatedParent`, and `x:Reference` bindings whose source type can't be
+resolved at compile time continue to use the runtime binding path. An
+`AncestorType` that can't be resolved causes XAML compilation to fail. A
+follow-up also removes a false-positive `MAUIG2045` warning for unsealed
+ancestor types
 ([dotnet/maui #36905](https://github.com/dotnet/maui/pull/36905)).
 
 ## Third-party platform backends


### PR DESCRIPTION
Component release notes for `dotnetmaui.md` in .NET 11 Preview 7.

Targets the milestone base branch `release-notes/11.0-preview7` (see #10501).

This content is AI-authored and needs a review pass from the component team before it goes ready-for-review.