### PR TITLE
[release-notes] WPF in .NET 11 RC 1

### DIFF
--- a/release-notes/11.0/preview/rc1/wpf.md
+++ b/release-notes/11.0/preview/rc1/wpf.md
@@ -1,0 +1,9 @@
+# WPF in .NET 11 RC 1 - Release Notes
+
+<!-- Verified against changes.json, features.json, and the Microsoft.WindowsDesktop.App API diff. No new public WPF APIs were identified for RC 1. -->
+
+.NET 11 RC 1 contains no new user-facing WPF features. This release includes
+native-code hardening and reliability fixes across text, graphics, fonts,
+printing, XPS, and resource loading
+([dotnet/wpf #11797](https://github.com/dotnet/wpf/pull/11797),
+[dotnet/wpf #11835](https://github.com/dotnet/wpf/pull/11835)).

--- a/release-notes/11.0/preview/rc1/wpf.md
+++ b/release-notes/11.0/preview/rc1/wpf.md
@@ -4,6 +4,8 @@
 
 .NET 11 RC 1 contains no new user-facing WPF features. This release includes
 native-code hardening and reliability fixes across text, graphics, fonts,
-printing, XPS, and resource loading
+printing, XPS, and resource loading.
+WPF's two C++/CLI projects migrated from /clr:pure to standard /clr:netcore.
 ([dotnet/wpf #11797](https://github.com/dotnet/wpf/pull/11797),
-[dotnet/wpf #11835](https://github.com/dotnet/wpf/pull/11835)).
+[dotnet/wpf #11835](https://github.com/dotnet/wpf/pull/11835),
+[dotnet/wpf #11575](https://github.com/dotnet/wpf/pull/11575)).


### PR DESCRIPTION
## Summary

Add the WPF release notes for .NET 11 RC 1. This component PR targets the RC 1 base branch so the component team can review and refine it independently.

The RC 1 release branch is still moving; the base metadata and this note will be refreshed against the final tag before publication.