### PR TITLE
Refresh .NET 11 release notes index

### DIFF
--- a/release-notes/11.0/README.md
+++ b/release-notes/11.0/README.md
@@ -1,10 +1,15 @@
 # .NET 11
 
-[.NET 11](https://aka.ms/dotnet/11/preview2) is a [Standard Term Support (STS)](../../release-policies.md) release and will be supported for two years, from November 10, 2026 to November 9, 2028, on multiple operating systems.
+.NET 11 is a [Standard Term Support (STS)](../../release-policies.md) release and will be supported on [multiple operating systems](supported-os.md) for two years, from November 10, 2026, to November 9, 2028.
 
 - [Downloads](https://dotnet.microsoft.com/download/dotnet/11.0)
 - [Linux Package Managers](https://learn.microsoft.com/dotnet/core/install/linux)
 - [Containers](https://hub.docker.com/_/microsoft-dotnet)
+- [Supported OSes](supported-os.md)
+- [OS packages](dotnet-dependencies.md)
+- [Known issues](known-issues.md)
+- [Getting started](get-started.md)
+- [Linux installation instructions](install-linux.md)
 
 ## Release notes
 
@@ -21,58 +26,146 @@
 
 ### .NET Libraries
 
+- [RC 1](preview/rc1/libraries.md)
+- [Preview 7](preview/preview7/libraries.md)
+- [Preview 6](preview/preview6/libraries.md)
 - [Preview 5](preview/preview5/libraries.md)
+- [Preview 4](preview/preview4/libraries.md)
+- [Preview 3](preview/preview3/libraries.md)
+- [Preview 2](preview/preview2/libraries.md)
+- [Preview 1](preview/preview1/libraries.md)
 
 ### .NET Runtime
 
+- [RC 1](preview/rc1/runtime.md)
+- [Preview 7](preview/preview7/runtime.md)
+- [Preview 6](preview/preview6/runtime.md)
 - [Preview 5](preview/preview5/runtime.md)
+- [Preview 4](preview/preview4/runtime.md)
+- [Preview 3](preview/preview3/runtime.md)
+- [Preview 2](preview/preview2/runtime.md)
+- [Preview 1](preview/preview1/runtime.md)
 
 ### .NET SDK
 
+- [RC 1](preview/rc1/sdk.md)
+- [Preview 7](preview/preview7/sdk.md)
+- [Preview 6](preview/preview6/sdk.md)
 - [Preview 5](preview/preview5/sdk.md)
+- [Preview 4](preview/preview4/sdk.md)
+- [Preview 3](preview/preview3/sdk.md)
+- [Preview 2](preview/preview2/sdk.md)
+- [Preview 1](preview/preview1/sdk.md)
 
 ### MSBuild
 
+- [RC 1](preview/rc1/msbuild.md)
+- [Preview 7](preview/preview7/msbuild.md)
+- [Preview 6](preview/preview6/msbuild.md)
 - [Preview 5](preview/preview5/msbuild.md)
+- [Preview 4](preview/preview4/msbuild.md)
+- [Preview 1](preview/preview1/msbuild.md)
+
+### NuGet
+
+- [RC 1](preview/rc1/nuget.md)
+- [Preview 7](preview/preview7/nuget.md)
+- [Preview 6](preview/preview6/nuget.md)
+- [Preview 5](preview/preview5/nuget.md)
+- [Preview 4](preview/preview4/nuget.md)
 
 ### C\#
 
 - [What's new in C#](https://learn.microsoft.com/dotnet/csharp/whats-new/)
+- [RC 1](preview/rc1/csharp.md)
+- [Preview 7](preview/preview7/csharp.md)
+- [Preview 6](preview/preview6/csharp.md)
 - [Preview 5](preview/preview5/csharp.md)
+- [Preview 4](preview/preview4/csharp.md)
+- [Preview 3](preview/preview3/csharp.md)
+- [Preview 1](preview/preview1/csharp.md)
 
 ### F\#
 
 - [What's new in F#](https://learn.microsoft.com/dotnet/fsharp/whats-new/)
+- [RC 1](preview/rc1/fsharp.md)
+- [Preview 7](preview/preview7/fsharp.md)
+- [Preview 6](preview/preview6/fsharp.md)
 - [Preview 5](preview/preview5/fsharp.md)
+- [Preview 4](preview/preview4/fsharp.md)
+- [Preview 3](preview/preview3/fsharp.md)
+- [Preview 2](preview/preview2/fsharp.md)
+- [Preview 1](preview/preview1/fsharp.md)
 
 ### Visual Basic
 
 - [What's new in Visual Basic](https://learn.microsoft.com/dotnet/visual-basic/whats-new/)
+- [Preview 1](preview/preview1/visualbasic.md)
 
 ### ASP.NET Core
 
+- [RC 1](preview/rc1/aspnetcore.md)
+- [Preview 7](preview/preview7/aspnetcore.md)
+- [Preview 6](preview/preview6/aspnetcore.md)
 - [Preview 5](preview/preview5/aspnetcore.md)
+- [Preview 4](preview/preview4/aspnetcore.md)
+- [Preview 3](preview/preview3/aspnetcore.md)
+- [Preview 2](preview/preview2/aspnetcore.md)
+- [Preview 1](preview/preview1/aspnetcore.md)
 
 ### .NET MAUI
 
 - [What's new in .NET MAUI](https://learn.microsoft.com/dotnet/maui/whats-new/)
+- [RC 1](preview/rc1/dotnetmaui.md)
+- [Preview 7](preview/preview7/dotnetmaui.md)
+- [Preview 6](preview/preview6/dotnetmaui.md)
 - [Preview 5](preview/preview5/dotnetmaui.md)
+- [Preview 4](preview/preview4/dotnetmaui.md)
+- [Preview 3](preview/preview3/dotnetmaui.md)
+- [Preview 2](preview/preview2/dotnetmaui.md)
+- [Preview 1](preview/preview1/dotnetmaui.md)
 
 ### Entity Framework Core
 
 - [What's new in EF Core](https://learn.microsoft.com/ef/core/what-is-new/)
+- [RC 1](preview/rc1/efcore.md)
+- [Preview 7](preview/preview7/efcore.md)
+- [Preview 6](preview/preview6/efcore.md)
 - [Preview 5](preview/preview5/efcore.md)
+- [Preview 4](preview/preview4/efcore.md)
+- [Preview 3](preview/preview3/efcore.md)
+- [Preview 2](preview/preview2/efcore.md)
+- [Preview 1](preview/preview1/efcore.md)
 
 ### Windows Forms
 
 - [What's new in Windows Forms](https://learn.microsoft.com/dotnet/desktop/winforms/whats-new/)
+- [RC 1](preview/rc1/winforms.md)
+- [Preview 7](preview/preview7/winforms.md)
+- [Preview 6](preview/preview6/winforms.md)
 - [Preview 5](preview/preview5/winforms.md)
+- [Preview 4](preview/preview4/winforms.md)
+- [Preview 1](preview/preview1/winforms.md)
 
 ### Windows Presentation Foundation (WPF)
 
 - [What's new in WPF](https://learn.microsoft.com/dotnet/desktop/wpf/whats-new/)
+- [RC 1](preview/rc1/wpf.md)
+- [Preview 7](preview/preview7/wpf.md)
+- [Preview 6](preview/preview6/wpf.md)
 - [Preview 5](preview/preview5/wpf.md)
+- [Preview 4](preview/preview4/wpf.md)
+- [Preview 3](preview/preview3/wpf.md)
+- [Preview 2](preview/preview2/wpf.md)
+- [Preview 1](preview/preview1/wpf.md)
 
 ### Container images
 
+- [RC 1](preview/rc1/containers.md)
+- [Preview 7](preview/preview7/containers.md)
+- [Preview 6](preview/preview6/containers.md)
 - [Preview 5](preview/preview5/containers.md)
+- [Preview 4](preview/preview4/containers.md)
+- [Preview 3](preview/preview3/containers.md)
+- [Preview 2](preview/preview2/containers.md)
+- [Preview 1](preview/preview1/containers.md)

--- a/release-notes/11.0/README.md
+++ b/release-notes/11.0/README.md
@@ -48,7 +48,6 @@
 ### Visual Basic
 
 - [What's new in Visual Basic](https://learn.microsoft.com/dotnet/visual-basic/whats-new/)
-- [Preview 5](preview/preview5/visualbasic.md)
 
 ### ASP.NET Core
 


### PR DESCRIPTION
Refreshes the .NET 11 channel README so it accurately indexes the available release notes.

- Adds cumulative component links for Preview 1 through RC 1 where files exist
- Adds the missing NuGet section and restores the valid Preview 1 Visual Basic link
- Removes the stale Preview 2 redirect
- Adds links to supported OS, dependency, known-issue, getting-started, and Linux installation pages

This also fixes the `markdown-link-check` failure reported on #10565. All local links in the updated README were verified to resolve.