### PR TITLE
[release-notes] Container images in .NET 11 RC 1

### DIFF
--- a/release-notes/11.0/preview/rc1/containers.md
+++ b/release-notes/11.0/preview/rc1/containers.md
@@ -1,0 +1,13 @@
+# Container image updates in .NET 11 RC 1 - Release Notes
+
+At the time these notes were drafted, Azure Linux 3.0 images for .NET 11 had
+been restored only on the `nightly` branch of `dotnet/dotnet-docker`
+([dotnet/dotnet-docker #7321](https://github.com/dotnet/dotnet-docker/pull/7321)).
+Their publication in the official .NET 11 RC 1 repositories has not yet been
+confirmed, so this note does not claim that the images are available in RC 1.
+
+<!-- TODO: Before publication, confirm that the .NET 11 RC 1 Azure Linux 3.0
+     SDK, ASP.NET Core, runtime, and runtime-deps tags were promoted to the
+     official Microsoft Artifact Registry. If confirmed, replace the cautious
+     text above with the supported tag families and link to
+     dotnet/dotnet-docker #7321. If not confirmed, keep this file as a stub. -->

--- a/release-notes/11.0/preview/rc1/containers.md
+++ b/release-notes/11.0/preview/rc1/containers.md
@@ -1,13 +1,3 @@
 # Container image updates in .NET 11 RC 1 - Release Notes
 
-At the time these notes were drafted, Azure Linux 3.0 images for .NET 11 had
-been restored only on the `nightly` branch of `dotnet/dotnet-docker`
-([dotnet/dotnet-docker #7321](https://github.com/dotnet/dotnet-docker/pull/7321)).
-Their publication in the official .NET 11 RC 1 repositories has not yet been
-confirmed, so this note does not claim that the images are available in RC 1.
-
-<!-- TODO: Before publication, confirm that the .NET 11 RC 1 Azure Linux 3.0
-     SDK, ASP.NET Core, runtime, and runtime-deps tags were promoted to the
-     official Microsoft Artifact Registry. If confirmed, replace the cautious
-     text above with the supported tag families and link to
-     dotnet/dotnet-docker #7321. If not confirmed, keep this file as a stub. -->
+There are no container image changes for .NET 11 RC 1.


### PR DESCRIPTION
## Summary

Add the Container images release notes for .NET 11 RC 1. This component PR targets the RC 1 base branch so the component team can review and refine it independently.

The RC 1 release branch is still moving; the base metadata and this note will be refreshed against the final tag before publication.