### PR TITLE
Document August 2026 WPF known issue

### DIFF
--- a/release-notes/10.0/known-issues.md
+++ b/release-notes/10.0/known-issues.md
@@ -2,6 +2,28 @@
 
 You may encounter some known issues, which may include workarounds, mitigations, or expected resolution timeframes. Watch this space for any known issues in .NET 10.0.
 
+## WPF printing and PDF/XPS generation may fail with certain fonts
+
+After installing the August 2026 .NET update, some WPF applications may fail with a `System.IO.FileFormatException` when printing or generating PDF/XPS content that uses certain fonts, including Calibri.
+
+### Workaround for WPF printing and PDF/XPS generation
+
+Applications may mitigate the issue by enabling the `Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection` AppContext switch in the application's `runtimeconfig.json` file:
+
+```json
+{
+  "configProperties": {
+    "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
+    "CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS": false,
+    "Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection": true
+  }
+}
+```
+
+This switch disables security protections introduced in the August 2026 update and may increase exposure to the vulnerabilities addressed by that update. Microsoft recommends using this workaround only as a temporary measure and only when required to address this issue.
+
+**Status:** Investigating.
+
 ## Debugger crashes on macOS when using VS Code with .NET 10.0.4
 
 We have a known issue in .NET 10.0.4 that causes the debugger to crash when debugging applications on macOS using Visual Studio Code. This regression is unrelated to the security fixes included in 10.0.4.
@@ -114,4 +136,3 @@ Impacts 10.0.101 and newer .NET SDK versions.
 **Workaround**: `dotnet workload config --update-mode manifests` then `dotnet workload update`. After that you can switch back to workload-set updates or stick with manifest until this is resolved. You may need to delete the dotnet/metadata folder as well.
 
 Alternatively, you can install the previous SDK that included the manifests that are missing, then update, then uninstall that SDK.
-

--- a/release-notes/8.0/known-issues.md
+++ b/release-notes/8.0/known-issues.md
@@ -2,6 +2,28 @@
 
 You may encounter the following known issues, which may include workarounds, mitigations, or expected resolution timeframes.
 
+## WPF printing and PDF/XPS generation may fail with certain fonts
+
+After installing the August 2026 .NET update, some WPF applications may fail with a `System.IO.FileFormatException` when printing or generating PDF/XPS content that uses certain fonts, including Calibri.
+
+### Workaround for WPF printing and PDF/XPS generation
+
+Applications may mitigate the issue by enabling the `Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection` AppContext switch in the application's `runtimeconfig.json` file:
+
+```json
+{
+  "configProperties": {
+    "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
+    "CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS": false,
+    "Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection": true
+  }
+}
+```
+
+This switch disables security protections introduced in the August 2026 update and may increase exposure to the vulnerabilities addressed by that update. Microsoft recommends using this workaround only as a temporary measure and only when required to address this issue.
+
+**Status:** Investigating.
+
 ## ASP.NET
 
 ### [8.0.17] Breaking Change: UseForwardedHeaders middleware now always checks ForwardedHeadersOptions.KnownNetworks and ForwardedHeadersOptions.KnownProxies

--- a/release-notes/9.0/known-issues.md
+++ b/release-notes/9.0/known-issues.md
@@ -2,6 +2,28 @@
 
 You may encounter the following known issues, which may include workarounds, mitigations, or expected resolution timeframes.
 
+## WPF printing and PDF/XPS generation may fail with certain fonts
+
+After installing the August 2026 .NET update, some WPF applications may fail with a `System.IO.FileFormatException` when printing or generating PDF/XPS content that uses certain fonts, including Calibri.
+
+### Workaround for WPF printing and PDF/XPS generation
+
+Applications may mitigate the issue by enabling the `Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection` AppContext switch in the application's `runtimeconfig.json` file:
+
+```json
+{
+  "configProperties": {
+    "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
+    "CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS": false,
+    "Switch.MS.Internal.TtfDelta.DisableCmapAndSbitOverflowProtection": true
+  }
+}
+```
+
+This switch disables security protections introduced in the August 2026 update and may increase exposure to the vulnerabilities addressed by that update. Microsoft recommends using this workaround only as a temporary measure and only when required to address this issue.
+
+**Status:** Investigating.
+
 ## F#
 ### error NU1403: Package content hash validation failed for FSharp.Core.9.0.300. The package is different than the last restore.
 When using lock files with nuget, a package content hash validation fails for FSharp.Core 9.0.303.


### PR DESCRIPTION
## Summary

- document the August 2026 WPF printing and PDF/XPS known issue for .NET 8, 9, and 10
- provide the temporary `runtimeconfig.json` AppContext switch workaround
- warn that the workaround disables protections introduced in the August 2026 update

## Validation

- markdownlint passes for each newly added section
- markdown link checks pass for all three changed files
- diff whitespace check passes with the existing CRLF format in the .NET 10 file