### PR TITLE
Correct .NET 11 RC1 libraries release notes

### DIFF
--- a/release-notes/11.0/preview/rc1/libraries.md
+++ b/release-notes/11.0/preview/rc1/libraries.md
@@ -231,6 +231,12 @@ Console.WriteLine(
 
 ## Breaking changes
 
+### Numeric conversions are now correctly rounded
+
+Starting in .NET 11 Preview 7, conversions between `decimal` and binary floating-point types, and conversions from `BigInteger` to binary floating-point types, round the exact source value once to the nearest representable destination value ([dotnet/runtime #130565](https://github.com/dotnet/runtime/pull/130565), [dotnet/runtime #130566](https://github.com/dotnet/runtime/pull/130566)). The previous conversions could lose significant digits or round through an intermediate value, so existing binaries and code rebuilt with a .NET 11 Preview 7 or later SDK can produce different results.
+
+For example, converting the `double` literal `1.23` to `decimal` now preserves the exact binary floating-point value rather than producing `1.23`. If a value is intended to be decimal, use a decimal literal such as `1.23m` instead of converting a `double` literal. Update tests and serialized expected values that relied on the previous result; there is no compatibility switch to restore the former conversion algorithms. For complete guidance, see [dotnet/docs#55743](https://github.com/dotnet/docs/issues/55743).
+
 ### HTTP metrics are observable instruments
 
 The high-cardinality HTTP `open_connections` and `active_requests` metrics are now observable instruments ([dotnet/runtime #131275](https://github.com/dotnet/runtime/pull/131275)). Code that uses `MeterListener` directly must call `RecordObservableInstruments` to receive measurements from these instruments.

--- a/release-notes/11.0/preview/rc1/libraries.md
+++ b/release-notes/11.0/preview/rc1/libraries.md
@@ -98,8 +98,6 @@ The `Memory<byte>` and `ReadOnlyMemory<byte>` schemas remain non-nullable (`"typ
 For a union with object-shaped cases, specify the classifier on the union to select the case from its distinguishing property names:
 
 ```csharp
-#:property LangVersion=preview
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -213,17 +211,25 @@ On an Apple M1 Ultra running macOS Tahoe 26.6, encrypting a 16-byte payload with
 
 ## AES Key Wrap support
 
-The `Aes` class now supports the unpadded AES Key Wrap algorithm defined by RFC 3394 ([dotnet/runtime #132477](https://github.com/dotnet/runtime/pull/132477)). The new `EncryptKeyWrap`, `DecryptKeyWrap`, `TryDecryptKeyWrap`, and `GetKeyWrapLength` methods complement the padded AES-KWP APIs added earlier in .NET 11.
+The `Aes` class now supports the unpadded AES Key Wrap algorithm defined by RFC 3394 ([dotnet/runtime #132477](https://github.com/dotnet/runtime/pull/132477)). The new `EncryptKeyWrap`, `DecryptKeyWrap`, `TryDecryptKeyWrap`, and `GetKeyWrapLength` methods complement the padded AES-KWP APIs added in .NET 10.
 
 The APIs provide array-returning and span-based overloads for wrapping cryptographic keys, including scenarios used by JOSE libraries.
 
+```csharp
+using System.Security.Cryptography;
+
+using Aes aes = Aes.Create();
+aes.Key = RandomNumberGenerator.GetBytes(32);
+
+byte[] keyToWrap = RandomNumberGenerator.GetBytes(16);
+byte[] wrappedKey = aes.EncryptKeyWrap(keyToWrap);
+byte[] unwrappedKey = aes.DecryptKeyWrap(wrappedKey);
+
+Console.WriteLine(
+    CryptographicOperations.FixedTimeEquals(keyToWrap, unwrappedKey));
+```
+
 ## Breaking changes
-
-### Numeric conversions are now correctly rounded
-
-Starting in .NET 11 Preview 7, conversions between `decimal` and binary floating-point types, and conversions from `BigInteger` to binary floating-point types, round the exact source value once to the nearest representable destination value ([dotnet/runtime #130565](https://github.com/dotnet/runtime/pull/130565), [dotnet/runtime #130566](https://github.com/dotnet/runtime/pull/130566)). The previous conversions could lose significant digits or round through an intermediate value, so existing binaries and code rebuilt with a .NET 11 Preview 7 or later SDK can produce different results.
-
-For example, converting the `double` literal `1.23` to `decimal` now preserves the exact binary floating-point value rather than producing `1.23`. If a value is intended to be decimal, use a decimal literal such as `1.23m` instead of converting a `double` literal. Update tests and serialized expected values that relied on the previous result; there is no compatibility switch to restore the former conversion algorithms. For complete guidance, see [dotnet/docs#55743](https://github.com/dotnet/docs/issues/55743).
 
 ### HTTP metrics are observable instruments
 


### PR DESCRIPTION
## Summary

- remove numeric conversion breaking-change notes that already shipped and were documented in .NET 11 Preview 7
- correct the AES-KWP attribution from .NET 11 to .NET 10
- remove the obsolete preview language-version directive from the C# 15 JSON union sample
- add a runnable AES Key Wrap example

## Validation

- compiled and ran the JSON union, AES-KW, and AES-KWP examples with .NET 11 RC1
- verified AES-KW and AES-KWP round trips with `CryptographicOperations.FixedTimeEquals`
- verified dotnet/runtime#130565 and dotnet/runtime#130566 are absent from the RC1 change manifest and already documented in Preview 7
- verified the padded AES-KWP APIs are present in the .NET 10 API diff
- ran Markdown linting and link checking for `libraries.md`