### PR TITLE
[release-notes] Highlight Avalonia template support in Preview 7

### DIFF
--- a/release-notes/11.0/preview/preview7/dotnetmaui.md
+++ b/release-notes/11.0/preview/preview7/dotnetmaui.md
@@ -1,12 +1,13 @@
 # .NET MAUI in .NET 11 Preview 7 - Release Notes
 
 .NET 11 Preview 7 adds cross-platform passkey authentication, XAML
-Incremental Hot Reload, Shell route templates, and faster device development
-workflows:
+Incremental Hot Reload, Shell route templates, Avalonia support for the MAUI
+app template, and faster device development workflows:
 
 - [Cross-platform passkey authentication](#cross-platform-passkey-authentication)
 - [XAML Incremental Hot Reload](#xaml-incremental-hot-reload)
 - [Shell route templates](#shell-route-templates)
+- [Create MAUI apps with Avalonia support](#create-maui-apps-with-avalonia-support)
 - [AOT-safe RelativeSource bindings](#aot-safe-relativesource-bindings)
 - [Third-party platform backends](#third-party-platform-backends)
 - [NavigationPage and TabbedPage adopt handlers on Apple platforms](#navigationpage-and-tabbedpage-adopt-handlers-on-apple-platforms)
@@ -83,6 +84,27 @@ navigation; relative navigation is not yet supported.
 
 See [Shell
 navigation](https://learn.microsoft.com/dotnet/maui/fundamentals/shell/navigation?view=net-maui-11.0).
+
+## Create MAUI apps with Avalonia support
+
+The MAUI app template now supports `--with-avalonia`, which adds
+`Avalonia.Controls.Maui`, `Avalonia.Controls.Maui.Desktop`, and a
+platform-neutral `net11.0` desktop target to the generated project. The desktop
+target renders with Avalonia on Windows, macOS, and Linux. The Android, iOS,
+Mac Catalyst, and Windows heads keep native MAUI controls as the default and
+enable Avalonia embedding, so apps can combine native and Avalonia UI
+([dotnet/maui #35950](https://github.com/dotnet/maui/pull/35950)).
+
+```console
+dotnet new maui --with-avalonia
+```
+
+The Avalonia option is ignored when `--sample-content` is enabled.
+
+<https://github.com/user-attachments/assets/2bc14441-7feb-4cd4-83ca-5558a15390d2>
+
+Thank you [@drasticactions](https://github.com/drasticactions) for this
+contribution!
 
 ## AOT-safe RelativeSource bindings
 


### PR DESCRIPTION
## Summary

- add `dotnet new maui --with-avalonia` to the Preview 7 highlights and table of contents
- explain the generated Avalonia desktop target and Avalonia embedding on MAUI platform heads
- embed the public demo video from dotnet/maui#35950 and credit @drasticactions

## Source verification

- dotnet/maui#35950 merged into `release/11.0.1xx-preview7` as `b088593f`
- the shipped template exposes `--with-avalonia` and adds both `Avalonia.Controls.Maui` packages plus the `net11.0` desktop target
- the installed Preview 7 template help confirms the option and its `--sample-content` exclusion

## Media

The source PR contains a public MP4 demo rather than a static image. This update uses that existing demo, following the user-attachment media convention already present in dotnet/core MAUI release notes.

## Validation

- markdownlint: passed
- markdown link check: passed
- demo video download and media type: passed
- factual pre-push review: no findings