### PR TITLE
[release-notes] Entity Framework Core in .NET 11 RC 1

### DIFF
--- a/release-notes/11.0/preview/rc1/efcore.md
+++ b/release-notes/11.0/preview/rc1/efcore.md
@@ -1,0 +1,36 @@
+# Entity Framework Core in .NET 11 RC 1 - Release Notes
+
+.NET 11 RC 1 focuses on fixes and stabilization for EF Core 11. For the full
+set of EF Core 11 features, see
+[What's new in EF Core 11](https://learn.microsoft.com/ef/core/what-is-new/ef-core-11.0/whatsnew).
+
+## Bug fixes
+
+- **Query translation**
+  - Fixed `OPENJSON ... AS JSON` queries for native `json` columns on Azure SQL
+    at compatibility level 170
+    ([dotnet/efcore #38665](https://github.com/dotnet/efcore/pull/38665)).
+- **Model building and migrations**
+  - Fixed model finalization and migration scaffolding when a foreign key
+    references a key declared on a complex type property
+    ([dotnet/efcore #38764](https://github.com/dotnet/efcore/pull/38764)).
+  - Fixed the default `IsTableExcludedFromMigrations` value for entity
+    splitting
+    ([dotnet/efcore #38802](https://github.com/dotnet/efcore/pull/38802)).
+- **SQLite**
+  - Handled unavailable WinRT APIs when initializing `Microsoft.Data.Sqlite`,
+    including partially implemented APIs under Wine
+    ([dotnet/efcore #38612](https://github.com/dotnet/efcore/pull/38612)).
+
+<!-- Filtered features:
+  - No new broadly useful EF Core feature was identified in the authoritative
+    RC 1 change set. This note intentionally summarizes customer-facing fixes
+    rather than promoting dependency, infrastructure, analyzer-performance, or
+    documentation-only changes as features.
+-->
+
+## Community contributors
+
+Thank you contributors! ❤️
+
+- [@BrycensRanch](https://github.com/dotnet/efcore/pulls?q=is%3Apr+is%3Amerged+author%3ABrycensRanch)

--- a/release-notes/11.0/preview/rc1/efcore.md
+++ b/release-notes/11.0/preview/rc1/efcore.md
@@ -10,6 +10,12 @@ set of EF Core 11 features, see
   - Fixed `OPENJSON ... AS JSON` queries for native `json` columns on Azure SQL
     at compatibility level 170
     ([dotnet/efcore #38665](https://github.com/dotnet/efcore/pull/38665)).
+  - Fixed query shaping for primitive collections that use native provider
+    representations instead of JSON strings
+    ([dotnet/efcore #38810](https://github.com/dotnet/efcore/pull/38810)).
+  - Preserved the discriminating `ORDER BY` expression required to materialize
+    many-to-many collections reliably
+    ([dotnet/efcore #38811](https://github.com/dotnet/efcore/pull/38811)).
 - **Model building and migrations**
   - Fixed model finalization and migration scaffolding when a foreign key
     references a key declared on a complex type property


### PR DESCRIPTION
## Summary

Add the Entity Framework Core release notes for .NET 11 RC 1. This component PR targets the RC 1 base branch so the component team can review and refine it independently.

The RC 1 release branch is still moving; the base metadata and this note will be refreshed against the final tag before publication.