### PR TITLE
Fix .NET 10.0.3 VS metadata typo

### DIFF
--- a/release-notes/10.0/10.0.3/release.json
+++ b/release-notes/10.0/10.0.3/release.json
@@ -13,7 +13,7 @@
       "runtime": {
         "version": "10.0.3",
         "version-display": "10.0.3",
-        "vs-version": "18.2.0, 18.3..0",
+        "vs-version": "18.2.0, 18.3.0",
         "vs-mac-version": "",
         "files": [
           {


### PR DESCRIPTION
## Summary

Correct a malformed Visual Studio version in the .NET 10.0.3 per-release metadata:

`18.3..0` -> `18.3.0`

## Why

The per-release `release.json` contains a typo, while the aggregate `release-notes/10.0/releases.json` and the SDK metadata for the same release already contain `18.3.0`. The malformed value is also exposed by the published per-release metadata endpoints.

## Validation

- Parsed both JSON files successfully.
- Confirmed the corrected runtime `vs-version` matches the .NET 10.0.3 aggregate entry.
- Ran `git diff --check`.
