### PR TITLE
Add Ubuntu 26.04 version to the supported OS list

### DIFF
--- a/release-notes/10.0/supported-os.md
+++ b/release-notes/10.0/supported-os.md
@@ -42,7 +42,7 @@ Notes:
 | [openSUSE Leap][15]            | 16.0                | Arm64, x64                 | [Lifecycle][16] |
 | [Red Hat Enterprise Linux][17] | 10, 9, 8            | Arm64, ppc64le, s390x, x64 | [Lifecycle][18] |
 | [SUSE Linux Enterprise][19]    | 16.0, 15.7          | Arm64, x64                 | [Lifecycle][20] |
-| [Ubuntu][21]                   | 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
+| [Ubuntu][21]                   | 26.04, 25.10, 24.04, 22.04 | Arm32, Arm64, x64          | [Lifecycle][22] |
 
 Notes:
 


### PR DESCRIPTION
This [learn.microsoft.com page shows that .NET10 is supported on Ubuntu 26.04](https://learn.microsoft.com/en-gb/dotnet/core/install/linux-ubuntu-install?tabs=dotnet10&pivots=os-linux-ubuntu-2604#ubuntu-2604) however the developer docs say it isn't

Updating these docs to match the published docs as this has caused some confusion in 
- https://github.com/PowerShell/PowerShell/issues/27388