### PR TITLE
Update EF Core, WPF, and Windows Forms release notes owners

### DIFF
--- a/.github/skills/release-notes/references/component-mapping.md
+++ b/.github/skills/release-notes/references/component-mapping.md
@@ -13,8 +13,8 @@ Uses the `repo` field from `changes.json` (which matches `source-manifest.json` 
 | `sdk` | .NET SDK | `dotnet/sdk` | `sdk.md` | @baronfel |
 | `templating` | .NET SDK (Templating) | `dotnet/templating` | `sdk.md` | @baronfel |
 | `msbuild` | MSBuild | `dotnet/msbuild` | `msbuild.md` | @baronfel |
-| `winforms` | Windows Forms | `dotnet/winforms` | `winforms.md` | @KlausLoeffelmann @merriemcgaw |
-| `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @harshit7962 @adegeo |
+| `winforms` | Windows Forms | `dotnet/winforms` | `winforms.md` | @KlausLoeffelmann |
+| `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @vinnarayana-msft |
 | `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT @roji |
 | `roslyn` | C# / Visual Basic | `dotnet/roslyn` | `csharp.md` | @BillWagner |
 | `fsharp` | F# | `dotnet/fsharp` | `fsharp.md` | @T-Gro |

--- a/.github/skills/release-notes/references/component-mapping.md
+++ b/.github/skills/release-notes/references/component-mapping.md
@@ -15,7 +15,7 @@ Uses the `repo` field from `changes.json` (which matches `source-manifest.json` 
 | `msbuild` | MSBuild | `dotnet/msbuild` | `msbuild.md` | @baronfel |
 | `winforms` | Windows Forms | `dotnet/winforms` | `winforms.md` | @KlausLoeffelmann |
 | `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @vinnarayana-msft |
-| `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT @roji |
+| `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT |
 | `roslyn` | C# / Visual Basic | `dotnet/roslyn` | `csharp.md` | @BillWagner |
 | `fsharp` | F# | `dotnet/fsharp` | `fsharp.md` | @T-Gro |
 | `nuget-client` | NuGet | `nuget/nuget.client` | `nuget.md` | @baronfel |

--- a/.github/skills/release-notes/references/component-mapping.md
+++ b/.github/skills/release-notes/references/component-mapping.md
@@ -14,7 +14,7 @@ Uses the `repo` field from `changes.json` (which matches `source-manifest.json` 
 | `templating` | .NET SDK (Templating) | `dotnet/templating` | `sdk.md` | @baronfel |
 | `msbuild` | MSBuild | `dotnet/msbuild` | `msbuild.md` | @baronfel |
 | `winforms` | Windows Forms | `dotnet/winforms` | `winforms.md` | @KlausLoeffelmann |
-| `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @vinnarayana-msft |
+| `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @subhajitm |
 | `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT @AndriySvyryd |
 | `roslyn` | C# / Visual Basic | `dotnet/roslyn` | `csharp.md` | @BillWagner |
 | `fsharp` | F# | `dotnet/fsharp` | `fsharp.md` | @T-Gro |

--- a/.github/skills/release-notes/references/component-mapping.md
+++ b/.github/skills/release-notes/references/component-mapping.md
@@ -15,7 +15,7 @@ Uses the `repo` field from `changes.json` (which matches `source-manifest.json` 
 | `msbuild` | MSBuild | `dotnet/msbuild` | `msbuild.md` | @baronfel |
 | `winforms` | Windows Forms | `dotnet/winforms` | `winforms.md` | @KlausLoeffelmann |
 | `wpf` | WPF | `dotnet/wpf` | `wpf.md` | @vinnarayana-msft |
-| `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT |
+| `efcore` | EF Core | `dotnet/efcore` | `efcore.md` | @SamMonoRT @AndriySvyryd |
 | `roslyn` | C# / Visual Basic | `dotnet/roslyn` | `csharp.md` | @BillWagner |
 | `fsharp` | F# | `dotnet/fsharp` | `fsharp.md` | @T-Gro |
 | `nuget-client` | NuGet | `nuget/nuget.client` | `nuget.md` | @baronfel |


### PR DESCRIPTION
Updates the default release notes assignees in the `release-notes` skill's component mapping.

- **Windows Forms** - Merrie McGaw has retired and is no longer working on Windows Forms, so `winforms.md` is now owned by @KlausLoeffelmann alone.
- **WPF** - ownership moves to Subhajit Mandal (@subhajitm), replacing @harshit7962 and @adegeo.
- **EF Core** - @roji no longer works on EF Core. `efcore.md` is now owned by @SamMonoRT and @AndriySvyryd.

Surfaced while opening the .NET 11 Preview 7 release notes PRs (#10501). The already-open Preview 7 PRs (#10506, #10513, #10514) have been reassigned to match.