### PR TITLE
Improve release notes index generation

### DIFF
--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -16,7 +16,7 @@ This skill is the **editorial writing stage** of the pipeline. It turns a scored
 2. `generate-features` reads `changes.json`, resolves revert/backout relationships, and emits `features.json` with optional scores using the shared `editorial-scoring` rubric
 3. `update-existing-branch` handles incremental reruns when a milestone branch already exists, merging deltas instead of restarting from scratch
 4. `api-diff-validation` / `dotnet-inspect` verifies public APIs and confirms suspect features still exist in the shipped build
-5. `release-notes` writes curated markdown using the higher-value entries from `features.json`
+5. `release-notes` writes curated component markdown using the higher-value entries from `features.json` and creates a reader-facing milestone index using the standard `README.md` structure in [`format-template.md`](references/format-template.md)
 6. `review-release-notes` runs a final multi-model editorial QA pass against the scoring rubric and examples
 7. Output is a set of pull requests per release milestone in dotnet/core: a base PR that holds shared metadata (`changes.json`, `features.json`, `README.md`, `build-metadata.json`) and one PR per component file. Each component PR targets the base branch so component teams review and edit their file in isolation. See [`pr-layout.md`](references/pr-layout.md) for the full layout and naming scheme.
 

--- a/.github/skills/release-notes/references/format-template.md
+++ b/.github/skills/release-notes/references/format-template.md
@@ -33,36 +33,71 @@ Standard document structure for .NET release notes markdown files.
 
 ### README.md (index file)
 
-The README.md links to all component files and includes the general docs link. Component files do NOT include the general "What's new" link — that goes in the README only.
+The README.md is the reader-facing index for the milestone. It links to every
+component file, groups the links consistently, points to the release downloads,
+and provides durable product documentation links. Component files do NOT repeat
+these general links.
 
 ```markdown
-# .NET <VERSION> <PREVIEW> - Release Notes
+# .NET <VERSION> <MILESTONE> - Release Notes
 
-- [Libraries](libraries.md)
-- [Runtime](runtime.md)
-- [ASP.NET Core](aspnetcore.md)
-...
+.NET <VERSION> <MILESTONE> release notes. Find more information on new features released in .NET <VERSION> <MILESTONE> by browsing through the release notes below:
 
-.NET <VERSION> updates:
+- [Libraries](./libraries.md)
+- [Runtime](./runtime.md)
+- [SDK](./sdk.md)
+- [MSBuild](./msbuild.md)
+- [NuGet](./nuget.md)
 
-- [What's new in .NET <VERSION>](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-<version>/overview)
+## Languages
 
-## Release information
+- [C#](./csharp.md)
+- [F#](./fsharp.md)
+- [Visual Basic](./visualbasic.md)
 
-| | Version |
-| --- | --- |
-| Runtime | <runtime-version> |
-| SDK | <sdk-version> |
+## Workloads, Libraries, & More
 
-### VMR refs
+- [.NET MAUI](./dotnetmaui.md)
+- [ASP.NET Core](./aspnetcore.md)
+- [Container images](./containers.md)
+- [EF Core & Data](./efcore.md)
+- [Windows Forms](./winforms.md)
+- [WPF](./wpf.md)
 
-These release notes were generated from the [dotnet/dotnet](https://github.com/dotnet/dotnet) VMR:
+## Get Started
 
-- **Base**: [`<base-tag>`](https://github.com/dotnet/dotnet/tree/<base-tag>)
-- **Head**: [`<head-branch>`](https://github.com/dotnet/dotnet/tree/<head-branch>)
+Instructions on getting started with .NET <VERSION> can be found in the [getting started guide](../../get-started.md). Installers and binaries for .NET <VERSION> <MILESTONE> are available from [dotnet.microsoft.com](https://dotnet.microsoft.com/download/dotnet/<version>) and [.NET <VERSION> Releases](../../README.md).
+
+## Stay up-to-date
+
+You can find a detailed overview of all new features in .NET <VERSION>:
+
+- [What's new in C#](https://learn.microsoft.com/dotnet/csharp/whats-new/)
+- [What's new in .NET MAUI](https://learn.microsoft.com/dotnet/maui/whats-new/)
+- [What's new in Entity Framework Core](https://learn.microsoft.com/ef/core/what-is-new/)
+- [What's new in Windows Forms](https://learn.microsoft.com/dotnet/desktop/winforms/whats-new/)
+- [What's new in WPF](https://learn.microsoft.com/dotnet/desktop/wpf/whats-new/)
+
+The latest .NET <VERSION> release is always available at [dotnet.microsoft.com](https://dotnet.microsoft.com/download/dotnet/<version>) and [.NET <VERSION> Releases](../../README.md).
 ```
 
-Read the runtime version, SDK version, base ref, and head ref from `build-metadata.json`.
+Apply these rules when generating the index:
+
+1. Link every component markdown file exactly once. Omit only optional files
+   that were not produced, such as `visualbasic.md`.
+2. Keep Libraries, Runtime, SDK, MSBuild, and NuGet before the grouped sections.
+3. Use **Languages** for language release notes and
+   **Workloads, Libraries, & More** for application frameworks, workloads,
+   container images, and desktop frameworks.
+4. If the artifacts-publishing automation has already created the milestone
+   landing page, link to it directly from **Get Started**. Otherwise, use the
+   general download page and version release index shown in the template; do
+   not create or link to a landing page that does not exist yet.
+5. Keep the reader-facing index focused on navigation and documentation. Store
+   runtime/SDK versions and VMR base/head refs in `build-metadata.json`; do not
+   expose release-notes generation provenance in README.md.
+6. Use the stable documentation entry points shown in the template. Do not
+   guess milestone-specific documentation URLs that might not exist yet.
 
 ### Component-specific docs links
 


### PR DESCRIPTION
## Summary

- make creation of the reader-facing milestone index an explicit release-notes skill responsibility
- replace the loose README example with the established release index structure used by the early .NET 11 previews
- require every generated component file to be linked exactly once in consistent product groupings
- keep build versions and VMR provenance in `build-metadata.json` instead of the public index
- use stable documentation and download links, with the exact milestone landing page only after artifacts publishing creates it

## Validation

- Markdown lint and link checks pass for the changed skill files
- repository Checkov scan reports the existing `CKV2_GHA_1` failure in `.github/workflows/copilot-setup-steps.yml`
- repository-wide Prettier reports existing formatting warnings; the changed Markdown also follows the repository's existing non-Prettier style