### PR TITLE
Update September release feedback links

### DIFF
--- a/release-notes/10.0/10.0.12/10.0.12.md
+++ b/release-notes/10.0/10.0.12/10.0.12.md
@@ -63,7 +63,7 @@ You can also use Visual Studio Code and the [C# Dev Kit](https://marketplace.vis
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #](https://github.com/dotnet/core/issues) for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core #10567](https://github.com/dotnet/core/issues/10567) for your questions and comments.
 
 [10.0.401]: 10.0.12.md
 [10.0.112]: 10.0.112.md

--- a/release-notes/8.0/8.0.31/8.0.31.md
+++ b/release-notes/8.0/8.0.31/8.0.31.md
@@ -54,7 +54,7 @@ You need [Visual Studio 17.10](https://visualstudio.microsoft.com) or later to u
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #](https://github.com/dotnet/core/issues) for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core #10567](https://github.com/dotnet/core/issues/10567) for your questions and comments.
 
 [8.0.425]: 8.0.31.md
 [8.0.131]: 8.0.131.md

--- a/release-notes/9.0/9.0.20/9.0.20.md
+++ b/release-notes/9.0/9.0.20/9.0.20.md
@@ -55,7 +55,7 @@ You need [Visual Studio 17.12](https://visualstudio.microsoft.com) or later to u
 
 ## Feedback
 
-Your feedback is important and appreciated. We've created an issue at [dotnet/core #](https://github.com/dotnet/core/issues) for your questions and comments.
+Your feedback is important and appreciated. We've created an issue at [dotnet/core #10567](https://github.com/dotnet/core/issues/10567) for your questions and comments.
 
 [9.0.318]: 9.0.20.md
 [9.0.121]: 9.0.121.md


### PR DESCRIPTION
Replace the placeholder feedback links in the .NET 8.0.31, 9.0.20, and 10.0.12 release notes with the September feedback issue, #10567.