### PR TITLE
Remove unavailable affected-test workflow from RC1 notes

### DIFF
--- a/release-notes/11.0/preview/rc1/sdk.md
+++ b/release-notes/11.0/preview/rc1/sdk.md
@@ -100,20 +100,6 @@ option, and `--no-banner` appears in the command help
 ([dotnet/sdk #55376](https://github.com/dotnet/sdk/pull/55376) and
 [dotnet/sdk #55412](https://github.com/dotnet/sdk/pull/55412)).
 
-An experimental affected-test workflow is also available through a separately
-distributed Microsoft.Testing.Platform extension. It can collect a repository's
-test map and then run the tests affected by a change
-([dotnet/sdk #55574](https://github.com/dotnet/sdk/pull/55574)):
-
-```powershell
-$env:DOTNET_CLI_ENABLE_AFFECTED_TESTS = "1"
-dotnet test --collect-test-map
-dotnet test --affected-tests
-```
-
-Collection and affected-test selection are mutually exclusive and cannot be
-combined with device testing, parallel modules, or minimum-test policies.
-
 ## Container publishing produces reproducible images and skips redundant uploads
 
 Publishing the same application more than once could previously produce
@@ -205,6 +191,7 @@ Thank you [@wellWINeo](https://github.com/wellWINeo) for this contribution!
   property name ([dotnet/sdk #55671](https://github.com/dotnet/sdk/pull/55671)).
 
 <!-- Filtered features (significant engineering work, but too niche for release notes):
+  - Affected-test selection: experimental SDK orchestration requires a separately distributed MTP extension and storage contract that are not available for RC 1, so no complete user workflow ships in this release.
   - Shared SDK resolution during Pack and Publish discovery: internal evaluation reuse without a distinct user workflow.
   - NativeAOT CLI size optimization: useful engineering work, but no stable customer-facing command change or published size measurement in the authoritative entry.
   - MSBuild task multithreading migrations: implementation work covered by the broader MSBuild multithreading story in earlier previews.


### PR DESCRIPTION
## Summary

Remove the affected-test workflow from the .NET 11 RC1 SDK release notes. The SDK includes experimental command-line orchestration, but the separately distributed Microsoft.Testing.Platform extension and its storage contract are not available for RC1, so the documented commands do not provide a usable end-to-end workflow.

The SDK work remains recorded in the filtered-features comment for future release-note generation.

## Validation

- verified a normal Microsoft.Testing.Platform test app passes with .NET SDK `11.0.100-rc.1.26427.112`
- verified the SDK exposes `--collect-test-map` and `--affected-tests` only when `DOTNET_CLI_ENABLE_AFFECTED_TESTS` is enabled
- verified both commands fail with `Unknown option` when executed without the unpublished extension
- confirmed the microsoft/testfx rollout documentation says the extension package and public storage contract are not available yet
- ran Markdown linting, link checking, and `git diff --check`