### PR TITLE
Update and correct dotnet blog link in release notes of 11.0 rc1

### DIFF
--- a/release-notes/11.0/preview/rc1/11.0.0-rc.1.md
+++ b/release-notes/11.0/preview/rc1/11.0.0-rc.1.md
@@ -69,7 +69,7 @@ Your feedback is important and appreciated. We've created an issue at [dotnet/co
 [checksums-runtime]: https://builds.dotnet.microsoft.com/dotnet/checksums/11.0.0-rc.1-sha.txt
 [checksums-sdk]: https://builds.dotnet.microsoft.com/dotnet/checksums/11.0.0-rc.1-sha.txt
 
-[dotnet-blog]: https://devblogs.microsoft.com/dotnet/dotnet-and-dotnet-framework-september-2026-servicing-updates/
+[dotnet-blog]: https://devblogs.microsoft.com/dotnet/dotnet-11-rc-1/
 
 [linux-packages]: ../install-linux.md
 


### PR DESCRIPTION
Update and correct dotnet blog link in release notes of 11.0 rc1